### PR TITLE
Wait for installer service to start

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
@@ -44,17 +44,12 @@ func (s *baseInstallerPackageSuite) startServiceWithConfigFile() {
 	s.Require().NoError(common.StartService(s.Env().RemoteHost, consts.ServiceName))
 
 	// Assert
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running")
+	s.requireRunning()
 }
 
 func (s *baseInstallerPackageSuite) requireRunning() {
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running").
-		// no named pipe when service is not running
-		HasNamedPipe(consts.NamedPipe)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+	s.Require().Host(s.Env().RemoteHost).HasARunningDatadogInstallerService()
 }
 
 func (s *baseInstallerPackageSuite) requireNotRunning() {

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -77,7 +77,7 @@ func (s *testInstallerSuite) startServiceWithConfigFileUpdatesEnabled() {
 	s.Require().NoError(common.StartService(s.Env().RemoteHost, consts.ServiceName))
 
 	// Assert
-	s.Require().Host(s.Env().RemoteHost).HasARunningDatadogInstallerService()
+	s.requireRunning()
 	status, err := s.Installer().Status()
 	s.Require().NoError(err)
 	// with no packages installed just prints version
@@ -107,9 +107,7 @@ func (s *testInstallerSuite) installWithExistingConfigFile(logFilename string) {
 
 	// Assert
 	s.requireInstalled()
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running")
+	s.requireRunning()
 }
 
 func (s *testInstallerSuite) repair() {
@@ -124,9 +122,7 @@ func (s *testInstallerSuite) repair() {
 
 	// Assert
 	s.requireInstalled()
-	s.Require().Host(s.Env().RemoteHost).
-		HasAService(consts.ServiceName).
-		WithStatus("Running")
+	s.requireRunning()
 }
 
 func (s *testInstallerSuite) purge() {


### PR DESCRIPTION
### What does this PR do?

Fixes flakiness in the Windows installer-package E2E tests by waiting for the installer service to start before asserting its running state.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2132
The tests were failing intermittently because they were asserting the service state before it had finished starting.
