### PR TITLE
Add `manual` tags to utility binaries

### DIFF
--- a/bazel/rules/BUILD.bazel
+++ b/bazel/rules/BUILD.bazel
@@ -14,4 +14,5 @@ sh_binary(
         "@platforms//os:linux": ["@patchelf"],
         "//conditions:default": [],
     }),
+    tags = ["manual"],
 )

--- a/deps/openssl/BUILD.bazel
+++ b/deps/openssl/BUILD.bazel
@@ -5,4 +5,5 @@ package(default_visibility = ["//visibility:public"])
 sh_binary(
     name = "fix_openssl_paths",
     srcs = ["fix_openssl_paths.sh"],
+    tags = ["manual"],
 )


### PR DESCRIPTION
### What does this PR do?
Add `tags = ["manual"]` to utility `sh_binary` targets in:
- bazel/rules/BUILD.bazel (`replace_prefix`)
- deps/openssl/BUILD.bazel (`fix_openssl_paths`)

### Motivation
These utility binaries are not tests, but without the `manual` tag they are included in `bazel test //...` queries.

This follows the pattern already established for generator targets like `generate_module_bazel` in `deps/acl`, `deps/libpcap`, and `deps/openssl3`, which already have `tags = ["manual"]` for the same reason.

### Additional Notes
The binaries remain usable when _explicitly_ invoked:
```sh
bazel run //bazel/rules:replace_prefix
bazel run //deps/openssl:fix_openssl_paths
```