### PR TITLE
[CONTINT-4925] Add new-e2e-containers-k8s-latest job for tracking latest K8s version

### DIFF
--- a/.github/workflows/update-kubernetes-versions.yml
+++ b/.github/workflows/update-kubernetes-versions.yml
@@ -61,10 +61,10 @@ jobs:
           branch: update-k8s-versions-automated
           token: ${{ steps.octo-sts.outputs.token }}
           sign-commits: true
-          title: "[automated] Add new Kubernetes version to e2e tests"
+          title: "[automated] Update Kubernetes latest version in e2e tests"
           body: |
             ### What does this PR do?
-            Adds the latest Kubernetes version from kindest/node to the e2e test matrix.
+            Updates the Kubernetes version used by the `new-e2e-containers-k8s-latest` job in `.gitlab/test/e2e/e2e.yml` to the latest stable release from `kindest/node`.
 
             ### Motivation
             Keep e2e tests running against the latest Kubernetes version to ensure compatibility.

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -250,12 +250,24 @@ new-e2e-containers:
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.22"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.27"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=1.29"
-      - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:20-04"
       - EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:osDescriptor=ubuntu:22-04"
       - EXTRA_PARAMS: --run TestDockerSuite
       - EXTRA_PARAMS: --run "TestK8S(CEL|Legacy)FilteringSuite"
       - EXTRA_PARAMS: --skip "Test(Kind|EKS|ECS|Docker|K8SCELFiltering|K8SLegacyFiltering)Suite"
+
+new-e2e-containers-k8s-latest:
+  extends:
+    - .new_e2e_template_needs_container_deploy
+  rules:
+    - !reference [.on_container_or_e2e_changes]
+    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
+    - !reference [.manual]
+  variables:
+    TARGETS: ./tests/containers
+    TEAM: container-integrations
+    ON_NIGHTLY_FIPS: "true"
+    EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
 
 new-e2e-containers-eks-init:
   stage: e2e_init

--- a/tasks/k8s_versions.py
+++ b/tasks/k8s_versions.py
@@ -216,7 +216,7 @@ def _find_matrix_section(content: str) -> tuple:
     return None, None, None
 
 
-def _parse_existing_k8s_versions(content: str) -> list[dict[str, str]]:
+def _parse_existing_k8s_versions(content: str, matrix_start: int, matrix_end: int) -> list[dict[str, str]]:
     """
     Parse existing Kubernetes versions from the matrix section.
     Returns a list of dicts with 'version' and 'digest' keys.
@@ -227,7 +227,8 @@ def _parse_existing_k8s_versions(content: str) -> list[dict[str, str]]:
     # Pattern to match Kubernetes version entries
     pattern = r'kubernetesVersion=(v?\d+\.\d+(?:\.\d+)?(?:@sha256:[a-f0-9]+)?)'
 
-    for line in lines:
+    for i in range(matrix_start, matrix_end):
+        line = lines[i]
         match = re.search(pattern, line)
         if match:
             version_str = match.group(1)
@@ -354,7 +355,8 @@ def _update_e2e_yaml_file(new_versions: dict[str, dict[str, str]]) -> tuple:
     lines = content.split('\n')
     added_versions = []
 
-    existing_versions = _parse_existing_k8s_versions(content)
+    # Parse versions only from the matrix section to avoid matching the k8s-latest job
+    existing_versions = _parse_existing_k8s_versions(content, matrix_start, matrix_end)
     existing_version_strs = {v['version'] for v in existing_versions}
 
     if current_latest['version'] not in existing_version_strs:

--- a/tasks/k8s_versions.py
+++ b/tasks/k8s_versions.py
@@ -304,13 +304,7 @@ def _extract_version_from_latest_job(content: str) -> dict[str, str] | None:
 
 
 def _add_version_to_matrix(
-    lines: list[str],
-    version: str,
-    digest: str,
-    matrix_start: int,
-    matrix_end: int,
-    indent: int,
-    extra_params_line: int
+    lines: list[str], version: str, digest: str, matrix_start: int, matrix_end: int, indent: int, extra_params_line: int
 ) -> tuple[list[str], int]:
     """
     Add a version to the matrix section.
@@ -397,7 +391,7 @@ def _update_e2e_yaml_file(new_versions: dict[str, dict[str, str]]) -> tuple[bool
             matrix_start,
             matrix_end,
             indent,
-            extra_params_line
+            extra_params_line,
         )
         added_versions.append(current_latest['version'])
 
@@ -406,7 +400,7 @@ def _update_e2e_yaml_file(new_versions: dict[str, dict[str, str]]) -> tuple[bool
     new_line = re.sub(
         r'kubernetesVersion=v?\d+\.\d+\.\d+@sha256:[a-f0-9]+',
         f'kubernetesVersion={desired_latest_version}@{desired_latest_digest}',
-        old_line
+        old_line,
     )
     lines[extra_params_line] = new_line
 

--- a/tasks/k8s_versions_README.md
+++ b/tasks/k8s_versions_README.md
@@ -37,10 +37,9 @@ Updates the e2e.yml file with the new Kubernetes version.
 
 **What it does:**
 - Reads the stored versions from `k8s_versions.json`
-- Parses `.gitlab/test/e2e/e2e.yml` to find the `new-e2e-containers` matrix section
-- Checks which versions are already present
-- Adds new versions in the format: `kubernetesVersion=v1.34.0@sha256:...`
-- Inserts new entries after the last Kubernetes version in the matrix
+- Compares with current version in `new-e2e-containers-k8s-latest` job
+- If different, moves current k8s-latest version to the matrix
+- Updates `new-e2e-containers-k8s-latest` job with the new version
 
 **Usage:**
 ```bash
@@ -109,10 +108,10 @@ The task extracts the **index digest** (not the image digest) for the latest ver
 
 ### YAML Update Strategy
 The task:
-1. Locates the `new-e2e-containers` job in `.gitlab/test/e2e/e2e.yml`
-2. Finds the `parallel.matrix` section
-3. Identifies existing Kubernetes version entries
-4. Adds the new version after the last Kubernetes version entry (if not already present)
+1. Locates the `new-e2e-containers` matrix and `new-e2e-containers-k8s-latest` job in `.gitlab/test/e2e/e2e.yml`
+2. Compares the desired latest version with current version in k8s-latest job
+3. If different, moves current k8s-latest version to the matrix (if not already present)
+4. Updates the k8s-latest job with the new version
 5. Maintains proper YAML indentation (6 spaces)
 
 ### PR Creation


### PR DESCRIPTION
### What does this PR do?
This PR modifies the `new-e2e-containers` job and adds a `new-e2e-containers-k8s-latest` job to the E2E workflow. Specifically:
- Adds new `new-e2e-containers-k8s-latest` job that always runs against the latest K8s version from Dockerhub.
- Removes some of the now unused version matrix logic 
- When a new version of K8s is released, replace version in the `new-e2e-containers-k8s-latest` job with the new latest version. 

This leaves the `new-e2e-containers` as a designated area where we will pin K8s versions that we have special interest in maintaining support for. 

### Motivation
https://datadoghq.atlassian.net/browse/CONTINT-4925

Specifically, this will make it easier to setup monitors about the latest version. 

### Describe how you validated your changes
Running the commands in the `update-kubernetes-versions.yml` workflow:
```bash
$ dda inv k8s-versions.fetch-versions
Fetching latest Kubernetes version from Docker Hub...
Latest Kubernetes version: v1.35.0
  Digest: sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661

New version found!
  v1.35.0: sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
::set-output name=has_new_versions::true
::set-output name=new_versions::{"v1.35.0": {"digest": "sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661", "tag": "v1.35.0"}}

$ dda inv k8s-versions.update-e2e-yaml

Checking for new versions to add to e2e.yml...
Desired latest version from new_versions: v1.35.0
Current latest version in new-e2e-containers-k8s-latest job: v1.34.0
Updating new-e2e-containers-k8s-latest job to v1.35.0
Successfully updated .gitlab/e2e/e2e.yml
::set-output name=updated::true
::set-output name=new_versions::- `v1.35.0`

Successfully updated to latest version: v1.35.0

$ git diff | cat
diff --git a/.gitlab/e2e/e2e.yml b/.gitlab/e2e/e2e.yml
index 5313eeb716c..83c45d07607 100644
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -267,7 +267,7 @@ new-e2e-containers-k8s-latest:
     TARGETS: ./tests/containers
     TEAM: container-integrations
     ON_NIGHTLY_FIPS: "true"
-    EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
+    EXTRA_PARAMS: "--run TestKindSuite -c ddinfra:kubernetesVersion=v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"

 new-e2e-containers-eks-init:
   stage: e2e_init
diff --git a/k8s_versions.json b/k8s_versions.json
index 36722c200ad..3751b3cbad7 100644
--- a/k8s_versions.json
+++ b/k8s_versions.json
@@ -2,5 +2,9 @@
   "v1.34.0": {
     "digest": "sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a",
     "tag": "v1.34.0"
+  },
+  "v1.35.0": {
+    "digest": "sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661",
+    "tag": "v1.35.0"
   }
 }
\ No newline at end of file
```

### Additional Notes
