### PR TITLE
Pre-allocate in normalizeTags

### DIFF
--- a/pkg/logs/internal/parsers/integrations/integrations.go
+++ b/pkg/logs/internal/parsers/integrations/integrations.go
@@ -72,7 +72,7 @@ func (p *integrationFileFormat) Parse(msg *message.Message) (*message.Message, e
 
 // normalizeTags removes any whitespace and blank tags from the taglist
 func normalizeTags(tags []string) []string {
-	var normalizedTags []string
+	normalizedTags := make([]string, 0, len(tags))
 	for i, tag := range tags {
 		tags[i] = strings.TrimSpace(tag)
 	}

--- a/pkg/logs/internal/parsers/integrations/integrations_test.go
+++ b/pkg/logs/internal/parsers/integrations/integrations_test.go
@@ -6,6 +6,7 @@
 package integrations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,4 +101,25 @@ func TestIntegrationsFile(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(`{"log":"foo bar"}`), msg.GetContent())
 	assert.Equal(t, []string{"foo:bar", "env:prød", "sp@ce:ch@r"}, msg.ParsingExtra.Tags)
+}
+
+// BenchmarkNormalizeTags benchmarks the normalizeTags function
+func BenchmarkNormalizeTags(b *testing.B) {
+	// Test with realistic tag counts (5-20 tags)
+	for _, tagCount := range []int{5, 10, 20} {
+		b.Run(fmt.Sprintf("%d_tags", tagCount), func(b *testing.B) {
+			tags := make([]string, tagCount)
+			for i := 0; i < tagCount; i++ {
+				tags[i] = fmt.Sprintf("  tag%d:value  ", i)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Create a copy since normalizeTags modifies in place (existing behavior)
+				tagsCopy := make([]string, len(tags))
+				copy(tagsCopy, tags)
+				_ = normalizeTags(tagsCopy)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This commit pre-allocates the result slice based on the input length of `normalizeTags`. This reduces the total number of allocations to a constant 2/op from a previously variable number.

### Motivation

`NormalizeTags` benchmark demonstrates ~50% improvement in allocations and runtime. The results below are measured with `main` branch as baseline:

```
Benchmark results for normalizeTags (n=10):
                          │  baseline  │   optimized   │
                          │   sec/op   │ sec/op vs base│
NormalizeTags/5_tags-32      352ns        178ns   -49.43%
NormalizeTags/10_tags-32     596ns        308ns   -48.32%
NormalizeTags/20_tags-32    1052ns        530ns   -49.62%

                          │ baseline │   optimized   │
                          │   B/op   │  B/op vs base │
NormalizeTags/5_tags-32      320        160      -50.00%
NormalizeTags/10_tags-32     656        320      -51.22%
NormalizeTags/20_tags-32    1328        640      -51.81%

                          │ baseline │   optimized    │
                          │ allocs/op│ allocs/op vs   │
NormalizeTags/5_tags-32        5          2       -60.00%
NormalizeTags/10_tags-32       6          2       -66.67%
NormalizeTags/20_tags-32       7          2       -71.43%
```
