### PR TITLE
:window: Do not dump `bazel` diagnostics on trivial test failures

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -58,7 +58,7 @@ set "bazel_exit=!errorlevel!"
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
 set "should_diagnose=1"
-for %%c in (0 1 36) do if !bazel_exit!==%%c set "should_diagnose=0"
+for %%c in (0 1 3 36) do if !bazel_exit!==%%c set "should_diagnose=0"
 if !should_diagnose!==1 (
   >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (


### PR DESCRIPTION
### Motivation
`bazel` diagnostics on Windows are too verbose, which dilutes the payload on trivial test failures ([exit code](https://bazel.build/run/scripts#exit-codes) `3 - Build OK, but some tests failed or timed out`).