### PR TITLE
secret-backend build fips compliance

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -8,6 +8,24 @@ if linux_target?
 end
 if fips_mode?
   dependency 'openssl-fips-provider'
+else
+  if !heroku_target?
+    build do
+      command_on_repo_root "dda inv -- -e secret-backend.build --output-bin=bin/secret-backend/secret-generic-connector#{windows_target? ? '.exe' : ''}", :env => with_standard_compiler_flags({})
+
+      if windows_target?
+        mkdir "#{install_dir}/bin/agent"
+        copy "bin/secret-backend/secret-generic-connector.exe", "#{install_dir}/bin/agent/"
+      else
+        mkdir "#{install_dir}/embedded/bin"
+        copy "bin/secret-backend/secret-generic-connector", "#{install_dir}/embedded/bin/"
+        command "chmod 0500 #{install_dir}/embedded/bin/secret-generic-connector"
+      end
+
+      mkdir "#{install_dir}/LICENSES"
+      copy "cmd/secret-backend/LICENSE", "#{install_dir}/LICENSES/secret-generic-connector-LICENSE"
+    end
+  end
 end
 
 dependency 'datadog-agent-data-plane' if linux_target? && !heroku_target?

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -8,24 +8,6 @@ if linux_target?
 end
 if fips_mode?
   dependency 'openssl-fips-provider'
-else
-  if !heroku_target?
-    build do
-      command_on_repo_root "dda inv -- -e secret-backend.build --output-bin=bin/secret-backend/secret-generic-connector#{windows_target? ? '.exe' : ''}", :env => with_standard_compiler_flags({})
-
-      if windows_target?
-        mkdir "#{install_dir}/bin/agent"
-        copy "bin/secret-backend/secret-generic-connector.exe", "#{install_dir}/bin/agent/"
-      else
-        mkdir "#{install_dir}/embedded/bin"
-        copy "bin/secret-backend/secret-generic-connector", "#{install_dir}/embedded/bin/"
-        command "chmod 0500 #{install_dir}/embedded/bin/secret-generic-connector"
-      end
-
-      mkdir "#{install_dir}/LICENSES"
-      copy "cmd/secret-backend/LICENSE", "#{install_dir}/LICENSES/secret-generic-connector-LICENSE"
-    end
-  end
 end
 
 dependency 'datadog-agent-data-plane' if linux_target? && !heroku_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -253,10 +253,9 @@ build do
     copy 'bin/cws-instrumentation/cws-instrumentation', "#{install_dir}/embedded/bin"
   end
 
-  # Secret Generic Connector
-  # TODO: (next) fips support
+# Secret Generic Connector
   if !fips_mode? && !heroku_target?
-    command "dda inv -- -e secret-generic-connector.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
+    command "dda inv -- -e secret-generic-connector.build #{fips_args}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     if windows_target?
       copy 'bin/secret-generic-connector/secret-generic-connector.exe', "#{install_dir}/bin/agent"
     else
@@ -327,6 +326,7 @@ build do
         "#{install_dir}/embedded/bin/security-agent",
         "#{install_dir}/embedded/bin/system-probe",
         "#{install_dir}/embedded/bin/installer",
+        "#{install_dir}/embedded/bin/secret-generic-connector",
       ]
 
       symbol = "_Cfunc__mkcgo_OPENSSL"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -254,7 +254,7 @@ build do
   end
 
 # Secret Generic Connector
-  if !fips_mode? && !heroku_target?
+  if !heroku_target?
     command "dda inv -- -e secret-generic-connector.build #{fips_args}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     if windows_target?
       copy 'bin/secret-generic-connector/secret-generic-connector.exe', "#{install_dir}/bin/agent"

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -34,15 +34,10 @@ def build(
     version = get_version(ctx, include_git=True)
 
     # ldflags: -s -w to reduce binary size
-    # -s = strip Go symbol table (breaks FIPS verification with `go tool nm`)
-    # -w = strip DWARF debug info (safe for FIPS, keeps Go symbol table)
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
     ldflags = f"-X main.appVersion={version}"
     if not no_strip_binary:
-        if fips_mode:
-            ldflags += " -w"
-        else:
-            ldflags += " -s -w"
+        ldflags += " -s -w"
 
     # gcflags: -l disables inlining to reduce binary size
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -33,11 +33,14 @@ def build(
 
     version = get_version(ctx, include_git=True)
 
-    # ldflags: -s -w to reduce binary size
+    # ldflags: -s -w to reduce binary size, -s not compatible with FIPS
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
     ldflags = f"-X main.appVersion={version}"
     if not no_strip_binary:
-        ldflags += " -s -w"
+        if fips_mode:
+            ldflags += " -w"
+        else:
+            ldflags += " -s -w"
 
     # gcflags: -l disables inlining to reduce binary size
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml

--- a/tasks/secret_generic_connector.py
+++ b/tasks/secret_generic_connector.py
@@ -35,8 +35,9 @@ def build(
 
     # ldflags: -s -w to reduce binary size
     # https://github.com/DataDog/datadog-secret-backend/blob/v1/.github/workflows/release.yaml
+    # Note: FIPS mode requires symbols for verification so cannot use -s -w
     ldflags = f"-X main.appVersion={version}"
-    if not no_strip_binary:
+    if not no_strip_binary and not fips_mode:
         ldflags += " -s -w"
 
     # gcflags: -l disables inlining to reduce binary size

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -2,8 +2,8 @@ static_quality_gate_agent_deb_amd64:
   max_on_disk_size: 754.83 MiB
   max_on_wire_size: 184.81 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 704.0 MiB
-  max_on_wire_size: 173.79 MiB
+  max_on_disk_size: 715.32 MiB
+  max_on_wire_size: 177.56 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 329.53 MiB
   max_on_wire_size: 88.45 MiB
@@ -14,26 +14,26 @@ static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 754.8 MiB
   max_on_wire_size: 188.16 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 703.99 MiB
-  max_on_wire_size: 176.6 MiB
+  max_on_disk_size: 715.31 MiB
+  max_on_wire_size: 178.9 MiB
 static_quality_gate_agent_rpm_arm64:
   max_on_disk_size: 737.34 MiB
   max_on_wire_size: 169.93 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 688.48 MiB
-  max_on_wire_size: 160.55 MiB
+  max_on_disk_size: 698.93 MiB
+  max_on_wire_size: 163.12 MiB
 static_quality_gate_agent_suse_amd64:
   max_on_disk_size: 754.8 MiB
   max_on_wire_size: 188.16 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 703.99 MiB
-  max_on_wire_size: 176.6 MiB
+  max_on_disk_size: 715.31 MiB
+  max_on_wire_size: 178.9 MiB
 static_quality_gate_agent_suse_arm64:
   max_on_disk_size: 737.34 MiB
   max_on_wire_size: 169.93 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 688.48 MiB
-  max_on_wire_size: 160.55 MiB
+  max_on_disk_size: 698.93 MiB
+  max_on_wire_size: 163.12 MiB
 static_quality_gate_docker_agent_amd64:
   max_on_disk_size: 817.14 MiB
   max_on_wire_size: 277.4 MiB


### PR DESCRIPTION
### What does this PR do?
adds fips compliance tags to the `secret-backend` build system based on this PR https://github.com/DataDog/datadog-agent/pull/44865

### Motivation
agent-config wants to move the datadog-secret-backend into the agent repo to be able to use the build system for fips compliance and inherit a lot of the benefits of the Agent repo.

### Describe how you validated your changes

### Additional Notes
