### PR TITLE
Backport 43518 to 7.74.x

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -255,9 +255,12 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestUninstallScript$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestMSIPurge$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestDisableEnableScript$"
+      - EXTRA_PARAMS: --run "TestAgentMSIInstallsDotnetLibrary/TestEnableSSIOnReinstall$"
       - EXTRA_PARAMS: --run "TestAgentScriptInstallsDotnetLibrary/TestInstallFromScript$"
       # apm-inject-package
       - EXTRA_PARAMS: --run "TestAPMInjectInstall/TestInstallUninstallAPMInjectPackage$"
       - EXTRA_PARAMS: --run "TestAgentScriptInstallsAPMInject/TestInstallFromScript$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSI$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestEnableDisable$"
+      - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSIWithIIS$"
+      - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSIWithJava$"

--- a/test/new-e2e/tests/installer/windows/iis_helper.go
+++ b/test/new-e2e/tests/installer/windows/iis_helper.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	suiteasserts "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/suite-assertions"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+)
+
+// WindowsSuite is an interface that provides access to the test suite's Require and Env methods.
+// It must be implemented by any suite that wants to use IISHelper.
+type WindowsSuite interface {
+	Env() *environments.WindowsHost
+	Require() *suiteasserts.SuiteAssertions
+}
+
+// IISHelper provides reusable IIS testing functionality that can be composed with any test suite.
+// It requires a suite that implements the WindowsSuite interface to access the remote host and assertions.
+type IISHelper struct {
+	suite WindowsSuite
+}
+
+// NewIISHelper creates a new IISHelper with the given suite.
+func NewIISHelper(s WindowsSuite) *IISHelper {
+	return &IISHelper{suite: s}
+}
+
+// SetupIIS installs IIS and ASP.NET on the remote host.
+// This should be called in the suite's SetupSuite method.
+func (h *IISHelper) SetupIIS() {
+	h.installIIS()
+	h.installAspNet()
+}
+
+func (h *IISHelper) installIIS() {
+	host := h.suite.Env().RemoteHost
+	err := windows.InstallIIS(host)
+	h.suite.Require().NoError(err)
+}
+
+func (h *IISHelper) installAspNet() {
+	host := h.suite.Env().RemoteHost
+	output, err := host.Execute("Install-WindowsFeature Web-Asp-Net45")
+	h.suite.Require().NoErrorf(err, "failed to install Asp.Net: %s", output)
+}
+
+// StartIISApp creates and starts an IIS application with the provided web.config and index.aspx files.
+func (h *IISHelper) StartIISApp(webConfigFile, aspxFile []byte) {
+	host := h.suite.Env().RemoteHost
+	err := host.MkdirAll("C:\\inetpub\\wwwroot\\DummyApp")
+	h.suite.Require().NoError(err, "failed to create directory for DummyApp")
+	_, err = host.WriteFile("C:\\inetpub\\wwwroot\\DummyApp\\web.config", webConfigFile)
+	h.suite.Require().NoError(err, "failed to write web.config file")
+	_, err = host.WriteFile("C:\\inetpub\\wwwroot\\DummyApp\\index.aspx", aspxFile)
+	h.suite.Require().NoError(err, "failed to write index.aspx file")
+	script := `
+$SitePath = "C:\inetpub\wwwroot\DummyApp"
+New-WebSite -Name DummyApp -PhysicalPath $SitePath -Port 8080 -ApplicationPool "DefaultAppPool" -Force
+Stop-WebSite -Name "DummyApp"
+Start-WebSite -Name "DummyApp"
+$state = (Get-WebAppPoolState -Name "DefaultAppPool").Value
+if ($state -eq "Stopped") {
+    Start-WebAppPool -Name "DefaultAppPool"
+}
+Restart-WebAppPool -Name "DefaultAppPool"
+Invoke-WebRequest -Uri "http://localhost:8080/index.aspx" -UseBasicParsing
+	`
+	output, err := host.Execute(script)
+	h.suite.Require().NoErrorf(err, "failed to start site: %s", output)
+}
+
+// StopIISApp stops the IIS application and waits for the app pool to stop.
+func (h *IISHelper) StopIISApp() {
+	script := `
+Stop-WebSite -Name "DummyApp"
+$state = (Get-WebAppPoolState -Name "DefaultAppPool").Value
+if ($state -ne "Stopped") {
+	Stop-WebAppPool -Name "DefaultAppPool"
+	$retryCount = 0
+	do {
+		Start-Sleep -Seconds 1
+		$status = (Get-WebAppPoolState -Name DefaultAppPool).Value
+		$retryCount++
+	} while ($status -ne "Stopped" -and $retryCount -lt 60)
+	if ($status -ne "Stopped") {
+		exit -1
+	}
+}
+	`
+	host := h.suite.Env().RemoteHost
+	output, err := host.Execute(script)
+	h.suite.Require().NoErrorf(err, "failed to stop site: %s", output)
+}
+
+// GetLibraryPathFromInstrumentedIIS makes a request to the IIS app and returns the content.
+// This is typically used to get the path to the instrumented library from the ASP.NET page.
+func (h *IISHelper) GetLibraryPathFromInstrumentedIIS() string {
+	host := h.suite.Env().RemoteHost
+	output, err := host.Execute(`(Invoke-WebRequest -Uri "http://localhost:8080/index.aspx" -UseBasicParsing).Content`)
+	h.suite.Require().NoErrorf(err, "failed to get content from site: %s", output)
+	return strings.TrimSpace(output)
+}

