### PR TITLE
refactor(ssi): Refactor pod mutations

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
@@ -39,6 +39,19 @@ func (basicLibConfigInjector) mutatePod(pod *corev1.Pod) error {
 	return nil
 }
 
+// containerMutator returns a containerMutator that injects the basic lib config env vars.
+// This can be used with filteredContainerMutator to apply container filtering.
+func (basicLibConfigInjector) containerMutator() containerMutator {
+	libConfig := basicConfig()
+	envs := libConfig.ToEnvs()
+
+	var mutators containerMutators
+	for _, env := range envs {
+		mutators = append(mutators, envVarMutator(env))
+	}
+	return mutators
+}
+
 type libConfigInjector struct{}
 
 func (l *libConfigInjector) podMutator(lang language) podMutator {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -53,14 +53,16 @@ func (f podMutatorFunc) mutatePod(pod *corev1.Pod) error {
 	return f(pod)
 }
 
-// mutatePodContainers applies a containerMutator to all of
-// the containers of a pod (init and not).
-func mutatePodContainers(pod *corev1.Pod, mutator containerMutator) error {
-	for idx, c := range pod.Spec.InitContainers {
-		if err := mutator.mutateContainer(&c); err != nil {
-			return err
+// mutatePodContainers applies a containerMutator to containers of a pod.
+// If includeInitContainers is true, it also applies to init containers.
+func mutatePodContainers(pod *corev1.Pod, mutator containerMutator, includeInitContainers bool) error {
+	if includeInitContainers {
+		for idx, c := range pod.Spec.InitContainers {
+			if err := mutator.mutateContainer(&c); err != nil {
+				return err
+			}
+			pod.Spec.InitContainers[idx] = c
 		}
-		pod.Spec.InitContainers[idx] = c
 	}
 
 	for idx, c := range pod.Spec.Containers {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -53,88 +53,185 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		return nil
 	}
 
-	requirements, injectionDecision := initContainerResourceRequirements(pod, m.config.defaultResourceRequirements)
-	if injectionDecision.skipInjection {
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-		SetAnnotation(pod, AnnotationInjectionError, injectionDecision.message)
-		return nil
-	}
+	autoDetected := config.source.isFromLanguageDetection()
+	injectionType := config.source.injectionType()
 
-	var (
-		lastError      error
-		startTime      = time.Now()
-		configInjector = &libConfigInjector{}
-		injectionType  = config.source.injectionType()
-		autoDetected   = config.source.isFromLanguageDetection()
-
-		ustEnvVarMutator = m.ustEnvVarMutator(pod)
-
-		// initContainerMutators are resource and security constraints
-		// to all the init containers the init containers that we create.
-		initContainerMutators = append(
-			m.newInitContainerMutators(requirements, pod.Namespace),
-			ustEnvVarMutator,
-		)
-		injectorOptions = libRequirementOptions{
-			containerFilter:       m.config.containerFilter,
-			initContainerMutators: initContainerMutators,
-		}
-
-		injector          = m.newInjector(pod, startTime, injectorOptions)
-		containerMutators = containerMutators{
-			config.languageDetection.containerMutator(),
-			ustEnvVarMutator,
-		}
-	)
-
-	// Inject env variables used for Onboarding KPIs propagation...
-	// if Single Step Instrumentation is enabled, inject DD_INSTRUMENTATION_INSTALL_TYPE:k8s_single_step
-	// if local library injection is enabled, inject DD_INSTRUMENTATION_INSTALL_TYPE:k8s_lib_injection
-	if err := m.mutatePodContainers(pod, config.source.containerMutator()); err != nil {
-		return err
-	}
-
-	if err := injector.podMutator().mutatePod(pod); err != nil {
-		// setting the language tag to `injector` because this injection is not related to a specific supported language
-		metrics.LibInjectionErrors.Inc("injector", strconv.FormatBool(autoDetected), injectionType)
-		lastError = err
-		log.Errorf("Cannot inject library injector into pod %s: %s", mutatecommon.PodString(pod), err)
-	}
-
-	for _, lib := range config.libs {
-		injected := false
-		langStr := string(lib.lang)
-		defer func() {
-			metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
-		}()
-
-		if err := lib.podMutator(libRequirementOptions{
-			containerFilter:       m.config.containerFilter,
-			containerMutators:     containerMutators,
-			initContainerMutators: initContainerMutators,
-			podMutators:           []podMutator{configInjector.podMutator(lib.lang)},
-		}, m.imageResolver).mutatePod(pod); err != nil {
-			metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
+	// Apply all mutations in order
+	var lastError error
+	for _, mutator := range []podMutator{
+		// Injects DD_INSTRUMENTATION_INSTALL_TYPE, DD_INSTRUMENTATION_INSTALL_TIME, DD_INSTRUMENTATION_INSTALL_ID
+		m.kpiEnvVarsMutator(config),
+		// Injects APM injector + language-specific library init containers, volumes, and env vars
+		m.apmInjectionMutator(config, autoDetected, injectionType),
+		// Injects DD_VERSION and DD_ENV from pod labels/annotations
+		m.ustEnvVarsPodMutator(),
+		// Injects language detection annotations
+		m.languageDetectionMutator(config),
+		// Injects library config from annotations (admission.datadoghq.com/all-lib.config.v1)
+		m.libConfigFromAnnotationsMutator(config, autoDetected, injectionType),
+		// Injects default library config for SSI-eligible namespaces
+		m.defaultLibConfigMutator(pod.Namespace),
+	} {
+		if err := mutator.mutatePod(pod); err != nil {
 			lastError = err
-			continue
 		}
-
-		injected = true
-	}
-
-	if err := configInjector.podMutator(language("all")).mutatePod(pod); err != nil {
-		metrics.LibInjectionErrors.Inc("all", strconv.FormatBool(autoDetected), injectionType)
-		lastError = err
-		log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
-	}
-
-	if m.filter.IsNamespaceEligible(pod.Namespace) {
-		_ = basicLibConfigInjector{}.mutatePod(pod)
 	}
 
 	return lastError
+}
+
+// resolveInitSecurityContext determines the security context for init containers.
+func (m *mutatorCore) resolveInitSecurityContext(nsName string) *corev1.SecurityContext {
+	if m.config.initSecurityContext != nil {
+		return m.config.initSecurityContext
+	}
+	nsLabels, err := getNamespaceLabels(m.wmeta, nsName)
+	if err != nil {
+		log.Warnf("error getting labels for namespace=%s: %s", nsName, err)
+		return nil
+	}
+	if val, ok := nsLabels["pod-security.kubernetes.io/enforce"]; ok && val == "restricted" {
+		return defaultRestrictedSecurityContext
+	}
+	return nil
+}
+
+// kpiEnvVarsMutator returns a mutator that injects KPI-related env vars.
+// (DD_INSTRUMENTATION_INSTALL_TYPE, DD_INSTRUMENTATION_INSTALL_TIME, DD_INSTRUMENTATION_INSTALL_ID)
+func (m *mutatorCore) kpiEnvVarsMutator(config extractedPodLibInfo) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		return m.mutatePodContainers(pod, config.source.containerMutator())
+	})
+}
+
+// apmInjectionMutator returns a mutator that injects the APM injector and language-specific libraries.
+// This is the core injection logic that will be replaced by providers in the future.
+func (m *mutatorCore) apmInjectionMutator(config extractedPodLibInfo, autoDetected bool, injectionType string) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		// Compute resource requirements (may skip injection if insufficient)
+		requirements, decision := initContainerResourceRequirements(pod, m.config.defaultResourceRequirements)
+		if decision.skipInjection {
+			if pod.Annotations == nil {
+				pod.Annotations = make(map[string]string)
+			}
+			SetAnnotation(pod, AnnotationInjectionError, decision.message)
+			return nil
+		}
+
+		securityContext := m.resolveInitSecurityContext(pod.Namespace)
+		initContainerMutators := containerMutators{containerResourceRequirements{requirements}}
+		if securityContext != nil {
+			initContainerMutators = append(initContainerMutators, containerSecurityContext{securityContext})
+		}
+
+		// Inject the APM injector
+		injector := m.newInjector(pod, time.Now(), libRequirementOptions{
+			containerFilter:       m.config.containerFilter,
+			initContainerMutators: initContainerMutators,
+		})
+		if err := injector.podMutator().mutatePod(pod); err != nil {
+			metrics.LibInjectionErrors.Inc("injector", strconv.FormatBool(autoDetected), injectionType)
+			log.Errorf("Cannot inject library injector into pod %s: %s", mutatecommon.PodString(pod), err)
+			return err
+		}
+
+		// Inject language-specific libraries
+		var lastError error
+		for _, lib := range config.libs {
+			injected := false
+			langStr := string(lib.lang)
+			defer func() {
+				metrics.LibInjectionAttempts.Inc(langStr, strconv.FormatBool(injected), strconv.FormatBool(autoDetected), injectionType)
+			}()
+
+			if err := lib.podMutator(libRequirementOptions{
+				containerFilter:       m.config.containerFilter,
+				initContainerMutators: initContainerMutators,
+			}, m.imageResolver).mutatePod(pod); err != nil {
+				metrics.LibInjectionErrors.Inc(langStr, strconv.FormatBool(autoDetected), injectionType)
+				lastError = err
+				continue
+			}
+
+			injected = true
+		}
+		return lastError
+	})
+}
+
+// libConfigFromAnnotationsMutator returns a mutator that reads library configuration
+// from pod annotations (admission.datadoghq.com/<lang>-lib.config.v1) and injects
+// the corresponding env vars. Reads config for each injected language + "all".
+// This allows users to customize library behavior via annotations.
+func (m *mutatorCore) libConfigFromAnnotationsMutator(config extractedPodLibInfo, autoDetected bool, injectionType string) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		configInjector := &libConfigInjector{}
+		var lastError error
+
+		// Inject config for each language
+		for _, lib := range config.libs {
+			if err := configInjector.podMutator(lib.lang).mutatePod(pod); err != nil {
+				metrics.LibInjectionErrors.Inc(string(lib.lang), strconv.FormatBool(autoDetected), injectionType)
+				log.Errorf("Cannot inject library configuration for %s into pod %s: %s", lib.lang, mutatecommon.PodString(pod), err)
+				lastError = err
+			}
+		}
+
+		// Inject config for "all" languages
+		if err := configInjector.podMutator(language("all")).mutatePod(pod); err != nil {
+			metrics.LibInjectionErrors.Inc("all", strconv.FormatBool(autoDetected), injectionType)
+			log.Errorf("Cannot inject library configuration into pod %s: %s", mutatecommon.PodString(pod), err)
+			lastError = err
+		}
+
+		return lastError
+	})
+}
+
+// defaultLibConfigMutator returns a mutator that injects default library configuration
+// for namespaces eligible to Single Step Instrumentation.
+// Defaults: DD_TRACE_ENABLED=true, DD_LOGS_INJECTION=true,
+// DD_TRACE_HEALTH_METRICS_ENABLED=true, DD_RUNTIME_METRICS_ENABLED=true.
+func (m *mutatorCore) defaultLibConfigMutator(namespace string) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		if m.filter.IsNamespaceEligible(namespace) {
+			_ = basicLibConfigInjector{}.mutatePod(pod)
+		}
+		return nil
+	})
+}
+
+// ustEnvVarsPodMutator returns a mutator that injects UST env vars (DD_VERSION, DD_ENV) to all containers.
+func (m *mutatorCore) ustEnvVarsPodMutator() podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		mutator := m.ustEnvVarMutator(pod)
+		// Apply to application containers
+		for i := range pod.Spec.Containers {
+			if err := mutator.mutateContainer(&pod.Spec.Containers[i]); err != nil {
+				return err
+			}
+		}
+		// Apply to init containers
+		for i := range pod.Spec.InitContainers {
+			if err := mutator.mutateContainer(&pod.Spec.InitContainers[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// languageDetectionMutator returns a mutator that applies language detection mutations.
+func (m *mutatorCore) languageDetectionMutator(config extractedPodLibInfo) podMutator {
+	return podMutatorFunc(func(pod *corev1.Pod) error {
+		mutator := config.languageDetection.containerMutator()
+		for i := range pod.Spec.Containers {
+			if err := mutator.mutateContainer(&pod.Spec.Containers[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // serviceNameMutator will attempt to find a service name to
@@ -187,37 +284,6 @@ func (m *mutatorCore) ustEnvVarMutator(pod *corev1.Pod) containerMutator {
 	return mutators
 }
 
-// newInitContainerMutators constructs container mutators for behavior
-// that is common and passed to the init containers we create.
-//
-// At this point in time it is: resource requirements and security contexts.
-func (m *mutatorCore) newInitContainerMutators(
-	requirements corev1.ResourceRequirements,
-	nsName string,
-) containerMutators {
-	securityContext := m.config.initSecurityContext
-	if securityContext == nil {
-		nsLabels, err := getNamespaceLabels(m.wmeta, nsName)
-		if err != nil {
-			log.Warnf("error getting labels for namespace=%s: %s", nsName, err)
-		} else if val, ok := nsLabels["pod-security.kubernetes.io/enforce"]; ok && val == "restricted" {
-			// https://datadoghq.atlassian.net/browse/INPLAT-492
-			securityContext = defaultRestrictedSecurityContext
-		}
-	}
-
-	mutators := []containerMutator{
-		containerResourceRequirements{requirements},
-	}
-
-	if securityContext != nil {
-		mutators = append(mutators, containerSecurityContext{securityContext})
-	}
-
-	return mutators
-}
-
-// newInjector creates an injector instance for this pod.
 func (m *mutatorCore) newInjector(pod *corev1.Pod, startTime time.Time, lopts libRequirementOptions) *injector {
 	opts := []injectorOption{
 		injectorWithLibRequirementOptions(lopts),

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -205,19 +205,19 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 	}
 
 	// Add the configuration for the security client library.
-	if err := m.core.mutatePodContainers(pod, m.securityClientLibraryMutator); err != nil {
+	if err := m.core.mutatePodContainers(pod, m.securityClientLibraryMutator, true); err != nil {
 		return false, fmt.Errorf("error mutating pod for security client: %w", err)
 	}
 
 	// Add the configuration for profiling.
-	if err := m.core.mutatePodContainers(pod, m.profilingClientLibraryMutator); err != nil {
+	if err := m.core.mutatePodContainers(pod, m.profilingClientLibraryMutator, true); err != nil {
 		return false, fmt.Errorf("error mutating pod for profiling client: %w", err)
 	}
 
 	// Inject the tracer configs. We do this before lib injection to ensure DD_SERVICE is set if the user configures it
 	// in the target.
 	for _, envVar := range target.envVars {
-		_ = m.core.mutatePodContainers(pod, envVarMutator(envVar))
+		_ = m.core.mutatePodContainers(pod, envVarMutator(envVar), true)
 	}
 
 	// Inject the libraries.
@@ -239,7 +239,7 @@ func (m *TargetMutator) addTargetJSONInfo(pod *corev1.Pod, target *targetInterna
 	_ = m.core.mutatePodContainers(pod, envVarMutator(corev1.EnvVar{
 		Name:  AppliedTargetEnvVar,
 		Value: target.json,
-	}))
+	}), true)
 
 	// Add the annotations to the pod.
 	SetAnnotation(pod, AnnotationAppliedTarget, target.json)

--- a/pkg/ssi/testutils/pod.go
+++ b/pkg/ssi/testutils/pod.go
@@ -205,6 +205,15 @@ func (v *PodValidator) RequireMissingEnvs(t *testing.T, missing []string, expect
 	}
 }
 
+// RequireUnmutatedContainers ensures that the specified containers have no Datadog-related environment variables.
+func (v *PodValidator) RequireUnmutatedContainers(t *testing.T, containerNames []string) {
+	for _, name := range containerNames {
+		validator, found := v.containers[name]
+		require.True(t, found, "invalid test setup, expected container %s does not exist in the pod", name)
+		validator.RequireUnmutated(t)
+	}
+}
+
 // RequireInjectorVersion is a high level function to ensure the injector version found for the pod matches expected.
 func (v *PodValidator) RequireInjectorVersion(t *testing.T, expected string) {
 	require.Equal(t, expected, v.injectorVersion, "the injector version does not match the expected")

--- a/releasenotes-dca/notes/refactor-autoinstrumentation-injectTracers-4c1aedf99439372c.yaml
+++ b/releasenotes-dca/notes/refactor-autoinstrumentation-injectTracers-4c1aedf99439372c.yaml
@@ -2,4 +2,4 @@
 other:
   - |
     Refactor the auto-instrumentation webhook's ``injectTracers`` function to use a modular, explicit mutation pattern.
-    This improves code readability and maintainability. Edge case behavior may slightly differ, but overall functionality remains unchanged.
+    This improves code readability and maintainability. Edge case behavior may differ slightly, but overall functionality remains unchanged.

--- a/releasenotes-dca/notes/refactor-autoinstrumentation-injectTracers-4c1aedf99439372c.yaml
+++ b/releasenotes-dca/notes/refactor-autoinstrumentation-injectTracers-4c1aedf99439372c.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Refactor the auto-instrumentation webhook's ``injectTracers`` function to use a modular, explicit mutation pattern.
+    This improves code readability and maintainability. Edge case behavior may slightly differ, but overall functionality remains unchanged.


### PR DESCRIPTION
### What does this PR do?

Refactors the `injectTracers` function in the auto-instrumentation webhook to use a modular, explicit mutation pattern. Instead of having mutations embedded within other mutations (e.g., UST injection happening inside injector/library mutations), each mutation step is now a separate, clearly defined `podMutator` that is called sequentially.

**Key changes:**
- Extracted UST env vars injection into a dedicated `ustEnvVarsPodMutator`
- Extracted language detection into a dedicated `languageDetectionMutator`
- Merged injector and libraries mutations into a single `apmInjectionMutator`
- Centralized lib config from annotations (per-language + "all") into `libConfigFromAnnotationsMutator`
- Resource check is now performed inside `apmInjectionMutator` instead of at the top level

### Motivation

The original `injectTracers` function was complex and hard to follow because:
1. Mutations were nested inside other mutations (e.g., UST was applied during injector/library init container creation)
2. The flow was not immediately visible from reading the main function
3. Adding or modifying a mutation step required understanding the entire flow

This refactoring makes the function easier to understand, test, and extend by making each mutation step explicit and independent.

**This is preparatory work for introducing a new APM injection mode using CSI driver instead of init containers.** The modular architecture will allow switching between init container-based injection and CSI-based injection without affecting the other mutation steps (KPI, UST, language detection, lib config).

### Describe how you validated your changes

- Ran existing unit tests: `go test -tags="kubeapiserver test" ./pkg/clusteragent/admission/mutate/autoinstrumentation/...`
- Added new integration tests for:
  - `ustEnvVarsPodMutator`: Verifies DD_VERSION and DD_ENV are injected from pod labels via `kubernetes_pod_labels_as_tags`
  - `libConfigFromAnnotationsMutator`: Verifies language-specific config injection for Python and JavaScript
  - Negative test: Verifies UST env vars are NOT injected when namespace is not eligible
- Verified each mutator by temporarily commenting it out and confirming tests fail

### Additional Notes

#### Behavioral Differences

<details>
<summary>Click to expand BEFORE vs AFTER comparison</summary>

**BEFORE:**

- Resource check
    - Stop if resources are insufficient

- KPI env vars (config.source.containerMutator())
    - DD_INSTRUMENTATION_INSTALL_TYPE, DD_INSTRUMENTATION_INSTALL_TIME, DD_INSTRUMENTATION_INSTALL_ID on app containers
    - Stop in case of error

- Injector mutation
    - Creates init container and applies resources, securityContext, UST
    - Injects volumes and env vars (LD_PRELOAD, etc.) to app containers
    - Continue in case of error

- Libraries mutation (for each lib):
    - Creates init container and applies resources, securityContext, UST
    - Applies language detection to app containers
    - Applies UST to app containers
    - Applies lib config from annotations (per language) to app containers and init containers
    - Continue in case of error

- Lib config from annotations (for "all" languages)
    - Set env vars from pod annotation to app containers and init containers
    - Continue in case of error

- Basic/default lib config
    - DD_TRACE_ENABLED, DD_LOGS_INJECTION, ...
    - Continue in case of error

---

**AFTER:**

- KPI env vars (config.source.containerMutator())
    - DD_INSTRUMENTATION_INSTALL_TYPE, DD_INSTRUMENTATION_INSTALL_TIME, DD_INSTRUMENTATION_INSTALL_ID on app containers
    - Continue in case of error

- APM injection
    - Resource check
        - Stop (only APM injection) if resources are insufficient

    - Injector mutation
        - Creates init container and applies resources, securityContext (**no UST**)
        - Injects volumes and env vars (LD_PRELOAD, etc.) to app containers
        - Stop (only APM injection) in case of error

    - Libraries mutation (for each lib):
        - Creates init container and applies resources, securityContext (**no UST**)
        - (**No language detection**)
        - (**No UST**)
        - (**No lib config from annotations per language**)
        - Continue in case of error

- UST env vars
    - App containers and init containers
    - Continue in case of error

- Language detection
    - App containers (no init containers)
    - Continue in case of error

- Lib config from annotations
    - Set env vars from pod annotation to app containers and init containers
    - Per language + "all"
    - Continue in case of error

- Basic/default lib config
    - DD_TRACE_ENABLED, DD_LOGS_INJECTION, ...
    - Continue in case of error

</details>

#### Key Behavioral Changes

1. **Resource check timing**: Previously, if resources were insufficient, nothing was mutated. Now, only APM injection is skipped — KPI env vars, UST env vars, language detection, lib config from annotations, and default lib config are still applied.

2. **Error handling for KPI**: Previously, KPI injection errors would stop the entire mutation. Now, errors are logged and mutation continues with the remaining steps.

3. **UST injection is now separate**: UST env vars (DD_VERSION, DD_ENV, DD_SERVICE) are now injected in a dedicated step that runs after APM injection, ensuring they are always applied to all containers (app + init) regardless of APM injection success.

4. **Language detection is now separate**: Applied after APM injection as a dedicated step.

5. **Lib config from annotations is centralized**: Both per-language and "all" language configs are now handled in a single mutator step.