### PR TITLE
[BARX-1523] - update octo sts policy without agent-delivery-staging

### DIFF
--- a/.github/chainguard/agentrelease-worker.clone-repo-staging.sts.yaml
+++ b/.github/chainguard/agentrelease-worker.clone-repo-staging.sts.yaml
@@ -1,9 +1,9 @@
 issuer: https://vault.us1.staging.dog/v1/identity/oidc
 
-# ddtool auth whois --datacenter us1.staging.dog agent-delivery-staging-agentrelease-worker --format json | jq -r .id
-subject_pattern: "0b2ea57a-9a31-3f6a-2554-df962659cc8f"
+# ddtool auth whois --datacenter us1.staging.dog agent-delivery-agentrelease-worker --format json | jq -r .id
+subject_pattern: "20398f5e-272c-2812-8f22-f084f07f951c"
 claim_pattern:
-  name: "agent-delivery-staging-agentrelease-worker"
+  name: "agent-delivery-agentrelease-worker"
 
 permissions:
   contents: read


### PR DESCRIPTION
### What does this PR do?
update octo sts policy without agent-delivery-staging

### Motivation
we're removing the agent-delivery-staging namespace because we don't need it
