### PR TITLE
Fix `bazel test //deps/acl:module_consistency_test`

### DIFF
--- a/bazel/tools/generate_module_bazel.bzl
+++ b/bazel/tools/generate_module_bazel.bzl
@@ -9,7 +9,7 @@ def _generate_module_bazel_impl(ctx):
     args.add("--files", overlay_files.path)
     args.add("--module", ctx.attr.module)
     args.add("--package", ctx.label.package)
-    args.add("--url", ctx.attr.url)
+    args.add_all(ctx.attr.urls, before_each = "--url")
     args.add("--sha256", ctx.attr.sha256)
     args.add("--strip_prefix", ctx.attr.strip_prefix)
     args.add("--output", ctx.outputs.out.path)
@@ -30,9 +30,9 @@ _generate_module_bazel = rule(
             mandatory = True,
             doc = "Name of the module",
         ),
-        "url": attr.string(
+        "urls": attr.string_list(
             mandatory = True,
-            doc = "URL for http_archive",
+            doc = "URLs for http_archive",
         ),
         "sha256": attr.string(
             mandatory = True,
@@ -57,7 +57,7 @@ _generate_module_bazel = rule(
     },
 )
 
-def generate_module_bazel(name = None, module = None, out = None, sha256 = None, strip_prefix = None, url = None, **kwargs):
+def generate_module_bazel(name = None, module = None, out = None, sha256 = None, strip_prefix = None, url = None, urls = [], **kwargs):
     _generate_module_bazel(
         name = name,
         module = module,
@@ -65,6 +65,6 @@ def generate_module_bazel(name = None, module = None, out = None, sha256 = None,
         overlay_files = native.glob(["overlay/**"]),
         sha256 = sha256,
         strip_prefix = strip_prefix,
-        url = url,
+        urls = urls or [url],
         **kwargs
     )

--- a/bazel/tools/generate_module_bazel.py
+++ b/bazel/tools/generate_module_bazel.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 def make_target_source_map(package, overlay_files):
@@ -14,11 +15,11 @@ def make_target_source_map(package, overlay_files):
             raise ValueError(f"'{path}' does not start with '{package}'")
         rel_path = Path(path).relative_to(overlay_dir)
         if rel_path.name == "overlay.BUILD.bazel":
-            dest_path = str(rel_path.parent / "BUILD.bazel")
+            dest_path = rel_path.parent / "BUILD.bazel"
         else:
-            dest_path = str(rel_path)
-        overlay_ref = f"//{package_path}:overlay/{rel_path}"
-        files[dest_path] = overlay_ref
+            dest_path = rel_path
+        overlay_ref = f"//{package_path.as_posix()}:overlay/{rel_path.as_posix()}"
+        files[dest_path.as_posix()] = overlay_ref
     return files
 
 
@@ -43,11 +44,15 @@ def generate_module_bazel(args, files):
             "    },",
             f'    sha256 = "{args.sha256}",',
             f'    strip_prefix = "{args.strip_prefix}",',
-            f'    url = "{args.url}",',
-            ")",
-            "",
         ]
     )
+    if len(args.urls) == 1:
+        lines.append(f'    url = "{args.urls[0]}",')
+    else:
+        lines.append("    urls = [")
+        lines.extend(f'        "{url}",' for url in args.urls)
+        lines.append("    ],")
+    lines.extend([")", ""])
     return "\n".join(lines)
 
 
@@ -56,13 +61,18 @@ def main():
     parser.add_argument("--files", help="File containing the list of files in the overlay")
     parser.add_argument("--module", help="Name of the module")
     parser.add_argument("--package", help="path to this package")
-    parser.add_argument("--url", help="URL for http_archive")
+    parser.add_argument("--url", action="append", dest="urls", required=True, help="URLs for http_archive")
     parser.add_argument("--sha256", help="SHA256 hash")
     parser.add_argument("--strip_prefix", help="Strip prefix for archive")
     parser.add_argument(
         "--output", nargs="?", default=None, help="Path to write output MODULE.bazel file (default: stdout)"
     )
     args = parser.parse_args()
+
+    # Validate that all URLs have the same basename
+    basenames = {Path(urlparse(url).path).name for url in args.urls}
+    if len(basenames) > 1:
+        parser.error(f"All URLs must have the same basename, found: {basenames}")
 
     # Get overlay files
     with open(args.files) as inp:

--- a/deps/acl/BUILD.bazel
+++ b/deps/acl/BUILD.bazel
@@ -10,7 +10,10 @@ generate_module_bazel(
     sha256 = "c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1",
     strip_prefix = "acl-%s" % VERSION,
     tags = ["manual"],
-    url = "http://download.savannah.nongnu.org/releases/acl/acl-%s.tar.xz" % VERSION,
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/acl-%s.tar.xz" % VERSION,
+        "https://download.savannah.nongnu.org/releases/acl/acl-%s.tar.xz" % VERSION,
+    ],
 )
 
 diff_test(

--- a/deps/acl/acl.MODULE.bazel
+++ b/deps/acl/acl.MODULE.bazel
@@ -11,7 +11,7 @@ http_archive(
     sha256 = "c0234042e17f11306c23c038b08e5e070edb7be44bef6697fb8734dcff1c66b1",
     strip_prefix = "acl-2.3.1",
     urls = [
-        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libacl-acl-2.3.1.tar.xz",
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/acl-2.3.1.tar.xz",
         "https://download.savannah.nongnu.org/releases/acl/acl-2.3.1.tar.xz",
     ],
 )


### PR DESCRIPTION
### Motivation
The `deps/acl/acl.MODULE.bazel` file was out of sync with its generated version, which the present change aims at addressing.

### What does this PR do?
- enhance `generate_module_bazel` to also accept multiple `urls`,
- validate that all URLs in `urls` have the same basename,
- fix out-of-sync `deps/acl/acl.MODULE.bazel` file.