### PR TITLE
[CONTP-1036] Support GPU device id collection from ECS container runtime

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
@@ -35,16 +35,6 @@ func Test_extractGPUDeviceIDs(t *testing.T) {
 			expected: []string{"GPU-aec058b1-c18e-236e-c14d-49d2990fda0f", "GPU-bec058b1-d18e-336e-d14d-59d2990fda1f"},
 		},
 		{
-			name:     "single GPU index",
-			envVars:  []string{"PATH=/usr/bin", "NVIDIA_VISIBLE_DEVICES=0"},
-			expected: []string{"0"},
-		},
-		{
-			name:     "multiple GPU indices",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=0,2,1"},
-			expected: []string{"0", "2", "1"},
-		},
-		{
 			name:     "all GPUs",
 			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=all"},
 			expected: nil,

--- a/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
@@ -18,6 +18,72 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
+func Test_extractGPUDeviceIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  []string
+		expected []string
+	}{
+		{
+			name:     "single GPU UUID",
+			envVars:  []string{"PATH=/usr/bin", "NVIDIA_VISIBLE_DEVICES=GPU-aec058b1-c18e-236e-c14d-49d2990fda0f"},
+			expected: []string{"GPU-aec058b1-c18e-236e-c14d-49d2990fda0f"},
+		},
+		{
+			name:     "multiple GPU UUIDs",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=GPU-aec058b1-c18e-236e-c14d-49d2990fda0f,GPU-bec058b1-d18e-336e-d14d-59d2990fda1f"},
+			expected: []string{"GPU-aec058b1-c18e-236e-c14d-49d2990fda0f", "GPU-bec058b1-d18e-336e-d14d-59d2990fda1f"},
+		},
+		{
+			name:     "single GPU index",
+			envVars:  []string{"PATH=/usr/bin", "NVIDIA_VISIBLE_DEVICES=0"},
+			expected: []string{"0"},
+		},
+		{
+			name:     "multiple GPU indices",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=0,2,1"},
+			expected: []string{"0", "2", "1"},
+		},
+		{
+			name:     "all GPUs",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=all"},
+			expected: nil,
+		},
+		{
+			name:     "none",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=none"},
+			expected: nil,
+		},
+		{
+			name:     "void",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=void"},
+			expected: nil,
+		},
+		{
+			name:     "empty value",
+			envVars:  []string{"NVIDIA_VISIBLE_DEVICES="},
+			expected: nil,
+		},
+		{
+			name:     "no NVIDIA_VISIBLE_DEVICES",
+			envVars:  []string{"PATH=/usr/bin", "HOME=/root"},
+			expected: nil,
+		},
+		{
+			name:     "empty env vars",
+			envVars:  []string{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractGPUDeviceIDs(tt.envVars)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 	var emptySize int64
 	var noDiffCmd = "ENV var=dummy"

--- a/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
@@ -37,17 +37,17 @@ func Test_extractGPUDeviceIDs(t *testing.T) {
 		{
 			name:     "all GPUs",
 			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=all"},
-			expected: nil,
+			expected: []string{"all"},
 		},
 		{
 			name:     "none",
 			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=none"},
-			expected: nil,
+			expected: []string{"none"},
 		},
 		{
 			name:     "void",
 			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=void"},
-			expected: nil,
+			expected: []string{"void"},
 		},
 		{
 			name:     "empty value",

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -647,6 +647,10 @@ type Container struct {
 	// ResolvedAllocatedResources is the list of resources allocated to this pod. Requires the
 	// PodResources API to query that data.
 	ResolvedAllocatedResources []ContainerAllocatedResource
+	// GPUDeviceIDs contains the GPU device UUIDs assigned to this container.
+	// Format: ["GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
+	// Source: ECS task metadata gpuIds, NVIDIA_VISIBLE_DEVICES env var, or container runtime spec
+	GPUDeviceIDs []string
 	// CgroupPath is a path to the cgroup of the container.
 	// It can be relative to the cgroup parent.
 	// Linux only.
@@ -740,6 +744,11 @@ func (c Container) String(verbose bool) string {
 				_, _ = fmt.Fprintln(&sb, "Localhost Profile:", c.SecurityContext.SeccompProfile.LocalhostProfile)
 			}
 		}
+	}
+
+	if len(c.GPUDeviceIDs) > 0 {
+		_, _ = fmt.Fprintln(&sb, "----------- GPU Info -----------")
+		_, _ = fmt.Fprintln(&sb, "GPU Device IDs:", c.GPUDeviceIDs)
 	}
 
 	if c.ECSContainer != nil {

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -649,7 +649,8 @@ type Container struct {
 	ResolvedAllocatedResources []ContainerAllocatedResource
 	// GPUDeviceIDs contains the GPU device UUIDs assigned to this container.
 	// Format: ["GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
-	// Source: ECS task metadata gpuIds, NVIDIA_VISIBLE_DEVICES env var, or container runtime spec
+	// Note: Currently only reliably populated in ECS environments, where it is extracted
+	// from the NVIDIA_VISIBLE_DEVICES environment variable set by the ECS agent.
 	GPUDeviceIDs []string
 	// CgroupPath is a path to the cgroup of the container.
 	// It can be relative to the cgroup parent.

--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -36,35 +36,49 @@ const (
 
 // HasGPUs returns true if the container has GPUs assigned to it.
 func HasGPUs(container *workloadmeta.Container) bool {
-	switch container.Runtime {
-	case workloadmeta.ContainerRuntimeDocker:
-		// If we have an error, we assume there are no GPUs for the container, so
-		// ignore it.
+	// Primary: Check GPUDeviceIDs from workloadmeta (populated by collectors)
+	if len(container.GPUDeviceIDs) > 0 {
+		return true
+	}
+
+	// Fallback for Kubernetes: Check ResolvedAllocatedResources from PodResources API
+	for _, resource := range container.ResolvedAllocatedResources {
+		if gpuutil.IsNvidiaKubernetesResource(resource.Name) {
+			return true
+		}
+	}
+
+	// Legacy fallback for Docker: Check via procfs
+	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
 		envVar, _ := getDockerVisibleDevicesEnv(container)
 		return envVar != ""
-	default:
-		// We have no specific support for other runtimes, so fall back to the Kubernetes device
-		// assignment if it's there
-		for _, resource := range container.ResolvedAllocatedResources {
-			if gpuutil.IsNvidiaKubernetesResource(resource.Name) {
-				return true
-			}
-		}
-		return false
 	}
+
+	return false
 }
 
 // MatchContainerDevices matches the devices assigned to a container to the list of available devices
 // It returns a list of devices that are assigned to the container, and an error if any of the devices cannot be matched
 func MatchContainerDevices(container *workloadmeta.Container, devices []ddnvml.Device) ([]ddnvml.Device, error) {
-	switch container.Runtime {
-	case workloadmeta.ContainerRuntimeDocker:
-		return matchDockerDevices(container, devices)
-	default:
-		// We have no specific support for other runtimes, so fall back to the Kubernetes device
-		// assignment if it's there
+	// Primary: Use GPUDeviceIDs from workloadmeta (populated by collectors like Docker, containerd)
+	// This handles both UUID format (ECS, some K8s) and index format (local Docker)
+	if len(container.GPUDeviceIDs) > 0 {
+		return matchByGPUDeviceIDs(container.GPUDeviceIDs, devices)
+	}
+
+	// Fallback for Kubernetes: Use ResolvedAllocatedResources from PodResources API
+	if len(container.ResolvedAllocatedResources) > 0 {
 		return matchKubernetesDevices(container, devices)
 	}
+
+	// Legacy fallback for Docker: Read from procfs directly
+	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
+		return matchDockerDevices(container, devices)
+	}
+
+	// No GPU information available - return empty list without error.
+	// This allows the caller to handle fallback cases (e.g., single-GPU systems).
+	return nil, nil
 }
 
 func getDockerVisibleDevicesEnv(container *workloadmeta.Container) (string, error) {
@@ -124,6 +138,42 @@ func matchDockerDevices(container *workloadmeta.Container, devices []ddnvml.Devi
 		}
 		filteredDevices = append(filteredDevices, matchingDevice)
 	}
+
+	return filteredDevices, multiErr
+}
+
+// matchByGPUDeviceIDs matches devices using GPUDeviceIDs from workloadmeta.
+// It handles both UUID format (e.g., "GPU-aec058b1-c18e-236e-c14d-49d2990fda0f")
+// and index format (e.g., "0", "1").
+func matchByGPUDeviceIDs(gpuDeviceIDs []string, devices []ddnvml.Device) ([]ddnvml.Device, error) {
+	var filteredDevices []ddnvml.Device
+	var multiErr error
+
+	for _, id := range gpuDeviceIDs {
+		var matchingDevice ddnvml.Device
+		var err error
+
+		if strings.HasPrefix(id, "GPU-") {
+			// UUID format (ECS, some K8s setups with NVIDIA device plugin)
+			matchingDevice, err = findDeviceByUUID(devices, id)
+		} else {
+			// Index format (local Docker)
+			matchingDevice, err = findDeviceByIndex(devices, id)
+		}
+
+		if err != nil {
+			multiErr = errors.Join(multiErr, err)
+			continue
+		}
+		filteredDevices = append(filteredDevices, matchingDevice)
+	}
+
+	// Sort by device index for consistent ordering
+	slices.SortFunc(filteredDevices, func(a, b ddnvml.Device) int {
+		aInfo := a.GetDeviceInfo()
+		bInfo := b.GetDeviceInfo()
+		return cmp.Compare(aInfo.Index, bInfo.Index)
+	})
 
 	return filteredDevices, multiErr
 }

--- a/pkg/gpu/containers/containers.go
+++ b/pkg/gpu/containers/containers.go
@@ -142,9 +142,22 @@ func matchDockerDevices(container *workloadmeta.Container, devices []ddnvml.Devi
 // matchByGPUDeviceIDs matches devices using GPUDeviceIDs from workloadmeta.
 // This is used for ECS containers where GPU UUIDs are provided in the format
 // "GPU-aec058b1-c18e-236e-c14d-49d2990fda0f".
+// Special values:
+//   - "all" returns all available devices (GPU sharing)
+//   - "none", "void" returns empty slice (no GPU access)
+//
 // The order of devices is preserved from the input gpuDeviceIDs, as this matches
 // the order CUDA will use when selecting devices.
 func matchByGPUDeviceIDs(gpuDeviceIDs []string, devices []ddnvml.Device) ([]ddnvml.Device, error) {
+	if len(gpuDeviceIDs) == 1 {
+		switch gpuDeviceIDs[0] {
+		case "all":
+			return devices, nil
+		case "none", "void":
+			return nil, nil
+		}
+	}
+
 	var filteredDevices []ddnvml.Device
 	var multiErr error
 

--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -496,39 +496,13 @@ func TestMatchByGPUDeviceIDs(t *testing.T) {
 		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 2)
-		// Should be sorted by device index
-		assert.Equal(t, devices[0], filteredDevices[0])
-		assert.Equal(t, devices[2], filteredDevices[1])
-	})
-
-	t.Run("SingleIndex", func(t *testing.T) {
-		gpuDeviceIDs := []string{"1"}
-		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
-		require.NoError(t, err)
-		require.Len(t, filteredDevices, 1)
-		assert.Equal(t, devices[1], filteredDevices[0])
-	})
-
-	t.Run("MultipleIndices", func(t *testing.T) {
-		gpuDeviceIDs := []string{"2", "0"}
-		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
-		require.NoError(t, err)
-		require.Len(t, filteredDevices, 2)
-		// Should be sorted by device index
-		assert.Equal(t, devices[0], filteredDevices[0])
-		assert.Equal(t, devices[2], filteredDevices[1])
+		// Order preserved from input (matches CUDA device selection order)
+		assert.Equal(t, devices[2], filteredDevices[0])
+		assert.Equal(t, devices[0], filteredDevices[1])
 	})
 
 	t.Run("InvalidUUID", func(t *testing.T) {
 		gpuDeviceIDs := []string{"GPU-invalid-uuid"}
-		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
-		require.Error(t, err)
-		require.Len(t, filteredDevices, 0)
-		require.ErrorIs(t, err, ErrCannotMatchDevice)
-	})
-
-	t.Run("InvalidIndex", func(t *testing.T) {
-		gpuDeviceIDs := []string{"999"}
 		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
 		require.Error(t, err)
 		require.Len(t, filteredDevices, 0)
@@ -540,9 +514,9 @@ func TestMatchByGPUDeviceIDs(t *testing.T) {
 		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
 		require.Error(t, err) // Error for invalid UUID
 		require.Len(t, filteredDevices, 2)
-		// Should be sorted by device index
-		assert.Equal(t, devices[0], filteredDevices[0])
-		assert.Equal(t, devices[1], filteredDevices[1])
+		// Order preserved from input (matches CUDA device selection order), invalid skipped
+		assert.Equal(t, devices[1], filteredDevices[0])
+		assert.Equal(t, devices[0], filteredDevices[1])
 	})
 
 	t.Run("EmptyList", func(t *testing.T) {
@@ -574,23 +548,6 @@ func TestMatchContainerDevicesWithGPUDeviceIDs(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filteredDevices, 1)
 		assert.Equal(t, devices[1], filteredDevices[0])
-	})
-
-	t.Run("ContainerWithGPUDeviceIDsIndex", func(t *testing.T) {
-		// Simulates local Docker container with index in GPUDeviceIDs
-		container := &workloadmeta.Container{
-			EntityID: workloadmeta.EntityID{
-				Kind: workloadmeta.KindContainer,
-				ID:   "test-docker-container",
-			},
-			GPUDeviceIDs: []string{"0", "2"},
-		}
-
-		filteredDevices, err := MatchContainerDevices(container, devices)
-		require.NoError(t, err)
-		require.Len(t, filteredDevices, 2)
-		assert.Equal(t, devices[0], filteredDevices[0])
-		assert.Equal(t, devices[2], filteredDevices[1])
 	})
 
 	t.Run("GPUDeviceIDsTakesPrecedenceOverResolvedAllocatedResources", func(t *testing.T) {

--- a/pkg/gpu/containers/containers_test.go
+++ b/pkg/gpu/containers/containers_test.go
@@ -476,6 +476,146 @@ func TestFindDeviceByIndex(t *testing.T) {
 
 }
 
+func TestMatchByGPUDeviceIDs(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("SingleUUID", func(t *testing.T) {
+		gpuDeviceIDs := []string{testutil.GPUUUIDs[1]}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 1)
+		assert.Equal(t, devices[1], filteredDevices[0])
+	})
+
+	t.Run("MultipleUUIDs", func(t *testing.T) {
+		gpuDeviceIDs := []string{testutil.GPUUUIDs[2], testutil.GPUUUIDs[0]}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 2)
+		// Should be sorted by device index
+		assert.Equal(t, devices[0], filteredDevices[0])
+		assert.Equal(t, devices[2], filteredDevices[1])
+	})
+
+	t.Run("SingleIndex", func(t *testing.T) {
+		gpuDeviceIDs := []string{"1"}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 1)
+		assert.Equal(t, devices[1], filteredDevices[0])
+	})
+
+	t.Run("MultipleIndices", func(t *testing.T) {
+		gpuDeviceIDs := []string{"2", "0"}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 2)
+		// Should be sorted by device index
+		assert.Equal(t, devices[0], filteredDevices[0])
+		assert.Equal(t, devices[2], filteredDevices[1])
+	})
+
+	t.Run("InvalidUUID", func(t *testing.T) {
+		gpuDeviceIDs := []string{"GPU-invalid-uuid"}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.Error(t, err)
+		require.Len(t, filteredDevices, 0)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
+	})
+
+	t.Run("InvalidIndex", func(t *testing.T) {
+		gpuDeviceIDs := []string{"999"}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.Error(t, err)
+		require.Len(t, filteredDevices, 0)
+		require.ErrorIs(t, err, ErrCannotMatchDevice)
+	})
+
+	t.Run("MixedValidAndInvalid", func(t *testing.T) {
+		gpuDeviceIDs := []string{testutil.GPUUUIDs[1], "GPU-invalid", testutil.GPUUUIDs[0]}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.Error(t, err) // Error for invalid UUID
+		require.Len(t, filteredDevices, 2)
+		// Should be sorted by device index
+		assert.Equal(t, devices[0], filteredDevices[0])
+		assert.Equal(t, devices[1], filteredDevices[1])
+	})
+
+	t.Run("EmptyList", func(t *testing.T) {
+		gpuDeviceIDs := []string{}
+		filteredDevices, err := matchByGPUDeviceIDs(gpuDeviceIDs, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 0)
+	})
+}
+
+func TestMatchContainerDevicesWithGPUDeviceIDs(t *testing.T) {
+	// Setup mock NVML with basic devices
+	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))
+
+	// Get test devices
+	devices := nvmltestutil.GetDDNVMLMocksWithIndexes(t, 0, 1, 2)
+
+	t.Run("ContainerWithGPUDeviceIDsUUID", func(t *testing.T) {
+		// Simulates ECS GPU container with UUID in GPUDeviceIDs
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-ecs-container",
+			},
+			GPUDeviceIDs: []string{testutil.GPUUUIDs[1]},
+		}
+
+		filteredDevices, err := MatchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 1)
+		assert.Equal(t, devices[1], filteredDevices[0])
+	})
+
+	t.Run("ContainerWithGPUDeviceIDsIndex", func(t *testing.T) {
+		// Simulates local Docker container with index in GPUDeviceIDs
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-docker-container",
+			},
+			GPUDeviceIDs: []string{"0", "2"},
+		}
+
+		filteredDevices, err := MatchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 2)
+		assert.Equal(t, devices[0], filteredDevices[0])
+		assert.Equal(t, devices[2], filteredDevices[1])
+	})
+
+	t.Run("GPUDeviceIDsTakesPrecedenceOverResolvedAllocatedResources", func(t *testing.T) {
+		// GPUDeviceIDs should be used even if ResolvedAllocatedResources is set
+		container := &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   "test-precedence-container",
+			},
+			GPUDeviceIDs: []string{testutil.GPUUUIDs[0]}, // Should use this
+			ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
+				{
+					Name: string(gpuutil.GpuNvidiaGeneric),
+					ID:   testutil.GPUUUIDs[2], // Should NOT use this
+				},
+			},
+		}
+
+		filteredDevices, err := MatchContainerDevices(container, devices)
+		require.NoError(t, err)
+		require.Len(t, filteredDevices, 1)
+		assert.Equal(t, devices[0], filteredDevices[0]) // Should be device 0, not device 2
+	})
+}
+
 func TestMatchContainerDevicesWithErrors(t *testing.T) {
 	// Setup mock NVML with basic devices
 	ddnvml.WithMockNVML(t, testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled()))

