### PR TITLE
fix(ot): Use correct image name for ot in nightly pipelines

### DIFF
--- a/.gitlab/common/container_publish_job_templates.yml
+++ b/.gitlab/common/container_publish_job_templates.yml
@@ -16,7 +16,7 @@
     IMG_SIGNING: "false"
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - |
-      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMG_SOURCES" =~ "$SRC_AGENT" || "$IMG_SOURCES" =~ "$SRC_DCA" || "$IMG_SOURCES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_SOURCES" =~ "$SRC_DDOT_EBPF" || "$IMG_VARIABLES" =~ "$SRC_AGENT" || "$IMG_VARIABLES" =~ "$SRC_DCA" || "$IMG_VARIABLES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_VARIABLES" =~ "$SRC_DDOT_EBPF" ) ]]; then
+      if [[ "$BUCKET_BRANCH" == "nightly" && ( "$IMG_SOURCES" =~ "$SRC_AGENT" || "$IMG_SOURCES" =~ "$SRC_OTEL_AGENT" || "$IMG_SOURCES" =~ "$SRC_DDOT_EBPF" || "$IMG_SOURCES" =~ "$SRC_DCA" || "$IMG_SOURCES" =~ "$SRC_CWS_INSTRUMENTATION" || "$IMG_VARIABLES" =~ "$SRC_AGENT" || "$IMG_VARIABLES" =~ "$SRC_DDOT_EBPF" || "$IMG_VARIABLES" =~ "$SRC_DCA" || "$IMG_VARIABLES" =~ "$SRC_CWS_INSTRUMENTATION" ) ]]; then
         export ECR_RELEASE_SUFFIX="-nightly"
       else
         export ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"


### PR DESCRIPTION
### What does this PR do?
- Add `SRC_OTEL_AGENT` in the list of images considered for nightly pipelines
- Re-ordered the name of the variables to align with the rest of the file

### Motivation
Since we merged #44537 the `qa_agent_ot_standalone` job [failed twice at the same time every day](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3A%22qa_ot_agent_standalone%22%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1767258881692&end=1767863681692&paused=false).
Looking in details the [failed job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1335013646) has a "no file found" error [in public images](https://gitlab.ddbuild.io/DataDog/public-images/-/jobs/1335021238)
```
GET https://registry.ddbuild.io/v2/ci/datadog-agent/otel-agent/manifests/v89600266-ffb33d92-7-amd64: MANIFEST_UNKNOWN: manifest unknown; unknown tag=v89600266-ffb33d92-7-amd64
````
This job looks for `ci/datadog-agent/otel-agent` and in the [parent jobs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1335002580) we are pushing `datadog-agent/otel-agent-nightly`

I think the update on the publish template should solve the issue. 

### Describe how you validated your changes
I cannot test this as the changed condition is only evaluated during nightly pipeline. But I suppose the change is easy enough that code review only can be accepted.

### Additional Notes
`SRC_DSD` is also missing in the condition (if we compare with line 24) but this is maybe not an issue.
