### PR TITLE
[SQG] Fix ancestor resolution in main

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -13,7 +13,13 @@ from tasks.github_tasks import pr_commenter
 from tasks.libs.ciproviders.github_api import GithubAPI, create_datadog_agent_pr
 from tasks.libs.ciproviders.gitlab_api import get_gitlab_repo
 from tasks.libs.common.color import color_message
-from tasks.libs.common.git import create_tree, get_common_ancestor, get_current_branch, is_a_release_branch
+from tasks.libs.common.git import (
+    create_tree,
+    get_commit_sha,
+    get_common_ancestor,
+    get_current_branch,
+    is_a_release_branch,
+)
 from tasks.libs.common.utils import running_in_ci
 from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.experimental_gates import (
@@ -466,6 +472,12 @@ def parse_and_trigger_gates(ctx, config_path: str = GATE_CONFIG_PATH) -> list[St
     # Calculate relative sizes (delta from ancestor) before sending metrics
     # This is done for all branches to include delta metrics in Datadog
     ancestor = get_common_ancestor(ctx, "HEAD")
+    current_commit = get_commit_sha(ctx)
+    # When on main branch, get_common_ancestor returns HEAD itself since merge-base of HEAD and origin/main
+    # is the current commit. In this case, use the parent commit as the ancestor instead.
+    if ancestor == current_commit:
+        ancestor = get_commit_sha(ctx, commit="HEAD~1")
+        print(color_message(f"On main branch, using parent commit {ancestor} as ancestor", "cyan"))
     metric_handler.generate_relative_size(ctx, ancestor=ancestor, report_path="ancestor_static_gate_report.json")
 
     # Post-process gate failures: mark as non-blocking if delta <= 0


### PR DESCRIPTION
### What does this PR do?
SQG job pulls a JSON report from an ancestor to compare current artifact size vs the ancestor. Recent jobs reported they are unable to find an ancestor's JSON report. The reason is that we resolve ancestor to the current commit so the report wasn't even uploaded yet. This PR addresses it by taking previous commit in case current commit SHA equals to the resolved ancestor.

`get_common_ancestor` resolves to the following command `git merge-base HEAD origin/main`. Executing it locally whilst having main branch active does indeed return the same commit as a merge-base as HEAD.

Example:
`commit ae720c604a9533cd0892e264afa053df25ef774b (HEAD -> main, origin/main, origin/HEAD)`

```bash
➜  datadog-agent git:(main) git merge-base HEAD origin/main 
ae720c604a9533cd0892e264afa053df25ef774b
```