--- a/releasenotes/notes/gpu-runtime-discovery-1a483dc61afce7e0.yaml
+++ b/releasenotes/notes/gpu-runtime-discovery-1a483dc61afce7e0.yaml
@@ -10,17 +10,16 @@ features:
   - |
     Added GPU runtime discovery support for ECS EC2 environments. The Datadog Agent
     can now detect GPU device UUIDs assigned to containers by extracting the
-    ``NVIDIA_VISIBLE_DEVICES`` environment variable from the Docker container runtime.
+    ``NVIDIA_VISIBLE_DEVICES`` environment variable from the Docker container configuration.
     This enables GPU-to-container mapping for GPU metrics without requiring the
     Kubernetes PodResources API, which is not available in ECS environments.
 enhancements:
   - |
     Added ``GPUDeviceIDs`` field to the workloadmeta Container entity to store
-    GPU device identifiers. This field is populated by the Docker collector from
-    the ``NVIDIA_VISIBLE_DEVICES`` environment variable and supports both UUID format
-    (e.g., ``GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``) and device index format
-    (e.g., ``0``, ``1``).
+    GPU device UUIDs. This field is populated by the Docker collector in ECS
+    environments from the ``NVIDIA_VISIBLE_DEVICES`` environment variable
+    (e.g., ``GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``).
   - |
     The GPU collector now uses ``GPUDeviceIDs`` from workloadmeta as the primary
