### PR TITLE
Remove container-integrations as codeowner of autoscaling paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -457,7 +457,7 @@
 /comp/core/autodiscovery/providers/datastreams @DataDog/data-streams-monitoring
 /pkg/cloudfoundry                       @DataDog/agent-integrations
 /pkg/clusteragent/                      @DataDog/container-platform
-/pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling @DataDog/container-integrations
+/pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling
 /pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
 /pkg/clusteragent/admission/mutate/autoinstrumentation/ @DataDog/container-platform @DataDog/injection-platform
 /pkg/clusteragent/admission/mutate/cwsinstrumentation    @DataDog/agent-security


### PR DESCRIPTION
### What does this PR do?

Remove the container-integrations team as codeowner of the `pkg/clusteragent/autoscaling/` codepaths

### Motivation

Keep codeowners file up-to-date

### Describe how you validated your changes

### Additional Notes
