### PR TITLE
[Backport 7.75.x] [pkg/clusteragent/autoscaling] Fix logic for creating replica NodePools

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
@@ -137,22 +138,23 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 	npi, foundInStore := c.store.LockRead(name, true)
 	defer c.store.Unlock(name)
 
-	// Get Target NodePool from Lister if needed
-	targetNp := &karpenterv1.NodePool{}
-	if npi.TargetName() != "" {
-		targetNpUnstr, err := c.Lister.Get(npi.TargetName())
-		if err != nil {
-			log.Errorf("Error retrieving Target NodePool: %v", err)
-			return autoscaling.Requeue
-		}
-		err = autoscaling.FromUnstructured(targetNpUnstr, targetNp)
-		if err != nil {
-			log.Errorf("Error converting Target NodePool: %v", err)
-			return autoscaling.Requeue
-		}
-	}
-
 	if foundInStore {
+		// Get Target NodePool from Lister if needed
+		var targetNp *karpenterv1.NodePool
+		if npi.TargetName() != "" {
+			targetNp = &karpenterv1.NodePool{}
+			targetNpUnstr, err := c.Lister.Get(npi.TargetName())
+			if err != nil {
+				log.Errorf("Error retrieving Target NodePool: %v", err)
+				return autoscaling.Requeue
+			}
+			err = autoscaling.FromUnstructured(targetNpUnstr, targetNp)
+			if err != nil {
+				log.Errorf("Error converting Target NodePool: %v", err)
+				return autoscaling.Requeue
+			}
+		}
+
 		// Only create or update if there is no TargetHash (i.e. it is fully Datadog-managed), or if the TargetHash has not changed
 		if !checkTargetHash(npi, targetNp) {
 			log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
@@ -189,6 +191,9 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 }
 
 func checkTargetHash(npi model.NodePoolInternal, targetNp *karpenterv1.NodePool) bool {
+	if targetNp == nil {
+		return false
+	}
 	return npi.TargetHash() == "" || npi.TargetHash() == targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey]
 }
 
@@ -197,6 +202,7 @@ func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInter
 
 	// Create replica of original NodePool if TargetName exists; otherwise use NodePoolInternal to create a NodePool
 	if knp != nil {
+		log.Debugf("Building replica of NodePool: %s", npi.Name())
 		model.BuildReplicaNodePool(knp, npi)
 	} else {
 		// Get NodeClass. If there's none or more than one, then we should not create the NodePool
@@ -217,7 +223,7 @@ func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInter
 		knp = model.ConvertToKarpenterNodePool(npi, u.GetName())
 	}
 
-	npUnstr, err := autoscaling.ToUnstructured(knp)
+	npUnstr, err := convertNodePoolToUnstructured(knp)
 	if err != nil {
 		return err
 	}
@@ -264,4 +270,26 @@ func isCreatedByDatadog(labels map[string]string) bool {
 		return true
 	}
 	return false
+}
+
+// Helper function to convert a typed Karpenter NodePool object to unstructured. Handles custom Go types gracefully
+func convertNodePoolToUnstructured(np interface{}) (*unstructured.Unstructured, error) {
+	// Marshal the structured object to JSON bytes.
+	bytes, err := json.Marshal(np)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the JSON bytes into a map[string]interface{}.
+	var unstructuredMap map[string]interface{}
+	if err := json.Unmarshal(bytes, &unstructuredMap); err != nil {
+		return nil, err
+	}
+
+	// Wrap the map in unstructured.Unstructured.
+	unstructuredObj := &unstructured.Unstructured{
+		Object: unstructuredMap,
+	}
+
+	return unstructuredObj, nil
 }


### PR DESCRIPTION
Backport 6520642120d42250b4fa93b7baa150945b90893d from #44711 .

___

### What does this PR do?

We would sometimes trigger the build replica nodepool flow when we actually want to create a new nodepool. This ensures we properly create a new nodepool including all of the necessary fields.

Also adds some checks to avoid some nil pointer exceptions in replica NodePool flow

### Motivation

Testing full E2E flow for cluster scaling

### Describe how you validated your changes
1. Setup a new cluster for cluster scaling
2. Ensure that instance recommender recommends a new nodepool
3. Verify new nodepool is created properly
4. Create a nodepool
5. Verify that duplicate nodepool is created properly

### Additional Notes
