### PR TITLE
fix(issue template): Use a shorter description

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic-issue.yml
+++ b/.github/ISSUE_TEMPLATE/generic-issue.yml
@@ -1,6 +1,6 @@
 ---
-name: Generic Issue
-description: "Choose this only if you can reproduce the issue in a clean, generic environment, and it does not depend on customer-specific configuration. If the issue requires extensive logs, flares, or environment debugging, please open a Support ticket using the 'Support Request' option above."
+name: Generic Issue (Requires clean, generic reproduction)
+description: "Choose this only if the issue reproduces in a clean, generic environment. If it requires logs, flares, or environment debugging, open a Support ticket using the ‘Support Request’ option above"
 title: "[BUG] "
 labels: bug,pending
 body:


### PR DESCRIPTION
### What does this PR do?
The issue description must be within 3 and 200 character. The previous update prevented the generic issue to be displayed at issue creation
<img width="686" height="186" alt="image" src="https://github.com/user-attachments/assets/c52a2d7f-6fdf-47af-8f25-b9bd56efb020" />


### Motivation
Restore the `generic issue` creation

### Describe how you validated your changes
Tested [on my fork](https://github.com/chouetz/datadog-agent/issues/new/choose)

### Additional Notes
