### PR TITLE
[CONTINT-4794]: Add a flag to alter kube_service tag behavior

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -225,9 +225,13 @@ func (c *collector) parsePods(
 			log.Debugf("Could not fetch metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
 		}
 
-		// Skip `kube_service` label for pods that are not ready (since their endpoint will be disabled from the service)
 		services := []string{}
-		if kubelet.IsPodReady(pod) {
+
+		// collectService if new kube_service bahavior is active
+		// or if not active, use old condition IsPodReady
+		collectService := pkgconfigsetup.Datadog().GetBool("kubernetes_kube_service_new_behavior") || kubelet.IsPodReady(pod)
+
+		if collectService {
 			for _, data := range metadata {
 				d := strings.Split(data, ":")
 				switch len(d) {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2072,6 +2072,7 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("kubernetes_map_services_on_ip", false) // temporary opt-out of the new mapping logic
 	config.BindEnvAndSetDefault("kubernetes_apiserver_use_protobuf", false)
 	config.BindEnvAndSetDefault("kubernetes_ad_tags_disabled", []string{})
+	config.BindEnvAndSetDefault("kubernetes_kube_service_new_behavior", false)
 
 	if runtime.GOOS == "windows" {
 		config.BindEnvAndSetDefault("kubernetes_kubelet_podresources_socket", `\\.\pipe\kubelet-pod-resources`)

--- a/releasenotes/notes/alter-kube-service-flag-c1fba27917047437.yaml
+++ b/releasenotes/notes/alter-kube-service-flag-c1fba27917047437.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a `kubernetes_kube_service_new_behavior` flag (default false) to alter kube_service tag behavior.
+    If flag is set to true kube_service tag is attached unconditionaly.
+    Old behavior was that tag only attached when k8s service has status Ready.

--- a/releasenotes/notes/alter-kube-service-flag-c1fba27917047437.yaml
+++ b/releasenotes/notes/alter-kube-service-flag-c1fba27917047437.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Add a `kubernetes_kube_service_new_behavior` flag (default false) to alter kube_service tag behavior.
-    If flag is set to true kube_service tag is attached unconditionaly.
-    Old behavior was that tag only attached when k8s service has status Ready.
+    Adds a `kubernetes_kube_service_new_behavior` flag (default false) to alter `kube_service` tag behavior.
+    If the flag is set to true, `kube_service` tag is attached unconditionally.
+    Previously, the tag was only attached when the Kubernetes service has the status `Ready`.


### PR DESCRIPTION
### What does this PR do?
`kube_service` is attached unconditionally (w/o respecting pod_ready status) if flag is set true.

### Motivation
Fix flaky behavior customers has complained about.
https://datadoghq.atlassian.net/browse/CONTINT-4794

### Describe how you validated your changes
1. Create kind cluster
2. Deploy an agent with default values
3. Deploy test load that has probes
```
          livenessProbe:
            httpGet:
              # host: 0.0.0.0
              port: 80
              path: /livez

          readinessProbe:
            httpGet:
              # host: 0.0.0.0
              port: 80
              path: /readyz
            periodSeconds: 5

          startupProbe:
            httpGet:
              path: /startup
              port: 80
            failureThreshold: 30
            periodSeconds: 3
```

testload code:
```go
package main

import (
	"context"
	"log"
	"log/slog"
	"net/http"
	"os"
	"os/signal"
	"syscall"
	"time"
)

func main() {
	var srv http.Server
	srv.Addr = ":80"

	// Make a channel to exit the function
	stopCh := make(chan error)

	go func() {
		// Setup a channel to catch OS signals
		signalCh := make(chan os.Signal, 1)
		signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)

		sig := <-signalCh
		log.Printf("Received signal '%s', shutting down...", sig)

		// We received an interrupt signal, shut down.
		if err := srv.Shutdown(context.Background()); err != nil {
			// Error from closing listeners, or context timeout:
			log.Printf("HTTP server Shutdown: %v", err)
		}
		close(stopCh)
	}()

	var tLive time.Time
	tStart := time.Now()
	failReadiness := true

	startup := func(w http.ResponseWriter, _ *http.Request) {
		slog.Info("Startup probe")
		if time.Since(tStart) > 80 * time.Second {
			w.WriteHeader(http.StatusOK)
		} else {
			w.WriteHeader(http.StatusInternalServerError)
		}
	}

	live := func(w http.ResponseWriter, _ *http.Request) {
		slog.Info("Livez")
		w.WriteHeader(http.StatusOK)
		if tLive.Equal(time.Time{}) {
			tLive = time.Now()
			failReadiness = false
		}
	}

	ready := func(w http.ResponseWriter, _ *http.Request) {
		slog.Info("Readyz")
		if !failReadiness && time.Since(tLive) > 120 * time.Second {
			w.WriteHeader(http.StatusOK)
			slog.Info("Readyz OK")
		} else {
			w.WriteHeader(http.StatusInternalServerError)
			slog.Info("Readyz NOK")
		}
	}

	http.HandleFunc("/livez", live)
	http.HandleFunc("/readyz", ready)
	http.HandleFunc("/startup", startup)

	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
		// Error starting or closing listener:
		log.Fatalf("HTTP server ListenAndServe: %v", err)
	}

	<-stopCh
}
```

Docker file for the image

```docker
FROM ubuntu:24.04

COPY main_linux /bin/main

EXPOSE 80
EXPOSE 5005

CMD ["/bin/main"]
```

Services:
```yaml
---
apiVersion: v1
kind: Service
metadata:
  name: {{ include "testload.fullname" . }}-service1
  # namespace: default
  labels:
    {{- include "testload.labels" . | nindent 4 }}
spec:
  selector:
    {{- include "testload.selectorLabels" . | nindent 4 }}
  ports:
    - port: 8080
      targetPort: main-port
      protocol: TCP
---
apiVersion: v1
kind: Service
metadata:
  name: {{ include "testload.fullname" . }}-service2
  # namespace: default
  labels: {}
spec:
  type: ClusterIP
  selector:
    {{- include "testload.selectorLabels" . | nindent 4 }}
  ports:
    - port: 5005
      targetPort: test-port
      protocol: TCP
```

### Additional Notes
Fixed behavior:
![endpoints-with-fix-split-na](https://github.com/user-attachments/assets/c1a7cf41-ebfa-478d-89ac-e6be9eb5f612)

Regular behavior:
![enpoints-no-fix](https://github.com/user-attachments/assets/5d7a6e30-489a-41be-b3f2-665626ced6ec)
