### PR TITLE
fix(Tagger): Retry Tag Enrichment on Invalid Entity IDs

### DIFF
--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -19,7 +19,6 @@ import (
 type Component interface {
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
-	AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error
 	Standard(entityID types.EntityID) ([]string, error)
 	List() types.TaggerListResponse
 	GetEntity(entityID types.EntityID) (*types.Entity, error)

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -33,10 +33,6 @@ func (n *noopTagger) GenerateContainerIDFromOriginInfo(origindetection.OriginInf
 	return "", nil
 }
 
-func (n *noopTagger) AccumulateTagsFor(types.EntityID, types.TagCardinality, tagset.TagsAccumulator) error {
-	return nil
-}
-
 func (n *noopTagger) Standard(types.EntityID) ([]string, error) {
 	return nil, nil
 }

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -370,8 +370,8 @@ func (t *remoteTagger) queryContainerIDFromOriginInfo(originInfo origindetection
 	return containerID, err
 }
 
-// AccumulateTagsFor returns tags for a given entity at the desired cardinality.
-func (t *remoteTagger) AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
+// accumulateTagsFor returns tags for a given entity at the desired cardinality.
+func (t *remoteTagger) accumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
 	tags, err := t.Tag(entityID, cardinality)
 	if err != nil {
 		return err
@@ -450,7 +450,7 @@ func (t *remoteTagger) GlobalTags(cardinality types.TagCardinality) ([]string, e
 // and they always use the local tagger.
 // This function can only add the global tags.
 func (t *remoteTagger) EnrichTags(tb tagset.TagsAccumulator, _ taggertypes.OriginInfo) {
-	if err := t.AccumulateTagsFor(types.GetGlobalEntityID(), t.dogstatsdCardinality, tb); err != nil {
+	if err := t.accumulateTagsFor(types.GetGlobalEntityID(), t.dogstatsdCardinality, tb); err != nil {
 		t.log.Error(err.Error())
 	}
 }

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -459,16 +459,7 @@ func (t *localTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertyp
 
 		// Enrich tags prioritzing most reliable origin detection methods first.
 
-		// 1. ContainerID from LocalData (includes inode resolution)
-		if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, originInfo.LocalData.ContainerID), cardinality, tb); err != nil {
-			if pkglog.ShouldLog(pkglog.TraceLvl) {
-				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.ContainerID, err)
-			}
-		} else {
-			return
-		}
-
-		// 2. ContainerID from Unix Domain Socket (process ID-based)
+		// 1. ContainerID from Unix Domain Socket (process ID-based)
 		if originInfo.ContainerIDFromSocket != packets.NoOrigin && len(originInfo.ContainerIDFromSocket) > containerIDFromSocketCutIndex {
 			containerID := originInfo.ContainerIDFromSocket[containerIDFromSocketCutIndex:]
 			if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, containerID), cardinality, tb); err != nil && err != tagstore.ErrNotFound {
@@ -476,6 +467,15 @@ func (t *localTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertyp
 			} else {
 				return
 			}
+		}
+
+		// 2. ContainerID from LocalData (includes inode resolution)
+		if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, originInfo.LocalData.ContainerID), cardinality, tb); err != nil {
+			if pkglog.ShouldLog(pkglog.TraceLvl) {
+				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.ContainerID, err)
+			}
+		} else {
+			return
 		}
 
 		// 3. ContainerID generated from ExternalData

--- a/comp/core/tagger/impl/tagger_mock.go
+++ b/comp/core/tagger/impl/tagger_mock.go
@@ -114,11 +114,6 @@ func (f *fakeTagger) GenerateContainerIDFromOriginInfo(originInfo origindetectio
 	return f.tagger.GenerateContainerIDFromOriginInfo(originInfo)
 }
 
