### PR TITLE
[CWS] do not allow constant init from outside of the model package

### DIFF
--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -281,7 +281,7 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 		// Access the EBPFProbe to get the UserSessionsResolver
 		if ebpfProbe, ok := p.PlatformProbe.(*probe.EBPFProbe); ok {
 			if model.UserSessionTypeStrings == nil {
-				model.InitUserSessionTypes()
+				model.SECLConstants()
 			}
 			// Create the user session context serializer
 			userSessionCtx := &serializers.SSHSessionContextSerializer{

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -280,9 +280,6 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 	if ev.ProcessContext.UserSession.SSHSessionID != 0 {
 		// Access the EBPFProbe to get the UserSessionsResolver
 		if ebpfProbe, ok := p.PlatformProbe.(*probe.EBPFProbe); ok {
-			if model.UserSessionTypeStrings == nil {
-				model.SECLConstants()
-			}
 			// Create the user session context serializer
 			userSessionCtx := &serializers.SSHSessionContextSerializer{
 				SSHSessionID:  strconv.FormatUint(uint64(ev.ProcessContext.UserSession.SSHSessionID), 16),

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -141,10 +141,7 @@ func (p *SSHUserSessionPatcher) PatchEvent(ev *serializers.EventSerializer) {
 	p.resolver.SSHSessionParsed.Mu.Unlock()
 
 	if ok {
-		if model.SSHAuthMethodStrings == nil {
-			model.SECLConstants()
-		}
-		ev.ProcessContextSerializer.UserSession.SSHAuthMethod = model.SSHAuthMethodStrings[usersession.AuthType(value.AuthenticationMethod)]
+		ev.ProcessContextSerializer.UserSession.SSHAuthMethod = model.SSHAuthMethodToString(usersession.AuthType(value.AuthenticationMethod))
 		ev.ProcessContextSerializer.UserSession.SSHPublicKey = value.PublicKey
 	}
 }

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -142,7 +142,7 @@ func (p *SSHUserSessionPatcher) PatchEvent(ev *serializers.EventSerializer) {
 
 	if ok {
 		if model.SSHAuthMethodStrings == nil {
-			model.InitSSHAuthMethodConstants()
+			model.SECLConstants()
 		}
 		ev.ProcessContextSerializer.UserSession.SSHAuthMethod = model.SSHAuthMethodStrings[usersession.AuthType(value.AuthenticationMethod)]
 		ev.ProcessContextSerializer.UserSession.SSHPublicKey = value.PublicKey

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -638,16 +638,14 @@ func initLinkageTypeConstants() {
 	}
 }
 
-// InitUserSessionTypes initialize the constants for user session types
-func InitUserSessionTypes() {
+func initUserSessionTypes() {
 	for k, v := range UserSessionTypes {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		UserSessionTypeStrings[v] = k
 	}
 }
 
-// InitSSHAuthMethodConstants initialize the constants for SSH auth methods
-func InitSSHAuthMethodConstants() {
+func initSSHAuthMethodConstants() {
 	for k, v := range SSHAuthMethodConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
 		SSHAuthMethodStrings[v] = k
@@ -701,8 +699,8 @@ func initConstants() {
 	initSocketFamilyConstants()
 	initSocketProtocolConstants()
 	initPrCtlOptionConstants()
-	InitUserSessionTypes()
-	InitSSHAuthMethodConstants()
+	initUserSessionTypes()
+	initSSHAuthMethodConstants()
 }
 
 // RetValError represents a syscall return error value

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -486,9 +486,9 @@ var (
 	fileTypeStrings            = map[FileType]string{}
 	linkageTypeStrings         = map[LinkageType]string{}
 	// UserSessionTypeStrings are the supported user session types
-	UserSessionTypeStrings = map[usersession.Type]string{}
+	userSessionTypeStrings = map[usersession.Type]string{}
 	// SSHAuthMethodStrings are the supported SSH authentication methods
-	SSHAuthMethodStrings = map[usersession.AuthType]string{}
+	sshAuthMethodStrings = map[usersession.AuthType]string{}
 )
 
 // File flags
@@ -641,14 +641,14 @@ func initLinkageTypeConstants() {
 func initUserSessionTypes() {
 	for k, v := range UserSessionTypes {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		UserSessionTypeStrings[v] = k
+		userSessionTypeStrings[v] = k
 	}
 }
 
 func initSSHAuthMethodConstants() {
 	for k, v := range SSHAuthMethodConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		SSHAuthMethodStrings[v] = k
+		sshAuthMethodStrings[v] = k
 	}
 }
 
@@ -1184,4 +1184,25 @@ func (l LinkageType) String() string {
 		initLinkageTypeConstants()
 	}
 	return linkageTypeStrings[l]
+}
+
+// UserSessionTypeToString converts a usersession.Type to its string representation
+func UserSessionTypeToString(t usersession.Type) string {
+	// init constants if needed
+	SECLConstants()
+
+	if val, ok := userSessionTypeStrings[t]; ok {
+		return val
+	}
+	return ""
+}
+
+func SSHAuthMethodToString(t usersession.AuthType) string {
+	// init constants if needed
+	SECLConstants()
+
+	if val, ok := sshAuthMethodStrings[t]; ok {
+		return val
+	}
+	return ""
 }

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -486,9 +486,9 @@ var (
 	fileTypeStrings            = map[FileType]string{}
 	linkageTypeStrings         = map[LinkageType]string{}
 	// UserSessionTypeStrings are the supported user session types
-	UserSessionTypeStrings = map[usersession.Type]string{}
+	userSessionTypeStrings = map[usersession.Type]string{}
 	// SSHAuthMethodStrings are the supported SSH authentication methods
-	SSHAuthMethodStrings = map[usersession.AuthType]string{}
+	sshAuthMethodStrings = map[usersession.AuthType]string{}
 )
 
 // File flags
@@ -638,19 +638,17 @@ func initLinkageTypeConstants() {
 	}
 }
 
-// InitUserSessionTypes initialize the constants for user session types
-func InitUserSessionTypes() {
+func initUserSessionTypes() {
 	for k, v := range UserSessionTypes {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		UserSessionTypeStrings[v] = k
+		userSessionTypeStrings[v] = k
 	}
 }
 
-// InitSSHAuthMethodConstants initialize the constants for SSH auth methods
-func InitSSHAuthMethodConstants() {
+func initSSHAuthMethodConstants() {
 	for k, v := range SSHAuthMethodConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		SSHAuthMethodStrings[v] = k
+		sshAuthMethodStrings[v] = k
 	}
 }
 
@@ -701,8 +699,8 @@ func initConstants() {
 	initSocketFamilyConstants()
 	initSocketProtocolConstants()
 	initPrCtlOptionConstants()
-	InitUserSessionTypes()
-	InitSSHAuthMethodConstants()
+	initUserSessionTypes()
+	initSSHAuthMethodConstants()
 }
 
 // RetValError represents a syscall return error value
@@ -1186,4 +1184,25 @@ func (l LinkageType) String() string {
 		initLinkageTypeConstants()
 	}
 	return linkageTypeStrings[l]
+}
+
+// UserSessionTypeToString converts a usersession.Type to its string representation
+func UserSessionTypeToString(t usersession.Type) string {
+	// init constants if needed
+	SECLConstants()
+
+	if val, ok := userSessionTypeStrings[t]; ok {
+		return val
+	}
+	return ""
+}
+
+func SSHAuthMethodToString(t usersession.AuthType) string {
+	// init constants if needed
+	SECLConstants()
+
+	if val, ok := sshAuthMethodStrings[t]; ok {
+		return val
+	}
+	return ""
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1031,7 +1031,7 @@ func serializeK8sContext(e *model.Event, ctx *model.UserSessionContext, userSess
 
 func serializeSSHContext(ctx *model.UserSessionContext, userSessionContextSerializer *UserSessionContextSerializer) {
 	if model.SSHAuthMethodStrings == nil {
-		model.InitSSHAuthMethodConstants()
+		model.SECLConstants()
 	}
 
 	sshClientIP := ctx.SSHClientIP.IP.String()
@@ -1061,7 +1061,7 @@ func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Eve
 		serializeSSHContext(ctx, userSessionContextSerializer)
 	}
 	// init the map if not already done
-	model.InitUserSessionTypes()
+	model.SECLConstants()
 
 	userSessionContextSerializer.SessionType = model.UserSessionTypeStrings[usersession.Type(e.FieldHandlers.ResolveSessionType(e, ctx))]
 	userSessionContextSerializer.ID = e.FieldHandlers.ResolveSessionID(e, ctx)

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1030,16 +1030,12 @@ func serializeK8sContext(e *model.Event, ctx *model.UserSessionContext, userSess
 }
 
 func serializeSSHContext(ctx *model.UserSessionContext, userSessionContextSerializer *UserSessionContextSerializer) {
-	if model.SSHAuthMethodStrings == nil {
-		model.SECLConstants()
-	}
-
 	sshClientIP := ctx.SSHClientIP.IP.String()
 	if sshClientIP == "<nil>" {
 		sshClientIP = ""
 	}
 
-	sshAuthMethod := model.SSHAuthMethodStrings[usersession.AuthType(ctx.SSHAuthMethod)]
+	sshAuthMethod := model.SSHAuthMethodToString(usersession.AuthType(ctx.SSHAuthMethod))
 	if sshAuthMethod == "<nil>" {
 		sshAuthMethod = ""
 	}
@@ -1060,10 +1056,8 @@ func newUserSessionContextSerializer(ctx *model.UserSessionContext, e *model.Eve
 	if ctx.SSHSessionID != 0 {
 		serializeSSHContext(ctx, userSessionContextSerializer)
 	}
-	// init the map if not already done
-	model.SECLConstants()
 
-	userSessionContextSerializer.SessionType = model.UserSessionTypeStrings[usersession.Type(e.FieldHandlers.ResolveSessionType(e, ctx))]
+	userSessionContextSerializer.SessionType = model.UserSessionTypeToString(usersession.Type(e.FieldHandlers.ResolveSessionType(e, ctx)))
 	userSessionContextSerializer.ID = e.FieldHandlers.ResolveSessionID(e, ctx)
 	userSessionContextSerializer.Identity = e.FieldHandlers.ResolveSessionIdentity(e, ctx)
 	return userSessionContextSerializer


### PR DESCRIPTION
### What does this PR do?

The model package is the only one that should init the constant, and do it under the `sync.Once`. Calling some `Init*` function from outside is taking the risk to call the init function multiple times, or to modify the constants map at the same time it's being read from.

This PR un-export the init/maps related to user sessions, and replace those with functions that manage the constant initialization correctly.

[Fixes this kind of error logs](https://app.datadoghq.com/logs?query=service%3Asystem-probe%20%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fsecurity%22%20%28%22panic%3A%20runtime%20error%22%20OR%20%22fatal%20error%22%29&agg_m=count&agg_m_source=base&agg_q=kube_cluster_name%2Cdatacenter&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&event=AwAAAZuZZS-AhHKFLgAAABhBWnVaWlQxREFBQkhZQUVCaUVsMXV3QU8AAAAkZjE5Yjk5NjYtYTY0ZC00NjZiLWIyMGQtNGRkYzNkNWVkNTk1AAhklg&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=flex_tier&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1767798009000&to_ts=1767805209000&live=false)

### Motivation

### Describe how you validated your changes

### Additional Notes