-    source for GPU-to-container mapping, with fallback to the Kubernetes PodResources
-    API and procfs for legacy Docker environments.
+    source for GPU-to-container mapping in ECS, with fallback to procfs for
+    regular Docker environments and PodResources API for Kubernetes.

--- a/releasenotes/notes/gpu-runtime-discovery-1a483dc61afce7e0.yaml
+++ b/releasenotes/notes/gpu-runtime-discovery-1a483dc61afce7e0.yaml
@@ -1,0 +1,26 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added GPU runtime discovery support for ECS EC2 environments. The Datadog Agent
+    can now detect GPU device UUIDs assigned to containers by extracting the
+    ``NVIDIA_VISIBLE_DEVICES`` environment variable from the Docker container runtime.
+    This enables GPU-to-container mapping for GPU metrics without requiring the
+    Kubernetes PodResources API, which is not available in ECS environments.
+enhancements:
+  - |
+    Added ``GPUDeviceIDs`` field to the workloadmeta Container entity to store
+    GPU device identifiers. This field is populated by the Docker collector from
+    the ``NVIDIA_VISIBLE_DEVICES`` environment variable and supports both UUID format
+    (e.g., ``GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx``) and device index format
+    (e.g., ``0``, ``1``).
+  - |
+    The GPU collector now uses ``GPUDeviceIDs`` from workloadmeta as the primary
+    source for GPU-to-container mapping, with fallback to the Kubernetes PodResources
+    API and procfs for legacy Docker environments.


