### PR TITLE
Extract buildTags() with preallocation

### DIFF
--- a/pkg/logs/tailers/container/tailer.go
+++ b/pkg/logs/tailers/container/tailer.go
@@ -393,14 +393,19 @@ func buildMessage(tailer *Tailer, output *message.Message) *message.Message {
 	tailer.setLastSince(output.ParsingExtra.Timestamp)
 	origin.Identifier = tailer.Identifier()
 
-	var tags []string
-	tags = append(tags, output.ParsingExtra.Tags...)
-	tags = append(tags, tailer.tagProvider.GetTags()...)
-	origin.SetTags(tags)
+	origin.SetTags(buildTags(output.ParsingExtra.Tags, tailer.tagProvider.GetTags()))
 
 	// XXX(remy): is it OK recreating a message here?
 	// Preserve ParsingExtra information from decoder output (including IsTruncated flag)
 	return message.NewMessageWithParsingExtra(output.GetContent(), origin, output.Status, output.IngestionTimestamp, output.ParsingExtra)
+}
+
+// buildTags combines two tag slices into one with exact capacity.
+func buildTags(parsingTags, providerTags []string) []string {
+	tags := make([]string, 0, len(parsingTags)+len(providerTags))
+	tags = append(tags, parsingTags...)
+	tags = append(tags, providerTags...)
+	return tags
 }
 
 // forward forwards decoded messages to the next pipeline,

--- a/pkg/logs/tailers/container/tailer_tags_bench_test.go
+++ b/pkg/logs/tailers/container/tailer_tags_bench_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package container
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkBuildTags benchmarks the buildTags function used in buildMessage().
+func BenchmarkBuildTags(b *testing.B) {
+	testCases := []struct {
+		name         string
+		parsingTags  int
+		providerTags int
+	}{
+		{"5_tags", 2, 3},
+		{"12_tags", 4, 8},
+		{"20_tags", 6, 14},
+	}
+
+	for _, tc := range testCases {
+		parsingTags := generateTags("parsing", tc.parsingTags)
+		providerTags := generateTags("provider", tc.providerTags)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = buildTags(parsingTags, providerTags)
+			}
+		})
+	}
+}
+
+func generateTags(prefix string, count int) []string {
+	tags := make([]string, count)
+	for i := 0; i < count; i++ {
+		tags[i] = fmt.Sprintf("%s_tag_%d:value_%d", prefix, i, i)
+	}
+	return tags
+}

--- a/pkg/logs/tailers/file/tailer.go
+++ b/pkg/logs/tailers/file/tailer.go
@@ -405,11 +405,7 @@ func (t *Tailer) forwardMessages() {
 		origin.FilePath = t.file.Path
 		origin.Fingerprint = t.fingerprint
 
-		tags := make([]string, len(t.tags))
-		copy(tags, t.tags)
-		tags = append(tags, t.tagProvider.GetTags()...)
-		tags = append(tags, output.ParsingExtra.Tags...)
-		origin.SetTags(tags)
+		origin.SetTags(buildTags(t.tags, t.tagProvider.GetTags(), output.ParsingExtra.Tags))
 		// Ignore empty lines once the registry offset is updated
 		if len(output.GetContent()) == 0 {
 			continue
@@ -427,6 +423,15 @@ func (t *Tailer) forwardMessages() {
 		case <-t.forwardContext.Done():
 		}
 	}
+}
+
+// buildTags combines multiple tag slices into one with exact capacity.
+func buildTags(baseTags, providerTags, parsingTags []string) []string {
+	tags := make([]string, 0, len(baseTags)+len(providerTags)+len(parsingTags))
+	tags = append(tags, baseTags...)
+	tags = append(tags, providerTags...)
+	tags = append(tags, parsingTags...)
+	return tags
 }
 
 // getFormattedTime return readable timestamp

--- a/pkg/logs/tailers/file/tailer_tags_bench_test.go
+++ b/pkg/logs/tailers/file/tailer_tags_bench_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkBuildTags benchmarks the buildTags function used in forwardMessages().
+// Real-world data shows 8-28 tags per log at ~42 logs/second throughput.
+func BenchmarkBuildTags(b *testing.B) {
+	testCases := []struct {
+		name         string
+		baseTags     int
+		providerTags int
+		parsingTags  int
+	}{
+		{"8_tags", 2, 4, 2},
+		{"15_tags", 3, 8, 4},
+		{"28_tags", 4, 18, 6},
+	}
+
+	for _, tc := range testCases {
+		baseTags := generateTags("base", tc.baseTags)
+		providerTags := generateTags("provider", tc.providerTags)
+		parsingTags := generateTags("parsing", tc.parsingTags)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = buildTags(baseTags, providerTags, parsingTags)
+			}
+		})
+	}
+}
+
+func generateTags(prefix string, count int) []string {
+	tags := make([]string, count)
+	for i := 0; i < count; i++ {
+		tags[i] = fmt.Sprintf("%s_tag_%d:value_%d", prefix, i, i)
+	}
+	return tags
+}


### PR DESCRIPTION
### What does this PR do?

Extract buildTags() helper functions that preallocate tag slices to exact capacity, eliminating reallocations during append operations.

Both buildTags functions are inlined and pose no function-call overhead.

### Additional Notes

REF PR #44846
