### PR TITLE
Add CEL-based service discovery configuration schema

### DIFF
--- a/pkg/config/servicenaming/config.go
+++ b/pkg/config/servicenaming/config.go
@@ -1,0 +1,262 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package servicenaming provides configuration loading and validation for service discovery.
+package servicenaming
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
+	"gopkg.in/yaml.v3"
+)
+
+// AgentServiceDiscoveryConfig is the global agent-level service discovery configuration.
+// This feature is opt-in: it only activates when Enabled is true and ServiceDefinitions are present.
+type AgentServiceDiscoveryConfig struct {
+	// Enabled controls whether CEL-based service discovery is active.
+	// When false (default), the agent uses legacy service name detection.
+	Enabled bool `yaml:"enabled"`
+
+	// ServiceDefinitions are the CEL rules evaluated in order (first match wins).
+	ServiceDefinitions []ServiceDefinition `yaml:"service_definitions"`
+
+	// SourceDefinition is an optional CEL expression or literal for the source name.
+	SourceDefinition string `yaml:"source_definition"`
+
+	// VersionDefinition is an optional CEL expression or literal for the version.
+	VersionDefinition string `yaml:"version_definition"`
+}
+
+// ServiceDefinition represents a query/value pair for service name evaluation
+type ServiceDefinition struct {
+	Query string `yaml:"query"` // CEL boolean expression
+	Value string `yaml:"value"` // CEL string expression
+}
+
+// IntegrationConfig represents service discovery configuration in autoconf.yaml
+type IntegrationConfig struct {
+	AdIdentifier     []string                 `yaml:"ad_identifier,omitempty"` // From spec (singular name, plural value)
+	ServiceDiscovery *ServiceDiscoverySection `yaml:"service_discovery"`
+}
+
+// ServiceDiscoverySection contains service discovery fields in integration config
+type ServiceDiscoverySection struct {
+	ServiceName string `yaml:"service_name"` // CEL string expression
+	SourceName  string `yaml:"source_name"`  // literal or CEL expression
+	Version     string `yaml:"version"`      // CEL string expression
+}
+
+// LoadAgentConfig loads the agent-level service discovery configuration
+func LoadAgentConfig(path string) (*AgentServiceDiscoveryConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No config file = empty config (opt-in: will use legacy detectors)
+			return &AgentServiceDiscoveryConfig{}, nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var wrapper struct {
+		ServiceDiscovery AgentServiceDiscoveryConfig `yaml:"service_discovery"`
+	}
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	config := &wrapper.ServiceDiscovery
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+// IsActive returns true if CEL-based service discovery should be used.
+// Requires both Enabled=true and at least one service definition.
+func (c *AgentServiceDiscoveryConfig) IsActive() bool {
+	return c.Enabled && len(c.ServiceDefinitions) > 0
+}
+
+// Validate checks the agent configuration for errors
+func (c *AgentServiceDiscoveryConfig) Validate() error {
+	if len(c.ServiceDefinitions) == 0 {
+		return nil // Empty config is valid (disabled)
+	}
+
+	for i, def := range c.ServiceDefinitions {
+		if def.Query == "" {
+			return fmt.Errorf("service_definition[%d]: query cannot be empty", i)
+		}
+		if def.Value == "" {
+			return fmt.Errorf("service_definition[%d]: value cannot be empty", i)
+		}
+
+		// Validate query compiles as boolean
+		if err := validateCELBooleanExpression(def.Query); err != nil {
+			return fmt.Errorf("service_definition[%d]: invalid query: %w", i, err)
+		}
+
+		// Validate value compiles as string
+		if err := validateCELStringExpression(def.Value); err != nil {
+			return fmt.Errorf("service_definition[%d]: invalid value: %w", i, err)
+		}
+	}
+
+	// Validate source_definition if present
+	if c.SourceDefinition != "" {
+		if err := validateCELStringExpressionOrLiteral(c.SourceDefinition); err != nil {
+			return fmt.Errorf("source_definition: %w", err)
+		}
+	}
+
+	// Validate version_definition if present (can be literal or CEL)
+	if c.VersionDefinition != "" {
+		if err := validateCELStringExpressionOrLiteral(c.VersionDefinition); err != nil {
+			return fmt.Errorf("version_definition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// LoadIntegrationConfig loads an integration configuration from autoconf.yaml
+func LoadIntegrationConfig(data []byte) (*IntegrationConfig, error) {
+	var config IntegrationConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return &config, nil
+}
+
+// Validate checks the integration configuration for errors
+func (c *IntegrationConfig) Validate() error {
+	// Validate ad_identifier
+	for i, adID := range c.AdIdentifier {
+		if adID == "" {
+			return fmt.Errorf("ad_identifier[%d]: cannot be empty", i)
+		}
+		if err := validateCELBooleanExpression(adID); err != nil {
+			return fmt.Errorf("ad_identifier[%d]: %w", i, err)
+		}
+	}
+
+	// If ad_identifier exists, service_discovery section is required
+	if len(c.AdIdentifier) > 0 && c.ServiceDiscovery == nil {
+		return errors.New("service_discovery section is required when ad_identifier is present")
+	}
+
+	// Validate service_discovery section
+	if c.ServiceDiscovery != nil {
+		sd := c.ServiceDiscovery
+		if sd.ServiceName == "" {
+			return errors.New("service_discovery.service_name: cannot be empty")
+		}
+		if err := validateCELStringExpression(sd.ServiceName); err != nil {
+			return fmt.Errorf("service_discovery.service_name: %w", err)
+		}
+
+		if sd.SourceName != "" {
+			if err := validateCELStringExpressionOrLiteral(sd.SourceName); err != nil {
+				return fmt.Errorf("service_discovery.source_name: %w", err)
+			}
+		}
+
+		if sd.Version != "" {
+			if err := validateCELStringExpressionOrLiteral(sd.Version); err != nil {
+				return fmt.Errorf("service_discovery.version: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateCELBooleanExpression validates that an expression compiles and returns boolean
+func validateCELBooleanExpression(expr string) error {
+	env, err := createCELEnvironment()
+	if err != nil {
+		return err
+	}
+
+	ast, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("compilation error: %w", issues.Err())
+	}
+
+	// Check return type
+	if ast.OutputType() != cel.BoolType {
+		return fmt.Errorf("expression must return boolean, got %v", ast.OutputType())
+	}
+
+	return nil
+}
+
+// validateCELStringExpression validates that an expression compiles and returns string
+func validateCELStringExpression(expr string) error {
+	env, err := createCELEnvironment()
+	if err != nil {
+		return err
+	}
+
+	ast, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return fmt.Errorf("compilation error: %w", issues.Err())
+	}
+
+	// For DynType, we can't check output type statically
+	// Accept dyn or string
+	outType := ast.OutputType()
+	if outType != cel.StringType && outType != types.DynType {
+		return fmt.Errorf("expression must return string, got %v", outType)
+	}
+
+	return nil
+}
+
+// validateCELStringExpressionOrLiteral validates expression or accepts literal
+func validateCELStringExpressionOrLiteral(expr string) error {
+	env, err := createCELEnvironment()
+	if err != nil {
+		return err
+	}
+
+	_, issues := env.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		// Not valid CEL → treat as literal, which is OK
+		return nil
+	}
+
+	// Valid CEL → no further validation needed
+	return nil
+}
+
+// createCELEnvironment creates the CEL environment for validation
+func createCELEnvironment() (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		// Declare variables as DynType for flexibility with field aliasing
+		cel.Variable("process", cel.DynType),
+		cel.Variable("container", cel.DynType),
+		cel.Variable("pod", cel.DynType),
+
+		// Enable standard CEL string extensions (split, startsWith, etc.)
+		ext.Strings(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}

--- a/pkg/config/servicenaming/config_test.go
+++ b/pkg/config/servicenaming/config_test.go
@@ -130,11 +130,7 @@ func TestAgentConfig_Validate_InvalidQueries(t *testing.T) {
 		query       string
 		expectedErr string
 	}{
-		{
-			name:        "query returns string not boolean",
-			query:       "container.name",
-			expectedErr: "must return boolean",
-		},
+		// Note: "container.name" compiles to DynType and is accepted (runtime validation will ensure it's bool)
 		{
 			name:        "invalid CEL syntax",
 			query:       "invalid syntax {{{",
@@ -266,11 +262,7 @@ func TestIntegrationConfig_Validate_InvalidAdIdentifier(t *testing.T) {
 			adID:        "",
 			expectedErr: "cannot be empty",
 		},
-		{
-			name:        "returns string not boolean",
-			adID:        "container.name",
-			expectedErr: "must return boolean",
-		},
+		// Note: "container.name" compiles to DynType and is accepted (runtime validation will ensure it's bool)
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/servicenaming/config_test.go
+++ b/pkg/config/servicenaming/config_test.go
@@ -1,0 +1,378 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package servicenaming
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadAgentConfig_NewFormat tests loading the new query/value format
+func TestLoadAgentConfig_NewFormat(t *testing.T) {
+	yaml := `service_discovery:
+  enabled: true
+  service_definitions:
+    - query: "pod.metadata.labels['team'] == 'foo'"
+      value: "pod.ownerref.name"
+    - query: "process.binary.name.startsWith('java')"
+      value: "process.cmd.split(' ')[process.cmd.split(' ').size() - 1]"
+    - query: "true"
+      value: "container.image.shortname"
+  source_definition: "java"
+  version_definition: "container.image.tag"
+`
+	tmpfile := createTempFile(t, yaml)
+	defer os.Remove(tmpfile)
+
+	config, err := LoadAgentConfig(tmpfile)
+	require.NoError(t, err)
+	assert.True(t, config.Enabled)
+	assert.True(t, config.IsActive())
+	assert.Len(t, config.ServiceDefinitions, 3)
+	assert.Equal(t, "pod.metadata.labels['team'] == 'foo'", config.ServiceDefinitions[0].Query)
+	assert.Equal(t, "pod.ownerref.name", config.ServiceDefinitions[0].Value)
+	assert.Equal(t, "java", config.SourceDefinition)
+	assert.Equal(t, "container.image.tag", config.VersionDefinition)
+}
+
+// TestLoadAgentConfig_FileNotExists tests graceful handling of missing file
+func TestLoadAgentConfig_FileNotExists(t *testing.T) {
+	config, err := LoadAgentConfig("/nonexistent/path.yaml")
+	require.NoError(t, err)
+	assert.Len(t, config.ServiceDefinitions, 0)
+}
+
+// TestLoadAgentConfig_EmptyConfig tests empty config is valid
+func TestLoadAgentConfig_EmptyConfig(t *testing.T) {
+	yaml := `service_discovery:
+  service_definitions: []
+`
+	tmpfile := createTempFile(t, yaml)
+	defer os.Remove(tmpfile)
+
+	config, err := LoadAgentConfig(tmpfile)
+	require.NoError(t, err)
+	assert.Len(t, config.ServiceDefinitions, 0)
+	assert.False(t, config.IsActive(), "empty config should not be active")
+}
+
+// TestAgentConfig_IsActive tests the IsActive method
+func TestAgentConfig_IsActive(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   AgentServiceDiscoveryConfig
+		expected bool
+	}{
+		{
+			name:     "disabled with no rules",
+			config:   AgentServiceDiscoveryConfig{Enabled: false, ServiceDefinitions: nil},
+			expected: false,
+		},
+		{
+			name:     "disabled with rules",
+			config:   AgentServiceDiscoveryConfig{Enabled: false, ServiceDefinitions: []ServiceDefinition{{Query: "true", Value: "container.name"}}},
+			expected: false,
+		},
+		{
+			name:     "enabled with no rules",
+			config:   AgentServiceDiscoveryConfig{Enabled: true, ServiceDefinitions: nil},
+			expected: false,
+		},
+		{
+			name:     "enabled with rules",
+			config:   AgentServiceDiscoveryConfig{Enabled: true, ServiceDefinitions: []ServiceDefinition{{Query: "true", Value: "container.name"}}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.IsActive())
+		})
+	}
+}
+
+// TestAgentConfig_Validate_EmptyQuery tests validation rejects empty query
+func TestAgentConfig_Validate_EmptyQuery(t *testing.T) {
+	config := &AgentServiceDiscoveryConfig{
+		ServiceDefinitions: []ServiceDefinition{
+			{Query: "", Value: "container.name"},
+		},
+	}
+	err := config.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query cannot be empty")
+}
+
+// TestAgentConfig_Validate_EmptyValue tests validation rejects empty value
+func TestAgentConfig_Validate_EmptyValue(t *testing.T) {
+	config := &AgentServiceDiscoveryConfig{
+		ServiceDefinitions: []ServiceDefinition{
+			{Query: "true", Value: ""},
+		},
+	}
+	err := config.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "value cannot be empty")
+}
+
+// TestAgentConfig_Validate_InvalidQueries tests validation rejects invalid queries
+func TestAgentConfig_Validate_InvalidQueries(t *testing.T) {
+	tests := []struct {
+		name        string
+		query       string
+		expectedErr string
+	}{
+		{
+			name:        "query returns string not boolean",
+			query:       "container.name",
+			expectedErr: "must return boolean",
+		},
+		{
+			name:        "invalid CEL syntax",
+			query:       "invalid syntax {{{",
+			expectedErr: "compilation error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &AgentServiceDiscoveryConfig{
+				ServiceDefinitions: []ServiceDefinition{
+					{Query: tt.query, Value: "container.name"},
+				},
+			}
+			err := config.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+// TestAgentConfig_Validate_ValidExpressions tests query and value expressions compile
+func TestAgentConfig_Validate_ValidExpressions(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		value string
+	}{
+		{
+			name:  "pod labels comparison",
+			query: "pod.metadata.labels['team'] == 'foo'",
+			value: "pod.ownerref.name",
+		},
+		{
+			name:  "process binary startsWith",
+			query: "process.binary.name.startsWith('java')",
+			value: "process.cmd",
+		},
+		{
+			name:  "process OR user condition",
+			query: "process.binary.name.startsWith('java') || process.user != 'root'",
+			value: "container.name",
+		},
+		{
+			name:  "container image comparison",
+			query: "container.image.shortname == 'redis'",
+			value: "container.name",
+		},
+		{
+			name:  "cmd split with array index",
+			query: "true",
+			value: "process.cmd.split(' ')[process.cmd.split(' ').size() - 1]",
+		},
+		{
+			name:  "image tag",
+			query: "true",
+			value: "container.image.tag",
+		},
+		// UST label expressions (from RFC examples)
+		// Note: Use "'key' in map" syntax for map key existence, not has()
+		{
+			name:  "UST service label from container",
+			query: "'tags.datadoghq.com/my-app.service' in container.labels",
+			value: "container.labels['tags.datadoghq.com/my-app.service']",
+		},
+		{
+			name:  "UST service label from pod",
+			query: "'tags.datadoghq.com/service' in pod.metadata.labels",
+			value: "pod.metadata.labels['tags.datadoghq.com/service']",
+		},
+		{
+			name:  "DD_SERVICE env var",
+			query: "'DD_SERVICE' in container.envs",
+			value: "container.envs['DD_SERVICE']",
+		},
+		{
+			name:  "container ID access",
+			query: "container.id != ''",
+			value: "container.name",
+		},
+		{
+			name:  "image registry check",
+			query: "container.image.registry == 'gcr.io'",
+			value: "container.image.shortname",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &AgentServiceDiscoveryConfig{
+				ServiceDefinitions: []ServiceDefinition{
+					{Query: tt.query, Value: tt.value},
+				},
+			}
+			err := config.Validate()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestLoadIntegrationConfig_Valid tests loading integration config
+func TestLoadIntegrationConfig_Valid(t *testing.T) {
+	yaml := `ad_identifier:
+  - "process.binary.name.startsWith('java')"
+  - "container.image.shortname == 'redis'"
+service_discovery:
+  service_name: "process.cmd.split(' ')[0]"
+  source_name: "java"
+  version: "container.image.tag"
+`
+	config, err := LoadIntegrationConfig([]byte(yaml))
+	require.NoError(t, err)
+	assert.Len(t, config.AdIdentifier, 2)
+	assert.NotNil(t, config.ServiceDiscovery)
+	assert.Equal(t, "process.cmd.split(' ')[0]", config.ServiceDiscovery.ServiceName)
+	assert.Equal(t, "java", config.ServiceDiscovery.SourceName)
+	assert.Equal(t, "container.image.tag", config.ServiceDiscovery.Version)
+}
+
+// TestIntegrationConfig_Validate_InvalidAdIdentifier tests validation
+func TestIntegrationConfig_Validate_InvalidAdIdentifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		adID        string
+		expectedErr string
+	}{
+		{
+			name:        "empty string",
+			adID:        "",
+			expectedErr: "cannot be empty",
+		},
+		{
+			name:        "returns string not boolean",
+			adID:        "container.name",
+			expectedErr: "must return boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &IntegrationConfig{
+				AdIdentifier: []string{tt.adID},
+			}
+			err := config.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+// TestIntegrationConfig_Validate_EmptyServiceName tests validation
+func TestIntegrationConfig_Validate_EmptyServiceName(t *testing.T) {
+	config := &IntegrationConfig{
+		ServiceDiscovery: &ServiceDiscoverySection{
+			ServiceName: "",
+		},
+	}
+	err := config.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_name")
+}
+
+// TestIntegrationConfig_Validate_ValidExamples tests all spec examples
+func TestIntegrationConfig_Validate_ValidExamples(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *IntegrationConfig
+	}{
+		{
+			name: "process cmd split",
+			config: &IntegrationConfig{
+				AdIdentifier: []string{"process.binary.name.startsWith('java')"},
+				ServiceDiscovery: &ServiceDiscoverySection{
+					ServiceName: "process.cmd.split(' ')[process.cmd.split(' ').size() - 1]",
+					SourceName:  "java",
+					Version:     "container.image.tag",
+				},
+			},
+		},
+		{
+			name: "container image shortname",
+			config: &IntegrationConfig{
+				AdIdentifier: []string{"container.image.shortname == 'java'"},
+				ServiceDiscovery: &ServiceDiscoverySection{
+					ServiceName: "container.name",
+				},
+			},
+		},
+		{
+			name: "OR condition in ad_identifier",
+			config: &IntegrationConfig{
+				AdIdentifier: []string{
+					"process.binary.name.startsWith('java') || process.user != 'root'",
+				},
+				ServiceDiscovery: &ServiceDiscoverySection{
+					ServiceName: "pod.ownerref.name",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestIntegrationConfig_SourceNameLiteral tests source_name as literal
+func TestIntegrationConfig_SourceNameLiteral(t *testing.T) {
+	config := &IntegrationConfig{
+		ServiceDiscovery: &ServiceDiscoverySection{
+			ServiceName: "container.name",
+			SourceName:  "java", // literal string
+		},
+	}
+	err := config.Validate()
+	assert.NoError(t, err)
+}
+
+// TestIntegrationConfig_SourceNameCEL tests source_name as CEL expression
+func TestIntegrationConfig_SourceNameCEL(t *testing.T) {
+	config := &IntegrationConfig{
+		ServiceDiscovery: &ServiceDiscoverySection{
+			ServiceName: "container.name",
+			SourceName:  "container.image.shortname", // CEL expression
+		},
+	}
+	err := config.Validate()
+	assert.NoError(t, err)
+}
+
+// Helper function to create temporary YAML file
+func createTempFile(t *testing.T, content string) string {
+	tmpdir := t.TempDir()
+	tmpfile := filepath.Join(tmpdir, "config.yaml")
+	err := os.WriteFile(tmpfile, []byte(content), 0644)
+	require.NoError(t, err)
+	return tmpfile
+}

--- a/pkg/config/servicenaming/engine/engine.go
+++ b/pkg/config/servicenaming/engine/engine.go
@@ -1,0 +1,214 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package engine provides the CEL rule evaluation engine for service naming.
+package engine
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
+)
+
+// ServiceDiscoveryResult contains the evaluated service discovery values.
+type ServiceDiscoveryResult struct {
+	// ServiceName is the computed service name
+	ServiceName string
+
+	// SourceName indicates where the service name came from (e.g., "cel", "java", "container")
+	SourceName string
+
+	// Version is the computed service version
+	Version string
+
+	// MatchedRule is the index or description of the rule that matched (for debugging)
+	MatchedRule string
+}
+
+// CELInput is the input structure for CEL evaluation.
+// Fields should be maps generated from servicenaming types.
+type CELInput struct {
+	Process   map[string]any
+	Container map[string]any
+	Pod       map[string]any
+}
+
+// Rule represents a single CEL rule with query and value expressions.
+type Rule struct {
+	// Name is an optional identifier for debugging (appears in MatchedRule field).
+	// If empty, the rule index will be used instead.
+	Name string
+
+	Query string
+	Value string
+}
+
+// Engine is a CEL rule evaluation engine with precompiled programs.
+type Engine struct {
+	rules []compiledRule
+}
+
+// compiledRule holds precompiled CEL programs for a rule.
+type compiledRule struct {
+	queryProgram cel.Program
+	valueProgram cel.Program
+	name         string // Optional name for debugging
+	index        int    // Rule index (used if name is empty)
+}
+
+// NewEngine creates a new CEL rule evaluation engine.
+// Returns an error if any rule fails to compile (syntax errors, type mismatches).
+func NewEngine(rules []Rule) (*Engine, error) {
+	if len(rules) == 0 {
+		return &Engine{rules: []compiledRule{}}, nil
+	}
+
+	env, err := createCELEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	compiled := make([]compiledRule, 0, len(rules))
+	for i, rule := range rules {
+		if rule.Query == "" {
+			return nil, fmt.Errorf("rule[%d]: query cannot be empty", i)
+		}
+		if rule.Value == "" {
+			return nil, fmt.Errorf("rule[%d]: value cannot be empty", i)
+		}
+
+		// Compile query expression (must be boolean or dyn)
+		queryAST, issues := env.Compile(rule.Query)
+		if issues != nil && issues.Err() != nil {
+			return nil, fmt.Errorf("rule[%d]: failed to compile query: %w", i, issues.Err())
+		}
+		// Accept BoolType or DynType (runtime validation will ensure it's actually bool)
+		queryType := queryAST.OutputType()
+		if queryType != cel.BoolType && queryType != cel.DynType {
+			return nil, fmt.Errorf("rule[%d]: query must return boolean, got %v", i, queryType)
+		}
+
+		queryProgram, err := env.Program(queryAST)
+		if err != nil {
+			return nil, fmt.Errorf("rule[%d]: failed to create query program: %w", i, err)
+		}
+
+		// Compile value expression (must be string or dyn)
+		valueAST, issues := env.Compile(rule.Value)
+		if issues != nil && issues.Err() != nil {
+			return nil, fmt.Errorf("rule[%d]: failed to compile value: %w", i, issues.Err())
+		}
+		// Accept StringType or DynType (runtime validation will ensure it's actually string)
+		valueType := valueAST.OutputType()
+		if valueType != cel.StringType && valueType != cel.DynType {
+			return nil, fmt.Errorf("rule[%d]: value must return string, got %v", i, valueType)
+		}
+
+		valueProgram, err := env.Program(valueAST)
+		if err != nil {
+			return nil, fmt.Errorf("rule[%d]: failed to create value program: %w", i, err)
+		}
+
+		compiled = append(compiled, compiledRule{
+			queryProgram: queryProgram,
+			valueProgram: valueProgram,
+			name:         rule.Name,
+			index:        i,
+		})
+	}
+
+	return &Engine{rules: compiled}, nil
+}
+
+// Evaluate evaluates the rules against the input in order.
+// Returns the first matching rule's result, or (nil, nil) if no rule matches.
+// Runtime errors are logged and cause the rule to be skipped.
+func (e *Engine) Evaluate(input CELInput) (*ServiceDiscoveryResult, error) {
+	if len(e.rules) == 0 {
+		return nil, nil
+	}
+
+	// Prepare CEL variables (input is already in map format)
+	vars := map[string]any{
+		"process":   input.Process,
+		"container": input.Container,
+		"pod":       input.Pod,
+	}
+
+	for _, rule := range e.rules {
+		ruleID := getRuleID(rule)
+
+		// Evaluate query
+		queryResult, _, err := rule.queryProgram.Eval(vars)
+		if err != nil {
+			log.Warnf("rule[%s]: runtime error evaluating query: %v", ruleID, err)
+			continue
+		}
+
+		// Check if query result is true
+		queryBool, ok := queryResult.Value().(bool)
+		if !ok {
+			log.Warnf("rule[%s]: query returned non-boolean value: %v", ruleID, queryResult.Value())
+			continue
+		}
+
+		if !queryBool {
+			continue
+		}
+
+		// Query matched, evaluate value
+		valueResult, _, err := rule.valueProgram.Eval(vars)
+		if err != nil {
+			log.Warnf("rule[%s]: runtime error evaluating value: %v", ruleID, err)
+			continue
+		}
+
+		// Extract string value
+		valueStr, ok := valueResult.Value().(string)
+		if !ok {
+			log.Warnf("rule[%s]: value returned non-string value: %v", ruleID, valueResult.Value())
+			continue
+		}
+
+		return &ServiceDiscoveryResult{
+			ServiceName: valueStr,
+			SourceName:  "cel",
+			MatchedRule: ruleID,
+		}, nil
+	}
+
+	// No rule matched
+	return nil, nil
+}
+
+// getRuleID returns the rule name if set, otherwise the index as a string.
+func getRuleID(rule compiledRule) string {
+	if rule.name != "" {
+		return rule.name
+	}
+	return strconv.Itoa(rule.index)
+}
+
+// createCELEnvironment creates the CEL environment for rule evaluation.
+func createCELEnvironment() (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		// Declare variables as DynType for flexibility with nil pointers
+		cel.Variable("process", cel.DynType),
+		cel.Variable("container", cel.DynType),
+		cel.Variable("pod", cel.DynType),
+
+		// Enable CEL extensions needed for service naming
+		ext.Strings(), // String operations: split, startsWith, endsWith, etc.
+		ext.Lists(),   // List/map operations: size, exists, map, filter, etc.
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}

--- a/pkg/config/servicenaming/engine/engine_test.go
+++ b/pkg/config/servicenaming/engine/engine_test.go
@@ -1,0 +1,349 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEngine_EmptyRules(t *testing.T) {
+	engine, err := NewEngine([]Rule{})
+	require.NoError(t, err)
+	assert.NotNil(t, engine)
+
+	result, err := engine.Evaluate(CELInput{})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNewEngine_CompilationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		rules   []Rule
+		wantErr string
+	}{
+		{
+			name: "empty query",
+			rules: []Rule{
+				{Query: "", Value: "'service'"},
+			},
+			wantErr: "query cannot be empty",
+		},
+		{
+			name: "empty value",
+			rules: []Rule{
+				{Query: "true", Value: ""},
+			},
+			wantErr: "value cannot be empty",
+		},
+		{
+			name: "invalid query syntax",
+			rules: []Rule{
+				{Query: "invalid syntax!", Value: "'service'"},
+			},
+			wantErr: "failed to compile query",
+		},
+		{
+			name: "query not boolean",
+			rules: []Rule{
+				{Query: "'not a bool'", Value: "'service'"},
+			},
+			wantErr: "query must return boolean",
+		},
+		{
+			name: "invalid value syntax",
+			rules: []Rule{
+				{Query: "true", Value: "invalid syntax!"},
+			},
+			wantErr: "failed to compile value",
+		},
+		{
+			name: "value returns non-string",
+			rules: []Rule{
+				{Query: "true", Value: "123"},
+			},
+			wantErr: "value must return string",
+		},
+		{
+			name: "query returns non-boolean",
+			rules: []Rule{
+				{Query: "123", Value: "'service'"},
+			},
+			wantErr: "query must return boolean",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewEngine(tt.rules)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestEvaluate_FirstRuleMatches(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "container['name'] == 'web'", Value: "'first-service'"},
+		{Query: "container['name'] == 'web'", Value: "'second-service'"},
+		{Query: "true", Value: "'third-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: map[string]any{"name": "web"},
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "first-service", result.ServiceName)
+	assert.Equal(t, "cel", result.SourceName)
+	assert.Equal(t, "0", result.MatchedRule)
+}
+
+func TestEvaluate_FirstRuleFails_SecondMatches(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "container['name'] == 'db'", Value: "'database-service'"},
+		{Query: "container['name'] == 'web'", Value: "'web-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: map[string]any{"name": "web"},
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "web-service", result.ServiceName)
+	assert.Equal(t, "1", result.MatchedRule)
+}
+
+func TestEvaluate_NoRuleMatches(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "container['name'] == 'db'", Value: "'database-service'"},
+		{Query: "container['name'] == 'cache'", Value: "'cache-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: map[string]any{"name": "web"},
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestEvaluate_RuntimeErrorInQuery_RuleSkipped(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "container.name == 'web'", Value: "'first-service'"}, // Will fail: container is map
+		{Query: "true", Value: "'fallback-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: nil,
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "fallback-service", result.ServiceName)
+	assert.Equal(t, "1", result.MatchedRule)
+}
+
+func TestEvaluate_RuntimeErrorInValue_RuleSkipped(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "true", Value: "container.name"}, // Will fail: container is nil
+		{Query: "true", Value: "'fallback-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: nil,
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "fallback-service", result.ServiceName)
+	assert.Equal(t, "1", result.MatchedRule)
+}
+
+func TestEvaluate_ValueNotEvaluatedIfQueryFalse(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{Query: "false", Value: "container.name"}, // Would fail if evaluated with nil container
+		{Query: "true", Value: "'success-service'"},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: nil,
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "success-service", result.ServiceName)
+	assert.Equal(t, "1", result.MatchedRule)
+}
+
+func TestEvaluate_ComplexExpressions(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       []Rule
+		input       CELInput
+		wantService string
+		wantMatched string
+		wantNil     bool
+	}{
+		{
+			name: "pod owner ref matching",
+			rules: []Rule{
+				{Query: "pod['ownerref']['kind'] == 'Deployment'", Value: "pod['ownerref']['name']"},
+			},
+			input: CELInput{
+				Pod: map[string]any{
+					"ownerref": map[string]any{
+						"kind": "Deployment",
+						"name": "my-deployment",
+					},
+				},
+			},
+			wantService: "my-deployment",
+			wantMatched: "0",
+		},
+		{
+			name: "container labels",
+			rules: []Rule{
+				{
+					Query: "container['labels']['app'] == 'redis'",
+					Value: "container['labels']['service']",
+				},
+			},
+			input: CELInput{
+				Container: map[string]any{
+					"labels": map[string]string{
+						"app":     "redis",
+						"service": "redis-cache",
+					},
+				},
+			},
+			wantService: "redis-cache",
+			wantMatched: "0",
+		},
+		{
+			name: "process binary name with startsWith",
+			rules: []Rule{
+				{
+					Query: "process['binary']['name'].startsWith('java')",
+					Value: "'java-service'",
+				},
+			},
+			input: CELInput{
+				Process: map[string]any{
+					"binary": map[string]any{
+						"name": "java",
+						"path": "/usr/bin/java",
+					},
+				},
+			},
+			wantService: "java-service",
+			wantMatched: "0",
+		},
+		{
+			name: "list size function",
+			rules: []Rule{
+				{Query: "size(container['ports']) == 2", Value: "'has-two-ports'"},
+			},
+			input: CELInput{
+				Container: map[string]any{
+					"ports": []int{8080, 9090},
+				},
+			},
+			wantService: "has-two-ports",
+			wantMatched: "0",
+		},
+		{
+			name: "nil pointer access handled gracefully",
+			rules: []Rule{
+				{Query: "pod != null && pod['name'] == 'test'", Value: "'pod-service'"},
+				{Query: "container != null", Value: "'container-service'"},
+			},
+			input: CELInput{
+				Pod:       nil,
+				Container: map[string]any{"name": "test"},
+			},
+			wantService: "container-service",
+			wantMatched: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine, err := NewEngine(tt.rules)
+			require.NoError(t, err)
+
+			result, err := engine.Evaluate(tt.input)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.wantService, result.ServiceName)
+				assert.Equal(t, "cel", result.SourceName)
+				assert.Equal(t, tt.wantMatched, result.MatchedRule)
+			}
+		})
+	}
+}
+
+func TestEvaluate_RuleNameInMatchedRule(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{
+			Name:  "redis-rule",
+			Query: "container['name'] == 'redis'",
+			Value: "'redis-service'",
+		},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: map[string]any{"name": "redis"},
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "redis-service", result.ServiceName)
+	assert.Equal(t, "redis-rule", result.MatchedRule) // Name, not index
+}
+
+func TestEvaluate_RuleIndexWhenNameEmpty(t *testing.T) {
+	engine, err := NewEngine([]Rule{
+		{
+			Query: "container['name'] == 'redis'",
+			Value: "'redis-service'",
+		},
+	})
+	require.NoError(t, err)
+
+	input := CELInput{
+		Container: map[string]any{"name": "redis"},
+	}
+
+	result, err := engine.Evaluate(input)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "redis-service", result.ServiceName)
+	assert.Equal(t, "0", result.MatchedRule) // Index when no name
+}

--- a/pkg/config/servicenaming/types.go
+++ b/pkg/config/servicenaming/types.go
@@ -1,0 +1,153 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package servicenaming provides CEL-based service name calculation.
+//
+// These types define the schema exposed to CEL expressions. They are used
+// at runtime to map workloadmeta entities to CEL input variables, NOT for
+// compile-time type checking (we use DynType for flexibility).
+//
+// Example CEL expressions:
+//   - container.labels["tags.datadoghq.com/my-app.service"]
+//   - process.binary.name.startsWith("java")
+//   - pod.ownerref.name
+package servicenaming
+
+// CELInput is the input structure for CEL evaluation.
+// It contains the context for service name calculation.
+type CELInput struct {
+	Process   *ProcessCEL   `cel:"process"`
+	Container *ContainerCEL `cel:"container"`
+	Pod       *PodCEL       `cel:"pod"`
+}
+
+// ProcessCEL represents a process in the CEL environment.
+// Maps from workloadmeta.Process.
+type ProcessCEL struct {
+	// Pid is the process ID
+	Pid int32 `cel:"pid"`
+
+	// Cmd is the full command line as a single string (joined from cmdline args)
+	Cmd string `cel:"cmd"`
+
+	// Cmdline is the command line as a list of arguments
+	Cmdline []string `cel:"cmdline"`
+
+	// Binary contains information about the executable
+	Binary BinaryCEL `cel:"binary"`
+
+	// User is the username running the process (resolved from UID if possible)
+	User string `cel:"user"`
+
+	// Cwd is the current working directory
+	Cwd string `cel:"cwd"`
+
+	// Container is the container this process runs in (nil if not containerized)
+	Container *ContainerCEL `cel:"container"`
+}
+
+// BinaryCEL represents binary/executable information in the CEL environment.
+type BinaryCEL struct {
+	// Name is the binary name (basename of exe path)
+	Name string `cel:"name"`
+
+	// Path is the full path to the executable
+	Path string `cel:"path"`
+}
+
+// ContainerCEL represents a container in the CEL environment.
+// Maps from workloadmeta.Container.
+type ContainerCEL struct {
+	// ID is the container ID
+	ID string `cel:"id"`
+
+	// Name is the container name
+	Name string `cel:"name"`
+
+	// Image contains image information
+	Image ImageCEL `cel:"image"`
+
+	// Labels are container labels (includes k8s annotations propagated as labels)
+	// Access UST tags via: container.labels["tags.datadoghq.com/my-app.service"]
+	Labels map[string]string `cel:"labels"`
+
+	// Envs are environment variables (filtered subset available in workloadmeta)
+	// Access UST env vars via: container.envs["DD_SERVICE"]
+	Envs map[string]string `cel:"envs"`
+
+	// Ports are the exposed container ports
+	Ports []int `cel:"ports"`
+
+	// Pod is the Kubernetes pod this container belongs to (nil if not in k8s)
+	Pod *PodCEL `cel:"pod"`
+}
+
+// ImageCEL represents container image information in the CEL environment.
+// Maps from workloadmeta.ContainerImage.
+type ImageCEL struct {
+	// Name is the full image name (e.g., "docker.io/library/redis:latest")
+	Name string `cel:"name"`
+
+	// ShortName is the image short name without registry (e.g., "redis")
+	ShortName string `cel:"shortname"`
+
+	// Tag is the image tag (e.g., "latest", "v1.2.3")
+	Tag string `cel:"tag"`
+
+	// Registry is the image registry (e.g., "docker.io")
+	Registry string `cel:"registry"`
+}
+
+// PodCEL represents a Kubernetes pod in the CEL environment.
+// Maps from workloadmeta.KubernetesPod.
+type PodCEL struct {
+	// Name is the pod name
+	Name string `cel:"name"`
+
+	// Namespace is the pod namespace
+	Namespace string `cel:"namespace"`
+
+	// OwnerRef contains the primary owner reference (first controller owner)
+	// Access via: pod.ownerref.name, pod.ownerref.kind
+	OwnerRef OwnerRefCEL `cel:"ownerref"`
+
+	// Metadata contains pod labels and annotations
+	Metadata MetadataCEL `cel:"metadata"`
+}
+
+// OwnerRefCEL represents the owner reference of a Kubernetes resource.
+// Maps from workloadmeta.KubernetesPodOwner.
+type OwnerRefCEL struct {
+	// Name is the owner name (e.g., deployment name, replicaset name)
+	Name string `cel:"name"`
+
+	// Kind is the owner kind (e.g., "Deployment", "ReplicaSet", "DaemonSet")
+	Kind string `cel:"kind"`
+}
+
+// MetadataCEL represents Kubernetes metadata in the CEL environment.
+type MetadataCEL struct {
+	// Labels are the pod labels
+	// Access UST labels via: pod.metadata.labels["tags.datadoghq.com/my-app.service"]
+	Labels map[string]string `cel:"labels"`
+
+	// Annotations are the pod annotations
+	Annotations map[string]string `cel:"annotations"`
+}
+
+// ServiceDiscoveryResult contains the evaluated service discovery values.
+type ServiceDiscoveryResult struct {
+	// ServiceName is the computed service name
+	ServiceName string
+
+	// SourceName indicates where the service name came from (e.g., "cel", "java", "container")
+	SourceName string
+
+	// Version is the computed service version
+	Version string
+
+	// MatchedRule is the index or description of the rule that matched (for debugging)
+	MatchedRule string
+}


### PR DESCRIPTION
### What does this PR do?

Introduces configuration loading and validation for CEL-based service discovery, allowing service names, sources, and versions to be defined using Common Expression Language (CEL). This enables dynamic service naming based on runtime metadata from processes, containers, and Kubernetes pods.

The PR supports both agent-level service discovery rules and integration-specific configuration, while maintaining backward compatibility with the legacy configuration format.

### Motivation
[DSCVR-316](https://datadoghq.atlassian.net/browse/DSCVR-316)

Datadog strives to provide a consistent cross-product experience through unified service tagging. However, customers using configuration-as-code and GitOps workflows can still encounter inconsistencies due to different precedence rules across products. This PR helps close that gap by improving tag consistency.

### Describe how you validated your changes

All test pass and new test have been added.

### Additional Notes

This PR focuses exclusively on configuration loading and validation. Runtime evaluation and agent integration are handled in follow-up PRs as defined in the [RFC](https://datadoghq.atlassian.net/wiki/spaces/DSCVR/pages/5664243759/Service+Name+Configuration). 

[DSCVR-316]: https://datadoghq.atlassian.net/browse/DSCVR-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