-// AccumulateTagsFor calls tagger.AccumulateTagsFor().
-func (f *fakeTagger) AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
-	return f.tagger.AccumulateTagsFor(entityID, cardinality, tb)
-}
-
 // Standard calls tagger.Standard().
 func (f *fakeTagger) Standard(entityID types.EntityID) ([]string, error) {
 	return f.tagger.Standard(entityID)

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -87,6 +87,10 @@ func TestTag(t *testing.T) {
 		},
 	})
 
+	noneCardTags, err := fakeTagger.Tag(entityID, types.NoneCardinality)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{}, noneCardTags)
+
 	lowCardTags, err := fakeTagger.Tag(entityID, types.LowCardinality)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"low1", "low2"}, lowCardTags)
@@ -98,6 +102,10 @@ func TestTag(t *testing.T) {
 	highCardTags, err := fakeTagger.Tag(entityID, types.HighCardinality)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"low1", "low2", "orchestrator1", "orchestrator2", "high1", "high2"}, highCardTags)
+
+	undefinedTags, err := fakeTagger.Tag(types.NewEntityID(types.ContainerID, "undefined-entity"), types.HighCardinality)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{}, undefinedTags)
 }
 
 func TestGenerateContainerIDFromOriginInfo(t *testing.T) {

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -88,6 +88,12 @@ func TestAccumulateTagsFor(t *testing.T) {
 	err := fakeTagger.AccumulateTagsFor(entityID, types.HighCardinality, tb)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []string{"high", "low1", "low2"}, tb.Get())
+
+	nonExistentEntityID := types.NewEntityID(types.ContainerID, "non_existent_entity")
+	tb = tagset.NewHashlessTagsAccumulator()
+	err = fakeTagger.AccumulateTagsFor(nonExistentEntityID, types.HighCardinality, tb)
+	assert.Error(t, err)
+	assert.Empty(t, tb.Get())
 }
 
 func TestTag(t *testing.T) {

--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -263,16 +263,17 @@ func (s *TagStore) LookupHashed(entityID types.EntityID, cardinality types.TagCa
 // This function is needed only for performance reasons. It functions like
 // LookupHashed, but accepts a string instead of an EntityID. This reduces the
 // allocations that occur when an EntityID is passed as a parameter.
-func (s *TagStore) LookupHashedWithEntityStr(entityID types.EntityID, cardinality types.TagCardinality) tagset.HashedTags {
+// Returns ErrNotFound if the entity is not present in the store.
+func (s *TagStore) LookupHashedWithEntityStr(entityID types.EntityID, cardinality types.TagCardinality) (tagset.HashedTags, error) {
 	s.RLock()
 	defer s.RUnlock()
 
 	storedTags, present := s.store.Get(entityID)
 	if !present {
-		return tagset.HashedTags{}
+		return tagset.HashedTags{}, ErrNotFound
 	}
 
-	return storedTags.getHashedTags(cardinality)
+	return storedTags.getHashedTags(cardinality), nil
 }
 
 // Lookup gets tags from the store and returns them concatenated in a string slice.

--- a/comp/core/tagger/tagstore/tagstore_test.go
+++ b/comp/core/tagger/tagstore/tagstore_test.go
@@ -117,15 +117,25 @@ func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
 		},
 	})
 
-	tagsLow := s.tagstore.LookupHashedWithEntityStr(entityID, types.LowCardinality)
-	tagsOrch := s.tagstore.LookupHashedWithEntityStr(entityID, types.OrchestratorCardinality)
-	tagsHigh := s.tagstore.LookupHashedWithEntityStr(entityID, types.HighCardinality)
-	tagsNone := s.tagstore.LookupHashedWithEntityStr(entityID, types.NoneCardinality)
+	tagsLow, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.LowCardinality)
+	assert.NoError(s.T(), err)
+	tagsOrch, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.OrchestratorCardinality)
+	assert.NoError(s.T(), err)
+	tagsHigh, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.HighCardinality)
+	assert.NoError(s.T(), err)
+	tagsNone, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.NoneCardinality)
+	assert.NoError(s.T(), err)
 
 	assert.ElementsMatch(s.T(), tagsLow.Get(), []string{"low1", "low2"})
 	assert.ElementsMatch(s.T(), tagsOrch.Get(), []string{"low1", "low2", "orchestrator1"})
 	assert.ElementsMatch(s.T(), tagsHigh.Get(), []string{"low1", "low2", "orchestrator1", "high1"})
 	assert.ElementsMatch(s.T(), tagsNone.Get(), []string{})
