### PR TITLE
Remove license exception for csaf-poc/csaf_distribution

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -383,7 +383,6 @@ github.com/apache/arrow/*: Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com
 github.com/tailscale/tailscale: Copyright (c) 2020 Tailscale Inc & AUTHORS.
 
 # Copyright information is in the source headers
-github.com/csaf-poc/csaf_distribution: Copyright 2021-2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 github.com/google/btree: Copyright 2014-2022 Google Inc.
 github.com/google/shlex: Copyright 2012 Google Inc. All Rights Reserved.
 github.com/facebook/time/*: Copyright (c) Facebook, Inc. and its affiliates.

--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -26,9 +26,6 @@ overrides:
   # https://github.com/aquasecurity/trivy-policies/blob/main/LICENSE
   "github.com/aquasecurity/trivy-policies/pkg/spec": MIT
   "github.com/aquasecurity/trivy-policies/rules/specs": MIT
-  # https://github.com/csaf-poc/csaf_distribution/blob/main/LICENSES/MIT.txt
-  "github.com/csaf-poc/csaf_distribution/v3/csaf": MIT
-  "github.com/csaf-poc/csaf_distribution/v3/util": MIT
   # https://bitbucket.org/atlassian/go-asap/src/master/LICENSE.txt
   "bitbucket.org/atlassian/go-asap/v2": Apache-2.0
   # https://github.com/JohnCGriffin/overflow/blob/master/README.md


### PR DESCRIPTION
### What does this PR do?

We had exception for csaf-poc/csaf_distribution that is not used any more.

### Motivation
Fix #30564.

### Describe how you validated your changes

### Additional Notes
