### PR TITLE
Handle invalid file data like how viper does with GetViperCombine

### DIFF
--- a/pkg/config/helper/get_combine.go
+++ b/pkg/config/helper/get_combine.go
@@ -29,6 +29,10 @@ func GetViperCombine(cfg model.Reader, key string) interface{} {
 		// If the setting has a scalar non-nil value, return it
 		return rawval
 	}
+	if reflect.ValueOf(rawval).Kind() == reflect.Slice {
+		// If the setting has a slice, return it
+		return rawval
+	}
 
 	// If the setting is a map, copy to the tree (return value)
 	tree := make(map[string]interface{})

--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/config/helper"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
@@ -666,17 +667,16 @@ c: 1234
 	})
 
 	cvalue := viperConf.Get("c")
-	assert.Equal(t, cvalue, 1234)
+	assert.Equal(t, 1234, cvalue)
 
 	dvalue := viperConf.Get("c.d")
-	assert.Equal(t, dvalue, nil)
+	assert.Equal(t, nil, dvalue)
 
-	// NOTE: Behavior difference, but it requires an error in the config
 	cvalue = ntmConf.Get("c")
-	assert.Equal(t, cvalue, map[string]interface{}{"d": true})
+	assert.Equal(t, 1234, cvalue)
 
 	dvalue = ntmConf.Get("c.d")
-	assert.Equal(t, dvalue, true)
+	assert.Equal(t, false, dvalue)
 }
 
 func TestCompareTimeDuration(t *testing.T) {
@@ -876,4 +876,47 @@ additional_endpoints:
 	}
 	assert.Equal(t, expectEndpoints, viperConf.GetStringMapStringSlice("additional_endpoints"))
 	assert.Equal(t, expectEndpoints, ntmConf.GetStringMapStringSlice("additional_endpoints"))
+}
+
+func TestGetViperCombineInvalidFileData(t *testing.T) {
+	// The setting in the yaml file has the wrong shape
+	// It is a list of an object, but it is supposed to not be a list
+	// The implementation should handle this predictabily and compatibly with Viper
+	// The rule when merging conflicts is that higher layers have branches kept, so
+	// the invalid file data will be kept rather than the default values.
+	configData := `network_path:
+  collector:
+    - input_chan_size: 23456
+`
+	// Two settings at path, but the file source has the wrong shape
+	viperConf, ntmConf := constructBothConfigs(configData, false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 0) //nolint:forbidigo // used to test behavior
+		cfg.BindEnvAndSetDefault("network_path.collector.workers", 0)         //nolint:forbidigo // used to test behavior
+	})
+
+	// Value at the path is a list of map
+	expectCollector := []interface{}{
+		map[interface{}]interface{}{
+			"input_chan_size": 23456,
+		},
+	}
+	// Parent of that element
+	expectNetworkPath := map[string]interface{}{
+		"collector": []interface{}{
+			map[interface{}]interface{}{
+				"input_chan_size": 23456,
+			},
+		},
+	}
+
+	// Test what the methods `Get, GetViperCombine, AllSettings` return for each impl
+	for _, cfg := range []model.Reader{viperConf, ntmConf} {
+		assert.Equal(t, expectCollector, cfg.Get("network_path.collector"))
+		assert.Equal(t, expectCollector, helper.GetViperCombine(cfg, "network_path.collector"))
+		assert.Equal(t, expectCollector, cfg.AllSettings()["network_path"].(map[string]interface{})["collector"])
+
+		// Test parent element as well
+		actual := helper.GetViperCombine(cfg, "network_path")
+		assert.Equal(t, expectNetworkPath, actual)
+	}
 }

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -94,14 +94,13 @@ func (n *nodeImpl) Merge(that *nodeImpl) (*nodeImpl, error) {
 		ourIsLeaf := ourChild.IsLeafNode()
 		theirIsLeaf := theirChild.IsLeafNode()
 
-		// If subtree shapes differ, take the longer branch
-		// TODO: Improve error handling in a follow-up PR. We should collect errors
-		// and log.Error them, but also display these errors in more places
-		if ourIsLeaf && !theirIsLeaf {
+		// If subtree shapes differ, take their branch, unless it is an empty leaf
+		if ourIsLeaf != theirIsLeaf {
+			if theirChild.IsLeafNode() && theirChild.Get() == nil {
+				newChildren[name] = ourChild
+				continue
+			}
 			newChildren[name] = theirChild
-			continue
-		} else if !ourIsLeaf && theirIsLeaf {
-			newChildren[name] = ourChild
 			continue
 		}
 

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -249,21 +249,19 @@ c: 1234
 > a
     leaf(#ptr<000001>), val:"orange", source:file
 > c
-  inner(#ptr<000002>)
-  > d
-      leaf(#ptr<000003>), val:true, source:default
-tree(#ptr<000004>) source=default
+    leaf(#ptr<000002>), val:1234, source:file
+tree(#ptr<000003>) source=default
 > a
-    leaf(#ptr<000005>), val:"apple", source:default
+    leaf(#ptr<000004>), val:"apple", source:default
 > c
-  inner(#ptr<000002>)
+  inner(#ptr<000005>)
   > d
-      leaf(#ptr<000003>), val:true, source:default
-tree(#ptr<000006>) source=file
+      leaf(#ptr<000006>), val:true, source:default
+tree(#ptr<000007>) source=file
 > a
     leaf(#ptr<000001>), val:"orange", source:file
 > c
-    leaf(#ptr<000007>), val:1234, source:file`
+    leaf(#ptr<000002>), val:1234, source:file`
 	assert.Equal(t, expected, c.Stringify("all", model.OmitPointerAddr))
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR re-applies #44605, which was rolled back due to binary size increase. This PR is based on top of [another PR](https://github.com/DataDog/datadog-agent/pull/44682) which decreases the binary size usage a bit.

Change how we handle merging config layers when there's invalid file data. If we need to merge nodes of different shape, we keep the higher layer's branch, unless it is a nil leaf. This means invalid file data is often kept in the merged root, but can be overriden by env vars, which improves compatibility with Viper.

### Motivation

Compatibility with Viper

### Describe how you validated your changes

Unit tests

### Additional Notes
