### PR TITLE
[ABLD-315] Use `write_source_file` for `diff_test` w/ update capability

### DIFF
--- a/deps/acl/BUILD.bazel
+++ b/deps/acl/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("//bazel/tools:generate_module_bazel.bzl", "generate_module_bazel")
 
 VERSION = "2.3.1"
@@ -13,9 +13,8 @@ generate_module_bazel(
     url = "http://download.savannah.nongnu.org/releases/acl/acl-%s.tar.xz" % VERSION,
 )
 
-diff_test(
-    name = "module_consistency_test",
-    failure_message = "To update: cp bazel-bin/deps/openssl3/openssl3.MODULE.bazel.new openssl3.MODULE.bazel",
-    file1 = ":acl.MODULE.bazel.new",
-    file2 = "acl.MODULE.bazel",
+write_source_file(
+    name = "module_consistency",
+    in_file = ":acl.MODULE.bazel.new",
+    out_file = "acl.MODULE.bazel",
 )

--- a/deps/libpcap/BUILD.bazel
+++ b/deps/libpcap/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("//bazel/tools:generate_module_bazel.bzl", "generate_module_bazel")
 
 VERSION = "1.10.5"
@@ -13,9 +13,8 @@ generate_module_bazel(
     url = "https://www.tcpdump.org/release/libpcap-%s.tar.xz" % VERSION,
 )
 
-diff_test(
-    name = "module_consistency_test",
-    failure_message = "To update: cp bazel-bin/deps/libpcap/libpcap.MODULE.bazel.new libpcap.MODULE.bazel",
-    file1 = ":libpcap.MODULE.bazel.new",
-    file2 = "libpcap.MODULE.bazel",
+write_source_file(
+    name = "module_consistency",
+    in_file = ":libpcap.MODULE.bazel.new",
+    out_file = "libpcap.MODULE.bazel",
 )

--- a/deps/openssl3/BUILD.bazel
+++ b/deps/openssl3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("//bazel/tools:generate_module_bazel.bzl", "generate_module_bazel")
 
 generate_module_bazel(
@@ -11,9 +11,8 @@ generate_module_bazel(
     url = "https://www.openssl.org/source/openssl-3.5.4.tar.gz",
 )
 
-diff_test(
-    name = "module_consistency_test",
-    failure_message = "To update: cp bazel-bin/deps/openssl3/openssl3.MODULE.bazel.new openssl3.MODULE.bazel",
-    file1 = ":openssl3.MODULE.bazel.new",
-    file2 = "openssl3.MODULE.bazel",
+write_source_file(
+    name = "module_consistency",
+    in_file = ":openssl3.MODULE.bazel.new",
+    out_file = "openssl3.MODULE.bazel",
 )


### PR DESCRIPTION
### What does this PR do?
Migrate module consistency checks from `diff_test` to the higher-level `write_source_file` in `deps/acl`, `deps/libpcap`, and `deps/openssl3`.

### Motivation
The lower-level `diff_test` required manual file copying with long `bazel-bin` paths when consistency checks failed.
The higher-level `write_source_file` rule [generates the former](https://alexeagle.github.io/doc.bzl/aspect_bazel_lib/lib/write_source_files#writesourcefile) while providing an automatic update capability via `bazel run`, making it easier and more cross-platform friendly.

### Describe how to test this PR
Run the consistency tests **as before** (still backed by a `diff_test`):
```
bazel test //deps/acl:module_consistency_test
bazel test //deps/libpcap:module_consistency_test
bazel test //deps/openssl3:module_consistency_test
```

If files are out of sync, update them with:
```
bazel run //deps/acl:module_consistency
bazel run //deps/libpcap:module_consistency
bazel run //deps/openssl3:module_consistency
```
### Additional Notes
Addresses [ABLD-315](https://datadoghq.atlassian.net/browse/ABLD-315): `Provide a "diff_test" that has update capability`.

[ABLD-315]: https://datadoghq.atlassian.net/browse/ABLD-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