### PR DESCRIPTION
### What does this PR do?
This PR adds GPU runtime discovery support for ECS EC2 environments by extracting GPU device IDs from the `NVIDIA_VISIBLE_DEVICES` environment variable via the Docker collector. This fixes a bug where GPU-to-container mapping failed on ECS due to UUID format not being supported. 

### Motivation
GPU metrics on ECS EC2 were not properly tagged with container information because the existing code path only supported **index format** (`0`, `1`, `2`) but ECS uses **UUID format** (`GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`).

**Before this fix:**
```go
// Old code path for Docker containers
visibleDevices := strings.Split(visibleDevicesVar, ",")  // e.g., ["GPU-f42756fc-..."] on ECS
for _, device := range visibleDevices {
    matchingDevice, err := findDeviceByIndex(devices, device)  // ❌ FAILS! strconv.Atoi("GPU-xxx") errors
}
```

#### NVIDIA_VISIBLE_DEVICES Format by Environment

  | Environment                    | Format | Example                                  |
  |--------------------------------|--------|------------------------------------------|
  | Local Docker (--gpus device=0) | Index  | 0, 1, 0,2                                |
  | Docker Compose                 | Index  | 0, 1                                     |
  | ECS EC2                        | UUID   | GPU-f42756fc-18cb-7bc7-d22c-46bc7cb226fe |
  | Kubernetes (NVIDIA plugin)     | UUID   | GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx |


