### PR TITLE
Also print output of failed `bazel test`s in dev

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,7 @@ common --enable_platform_specific_config # Supported OS identifiers are linux, m
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
 common --incompatible_strict_action_env # Do not leak local environment variables into the build context
+common --test_output=errors # Print test errors to console output instead of only capturing them in buried test.log
 common --verbose_failures
 
 # Linux config ---------------------------------------------------------------------------------------------------------
@@ -39,7 +40,6 @@ common:cache --remote_timeout=60
 
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=cache
-common:ci --test_output=errors # Print test setup errors to the job output instead of only capturing them in test.log
 
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
### Motivation
When enabling [--test_output=errors](https://bazel.build/docs/user-manual#test-output) for `bazel test` commands in #42536, I should have applied the [Dev/Prod parity](https://12factor.net/dev-prod-parity) principle.

### What does this PR do?
The present change fixes it:
- before:
```sh
$ bazel test //...
FAIL: //deps/acl:module_consistency_test (Exit 1) (see /a/very/long/path/to/test.log)
```
- after:
```sh
$ bazel test //...
FAIL: //deps/acl:module_consistency_test (Exit 1) (see /a/very/long/path/to/test.log)
INFO: From Testing //deps/acl:module_consistency_test:
==================== Test output for //deps/acl:module_consistency_test:
13c13,16
<     url = "http://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz",
---
>     urls = [
>         "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libacl-acl-2.3.1.tar.xz",
>         "https://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz",
>     ],
FAIL: files "deps/acl/acl.MODULE.bazel.new" and "deps/acl/acl.MODULE.bazel" differ. 

@@//deps/acl:acl.MODULE.bazel is out of date. To update this file, run:

    bazel run //deps/acl:module_consistency


================================================================================
```