### PR TITLE
Properly hide config.h from dependent packages

### DIFF
--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -44,6 +44,13 @@ copy_file(
     out = "config.h",
 )
 
+cc_library(
+    name = "config_h",
+    hdrs = [
+        ":copy_config_h",
+    ],
+)
+
 _PUBLIC_HEADERS = [
     "include/libattr.h",
     "include/attributes.h",
@@ -53,7 +60,6 @@ _PUBLIC_HEADERS = [
 cc_library(
     name = "libattr",
     srcs = [
-        ":copy_config_h",
         "libattr/attr_copy_action.c",
         "libattr/attr_copy_check.c",
         "libattr/attr_copy_fd.c",
@@ -72,6 +78,9 @@ cc_library(
     copts = [
         "-include $(location libattr/libattr.h)",
         "-O2",
+    ],
+    implementation_deps = [
+        ":config_h",
     ],
     local_defines = [
         "HAVE_CONFIG_H",

--- a/deps/dbus/dbus.BUILD.bazel
+++ b/deps/dbus/dbus.BUILD.bazel
@@ -23,6 +23,13 @@ copy_file(
     out = "config.h",
 )
 
+cc_library(
+    name = "config_h",
+    hdrs = [
+        ":copy_config_h"
+    ],
+)
+
 PUBLIC_HEADERS = [
     "dbus/dbus-address.h",
     "dbus/dbus-bus.h",
@@ -110,7 +117,6 @@ cc_library(
         "dbus/dbus-sysdeps-unix.c",
         "dbus/dbus-transport-unix.c",
         "dbus/dbus-userdb.c",
-        ":copy_config_h",
         ":dbus_arch_deps_h",
     ] + glob(["dbus/*.h"], exclude=PUBLIC_HEADERS),
     hdrs = PUBLIC_HEADERS,
@@ -123,6 +129,9 @@ cc_library(
         "-O2",
         "-fno-strict-aliasing",
         "-fvisibility=hidden",
+    ],
+    implementation_deps = [
+        ":config_h",
     ],
     includes = ["."],
     linkstatic = True,

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -46,6 +46,13 @@ copy_file(
     out = "config.h",
 )
 
+cc_library(
+    name = "config_h",
+    hdrs = [
+        ":copy_config_h",
+    ],
+)
+
 expand_template(
     name = "gcrypt_h",
     out = "src/gcrypt.h",
@@ -60,7 +67,6 @@ cc_library(
     name = "libcompat",
     srcs = [
         "compat/compat.c",
-        ":copy_config_h",
         "src/g10lib.h",
         "src/visibility.h",
         "src/types.h",
@@ -74,6 +80,9 @@ cc_library(
     includes = [
         ".",
         "src",
+    ],
+    implementation_deps = [
+        ":config_h",
     ],
     deps = [
         "@gpg-error//:libgpg-error",
@@ -240,7 +249,6 @@ cc_library(
             "mpi/generic/mpih-rshift.c",
         ],
     }) + [
-        ":copy_config_h",
         ":mod-source-info_h",
         ":sysdep_h",
         ":asm-syntax_h",
@@ -260,6 +268,9 @@ cc_library(
             "mpi/aarch64",
         ],
     }),
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -300,7 +311,6 @@ cc_library(
         "src/visibility.h",
         "src/types.h",
         "cipher/bithelp.h",
-        ":copy_config_h",
         ":gcrypt_h",
     ] + _RAND_COMMON_SRCS,
     includes = [
@@ -311,6 +321,9 @@ cc_library(
         # librandom's Makefile.am mentions:
         # `The rndjent module needs to be compiled without optimization.``
         "-O0",
+    ],
+    implementation_deps = [
+        ":config_h",
     ],
     deps = [
         "@gpg-error//:libgpg-error",
@@ -343,11 +356,13 @@ cc_library(
         "cipher/sha1.h",
         "cipher/hash-common.h",
         "cipher/bufhelp.h",
-        ":copy_config_h",
         ":gcrypt_h",
     ] + _RAND_COMMON_SRCS,
     textual_hdrs = _RAND_TEXTUAL_HDRS,
     includes = ["."],
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -359,7 +374,6 @@ cc_library(
 )
 
 _CIPHER_COMMON_SRCS = [
-    ":copy_config_h",
     "src/g10lib.h",
     "src/visibility.h",
     "src/types.h",
@@ -387,6 +401,9 @@ cc_library(
         "src",
         "cipher",
     ],
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -406,6 +423,9 @@ cc_library(
         "cipher/simd-common-aarch64.h",
     ] + _CIPHER_COMMON_SRCS,
     copts = ["-O2", "-march=armv8-a+simd+crypto"],
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -425,6 +445,9 @@ cc_library(
         "cipher/asm-common-aarch64.h",
     ] + _CIPHER_COMMON_SRCS,
     copts = ["-O2", "-march=armv8-a+simd"],
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -633,6 +656,9 @@ cc_library(
                ],
            }),
     includes = ["."],
+    implementation_deps = [
+        ":config_h",
+    ],
     deps = [
         "@gpg-error//:libgpg-error",
         ":libcompat",
@@ -695,6 +721,9 @@ cc_library(
         "@@//:linux_x86_64": ["src/hwf-x86.c"],
         "@@//:linux_arm64": ["src/hwf-arm.c"],
     }),
+    implementation_deps = [
+        ":config_h",
+    ],
     copts = [
         "-O2",
     ],

--- a/deps/gpg-error/gpg-error.BUILD.bazel
+++ b/deps/gpg-error/gpg-error.BUILD.bazel
@@ -126,6 +126,13 @@ copy_file(
     out = "src/config.h",
 )
 
+cc_library(
+    name = "config_h",
+    hdrs = [
+        ":copy_config_h",
+    ],
+)
+
 genrule(
     name = "err-codes_h",
     srcs = [
@@ -155,8 +162,11 @@ cc_binary(
 
 cc_binary(
     name = "gen-posix-lock-obj",
-    srcs = ["src/gen-posix-lock-obj.c", "src/posix-lock-obj.h", ":copy_config_h"],
+    srcs = ["src/gen-posix-lock-obj.c", "src/posix-lock-obj.h"],
     local_defines = ["HAVE_CONFIG_H"],
+    deps = [
+        ":config_h",
+    ],
     includes = ["src"],
 )
 
@@ -236,7 +246,6 @@ cc_library(
         "src/argparse.c",
         "src/gettext.h",
         # Generated sources
-        ":copy_config_h",
         ":code_to_errno_h",
         ":code_from_errno_h",
         ":err-codes_h",
@@ -256,6 +265,9 @@ cc_library(
     copts = ["-O2"],
     includes = ["src"],
     visibility = ["//visibility:public"],
+    implementation_deps = [
+        ":config_h",
+    ],
 )
 
 cc_shared_library(

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -69,9 +69,15 @@ expand_template(
 )
 
 cc_library(
+    name = "xml2_config_h",
+    hdrs = [
+        ":copy_config_h"
+    ],
+)
+
+cc_library(
     name = "libxml2",
     srcs = [
-        ":copy_config_h",
         "buf.c",
         "chvalid.c",
         "dict.c",
@@ -116,6 +122,9 @@ cc_library(
         "c14n.c",
     ] + glob(["include/private/*.h"]),
     hdrs = PUBLIC_HEADERS,
+    implementation_deps = [
+        ":xml2_config_h"
+    ],
     deps = [
         "@zlib//:zlib",
         "@xz//:liblzma",

--- a/deps/xz.BUILD.bazel
+++ b/deps/xz.BUILD.bazel
@@ -49,13 +49,19 @@ _API_HEADERS = glob([
 ])
 
 cc_library(
+    name = "xz_config",
+    hdrs = [
+        "config.h"
+    ],
+)
+
+cc_library(
     name = "liblzma",
     srcs = [
         "src/common/tuklib_cpucores.c",
         "src/common/tuklib_physmem.c",
         "src/common/tuklib_exit.c",
         "src/common/tuklib_progname.c",
-        ":copy_config_h",
     ] + glob(
         [
             "src/**/*.h",
@@ -100,7 +106,10 @@ cc_library(
         "src/liblzma/simple",
         "src/liblzma/delta",
         "src/liblzma/rangecoder",
-    ]
+    ],
+    implementation_deps = [
+        ":xz_config",
+    ],
 )
 
 cc_shared_library(


### PR DESCRIPTION
### What does this PR do?

Wrap various `config.h` files in a `cc_library` and depend on it through `implementation_deps` so that it isn't forwarded to packages depending on the library generating the `config.h`

### Motivation

Ensure we won't use package B's `config.h` when building package `B` when `B` depends on `A`

### Describe how you validated your changes

Local build and CI

### Additional Notes
