### PR TITLE
Set GOMEMLIMIT on all processes automatically

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -197,6 +197,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// runtime init routines
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 )
 
@@ -216,9 +217,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		// TODO: once the agent is represented as a component, and not a function (run),
 		// this will use `fxutil.Run` instead of `fxutil.OneShot`.
 		return fxutil.OneShot(run,
-			fx.Invoke(func(_ log.Component) {
-				ddruntime.SetMaxProcs()
-			}),
+			fx.Invoke(func(_ log.Component) { ddruntime.PrepareGoRuntime(env.IsContainerized()) }),
 			fx.Supply(core.BundleParams{
 				ConfigParams:         config.NewAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(cliParams.ExtraConfFilePath), config.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath)),
 				SysprobeConfigParams: sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.SysProbeConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(cliParams.FleetPoliciesDirPath)),

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -90,11 +90,13 @@ import (
 	clusteragentMetricsStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstatus"
 	orchestratorStatus "github.com/DataDog/datadog-agent/pkg/clusteragent/orchestrator"
 	pkgcollector "github.com/DataDog/datadog-agent/pkg/collector"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/diagnose/connectivity"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	hostnameStatus "github.com/DataDog/datadog-agent/pkg/status/clusteragent/hostname"
 	endpointsStatus "github.com/DataDog/datadog-agent/pkg/status/endpoints"
@@ -288,6 +290,8 @@ func start(log log.Component,
 
 	// Starting Cluster Agent sequence
 	// Initialization order is important for multiple reasons, see comments
+
+	ddruntime.PrepareGoRuntime(env.IsContainerized())
 
 	if err := coredump.Setup(config); err != nil {
 		pkglog.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)

--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -17,6 +17,9 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
+
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -191,6 +194,8 @@ func start(
 	_ inventoryhost.Component,
 	_ healthprobe.Component,
 ) error {
+	ddruntime.PrepareGoRuntime(env.IsContainerized())
+
 	// Main context passed to components
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -64,6 +64,7 @@ import (
 	payloadmodifierfx "github.com/DataDog/datadog-agent/comp/trace/payload-modifier/fx"
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/trace/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
@@ -118,6 +119,7 @@ func runOTelAgentCommand(ctx context.Context, params *cliParams, opts ...fx.Opti
 
 	if err == agentConfig.ErrNoDDExporter {
 		return fxutil.Run(
+			fx.Invoke(func() { ddruntime.PrepareGoRuntime(pkgconfigenv.IsContainerized()) }),
 			fx.Supply(uris),
 			fx.Provide(func() coreconfig.Component {
 				return acfg

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -67,6 +67,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta/collector"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
+	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util/coredump"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -283,6 +284,8 @@ type miscDeps struct {
 // Todo: (Components) WorkloadMeta, remoteTagger
 // Todo: move metadata/workloadmeta/collector to workloadmeta
 func initMisc(deps miscDeps) error {
+	ddruntime.PrepareGoRuntime(env.IsContainerized())
+
 	if err := coredump.Setup(deps.Config); err != nil {
 		deps.Logger.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -58,6 +58,7 @@ import (
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
 	"github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -197,8 +198,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 func start(log log.Component, config config.Component, secrets secrets.Component, _ statsd.Component, _ sysprobeconfig.Component, telemetry telemetry.Component, statusComponent status.Component, _ pid.Component, _ autoexit.Component, settings settings.Component, wmeta workloadmeta.Component, ipc ipc.Component) error {
 	defer StopAgent(log)
 
-	// prepare go runtime
-	ddruntime.SetMaxProcs()
+	ddruntime.PrepareGoRuntime(env.IsContainerized())
 
 	if config.GetBool("security_agent.disable_thp") {
 		if err := ddruntime.DisableTransparentHugePages(); err != nil {

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -175,8 +175,7 @@ func run(log log.Component, _ config.Component, telemetry telemetry.Component, s
 		stopSystemProbe()
 	}()
 
-	// prepare go runtime
-	ddruntime.SetMaxProcs()
+	ddruntime.PrepareGoRuntime(env.IsContainerized())
 
 	if sysprobeconfig.GetBool("system_probe_config.disable_thp") {
 		if err := ddruntime.DisableTransparentHugePages(); err != nil {

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -185,9 +185,9 @@ func prepGoRuntime(tracecfg *tracecfg.AgentConfig) {
 		} else if tracecfg.MaxMemory > 0 {
 			// We have apm_config.max_memory, and no cgroup memory limit is in place.
 			// log.Infof("apm_config.max_memory: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024))
-			finalmem := int64(tracecfg.MaxMemory * 0.9)
+			finalmem := int64(tracecfg.MaxMemory * 0.85)
 			debug.SetMemoryLimit(finalmem)
-			log.Infof("apm_config.max_memory set to: %vMiB. Setting GOMEMLIMIT to 90%% of max: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024), finalmem/(1024*1024))
+			log.Infof("apm_config.max_memory set to: %vMiB. Setting GOMEMLIMIT to 85%% of max: %vMiB", int64(tracecfg.MaxMemory)/(1024*1024), finalmem/(1024*1024))
 		} else {
 			// There are no memory constraints
 			log.Infof("GOMEMLIMIT unconstrained.")

--- a/pkg/runtime/gomemlimit_linux.go
+++ b/pkg/runtime/gomemlimit_linux.go
@@ -17,7 +17,8 @@ import (
 )
 
 // SetGoMemLimit configures Go memory soft limit based on cgroups.
-// The soft limit is set to 90% of the cgroup memory hard limit.
+// The soft limit is set to 85% of the cgroup memory hard limit, which triggers
+// aggressive GC as memory approaches the cgroup ceiling.
 // The function is noop if
 //   - GOMEMLIMIT is set already
 //   - There is no cgroup limit
@@ -44,7 +45,7 @@ func SetGoMemLimit(isContainerized bool) (int64, error) {
 		log.Info("Cgroup memory limit not found, doing nothing")
 		return 0, nil
 	}
-	softLimit := int64(0.9 * float64(*stats.Limit))
+	softLimit := int64(0.85 * float64(*stats.Limit))
 	log.Infof("Cgroup memory limit is %d, setting gomemlimit to %d", *stats.Limit, softLimit)
 	debug.SetMemoryLimit(softLimit)
 	return softLimit, nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -88,3 +88,13 @@ func NumVCPU() int {
 	// Value < 1 returns the current value without altering it.
 	return runtime.GOMAXPROCS(0)
 }
+
+// PrepareGoRuntime configures the Go runtime for optimal performance in containerized environments.
+// It sets GOMAXPROCS based on cgroup CPU limits and GOMEMLIMIT based on cgroup memory limits.
+// This should be called early in the application startup, after the logger is initialized.
+func PrepareGoRuntime(isContainerized bool) {
+	SetMaxProcs()
+	if _, err := SetGoMemLimit(isContainerized); err != nil {
+		log.Infof("Couldn't set Go memory limit from cgroup: %s", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This commit is a spike for #incident-47337. It sets all Agent sub-processes to have GOMEMLIMIT set at 85% automatically, assuming the Agent is running in a cgroup environment with a limit set. This follows the pattern established by trace-agent, although we have adjusted the limit from 90% to 85% unilaterally.

### Additional Notes

If we pursue this future PRs will be split along code owner lines. 