### PR TITLE
Build xmlsec with bazel

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -322,7 +322,7 @@ http_archive(
     strip_prefix = "xmlsec1-1.3.7",
     files = {
         "BUILD.bazel": "//deps:xmlsec/xmlsec.BUILD.bazel",
-        "config-linux-x86_64.h": "//deps:dbus/config-linux-x86_64.h",
-        "config-linux-arm64.h": "//deps:dbus/config-linux-arm64.h",
+        "config-linux-x86_64.h": "//deps:xmlsec/config-linux-x86_64.h",
+        "config-linux-arm64.h": "//deps:xmlsec/config-linux-arm64.h",
     },
 )

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -314,3 +314,15 @@ http_archive(
         "license_file": "//deps:lua/license",
     },
 )
+
+http_archive(
+    name = "xmlsec",
+    url = "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
+    sha256 = "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
+    strip_prefix = "xmlsec1-1.3.7",
+    files = {
+        "BUILD.bazel": "//deps:xmlsec/xmlsec.BUILD.bazel",
+        "config-linux-x86_64.h": "//deps:dbus/config-linux-x86_64.h",
+        "config-linux-arm64.h": "//deps:dbus/config-linux-arm64.h",
+    },
+)

--- a/deps/xmlsec/config-linux-arm64.h
+++ b/deps/xmlsec/config-linux-arm64.h
@@ -1,0 +1,79 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+   */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "xmlsec1"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://www.aleksey.com/xmlsec"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "xmlsec1"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "xmlsec1 1.3.7"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xmlsec1"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.3.7"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "1.3.7"

