### PR TITLE
fix(ospo): Adapt the chainguard for issue labelling

### DIFF
--- a/.github/chainguard/self.assign-issue.label-issue.sts.yaml
+++ b/.github/chainguard/self.assign-issue.label-issue.sts.yaml
@@ -4,10 +4,10 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/datadog-agent:environment:main
 
 claim_pattern:
-  event_name: (issues|workflow_dispatch)
+  event_name: (issues|issue_comment|workflow_dispatch)
   ref: refs/heads/main
   ref_protected: "true"
-  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/assign_issue\.yml@refs/heads/main
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/(assign_issue|check_issue_status)\.yml@refs/heads/main
 
 permissions:
   contents: read


### PR DESCRIPTION
### What does this PR do?
Change the chainguard used to add/remove labels to work for both workflows used in OSPO

### Motivation
Prevent [this issue](https://github.com/DataDog/datadog-agent/actions/runs/20712234547/job/59455197180)

### Describe how you validated your changes
n/a

### Additional Notes
