### PR TITLE
fix/trace: Deep copy Tags when splitting payload

### DIFF
--- a/pkg/proto/pbgo/trace/trace.go
+++ b/pkg/proto/pbgo/trace/trace.go
@@ -5,6 +5,8 @@
 
 package trace
 
+import "maps"
+
 //go:generate go run github.com/tinylib/msgp -file=span.pb.go -o span_gen.go -io=false
 //go:generate go run github.com/tinylib/msgp -file=tracer_payload.pb.go -o tracer_payload_gen.go -io=false
 //go:generate go run github.com/tinylib/msgp -io=false
@@ -42,7 +44,7 @@ func (p *TracerPayload) Cut(i int) *TracerPayload {
 		Env:             p.GetEnv(),
 		Hostname:        p.GetHostname(),
 		AppVersion:      p.GetAppVersion(),
-		Tags:            p.GetTags(),
+		Tags:            maps.Clone(p.GetTags()), // deep copy to prevent concurrent map writes
 	}
 
 	newPayload.Chunks = p.Chunks[:i]

--- a/pkg/proto/pbgo/trace/trace_test.go
+++ b/pkg/proto/pbgo/trace/trace_test.go
@@ -154,4 +154,24 @@ func TestCut(t *testing.T) {
 			Chunks:          []*TraceChunk{},
 		})
 	})
+
+	t.Run("tags-deep-copy", func(t *testing.T) {
+		tp := &TracerPayload{
+			Tags: map[string]string{
+				"original": "value",
+			},
+			Chunks: []*TraceChunk{
+				{Origin: "chunk-0"},
+				{Origin: "chunk-1"},
+			},
+		}
+		tp1 := tp.Cut(1)
+
+		tp.Tags["new-key"] = "new-value"
+		assert.NotContains(t, tp1.Tags, "new-value", "Cut payload should have independent Tags map")
+		assert.Equal(t, map[string]string{"original": "value"}, tp1.Tags)
+
+		tp1.Tags["cut-key"] = "cut-value"
+		assert.NotContains(t, tp.Tags, "cut-key", "Original payload should have independent Tags map")
+	})
 }


### PR DESCRIPTION
### What does this PR do?
Payload splits (due to large size) currently perform shallow copies of the Tags field (container tags), which can result in race conditions when multiple goroutines try to access the map.

Deep-copying the tags gurantees that each new payload can be safely passed to the container tags enrinchment goroutine, which will take care of attaching tags + serializing the payload.

### Motivation
We noticed the current logic can result in runtime panics, when multiple goroutines access the Tags map. Example:

```go
panic: runtime error: index out of range [-1]
goroutine 214 [running]:
github.com/planetscale/vtprotobuf/protohelpers.EncodeVarint(...)
	github.com/planetscale/vtprotobuf@v0.6.1-0.20240319094008-0393e58bdf10/protohelpers/protohelpers.go:30
github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.(*Span).MarshalToSizedBufferVT(0x40014d95e0, {0x4005ce8000, 0x13, 0x233ea9})
	github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/span_vtproto.pb.go:447 +0x11f4
github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.(*TraceChunk).MarshalToSizedBufferVT(0x4001df08c0, {0x4005ce8000, 0x23, 0x233ea9})
	github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/tracer_payload_vtproto.pb.go:82 +0x5ec
github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.(*TracerPayload).MarshalToSizedBufferVT(0x4001d889c0, {0x4005ce8000, 0x233e89, 0x233ea9})
	github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/tracer_payload_vtproto.pb.go:179 +0xbd4
github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace.(*AgentPayload).MarshalToSizedBufferVT(0x400130d970, {0x4005ce8000, 0x233ea9, 0x233ea9})
	github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/agent_payload_vtproto.pb.go:129 +0x7d4
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).serialize(0x4000248640, 0x4000d53970)
	github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:298 +0x98
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).flushPayloads(0x4000248640, {0x4002197b80, 0x1, 0x2})
	github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:278 +0x2bc
github.com/DataDog/datadog-agent/pkg/trace/writer.(*TraceWriter).WriteChunks(0x4000248640, 0x400021d188?)
	github.com/DataDog/datadog-agent/pkg/trace/writer/trace.go:237 +0xe4
github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).writeChunks.func1({0x400021d188?, 0x400218e053?, 0x40028f1808?}, {0x0?, 0x0?})
	github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:565 +0x68
github.com/DataDog/datadog-agent/pkg/trace/containertags.(*containerTagsBuffer).AsyncEnrichment(0x40006fe640, {0x400218e053, 0x40}, 0x4001d206f0, 0x647)
	github.com/DataDog/datadog-agent/pkg/trace/containertags/buffer.go:251 +0x50
github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).writeChunks(0x40001bb200, 0x40000ad2e0)
	github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:567 +0xd8
github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).Process(0x40001bb200, 0x400157c8c0)
	github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:549 +0x98c
github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).work(0x40001bb200)
	github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:302 +0x58
created by github.com/DataDog/datadog-agent/pkg/trace/agent.(*Agent).Run in goroutine 149
	github.com/DataDog/datadog-agent/pkg/trace/agent/agent.go:254 +0x298
```

The serialization logic fails as the computed size is no longer accurate, after a different goroutine has added container tags to the same map.

### Describe how you validated your changes
Added unit tests.

### Additional Notes