+
+	// Test entity not found
+	nonExistentEntityID := types.NewEntityID(types.ContainerID, "non_existent")
+	_, err = s.tagstore.LookupHashedWithEntityStr(nonExistentEntityID, types.LowCardinality)
+	assert.Error(s.T(), err)
+	assert.Equal(s.T(), ErrNotFound, err)
 }
 
 func (s *StoreTestSuite) TestLookupStandard() {

--- a/releasenotes/notes/crio-tagging-dsd-693d99fdda776dfb.yaml
+++ b/releasenotes/notes/crio-tagging-dsd-693d99fdda776dfb.yaml
@@ -10,6 +10,6 @@ fixes:
   - |
     Updates tag enrichment logic to retry on failed tag resolution attempts.
     This regression was introduced in #41587 on Agent v7.73+.
-    Impacts origin detection on cgroupv2 runtimes with dogstatsd which led
-    to tags not being enriched even if origin detection was possible by
+    Impacts origin detection on cgroup v2 runtimes with DogStatsD, which led
+    to tags not being enriched, even if origin detection was possible by
     using other methods like container ID from socket or ExternalData.

--- a/releasenotes/notes/crio-tagging-dsd-693d99fdda776dfb.yaml
+++ b/releasenotes/notes/crio-tagging-dsd-693d99fdda776dfb.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Updates tag enrichment logic to retry on failed tag resolution attempts.
+    This regression was introduced in #41587 on Agent v7.73+.
+    Impacts origin detection on cgroupv2 runtimes with dogstatsd which led
+    to tags not being enriched even if origin detection was possible by
+    using other methods like container ID from socket or ExternalData.


### PR DESCRIPTION
### What does this PR do?

Previously, the `AccumlateTags` method would only throw an error if the provided EntityID was empty/nil. However, if the provided EntityID is invalid (no tags exist in the tagger), no error will be thrown and the tag enrichment will exit successfully without trying backup methods.

This PR updates tag enrichment steps to continue to fallback to other resolution methods when tags are not found for a given EntityID.

### Motivation

Fix bug on CRI-O container runtime with dogstatsd tagging which causes improper tagging to occur. The DogstatsD client provided the cri-o sandbox ID within `originInfo.LocalData.ContainerID` which causes tag enrichment to exit early even though no tags exist for the entityID.

We are able to detect the container from the socket in `originInfo.ContainerIDFromSocket` when using UDS or can also fallback to using `originInfo.ExternalData` in Kubernetes environments.

CONTP-1181

### Describe how you validated your changes

Deploy minikube cluster with CRIO runtime: `minikube start --container-runtime=cri-o`

Deploy DogStatsD dummy application:

```
apiVersion: v1
kind: Pod
metadata:
  name: dogstatsd-test-uds
  labels:
    app: dogstatsd-test-uds
spec:
  containers:
    - name: dogstatsd
      image: ghcr.io/datadog/apps-dogstatsd:latest
      env:
        - name: STATSD_URL
          value: "unix:///var/run/datadog/dsd.socket"
      volumeMounts:
        - name: datadog-socket
          mountPath: /var/run/datadog
  volumes:
    - name: datadog-socket
      hostPath:
        path: /var/run/datadog
```

Deploy Agent with DogStatsD collection and unified origin detection enabled:

```
datadog:
  kubelet:
    tlsVerify: false
  clusterName: <INSERT_NAME>
  originDetectionUnified:
    enabled: true
  dogstatsd:
    originDetection: true
    tagCardinality: high
```

Verify that the `custom.metric` generated by the dummy application has container/k8s tags.
