### PR TITLE
[Backport 7.75.x] dyninst/module: fix race with process removal and load (#44768)

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -192,6 +192,10 @@ func (a *effects) loadProgram(
 			programID, executable, processID, probes,
 		)
 		if err != nil {
+			log.Infof(
+				"failed to load program %v for process %v: %v",
+				programID, processID, err,
+			)
 			a.sendEvent(eventProgramLoadingFailed{
 				programID: programID,
 			})

--- a/pkg/dyninst/module/runtime_impl.go
+++ b/pkg/dyninst/module/runtime_impl.go
@@ -100,7 +100,10 @@ func (rt *runtimeImpl) Load(
 
 	runtimeID, ok := rt.store.updateOnLoad(processID, executable, programID)
 	if !ok {
-		return nil, nil
+		// This can happen if the process has gone away after the load call was
+		// initiated. Such a race is unavoidable because loading happens
+		// asynchronously.
+		return nil, fmt.Errorf("process %v not found", processID)
 	}
 
 	rt.procRuntimeIDbyProgramID.Store(programID, runtimeID)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that could happen if a program went away concurrent with the very beginning of program loading. It also adds a bit more defensiveness around this behavior from the dependency, and generally adds logging around the situation.

### Motivation

If a process went away while a program was being loaded, we could hit a nil pointer panic. The issue was due to an invariant violation that the runtime never returns a nil loaded program and a nil error. Code has also been added to handle this bad behavior defensively, but the bad behavior has been removed.

### Describe how you validated your changes

There's testing for the specific scenario.

### Additional Notes

Fixes [DEBUG-4910](https://datadoghq.atlassian.net/browse/DEBUG-4910).

See https://dd.slack.com/archives/C04858UA2QM/p1767620750363689




[DEBUG-4026]: https://datadoghq.atlassian.net/browse/DEBUG-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEBUG-4910]: https://datadoghq.atlassian.net/browse/DEBUG-4910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