--- a/test/new-e2e/tests/installer/windows/java_helper.go
+++ b/test/new-e2e/tests/installer/windows/java_helper.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import (
+	"strings"
+)
+
+// JavaHelper provides reusable Java testing functionality that can be composed with any test suite.
+// It requires a suite that implements the WindowsSuite interface to access the remote host and assertions.
+type JavaHelper struct {
+	suite WindowsSuite
+}
+
+// NewJavaHelper creates a new JavaHelper with the given suite.
+func NewJavaHelper(s WindowsSuite) *JavaHelper {
+	return &JavaHelper{suite: s}
+}
+
+// SetupJava installs Java JDK on the remote host.
+// This should be called in the suite's SetupSuite method.
+func (h *JavaHelper) SetupJava() {
+	host := h.suite.Env().RemoteHost
+
+	script := `
+# Install Chocolatey if not already installed
+if (!(Get-Command choco -ErrorAction SilentlyContinue)) {
+	Set-ExecutionPolicy Bypass -Scope Process -Force
+	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+	Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+	# Refresh PATH for current session
+	$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+}
+
+# Install Java
+choco install openjdk11 -y
+
+# Refresh PATH again to pick up Java
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+# Verify Java installation
+java -version
+	`
+	output, err := host.Execute(script)
+	h.suite.Require().NoErrorf(err, "failed to install Java: %s", output)
+}
+
+// StartJavaApp deploys, compiles, and runs a simple Java application.
+// Returns the output from running the application to verify injection.
+func (h *JavaHelper) StartJavaApp(javaSourceCode []byte) string {
+	host := h.suite.Env().RemoteHost
+
+	err := host.MkdirAll("C:\\JavaApp")
+	h.suite.Require().NoError(err, "failed to create directory for JavaApp")
+
+	_, err = host.WriteFile("C:\\JavaApp\\DummyApp.java", javaSourceCode)
+	h.suite.Require().NoError(err, "failed to write Java source file")
+
+	output, err := host.Execute("cd C:\\JavaApp; javac DummyApp.java")
+	h.suite.Require().NoErrorf(err, "failed to compile Java app: %s", output)
+
+	script := `
+$env:DD_INJECT_LOG_SINKS = "stdout"
+$env:DD_INJECT_LOG_LEVEL = "debug"
+cd C:\JavaApp
+java DummyApp
+	`
+	output, err = host.Execute(script)
+	h.suite.Require().NoErrorf(err, "failed to run Java app: %s", output)
+
+	return strings.TrimSpace(output)
+}

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
@@ -26,11 +26,11 @@ func (s *baseSuite) SetupSuite() {
 
 	s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("CURRENT_APM_INJECT_VERSION"))
 	if s.currentAPMInjectVersion.PackageVersion() == "" {
-		s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.ba30ecb.glci1208428525.g594e53fe-1")
+		s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.52.0-dev.b282e14.glci1291404213.g7ff18a26-1")
 	}
 	s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("PREVIOUS_APM_INJECT_VERSION"))
 	if s.previousAPMInjectVersion.PackageVersion() == "" {
-		s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.beb48a5.glci1208433719.g08c01dc4-1")
+		s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.ba30ecb.glci1208428525.g594e53fe-1")
 	}
 }
 func (s *baseSuite) assertSuccessfulPromoteExperiment() {
@@ -55,8 +55,8 @@ $env:DD_INJECT_LOG_LEVEL = "debug"
 	output, err := host.Execute(script)
 	s.Require().NoError(err)
 	if enabled {
-		s.Require().Contains(output, "Instrumenting Java")
+		s.Require().Contains(output, "main executable path")
 	} else {
-		s.Require().NotContains(output, "Instrumenting Java")
+		s.Require().NotContains(output, "main executable path")
 	}
 }

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
@@ -7,7 +7,6 @@ package injecttests
 
 import (
 	_ "embed"
-	"fmt"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
@@ -50,7 +49,7 @@ func (s *testAgentMSIInstallsAPMInject) TestInstallFromMSI() {
 		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=host"),
 		// TODO: remove override once image is published in prod
 		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com"),
-		installerwindows.WithMSIArg(fmt.Sprintf("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT=%s", s.currentAPMInjectVersion.PackageVersion())),
+		installerwindows.WithMSIArg("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="+s.currentAPMInjectVersion.PackageVersion()),
 		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:3,java:1"),
 		installerwindows.WithMSILogFile("install.log"),
 	)
@@ -68,7 +67,7 @@ func (s *testAgentMSIInstallsAPMInject) TestEnableDisable() {
 		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=host"),
 		// TODO: remove override once image is published in prod
 		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com"),
-		installerwindows.WithMSIArg(fmt.Sprintf("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT=%s", s.currentAPMInjectVersion.PackageVersion())),
+		installerwindows.WithMSIArg("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="+s.currentAPMInjectVersion.PackageVersion()),
 		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:3,java:1"),
 		installerwindows.WithMSILogFile("install.log"),
 	)
@@ -149,7 +148,7 @@ func (s *testAgentMSIInstallsAPMInject) installCurrentAgentVersion(opts ...insta
 	options := []installerwindows.MsiOption{
 		installerwindows.WithOption(installerwindows.WithInstallerURL(s.CurrentAgentVersion().MSIPackage().URL)),
 		installerwindows.WithMSILogFile("install-current-version.log"),
-		installerwindows.WithMSIArg(fmt.Sprintf("APIKEY=%s", installer.GetAPIKey())),
+		installerwindows.WithMSIArg("APIKEY=" + installer.GetAPIKey()),
 		installerwindows.WithMSIArg("SITE=datadoghq.com"),
 	}
 	options = append(options, opts...)

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
@@ -7,7 +7,7 @@ package injecttests
 
 import (
 	_ "embed"
-        "fmt"
+	"fmt"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/msi_install_test.go
@@ -6,15 +6,25 @@
 package injecttests
 
 import (
-	"fmt"
+	_ "embed"
+        "fmt"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 
 	"testing"
+)
+
+var (
+	//go:embed resources/web.config
+	webConfigFile []byte
+	//go:embed resources/index.aspx
+	aspxFile []byte
+	//go:embed resources/DummyApp.java
+	javaAppFile []byte
 )
 
 type testAgentMSIInstallsAPMInject struct {
@@ -77,6 +87,59 @@ func (s *testAgentMSIInstallsAPMInject) TestEnableDisable() {
 	s.Require().NoErrorf(err, "failed to run enable script: %s", output)
 
 	s.assertDriverInjections(true)
+}
+
+// TestInstallFromMSIWithIIS tests the Agent MSI can install the APM inject package with IIS instrumentation
+func (s *testAgentMSIInstallsAPMInject) TestInstallFromMSIWithIIS() {
+	// Setup IIS
+	iisHelper := installerwindows.NewIISHelper(s)
+	iisHelper.SetupIIS()
+
+	// Install with IIS instrumentation
+	s.installCurrentAgentVersion(
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=host"),
+		// TODO: remove override once image is published in prod
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com"),
+		installerwindows.WithMSIArg("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="+s.currentAPMInjectVersion.PackageVersion()),
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:3"),
+		installerwindows.WithMSILogFile("install.log"),
+	)
+
+	// Verify the package is installed
+	s.assertSuccessfulPromoteExperiment()
+
+	// Start the IIS app to load the library
+	defer iisHelper.StopIISApp()
+	iisHelper.StartIISApp(webConfigFile, aspxFile)
+
+	// Check that the .NET tracer is loaded
+	libraryPath := iisHelper.GetLibraryPathFromInstrumentedIIS()
+	s.Require().NotEmpty(libraryPath, "DD_DOTNET_TRACER_HOME should be set when instrumentation is enabled")
+	s.Require().Contains(libraryPath, "datadog")
+}
+
+// TestInstallFromMSIWithJava tests the Agent MSI can install the APM inject package with Java instrumentation
+func (s *testAgentMSIInstallsAPMInject) TestInstallFromMSIWithJava() {
+	// Setup Java
+	javaHelper := installerwindows.NewJavaHelper(s)
+	javaHelper.SetupJava()
+
+	// Install with Java instrumentation
+	s.installCurrentAgentVersion(
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=host"),
+		// TODO: remove override once image is published in prod
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com"),
+		installerwindows.WithMSIArg("DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT="+s.currentAPMInjectVersion.PackageVersion()),
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_LIBRARIES=java:1"),
+		installerwindows.WithMSILogFile("install.log"),
+	)
+
+	// Verify the package is installed
+	s.assertSuccessfulPromoteExperiment()
+
+	// Start the Java app and check that the Datadog tracer is loaded
+	output := javaHelper.StartJavaApp(javaAppFile)
+	s.Require().Contains(output, "Datadog Tracer is available", "Datadog tracer should be loaded when instrumentation is enabled")
 }
 
 // installCurrentAgentVersionWithAPMInject installs the current agent version with APM inject via script

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/DummyApp.java
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/DummyApp.java
@@ -1,0 +1,25 @@
+public class DummyApp {
+    public static void main(String[] args) {
+        try {
+            // Attempt to detect if Datadog Tracer is loaded by the javaagent
+            Class<?> tracerClass = Class.forName("datadog.trace.api.GlobalTracer");
+
+            System.out.println("Datadog Tracer is available.");
+
+            try {
+                // Try to get the version, if available
+                Class<?> versionClass = Class.forName("datadog.trace.api.Version");
+                String version = (String) versionClass.getDeclaredField("VERSION").get(null);
+
+                System.out.println("Datadog Tracer version: " + version);
+            } catch (ClassNotFoundException e) {
+                System.out.println("Datadog Version class not found. Tracer is present but version info is unavailable.");
+            }
+
+        } catch (ClassNotFoundException e) {
+            System.out.println("Datadog Tracer is NOT available.");
+        } catch (Exception e) {
+            System.out.println("Unexpected error: " + e.getMessage());
+        }
+    }
+}

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/index.aspx
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/index.aspx
@@ -1,0 +1,17 @@
+<%@ Page Language="C#" %>
+<%@ Import Namespace="System" %>
+<script runat="server">
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        Response.ContentType = "text/plain";
+        string tracerHome = Environment.GetEnvironmentVariable("DD_DOTNET_TRACER_HOME");
+
+        if (!string.IsNullOrEmpty(tracerHome))
+        {
+            Response.Write(tracerHome);
+        }
+
+        Response.End();
+
+    }
+</script>

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/web.config
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/resources/web.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <system.webServer>
+        <defaultDocument>
+            <files>
+                <add value="index.aspx" />
+            </files>
+        </defaultDocument>
+    </system.webServer>
+</configuration>

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/base_suite.go
@@ -7,14 +7,12 @@
 package dotnettests
 
 import (
-	"strings"
-
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 )
 
 type baseIISSuite struct {
 	installerwindows.BaseSuite
+	iisHelper *installerwindows.IISHelper
 }
 
 func (s *baseIISSuite) SetupSuite() {
@@ -22,73 +20,20 @@ func (s *baseIISSuite) SetupSuite() {
 	// SetupSuite needs to defer s.CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer s.CleanupOnSetupFailure()
 
-	s.installIIS()
-	s.installAspNet()
-}
-
-func (s *baseIISSuite) installIIS() {
-	host := s.Env().RemoteHost
-	err := windows.InstallIIS(host)
-	s.Require().NoError(err)
-}
-
-func (s *baseIISSuite) installAspNet() {
-	host := s.Env().RemoteHost
-	output, err := host.Execute("Install-WindowsFeature Web-Asp-Net45")
-	s.Require().NoErrorf(err, "failed to install Asp.Net: %s", output)
+	s.iisHelper = installerwindows.NewIISHelper(s)
+	s.iisHelper.SetupIIS()
 }
 
 func (s *baseIISSuite) startIISApp(webConfigFile, aspxFile []byte) {
-	host := s.Env().RemoteHost
-	err := host.MkdirAll("C:\\inetpub\\wwwroot\\DummyApp")
-	s.Require().NoError(err, "failed to create directory for DummyApp")
-	_, err = host.WriteFile("C:\\inetpub\\wwwroot\\DummyApp\\web.config", webConfigFile)
-	s.Require().NoError(err, "failed to write web.config file")
-	_, err = host.WriteFile("C:\\inetpub\\wwwroot\\DummyApp\\index.aspx", aspxFile)
-	s.Require().NoError(err, "failed to write index.aspx file")
-	script := `
-$SitePath = "C:\inetpub\wwwroot\DummyApp"
-New-WebSite -Name DummyApp -PhysicalPath $SitePath -Port 8080 -ApplicationPool "DefaultAppPool" -Force
-Stop-WebSite -Name "DummyApp"
-Start-WebSite -Name "DummyApp"
-$state = (Get-WebAppPoolState -Name "DefaultAppPool").Value
-if ($state -eq "Stopped") {
-    Start-WebAppPool -Name "DefaultAppPool"
-}
-Restart-WebAppPool -Name "DefaultAppPool"
-Invoke-WebRequest -Uri "http://localhost:8080/index.aspx" -UseBasicParsing
-	`
-	output, err := host.Execute(script)
-	s.Require().NoErrorf(err, "failed to start site: %s", output)
+	s.iisHelper.StartIISApp(webConfigFile, aspxFile)
 }
 
 func (s *baseIISSuite) stopIISApp() {
-	script := `
-Stop-WebSite -Name "DummyApp"
-$state = (Get-WebAppPoolState -Name "DefaultAppPool").Value
-if ($state -ne "Stopped") {
-	Stop-WebAppPool -Name "DefaultAppPool"
-	$retryCount = 0
-	do {
-		Start-Sleep -Seconds 1
-		$status = (Get-WebAppPoolState -Name DefaultAppPool).Value
-		$retryCount++
-	} while ($status -ne "Stopped" -and $retryCount -lt 60)
-	if ($status -ne "Stopped") {
-		exit -1
-	}
-}
-	`
-	host := s.Env().RemoteHost
-	output, err := host.Execute(script)
-	s.Require().NoErrorf(err, "failed to stop site: %s", output)
+	s.iisHelper.StopIISApp()
 }
 
 func (s *baseIISSuite) getLibraryPathFromInstrumentedIIS() string {
-	host := s.Env().RemoteHost
-	output, err := host.Execute(`(Invoke-WebRequest -Uri "http://localhost:8080/index.aspx" -UseBasicParsing).Content`)
-	s.Require().NoErrorf(err, "failed to get content from site: %s", output)
-	return strings.TrimSpace(output)
+	return s.iisHelper.GetLibraryPathFromInstrumentedIIS()
 }
 
 func (s *baseIISSuite) assertSuccessfulPromoteExperiment(version string) {

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/msi_install_test.go
@@ -366,6 +366,43 @@ func (s *testAgentMSIInstallsDotnetLibrary) TestDisableEnableScript() {
 	s.Require().Contains(libraryPath, version.Version())
 }
 
+// TestEnableSSIOnReinstall tests that SSI can be enabled when reinstalling the same version
+// of the agent after an initial installation without SSI enabled
+func (s *testAgentMSIInstallsDotnetLibrary) TestEnableSSIOnReinstall() {
+	version := s.currentDotnetLibraryVersion
+
+	// First install: Install agent without SSI enabled
+	s.installCurrentAgentVersion(
+		// TODO: remove override once image is published in prod
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com.internal.dda-testing.com"),
+		installerwindows.WithMSILogFile("install-no-ssi.log"),
+	)
+
+	// Start IIS and verify instrumentation is not active
+	defer s.stopIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
+	libraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Empty(libraryPath, "library should not be loaded when SSI is not enabled")
+
+	// Second install: Reinstall with SSI enabled
+	s.installCurrentAgentVersion(
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_ENABLED=iis"),
+		// TODO: remove override once image is published in prod
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=install.datad0g.com.internal.dda-testing.com"),
+		installerwindows.WithMSIArg("DD_APM_INSTRUMENTATION_LIBRARIES=dotnet:"+version.Version()),
+		installerwindows.WithMSILogFile("install-with-ssi.log"),
+	)
+
+	// Verify the library package is still at the expected version
+	s.assertSuccessfulPromoteExperiment(version.Version())
+
+	// Restart IIS and verify instrumentation is now active
+	s.stopIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
+	libraryPath = s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Contains(libraryPath, version.Version(), "library should be loaded when SSI is enabled")
+}
+
 func (s *testAgentMSIInstallsDotnetLibrary) installPreviousAgentVersion(opts ...installerwindows.MsiOption) {
 	agentVersion := s.StableAgentVersion().Version()
 	options := []installerwindows.MsiOption{


### PR DESCRIPTION
### What does this PR do?
Backport of #43518 

This PR adds 3 new E2E tests for windows SSI:

TestInstallFromMSIWithIIS checks that SSI with the kernel driver instruments an IIS application
TestInstallFromMSIWithJava checks that SSI with the kernel driver instruments a java application
TestEnableSSIOnReinstall checks that SSI gets turned on if after an initial installation without it, the same MSI gets reinstalled with the SSI properties configured.

### Motivation
Better coverage of SSI scenarios on Windows.

### Describe how you validated your changes
E2E tests


### Additional Notes
