### PR TITLE
7.74.x fix apm test packages

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
@@ -55,8 +55,8 @@ $env:DD_INJECT_LOG_LEVEL = "debug"
 	output, err := host.Execute(script)
 	s.Require().NoError(err)
 	if enabled {
-		s.Require().Contains(output, "Instrumenting Java")
+		s.Require().Contains(output, "main executable path")
 	} else {
-		s.Require().NotContains(output, "Instrumenting Java")
+		s.Require().NotContains(output, "main executable path")
 	}
 }

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/base_suite.go
@@ -26,11 +26,11 @@ func (s *baseSuite) SetupSuite() {
 
 	s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("CURRENT_APM_INJECT_VERSION"))
 	if s.currentAPMInjectVersion.PackageVersion() == "" {
-		s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.ba30ecb.glci1208428525.g594e53fe-1")
+		s.currentAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.52.0-dev.b282e14.glci1291404213.g7ff18a26-1")
 	}
 	s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion(os.Getenv("PREVIOUS_APM_INJECT_VERSION"))
 	if s.previousAPMInjectVersion.PackageVersion() == "" {
-		s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.beb48a5.glci1208433719.g08c01dc4-1")
+		s.previousAPMInjectVersion = installerwindows.NewVersionFromPackageVersion("0.50.0-dev.ba30ecb.glci1208428525.g594e53fe-1")
 	}
 }
 func (s *baseSuite) assertSuccessfulPromoteExperiment() {


### PR DESCRIPTION
### What does this PR do?
This test updates the packages used by the apm test to use ones that don't break on release branches.

### Motivation
#incident-47798

### Describe how you validated your changes
e2e test changes

### Additional Notes
