### PR TITLE
Don't pack nil values in 'agent check' marshalling

### DIFF
--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -202,7 +202,7 @@ func (series *Series) Append(serie *Serie) {
 // MarshalStrings converts the timeseries to a sorted slice of string slices
 func (series Series) MarshalStrings() ([]string, [][]string) {
 	headers := []string{"Metric", "Type", "Timestamp", "Value", "Tags"}
-	payload := make([][]string, len(series))
+	payload := make([][]string, 0, len(series))
 
 	for _, serie := range series {
 		payload = append(payload, []string{

--- a/pkg/metrics/servicecheck/service_check.go
+++ b/pkg/metrics/servicecheck/service_check.go
@@ -69,7 +69,7 @@ type ServiceChecks []*ServiceCheck
 // MarshalStrings converts the service checks to a sorted slice of string slices
 func (sc ServiceChecks) MarshalStrings() ([]string, [][]string) {
 	var headers = []string{"Check", "Hostname", "Timestamp", "Status", "Message", "Tags"}
-	var payload = make([][]string, len(sc))
+	var payload = make([][]string, 0, len(sc))
 
 	for _, c := range sc {
 		payload = append(payload, []string{


### PR DESCRIPTION
### What does this PR do?

This commit fixes a bug where agent check's marshalling code packed `len(x)` nil entries ahead of the check lines, appending those behind them. `make([][]string, len(x))` pre-allocates `len(x)` nil elements. `make([][]string, 0, len(x))` pre-allocates capacity but with zero length.

### Motivation

This code should pre-allocate its capacity and not require `2*len(x)` storage, nor do we want the first half of storage to be nil'ed. I have adjusted the `make` calls to achieve this.

