### PR TITLE
Prevent slice corruption in tagsToStringArray

### DIFF
--- a/pkg/logs/message/origin.go
+++ b/pkg/logs/message/origin.go
@@ -80,17 +80,27 @@ func (o *Origin) TagsToString(processingTags []string) string {
 }
 
 func (o *Origin) tagsToStringArray(processingTags []string) []string {
-	tags := o.tags
-
 	sourceCategory := o.LogSource.Config.SourceCategory
+	configTags := o.LogSource.Config.Tags
+
+	// Calculate total capacity needed
+	totalLen := len(o.tags) + len(configTags) + len(processingTags)
 	if sourceCategory != "" {
-		tags = append(tags, "sourcecategory"+":"+sourceCategory)
+		totalLen++
 	}
 
-	tags = append(tags, o.LogSource.Config.Tags...)
-	tags = append(tags, processingTags...)
+	// Preallocate result slice - don't modify o.tags
+	result := make([]string, 0, totalLen)
+	result = append(result, o.tags...)
 
-	return tags
+	if sourceCategory != "" {
+		result = append(result, "sourcecategory:"+sourceCategory)
+	}
+
+	result = append(result, configTags...)
+	result = append(result, processingTags...)
+
+	return result
 }
 
 // SetTags sets the tags of the origin.

--- a/pkg/logs/message/origin_slice_aliasing_test.go
+++ b/pkg/logs/message/origin_slice_aliasing_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package message
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+)
+
+// TestTags_NoMutation verifies that Tags() does not mutate the origin's tags slice.
+//
+// Accidental mutation may happen if for instance `tags := o.tags; append(tags,
+// ...)` is used, creating an alias that shares the backing array. If there's spare
+// capacity in `o.tags` then `append()` modifies the shared backing array.
+//
+// The consequence of this is a mistagging of logs.
+func TestTags_NoMutation(t *testing.T) {
+	cfg := &config.LogsConfig{}
+	source := sources.NewLogSource("", cfg)
+	origin := NewOrigin(source)
+
+	// Set tags with extra capacity to expose aliasing bugs
+	tagsWithCapacity := make([]string, 2, 10)
+	tagsWithCapacity[0] = "tag1:value1"
+	tagsWithCapacity[1] = "tag2:value2"
+	origin.SetTags(tagsWithCapacity)
+
+	// Capture original state
+	originalTags := origin.tags
+	originalLen := len(originalTags)
+
+	result := origin.Tags([]string{"proc1", "proc2"})
+
+	// Verify: Result contains all expected tags
+	assert.Contains(t, result, "tag1:value1")
+	assert.Contains(t, result, "tag2:value2")
+	assert.Contains(t, result, "proc1")
+	assert.Contains(t, result, "proc2")
+
+	// Verify: Original wasn't mutated
+	assert.Len(t, originalTags, originalLen, "origin.tags should not be modified")
+	assert.Equal(t, "tag1:value1", origin.tags[0])
+	assert.Equal(t, "tag2:value2", origin.tags[1])
+}


### PR DESCRIPTION
### Motivation

The original code would accidentally mutate `o.tags` when `cap(o.tags) > len(o.tags)`. This would happen because an alias of `o.tags` was created, sharing the original backing array, and was then appended to. This meant that the backing array could be visibly modified.

`TestTags_NoMutation` demonstrates that origin tags are not modified. The new result array is pre-allocated to the exact capacity required.

