### PR TITLE
replace simplelru with thread-safe lru

### DIFF
--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -16,7 +16,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pdhutil"
@@ -46,11 +46,11 @@ var (
 	PIDBufferIncrement uint32 = 1024
 )
 
-var fileDescCache *simplelru.LRU[string, string]
+var fileDescCache *lru.Cache[string, string]
 
 func init() {
 	var err error
-	fileDescCache, err = simplelru.NewLRU[string, string](512, nil)
+	fileDescCache, err = lru.New[string, string](512)
 	if err != nil {
 		log.Errorf("Failed to create file description cache: %v", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Fixes a panic caused by concurrent map access in Windows process-agent file description cache. Replace `simplelru.LRU` with the thread-safe `lru.Cache` from the same `hashicorp/golang-lru/v2` package. The `lru.Cache` wraps `simplelru.LRU` with a mutex, making it safe for concurrent access.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2131
Fix runtime panic in the process agent on Windows.