The UUID format is fixed and standardized by NVIDIA across all tools (NVML, nvidia-smi, container runtime).

#### Changes

 1. Data Model (`comp/core/workloadmeta/def/types.go`)
  - Added GPUDeviceIDs []string field to Container entity
  - Added GPU Info section to Container.String() for agent workload-list output

 2. Docker Collector (`comp/core/workloadmeta/collectors/internal/docker/docker.go`)
  - Added extractGPUDeviceIDsForECS() function that **only runs in ECS** (env.IsECS() check)
  - Parses NVIDIA_VISIBLE_DEVICES from Docker API container config (container.Config.Env)
  - Populates GPUDeviceIDs field during container discovery

3. GPU Collector (`pkg/gpu/containers/containers.go`)
  - Added `matchByGPUDeviceIDs()` to handle UUID format
  - **Preserved original precedence order**:
    1. `GPUDeviceIDs` (ECS only - checked first because ECS uses Docker runtime but needs UUID matching)
    2. Docker runtime → procfs (regular Docker unchanged)
    3. Other runtimes → `ResolvedAllocatedResources` (unchanged K8s with containerd/CRI)
  - **Preserves device order** from env var (no sorting) - this is the order CUDA uses when selecting devices

### Describe how you validated your changes

Cluster: `ecs-ec2-gpu-xxx` (g4dn.xlarge)
GPU UUID: `GPU-f42756fc-18cb-7bc7-d22c-46bc7cb226fe`

