### PR TITLE
fix(installer): Add a fallback to os.Executable

### DIFF
--- a/comp/core/agenttelemetry/def/go.mod
+++ b/comp/core/agenttelemetry/def/go.mod
@@ -5,10 +5,10 @@ go 1.24.0
 require github.com/DataDog/datadog-agent/pkg/fleet/installer v0.70.0
 
 require (
-	github.com/DataDog/datadog-agent/pkg/template v0.68.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/log v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.70.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.73.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.73.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/comp/core/agenttelemetry/fx/go.mod
+++ b/comp/core/agenttelemetry/fx/go.mod
@@ -36,21 +36,21 @@ require (
 	github.com/DataDog/datadog-agent/pkg/fleet/installer v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/gohai v0.69.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.71.0-rc.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/template v0.68.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.73.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.69.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostinfo v0.0.0-20251027120702-0e91eee9852f // indirect
 	github.com/DataDog/datadog-agent/pkg/util/http v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/log v0.72.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/option v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.72.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.69.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/version v0.72.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/version v0.73.2 // indirect
 	github.com/DataDog/viper v1.15.0 // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/comp/core/agenttelemetry/impl/go.mod
+++ b/comp/core/agenttelemetry/impl/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/hostinfo v0.0.0-20251027120702-0e91eee9852f
 	github.com/DataDog/datadog-agent/pkg/util/http v0.70.0
 	github.com/DataDog/datadog-agent/pkg/util/jsonquery v0.0.0-20251027120702-0e91eee9852f
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.72.2
-	github.com/DataDog/datadog-agent/pkg/version v0.72.2
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.2
+	github.com/DataDog/datadog-agent/pkg/version v0.73.2
 	github.com/DataDog/zstd v1.5.7
 	github.com/prometheus/client_model v0.6.2
 	github.com/robfig/cron/v3 v3.0.1
@@ -47,11 +47,11 @@ require (
 	github.com/DataDog/datadog-agent/pkg/fips v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/gohai v0.69.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/types v0.71.0-rc.1 // indirect
-	github.com/DataDog/datadog-agent/pkg/template v0.68.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/template v0.73.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.69.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.70.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/log v0.72.2 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/option v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.70.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.70.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -140,8 +140,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/tagset v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.73.0-rc.11
-	github.com/DataDog/datadog-agent/pkg/template v0.73.0-rc.11
-	github.com/DataDog/datadog-agent/pkg/trace v0.73.0-rc.11
+	github.com/DataDog/datadog-agent/pkg/template v0.73.2
+	github.com/DataDog/datadog-agent/pkg/trace v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.69.4
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.64.0-rc.3
@@ -159,14 +159,14 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/http v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/json v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/jsonquery v0.0.0-20251027120702-0e91eee9852f
-	github.com/DataDog/datadog-agent/pkg/util/log v0.73.0-rc.11
+	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.70.0
 	github.com/DataDog/datadog-agent/pkg/util/option v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.74.0-devel.0.20251125141836-2ae7a968751c
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/prometheus v0.64.0
 	github.com/DataDog/datadog-agent/pkg/util/quantile v0.73.0-rc.11
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.0-rc.11
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/sort v0.73.0-rc.11
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.70.0
 	github.com/DataDog/datadog-agent/pkg/util/system v0.73.0-rc.11
@@ -174,7 +174,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/utilizationtracker v0.0.0
 	github.com/DataDog/datadog-agent/pkg/util/uuid v0.69.4
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.73.0-rc.11
-	github.com/DataDog/datadog-agent/pkg/version v0.73.0-rc.11
+	github.com/DataDog/datadog-agent/pkg/version v0.73.2
 	github.com/DataDog/datadog-go/v5 v5.8.2
 	github.com/DataDog/datadog-operator/api v0.0.0-20251127112405-4be7033d5f47
 	github.com/DataDog/datadog-traceroute v0.1.33

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -106,7 +106,7 @@ func newInstaller(installerBin string) func(env *env.Env) installer.Installer {
 
 // NewDaemon returns a new daemon.
 func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config agentconfig.Reader) (Daemon, error) {
-	installerBin, err := os.Executable()
+	installerBin, err := exec.GetExecutable()
 	if err != nil {
 		return nil, fmt.Errorf("could not get installer executable path: %w", err)
 	}

--- a/pkg/fleet/installer/bootstrap/bootstrap.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap.go
@@ -9,7 +9,6 @@ package bootstrap
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	iexec "github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
@@ -36,7 +35,7 @@ func InstallExperiment(ctx context.Context, env *env.Env, url string) error {
 
 // getLocalInstaller returns an installer executor from the current binary
 func getLocalInstaller(env *env.Env) (*iexec.InstallerExec, error) {
-	installerBin, err := os.Executable()
+	installerBin, err := iexec.GetExecutable()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get executable path: %w", err)
 	}

--- a/pkg/fleet/installer/commands/command_test.go
+++ b/pkg/fleet/installer/commands/command_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestState(t *testing.T) {
-	installerBinary, err := os.Executable()
+	installerBinary, err := exec.GetExecutable()
 	assert.NoError(t, err)
 	env := &env.Env{
 		IsFromDaemon: true,
@@ -70,7 +70,7 @@ func TestState(t *testing.T) {
 }
 
 func TestConfigState(t *testing.T) {
-	installerBinary, err := os.Executable()
+	installerBinary, err := exec.GetExecutable()
 	assert.NoError(t, err)
 	env := &env.Env{
 		IsFromDaemon: true,
@@ -89,7 +89,7 @@ func TestConfigState(t *testing.T) {
 }
 
 func TestConfigAndPackageStates(t *testing.T) {
-	installerBinary, err := os.Executable()
+	installerBinary, err := exec.GetExecutable()
 	assert.NoError(t, err)
 	env := &env.Env{
 		IsFromDaemon: true,

--- a/pkg/fleet/installer/commands/status.go
+++ b/pkg/fleet/installer/commands/status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
+	installerexec "github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/ssi"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	template "github.com/DataDog/datadog-agent/pkg/template/html"
@@ -138,7 +139,7 @@ type errorWithCode struct {
 func getRCStatus() (remoteConfigState, error) {
 	var response remoteConfigState
 
-	installerBinary, err := os.Executable()
+	installerBinary, err := installerexec.GetExecutable()
 	if err != nil {
 		return response, fmt.Errorf("error getting executable path: %w", err)
 	}

--- a/pkg/fleet/installer/exec/path.go
+++ b/pkg/fleet/installer/exec/path.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package exec
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+)
+
+// GetExecutable returns the path to the current executable.
+// Most of the time it'll be a wrapper around os.Executable, but on the rare case it fails (e.g. /proc not dumpable, hidepid...)
+// we'll fall back on the absolute path of the current process.
+func GetExecutable() (string, error) {
+	executable, err1 := os.Executable()
+	if err1 == nil {
+		return executable, nil
+	}
+	log.Warnf("Failed to get executable using os.Executable: %v", err1)
+
+	// Get the absolute path of the current process from argv[0]
+	executable, err2 := fromArgv0()
+	if err2 == nil {
+		return executable, nil
+	}
+	return "", fmt.Errorf("failed to get executable: %w, %w", err1, err2)
+}
+
+func fromArgv0() (string, error) {
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return "", errors.New("empty argv[0]")
+	}
+
+	// LookPath handles both absolute and relative paths
+	path, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve symlinks to match os.Executable() behavior
+	return filepath.EvalSymlinks(path)
+}

--- a/pkg/fleet/installer/exec/path.go
+++ b/pkg/fleet/installer/exec/path.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 // GetExecutable returns the path to the current executable.
@@ -23,7 +21,6 @@ func GetExecutable() (string, error) {
 	if err1 == nil {
 		return executable, nil
 	}
-	log.Warnf("Failed to get executable using os.Executable: %v", err1)
 
 	// Get the absolute path of the current process from argv[0]
 	executable, err2 := fromArgv0()

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
 	github.com/DataDog/datadog-agent/pkg/template v0.73.2
-	github.com/DataDog/datadog-agent/pkg/trace v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.68.3
 	github.com/DataDog/datadog-agent/pkg/version v0.73.2

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -4,10 +4,11 @@ go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0
-	github.com/DataDog/datadog-agent/pkg/template v0.68.3
-	github.com/DataDog/datadog-agent/pkg/util/log v0.68.3
+	github.com/DataDog/datadog-agent/pkg/template v0.73.2
+	github.com/DataDog/datadog-agent/pkg/trace v0.73.2
+	github.com/DataDog/datadog-agent/pkg/util/log v0.73.2
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.68.3
-	github.com/DataDog/datadog-agent/pkg/version v0.68.3
+	github.com/DataDog/datadog-agent/pkg/version v0.73.2
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/fatih/color v1.18.0
@@ -28,7 +29,7 @@ require (
 )
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.68.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.73.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -122,3 +123,5 @@ replace github.com/DataDog/datadog-agent/pkg/util/system => ../../util/system
 replace github.com/DataDog/datadog-agent/pkg/util/system/socket => ../../util/system/socket
 
 replace github.com/DataDog/datadog-agent/pkg/util/testutil => ../../util/testutil
+
+replace github.com/DataDog/datadog-agent/pkg/trace => ../../trace

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -563,7 +563,7 @@ func getenv() *env.Env {
 }
 
 func newInstallerExec(env *env.Env) (*exec.InstallerExec, error) {
-	installerBin, err := os.Executable()
+	installerBin, err := exec.GetExecutable()
 	if err != nil {
 		return nil, fmt.Errorf("could not get installer executable path: %w", err)
 	}

--- a/pkg/fleet/installer/packages/packages.go
+++ b/pkg/fleet/installer/packages/packages.go
@@ -184,7 +184,7 @@ func (h *hooksCLI) getPath(pkg string, pkgType PackageType, experiment bool) str
 }
 
 func (h *hooksCLI) callHook(ctx context.Context, experiment bool, pkg string, name string, packageType PackageType, upgrade bool, windowsArgs []string) error {
-	hooksCLIPath, err := os.Executable()
+	hooksCLIPath, err := exec.GetExecutable()
 	if err != nil {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}

--- a/pkg/fleet/installer/setup/common/setup_nix.go
+++ b/pkg/fleet/installer/setup/common/setup_nix.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -42,7 +43,7 @@ func copyInstallerSSI() error {
 	destinationPath := "/opt/datadog-packages/run/datadog-installer-ssi"
 
 	// Get the current executable path
-	currentExecutable, err := os.Executable()
+	currentExecutable, err := exec.GetExecutable()
 	if err != nil {
 		return fmt.Errorf("failed to get current executable: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?
Some customers report failures of the installer daemon due to `os.Executable` returning `permission denied` as it can't read `/proc/self/exe`. This seems to be a complex interaction between the privilege changes the installer executes & the kernel, with no definitive answer. To counter this, we fall back to resolving `argv[0]`, which is the installer path (as defined in the `systemd` unit).

### Motivation
Defensive method to go around the customer's issue

### Describe how you validated your changes
Tested manually that resolving `argv[0]` works.

### Additional Notes
