### PR TITLE
Prevent deadlocks in the metrics client

### DIFF
--- a/releasenotes/notes/statsd-gauge-release-mutex-before-calling-meterprovider-26411b8b05bf1969.yaml
+++ b/releasenotes/notes/statsd-gauge-release-mutex-before-calling-meterprovider-26411b8b05bf1969.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Prevent a deadlock from occurring in the otel-agent when its internal telemetry Prometheus endpoint is scraped.


### PR DESCRIPTION
### What does this PR do?

Reduce the scope where the metrics client's mutex is held, to prevent a deadlock from happening when the meter's methods want to acquire another mutex

### Motivation

Prevent a deadlock we've seen occurring in prod [OTAGENT-753](https://datadoghq.atlassian.net/browse/OTAGENT-753?atlOrigin=eyJpIjoiODI3ZDZlNmY5ODViNDQxMzkyNDNjNzNjNzk1Mzg5OGUiLCJwIjoiaiJ9)

### Describe how you validated your changes

Reading the change

### Additional Notes

I'm making the assumption that holding the lock is not required when using the meter, just like it is done in the `Histogram` and `Count` functions


[OTAGENT-753]: https://datadoghq.atlassian.net/browse/OTAGENT-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