`agent workload-list` output now has GPU Info if gpu device is found:
```
=== Entity container sources(merged):[node_orchestrator runtime] id: 6cf0ff3f95175ff180801f87d48f204e6d25daff5d7a61b1c169de5a27bdfe41 ===
----------- Entity ID -----------
Kind: container ID: 6cf0ff3f95175ff180801f87d48f204e6d25daff5d7a61b1c169de5a27bdfe41
----------- Entity Meta -----------
Name: ecs-gpu-test-workload-2-gpu-info-dumper-ec9b92e49a83a98d3600
----------- Image -----------
Name: nvidia/cuda
Tag: 12.0.0-base-ubuntu22.04
----------- GPU Info -----------
GPU Device IDs: [GPU-f42756fc-18cb-7bc7-d22c-46bc7cb226fe]
```
**Behavior Comparison**

  | Environment           | GPUDeviceIDs | Runtime    | Path Used                       |
  |-----------------------|--------------|------------|---------------------------------|
  | ECS                   | ✅ Populated | Docker     | 1. GPUDeviceIDs (new)           |
  | Regular Docker        | ❌ Empty     | Docker     | 2. procfs (unchanged)           |
  | K8s (containerd)      | ❌ Empty     | containerd | 3. PodResources API (unchanged) |
  | K8s (Docker - legacy) | ❌ Empty     | Docker     | 2. procfs (unchanged)           |

GPU metrics with GPU uuid tag
<img width="1104" height="540" alt="Screenshot 2026-01-07 at 11 39 39 PM" src="https://github.com/user-attachments/assets/b45ebea3-89fd-4501-9d59-463a3eac3ddd" />


### Additional Notes

#### Why Not ECS Task Metadata API?

We investigated using the ECS Task Metadata v4 API but found it does **not** expose `gpuIds` yet.