### PR TITLE
fix(comp/trace): Only emit invalid APM Mode WARN log when value is set

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -2207,6 +2207,12 @@ func buildConfigComponentFromOverrides(t *testing.T, setHostnameInConfig bool, s
 }
 
 func buildComponent(t *testing.T, setHostnameInConfig bool, coreConfig configcomp.Component) Component {
+	t.Helper()
+	return buildComponentWithLoggerComponent(t, setHostnameInConfig, coreConfig, logmock.New(t))
+}
+
+func buildComponentWithLoggerComponent(t *testing.T, setHostnameInConfig bool, coreConfig configcomp.Component, loggerComponent logdef.Component) Component {
+	t.Helper()
 	// set the hostname in the config to avoid trying to create a connection to the core agent
 	// (This can be slow and flaky in tests that don't need to run this logic)
 	if setHostnameInConfig {
@@ -2216,7 +2222,7 @@ func buildComponent(t *testing.T, setHostnameInConfig bool, coreConfig configcom
 	pkgconfigsetup.LoadProxyFromEnv(coreConfig)
 	taggerComponent := fxutil.Test[taggermock.Mock](t,
 		fx.Provide(func() configcomp.Component { return coreConfig }),
-		fx.Provide(func() logdef.Component { return logmock.New(t) }),
+		fx.Provide(func() logdef.Component { return loggerComponent }),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 		noopTelemetry.Module(),
 		taggerfxmock.MockModule(),
@@ -2337,45 +2343,84 @@ func TestMultiRegionFailoverConfig(t *testing.T) {
 	})
 }
 
+// buildComponentWithBufferLogger builds a component using a logger that writes to a buffer
+func buildComponentWithBufferLogger(t *testing.T, setHostnameInConfig bool, coreConfig configcomp.Component, logBuffer *bytes.Buffer) Component {
+	// Create a logger component that writes to the buffer instead of t.Log()
+	var loggerComponent logdef.Component
+	if logBuffer != nil {
+		logger, err := log.LoggerFromWriterWithMinLevelAndFullFormat(logBuffer, log.DebugLvl)
+		require.NoError(t, err)
+		log.SetupLogger(logger, "debug")
+		loggerComponent = log.NewWrapper(2)
+	} else {
+		loggerComponent = logmock.New(t)
+	}
+
+	return buildComponentWithLoggerComponent(t, setHostnameInConfig, coreConfig, loggerComponent)
+}
+
 func TestNormalizeAPMMode(t *testing.T) {
+	const unsetRepresentation = "unset"
 	tests := []struct {
-		name     string
-		envValue string
-		expected string
+		name          string
+		envValue      string
+		expected      string
+		shouldHaveLog bool
 	}{
 		{
-			name:     "valid_edge",
-			envValue: "edge",
-			expected: "edge",
+			name:          "valid_edge",
+			envValue:      "edge",
+			expected:      "edge",
+			shouldHaveLog: false,
 		},
 		{
-			name:     "empty_defaults_to_empty",
-			envValue: "",
-			expected: "",
+			name:          "empty_defaults_to_empty",
+			envValue:      "",
+			expected:      "",
+			shouldHaveLog: false,
 		},
 		{
-			name:     "invalid_defaults_to_empty",
-			envValue: "invalid_mode",
-			expected: "",
+			name:          "invalid_defaults_to_empty",
+			envValue:      "invalid_mode",
+			expected:      "",
+			shouldHaveLog: true,
 		},
 		{
-			name:     "case_sensitive",
-			envValue: "Edge",
-			expected: "edge",
+			name:          "case_sensitive",
+			envValue:      "Edge",
+			expected:      "edge",
+			shouldHaveLog: false,
+		},
+		{
+			name:          "unset_no_log",
+			envValue:      unsetRepresentation,
+			expected:      "",
+			shouldHaveLog: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
+			var logBuffer bytes.Buffer
+			if tt.envValue != unsetRepresentation {
 				t.Setenv("DD_APM_MODE", tt.envValue)
 			}
 
-			config := buildConfigComponentFromYAML(t, true, "./testdata/no_apm_config.yaml")
+			coreConfig := configcomp.NewMockFromYAMLFile(t, "./testdata/no_apm_config.yaml")
+			config := buildComponentWithBufferLogger(t, true, coreConfig, &logBuffer)
 			cfg := config.Object()
+
+			log.Flush()
+			logOutput := logBuffer.String()
 
 			assert.NotNil(t, cfg)
 			assert.Equal(t, tt.expected, cfg.APMMode)
+
+			if tt.shouldHaveLog {
+				assert.Contains(t, logOutput, "invalid value for 'DD_APM_MODE'")
+			} else {
+				assert.NotContains(t, logOutput, "invalid value for 'DD_APM_MODE'")
+			}
 		})
 	}
 }

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -675,9 +675,11 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.enable_v1_trace_endpoint"; core.IsSet(k) {
 		c.EnableV1TraceEndpoint = core.GetBool("apm_config.enable_v1_trace_endpoint")
 	}
+	if k := "apm_config.mode"; core.IsSet(k) {
+		c.APMMode = normalizeAPMMode(core.GetString(k))
+	}
 	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
-	c.APMMode = normalizeAPMMode(core.GetString("apm_config.mode"))
 	c.ContainerTagsBuffer = core.GetBool("apm_config.enable_container_tags_buffer")
 	return nil
 }

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -675,7 +675,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "apm_config.enable_v1_trace_endpoint"; core.IsSet(k) {
 		c.EnableV1TraceEndpoint = core.GetBool("apm_config.enable_v1_trace_endpoint")
 	}
-	if k := "apm_config.mode"; core.IsSet(k) {
+	if k := "apm_config.mode"; core.IsConfigured(k) {
 		c.APMMode = normalizeAPMMode(core.GetString(k))
 	}
 	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false

--- a/releasenotes/notes/apm-fix-dd-apm-mode-logging-edd6528b25cd06ba.yaml
+++ b/releasenotes/notes/apm-fix-dd-apm-mode-logging-edd6528b25cd06ba.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    APM: Fix a bug where the Agent would log a warning when the `DD_APM_MODE` environment variable was unset.


### PR DESCRIPTION
### What does this PR do?
Fixes a warning log that was previously emitting when `DD_APM_MODE`/`apm_config.mode` was unset. Now, the log is emitted only when the value is explicitly set, and invalid.

### Motivation
WARN log about a setting you never touched could be annoying.

### Describe how you validated your changes
Added new test logic in TestNormalizeAPMMode

### Additional Notes
