### PR TITLE
[CWS] Tests with more kprobes available

### DIFF
--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -92,6 +92,7 @@ event_monitoring_config:
   event_stream:
     use_fentry: true
     use_kprobe_fallback: false
+    kretprobe_max_active: 4096
 {{if .DisableFilters}}
   enable_kernel_filters: false
 {{end}}


### PR DESCRIPTION
### What does this PR do?
Increase the number of max kprobes available in tests to see if it reduces the number of failing tests (and timeouts).
es