### PR TITLE
Octo STS policy for Python patch upgrades

### DIFF
--- a/.github/chainguard/self.upgrade-python-version.create-pr.sts.yaml
+++ b/.github/chainguard/self.upgrade-python-version.create-pr.sts.yaml
@@ -1,0 +1,16 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:environment:main
+
+claim_pattern:
+  event_name: workflow_dispatch|schedule
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/upgrade-python-patch-version\.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write
+  members: read
+

--- a/.github/workflows/upgrade-python-patch-version.yml
+++ b/.github/workflows/upgrade-python-patch-version.yml
@@ -21,7 +21,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/datadog-agent
-          policy: self.update-dependencies.create-pr
+          policy: self.upgrade-python-version.create-pr
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
### What does this PR do?
Creates an Octo STS policy for the Python patch version upgrade automation previously merged.
### Motivation

### Describe how you validated your changes

### Additional Notes
