### PR TITLE
Don't prepend `pids` with 0 values

### DIFF
--- a/pkg/util/containers/metrics/containerd/collector.go
+++ b/pkg/util/containers/metrics/containerd/collector.go
@@ -145,7 +145,7 @@ func (c *containerdCollector) GetPIDs(containerNS, containerID string, _ time.Du
 		return nil, err
 	}
 
-	pids := make([]int, len(processes))
+	pids := make([]int, 0, len(processes))
 	for _, process := range processes {
 		pids = append(pids, int(process.Pid))
 	}


### PR DESCRIPTION
### What does this PR do?

This commit -- similar to the logic in PR #44835 -- adjusts the call to `make([]int, len(processes))` to be `make([]int, 0, len(processes))`. This does two things. Firstly, we no longer unnecessarily prepend zeros to the pid array. If 0 appears in the `pids` array it should be the value of `process.Pid`. Second, we now avoid doubling the space needed by `pids`, allocating exactly the capacity needed before the append loop.