--- a/deps/xmlsec/config-linux-x86_64.h
+++ b/deps/xmlsec/config-linux-x86_64.h
@@ -1,0 +1,79 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+   */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+   */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "xmlsec1"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "http://www.aleksey.com/xmlsec"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "xmlsec1"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "xmlsec1 1.3.7"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "xmlsec1"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.3.7"
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "1.3.7"

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -1,0 +1,229 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+
+package(default_package_metadata = [":license"])
+
+VERSION = "1.3.7"
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:MIT"],
+    license_text = "Copyright",
+    visibility = ["//visibility:public"],
+)
+
+copy_file(
+    name = "copy_config_h",
+    src = select({
+        "@@//:linux_x86_64": "config-linux-x86_64.h",
+        "@@//:linux_arm64": "config-linux-arm64.h",
+    }),
+    out = "config.h",
+)
+
+cc_library(
+    name = "config_h",
+    hdrs = [
+        ":copy_config_h",
+    ],
+)
+
+PUBLIC_HEADERS = glob([
+    "include/xmlsec/*.h",
+])
+
+PUBLIC_OPENSSL_HEADERS = glob([
+    "include/xmlsec/openssl/*.h",
+])
+
+cc_library(
+    name = "libxmlsec1",
+    srcs = [
+        "src/app.c",
+        "src/base64.c",
+        "src/bn.c",
+        "src/buffer.c",
+        "src/c14n.c",
+        "src/dl.c",
+        "src/enveloped.c",
+        "src/errors.c",
+        "src/io.c",
+        "src/keyinfo.c",
+        "src/keys.c",
+        "src/keysdata.c",
+        "src/keysmngr.c",
+        "src/kw_aes_des.c",
+        "src/list.c",
+        "src/membuf.c",
+        "src/nodeset.c",
+        "src/parser.c",
+        "src/relationship.c",
+        "src/strings.c",
+        "src/templates.c",
+        "src/transforms.c",
+        "src/xmldsig.c",
+        "src/xmlenc.c",
+        "src/xmlsec.c",
+        "src/xmltree.c",
+        "src/xpath.c",
+        "src/xslt.c",
+    ] + glob(["src/*.h"]),
+    hdrs = PUBLIC_HEADERS,
+    strip_include_prefix = "include",
+    local_defines = [
+        'PACKAGE=\\"xmlsec1\\"',
+        'XMLSEC_DEFAULT_CRYPTO=\\"openssl\\"',
+        "HAVE_CONFIG_H",
+    ],
+    implementation_deps = [
+        ":config_h",
+    ],
+    deps = [
+        "@libxslt//:libxslt",
+        "@libxml2//:libxml2",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "xmlsec1",
+    deps = [
+        ":libxmlsec1",
+    ],
+    dynamic_deps = [
+        "@libxslt//:xslt",
+        "@libxml2//:xml2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+
+cc_library(
+    name = "libxmlsec1-openssl",
+    srcs = [
+        "src/openssl/app.c",
+        "src/openssl/ciphers.c",
+        "src/openssl/crypto.c",
+        "src/openssl/digests.c",
+        "src/openssl/evp.c",
+        "src/openssl/kdf.c",
+        "src/openssl/key_agrmnt.c",
+        "src/openssl/keysstore.c",
+        "src/openssl/hmac.c",
+        "src/openssl/kw_aes.c",
+        "src/openssl/kw_des.c",
+        "src/openssl/kt_rsa.c",
+        "src/openssl/signatures.c",
+        "src/openssl/signatures_legacy.c",
+        "src/openssl/symkeys.c",
+        "src/openssl/x509.c",
+        "src/openssl/x509vfy.c",
+        "src/openssl/globals.h",
+        "src/openssl/private.h",
+        "src/openssl/openssl_compat.h",
+    ],
+    hdrs = PUBLIC_OPENSSL_HEADERS,
+    implementation_deps = [
+        ":config_h",
+    ],
+    deps = [
+        "@libxslt//:libxslt",
+        "@libxml2//:libxml2",
+        "@openssl//:openssl",
+        ":libxmlsec1"
+    ],
+    strip_include_prefix = "include",
+    local_defines = [
+        'PACKAGE=\\"xmlsec1\\"',
+        "HAVE_CONFIG_H",
+    ],
+    includes = [
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_shared_library(
+    name = "xmlsec1-openssl",
+    deps = [
+        ":libxmlsec1-openssl",
+    ],
+    dynamic_deps = [
+        "@libxslt//:xslt",
+        "@libxml2//:xml2",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+so_symlink(
+    name = "libxmlsec_files",
+    src = ":xmlsec1",
+    libname = "libxmlsec1",
+    version = VERSION,
+)
+
+so_symlink(
+    name = "libxmlsec_openssl_files",
+    src = ":xmlsec1-openssl",
+    libname = "libxmlsec1-openssl",
+    version = VERSION,
+)
+
+pkg_files(
+    name = "headers_files",
+    srcs = PUBLIC_HEADERS,
+    prefix = "include/xmlsec1/xmlsec"
+)
+
+pkg_files(
+    name = "openssl_headers_files",
+    srcs = PUBLIC_OPENSSL_HEADERS,
+    prefix = "include/xmlsec1/xmlsec/openssl",
+)
+
+expand_template(
+    name = "fixup_pc_xmlsec",
+    template = "xmlsec1.pc",
+    out = "fixed/xmlsec1.pc",
+    substitutions = {
+        "prefix=/usr": "prefix=##PREFIX##",
+    },
+)
+
+expand_template(
+    name = "fixup_pc_xmlsec_openssl",
+    template = "xmlsec1-openssl.pc",
+    out = "fixed/xmlsec1-openssl.pc",
+    substitutions = {
+        "prefix=/usr": "prefix=##PREFIX##",
+    },
+)
+
+pkg_files(
+    name = "pc_files",
+    srcs = [
+        ":fixup_pc_xmlsec",
+        ":fixup_pc_xmlsec_openssl",
+    ],
+    prefix = "lib/pkgconfig",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":headers_files",
+        ":openssl_headers_files",
+        ":libxmlsec_files",
+        ":libxmlsec_openssl_files",
+        ":pc_files",
+    ],
+)

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -76,6 +76,7 @@ cc_library(
     ] + glob(["src/*.h"]),
     hdrs = PUBLIC_HEADERS,
     strip_include_prefix = "include",
+    copts = ["-O2"],
     local_defines = [
         'PACKAGE=\\"xmlsec1\\"',
         'XMLSEC_DEFAULT_CRYPTO=\\"openssl\\"',
@@ -135,6 +136,7 @@ cc_library(
     implementation_deps = [
         ":config_h",
     ],
+    copts = ["-O2"],
     deps = [
         "@libxslt//:libxslt",
         "@libxml2//:libxml2",

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -77,6 +77,9 @@ cc_library(
     hdrs = PUBLIC_HEADERS,
     strip_include_prefix = "include",
     copts = ["-O2"],
+    defines = [
+        "XMLSEC_CRYPTO_OPENSSL=1",
+    ],
     local_defines = [
         'PACKAGE=\\"xmlsec1\\"',
         'XMLSEC_DEFAULT_CRYPTO=\\"openssl\\"',

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -146,6 +146,14 @@ cc_library(
         "@openssl//:openssl",
         ":libxmlsec1"
     ],
+    defines = [
+        "XMLSEC_NO_FTP=1",
+        "XMLSEC_NO_HTTP=1",
+        "XMLSEC_NO_MD5=1",
+        "XMLSEC_NO_RIPEMD160=1",
+        "XMLSEC_NO_GOST=1",
+        "XMLSEC_NO_GOST2012=1",
+    ],
     strip_include_prefix = "include",
     local_defines = [
         'PACKAGE=\\"xmlsec1\\"',

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -173,6 +173,7 @@ cc_shared_library(
     dynamic_deps = [
         "@libxslt//:xslt",
         "@libxml2//:xml2",
+        ":xmlsec1",
     ],
     visibility = ["//visibility:public"],
 )

--- a/omnibus/config/software/xmlsec.rb
+++ b/omnibus/config/software/xmlsec.rb
@@ -21,32 +21,9 @@ license "MIT"
 license_file "Copyright"
 skip_transitive_dependency_licensing true
 
-dependency "libxml2"
-dependency "libxslt"
-dependency "libtool"
-dependency "libgcrypt"
-dependency "openssl3"
-
-version("1.3.1") { source sha256: "10f48384d4fd1afc05fea545b74fbf7c152582f0a895c189f164d55270400c63" }
-version("1.3.7") { source sha256: "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea" }
-
-source url: "https://github.com/lsh123/xmlsec/releases/download/#{version}/xmlsec1-#{version}.tar.gz"
-
-relative_path "xmlsec1-#{version}"
-
 build do
-  env = with_standard_compiler_flags(with_embedded_path)
-
-  env["CFLAGS"] << " -fPIC"
-  env["CFLAGS"] << " -std=c99"
-
-  update_config_guess
-  configure_options = [
-    "--disable-static",
-    "--disable-pedantic",
-    "--with-libxml=#{install_dir}/embedded/"
-  ]
-  configure(*configure_options, env: env)
-  make "-j #{workers}", env: env
-  make "install", env: env
+  command_on_repo_root "bazelisk run -- @xmlsec//:install --destdir='#{install_dir}/embedded'"
+  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    " #{install_dir}/embedded/lib/libxmlsec1*.so" \
+    " #{install_dir}/embedded/lib/pkgconfig/xmlsec1*.pc"
 end


### PR DESCRIPTION
### What does this PR do?

Migrate xmlsec build to bazel

### Motivation

Migrating our builds to bazel

### Describe how you validated your changes

Local build and checking against the list of currently installed files with the upstream build system.
We do not install `xmlsec1` and `xmlsec1-config` anymore.
The former isn't used by openscap, the latter is a build only tool

I also manually compared the list of defined symbols against the libs built with the upstream build system to ensure we don't include too much/too little

### Additional Notes

This will need to be verified with the CSPM test suite
