### PR TITLE
Remove reference to AL2 nodes

### DIFF
--- a/test/e2e-framework/resources/aws/eks/nodeGroups.go
+++ b/test/e2e-framework/resources/aws/eks/nodeGroups.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	amazonLinux2AMD64AmiType    = "AL2_x86_64"
-	amazonLinux2ARM64AmiType    = "AL2_ARM_64"
 	amazonLinux2023AMD64AmiType = "AL2023_x86_64_STANDARD"
 	amazonLinux2023ARM64AmiType = "AL2023_ARM_64_STANDARD"
 	bottlerocketAmiType         = "BOTTLEROCKET_x86_64"
@@ -48,14 +46,6 @@ func NewAL2023LinuxARMNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRol
 	}
 
 	return newManagedNodeGroup(e, name, cluster, nodeRole, amazonLinux2023ARM64AmiType, e.DefaultARMInstanceType(), lt, opts...)
-}
-
-func NewLinuxNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
-	return newManagedNodeGroup(e, "linux", cluster, nodeRole, amazonLinux2AMD64AmiType, e.DefaultInstanceType(), nil, opts...)
-}
-
-func NewLinuxARMNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
-	return newManagedNodeGroup(e, "linux-arm", cluster, nodeRole, amazonLinux2ARM64AmiType, e.DefaultARMInstanceType(), nil, opts...)
 }
 
 func NewBottlerocketNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {

--- a/test/e2e-framework/scenarios/aws/eks/args.go
+++ b/test/e2e-framework/scenarios/aws/eks/args.go
@@ -15,15 +15,12 @@ type Params struct {
 	LinuxARMNodeGroup     bool
 	BottleRocketNodeGroup bool
 	WindowsNodeGroup      bool
-	UseAL2023Nodes        bool
 }
 
 type Option = func(*Params) error
 
 func NewParams(options ...Option) (*Params, error) {
-	version := &Params{
-		UseAL2023Nodes: true,
-	}
+	version := &Params{}
 	return common.ApplyOption(version, options)
 }
 
@@ -51,13 +48,6 @@ func WithBottlerocketNodeGroup() Option {
 func WithWindowsNodeGroup() Option {
 	return func(p *Params) error {
 		p.WindowsNodeGroup = true
-		return nil
-	}
-}
-
-func WithUseAL2023Nodes() Option {
-	return func(p *Params) error {
-		p.UseAL2023Nodes = true
 		return nil
 	}
 }

--- a/test/e2e-framework/scenarios/aws/eks/cluster.go
+++ b/test/e2e-framework/scenarios/aws/eks/cluster.go
@@ -8,12 +8,6 @@ package eks
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
-	kubecomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
-	localEks "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
 	awsEks "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks"
 	awsIam "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
@@ -25,6 +19,13 @@ import (
 	v1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/rbac/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/samber/lo"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components"
+	kubecomp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	localEks "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws/eks"
 )
 
 func NewCluster(e aws.Environment, name string, opts ...Option) (*kubecomp.Cluster, error) {
@@ -261,31 +262,15 @@ func NewCluster(e aws.Environment, name string, opts ...Option) (*kubecomp.Clust
 		}
 
 		// Create managed node groups
-		if params.LinuxNodeGroup {
-			if params.UseAL2023Nodes {
-				_, err := localEks.NewAL2023LinuxNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
-				if err != nil {
-					return err
-				}
-			} else {
-				_, err := localEks.NewLinuxNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
-				if err != nil {
-					return err
-				}
-			}
+		_, err = localEks.NewAL2023LinuxNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
+		if err != nil {
+			return err
 		}
 
 		if params.LinuxARMNodeGroup {
-			if params.UseAL2023Nodes {
-				_, err := localEks.NewAL2023LinuxARMNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
-				if err != nil {
-					return err
-				}
-			} else {
-				_, err := localEks.NewLinuxARMNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
-				if err != nil {
-					return err
-				}
+			_, err := localEks.NewAL2023LinuxARMNodeGroup(e, cluster, linuxNodeRole, utils.PulumiDependsOn(nodeDeps...), pulumi.Parent(comp))
+			if err != nil {
+				return err
 			}
 		}
 

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -29,7 +29,6 @@ func TestEKSSuite(t *testing.T) {
 				sceneks.WithWindowsNodeGroup(),
 				sceneks.WithBottlerocketNodeGroup(),
 				sceneks.WithLinuxARMNodeGroup(),
-				sceneks.WithUseAL2023Nodes(),
 			),
 			sceneks.WithDeployDogstatsd(),
 			sceneks.WithDeployTestWorkload(),

--- a/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
@@ -46,7 +46,6 @@ agents:
 				proveks.WithRunOptions(
 					eks.WithEKSOptions(
 						eks.WithLinuxNodeGroup(),
-						eks.WithUseAL2023Nodes(),
 					),
 					eks.WithAgentOptions(
 						kubernetesagentparams.WithHelmValues(values),
@@ -116,7 +115,6 @@ agents:
 			proveks.WithRunOptions(
 				eks.WithEKSOptions(
 					eks.WithLinuxNodeGroup(),
-					eks.WithUseAL2023Nodes(),
 				),
 				eks.WithAgentOptions(
 					kubernetesagentparams.WithHelmValues(values),

--- a/test/new-e2e/tests/sbom/eks_test.go
+++ b/test/new-e2e/tests/sbom/eks_test.go
@@ -29,7 +29,6 @@ func TestSBOMEKSSuite(t *testing.T) {
 					sceneks.WithWindowsNodeGroup(),
 					sceneks.WithBottlerocketNodeGroup(),
 					sceneks.WithLinuxARMNodeGroup(),
-					sceneks.WithUseAL2023Nodes(),
 				),
 				sceneks.WithDeployDogstatsd(),
 				sceneks.WithDeployTestWorkload(),


### PR DESCRIPTION
### What does this PR do?

Remove references to AL2 nodes for EKS. Since they are now deprecated and should no longer be used
All the tests will now use AL2023 EKS nodes, and will not be able to target old nodes.

### Motivation

Clean code

### Describe how you validated your changes

CI should succeed

### Additional Notes
