### PR TITLE
[CWS] Fix calculation of bitmask combinations

### DIFF
--- a/pkg/security/secl/rules/approvers.go
+++ b/pkg/security/secl/rules/approvers.go
@@ -199,9 +199,9 @@ func bitmaskCombinations(bitmasks []int) []int {
 		return nil
 	}
 
-	combinationCount := 1 << len(bitmasks)
+	combinationCount := (1 << len(bitmasks)) - 1
 	result := make([]int, 0, combinationCount)
-	for i := 0; i < combinationCount; i++ {
+	for i := 1; i <= combinationCount; i++ {
 		var mask int
 		for j, value := range bitmasks {
 			if (i & (1 << j)) > 0 {

--- a/pkg/security/secl/rules/approvers_test.go
+++ b/pkg/security/secl/rules/approvers_test.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package rules holds rules related files
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBitmaskCombinations(t *testing.T) {
+	testCases := []struct {
+		values               []int
+		expectedCombinaisons []int
+	}{
+		{
+			values:               []int{},
+			expectedCombinaisons: []int{},
+		},
+		{
+			values:               []int{0},
+			expectedCombinaisons: []int{0},
+		},
+		{
+			values:               []int{1},
+			expectedCombinaisons: []int{1},
+		},
+		{
+			values:               []int{1, 2},
+			expectedCombinaisons: []int{1, 2, 1 | 2},
+		},
+		{
+			values:               []int{1, 2, 4},
+			expectedCombinaisons: []int{1, 2, 4, 1 | 2, 1 | 4, 2 | 4, 1 | 2 | 4},
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			result := bitmaskCombinations(testCase.values)
+			assert.ElementsMatch(t, result, testCase.expectedCombinaisons)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fix the `bitmaskCombinations` function that was always returning `0` as a combination option even when `0` wasn't passed in as an argument. 

### Motivation

### Describe how you validated your changes

Added unit tests.

### Additional Notes
