### PR TITLE
migrate secret-backend build process from external repo to `cmd/secret-backend`

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -11,7 +11,19 @@ if fips_mode?
 else
   if !heroku_target?
     build do
-      command_on_repo_root "bazelisk run -- //deps/secret_connector:install --verbose --destdir=#{install_dir}"
+      command_on_repo_root "dda inv -- -e secret-backend.build --output-bin=bin/secret-backend/secret-generic-connector#{windows_target? ? '.exe' : ''}", :env => with_standard_compiler_flags({})
+
+      if windows_target?
+        mkdir "#{install_dir}/bin/agent"
+        copy "bin/secret-backend/secret-generic-connector.exe", "#{install_dir}/bin/agent/"
+      else
+        mkdir "#{install_dir}/embedded/bin"
+        copy "bin/secret-backend/secret-generic-connector", "#{install_dir}/embedded/bin/"
+        command "chmod 0500 #{install_dir}/embedded/bin/secret-generic-connector"
+      end
+
+      mkdir "#{install_dir}/LICENSES"
+      copy "cmd/secret-backend/LICENSE", "#{install_dir}/LICENSES/secret-generic-connector-LICENSE"
     end
   end
 end

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -8,24 +8,6 @@ if linux_target?
 end
 if fips_mode?
   dependency 'openssl-fips-provider'
-else
-  if !heroku_target?
-    build do
-      command_on_repo_root "dda inv -- -e secret-backend.build --output-bin=bin/secret-backend/secret-generic-connector#{windows_target? ? '.exe' : ''}", :env => with_standard_compiler_flags({})
-
-      if windows_target?
-        mkdir "#{install_dir}/bin/agent"
-        copy "bin/secret-backend/secret-generic-connector.exe", "#{install_dir}/bin/agent/"
-      else
-        mkdir "#{install_dir}/embedded/bin"
-        copy "bin/secret-backend/secret-generic-connector", "#{install_dir}/embedded/bin/"
-        command "chmod 0500 #{install_dir}/embedded/bin/secret-generic-connector"
-      end
-
-      mkdir "#{install_dir}/LICENSES"
-      copy "cmd/secret-backend/LICENSE", "#{install_dir}/LICENSES/secret-generic-connector-LICENSE"
-    end
-  end
 end
 
 dependency 'datadog-agent-data-plane' if linux_target? && !heroku_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -242,6 +242,19 @@ build do
     copy 'bin/cws-instrumentation/cws-instrumentation', "#{install_dir}/embedded/bin"
   end
 
+  # Secret Backend (secret-generic-connector)
+  # TODO: (next) fips support
+  if !fips_mode? && !heroku_target?
+    command "dda inv -- -e secret-backend.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    if windows_target?
+      copy 'bin/secret-backend/secret-generic-connector.exe', "#{install_dir}/bin/agent"
+    else
+      copy 'bin/secret-backend/secret-generic-connector', "#{install_dir}/embedded/bin"
+    end
+    mkdir "#{install_dir}/LICENSES"
+    copy 'cmd/secret-backend/LICENSE', "#{install_dir}/LICENSES/secret-generic-connector-LICENSE"
+  end
+
   if osx_target?
     # Launchd service definition
     erb source: "launchd.plist.example.erb",

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -66,6 +66,7 @@ from tasks import (
     release,
     rtloader,
     sbomgen,
+    secret_backend,
     security_agent,
     selinux,
     setup,
@@ -221,6 +222,7 @@ ns.add_collection(rtloader)
 ns.add_collection(system_probe)
 ns.add_collection(process_agent)
 ns.add_collection(testwasher)
+ns.add_collection(secret_backend)
 ns.add_collection(security_agent)
 ns.add_collection(cws_instrumentation)
 ns.add_collection(vscode)

--- a/tasks/secret_backend.py
+++ b/tasks/secret_backend.py
@@ -1,0 +1,79 @@
+"""
+secret_backend namespaced tasks
+"""
+
+import os
+
+from invoke import task
+
+from tasks.libs.common.go import go_build
+from tasks.libs.common.utils import bin_name
+from tasks.libs.releasing.version import get_version
+
+# secret-backend "secret-generic-connector"
+BINARY_NAME = "secret-generic-connector"
+BIN_DIR = os.path.join(".", "bin", "secret-backend")
+BIN_PATH = os.path.join(BIN_DIR, bin_name(BINARY_NAME))
+
+
+@task
+def build(
+    ctx,
+    rebuild=False,
+    race=False,
+    go_mod="readonly",
+    output_bin=None,
+    no_strip_binary=False,
+):
+    """
+    Build the secret-backend binary (secret-generic-connector).
+    """
+
+    version = get_version(ctx, include_git=True)
+
+    # ldflags: -s -w to reduce binary size
+    # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
+    ldflags = f"-X main.appVersion={version}"
+    if not no_strip_binary:
+        ldflags += " -s -w"
+
+    # gcflags: -l disables inlining to reduce binary size
+    # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
+    gcflags = "all=-l"
+
+    env = {
+        "GO111MODULE": "on",
+        "CGO_ENABLED": "0",  # static binary, no CGO needed
+    }
+
+    bin_path = BIN_PATH
+    if output_bin:
+        bin_path = output_bin
+
+    bin_dir = os.path.dirname(bin_path)
+    if bin_dir and not os.path.exists(bin_dir):
+        os.makedirs(bin_dir)
+
+    with ctx.cd("cmd/secret-backend"):
+        go_build(
+            ctx,
+            ".",
+            mod=go_mod,
+            race=race,
+            rebuild=rebuild,
+            gcflags=gcflags,
+            ldflags=ldflags,
+            bin_path=os.path.join("..", "..", bin_path),
+            env=env,
+        )
+
+    print(f"Built secret-backend binary: {bin_path}")
+
+
+@task
+def clean(ctx):
+    """
+    Remove artifacts for secret-backend
+    """
+    print("Removing secret-backend binary artifacts")
+    ctx.run(f"rm -rf {BIN_DIR}")


### PR DESCRIPTION
### What does this PR do?
adds on to https://github.com/DataDog/datadog-agent/pull/44809 which migrated secret-backend from https://github.com/DataDog/datadog-agent to the agent. Now instead of building the secret-backend externally and pulling it in, this PR aims to build the secret-backend internally

### Motivation
agent-config wants to move the datadog-secret-backend into the agent repo to be able to use the build system for fips compliance and inherit a lot of the benefits of the Agent repo.

### Describe how you validated your changes

### Additional Notes
- what should be done with `deps/secret_connector` (`BUILD.bazel`, `secret_connector.MODULE.bazel`, etc) now that we want to move building within the agent repo? I am not too familiar with the status of the bazel build system
