### PR TITLE
Backport 44726 to 7.75.x

### DIFF
--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -16,7 +16,7 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pdhutil"
@@ -46,11 +46,11 @@ var (
 	PIDBufferIncrement uint32 = 1024
 )
 
-var fileDescCache *simplelru.LRU[string, string]
+var fileDescCache *lru.Cache[string, string]
 
 func init() {
 	var err error
-	fileDescCache, err = simplelru.NewLRU[string, string](512, nil)
+	fileDescCache, err = lru.New[string, string](512)
 	if err != nil {
 		log.Errorf("Failed to create file description cache: %v", err)
 	}

--- a/pkg/process/procutil/process_windows_toolhelp.go
+++ b/pkg/process/procutil/process_windows_toolhelp.go
@@ -243,9 +243,14 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 	if usererr != nil {
 		log.Debugf("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
 	}
+	imagePath, err := winutil.GetImagePathForProcess(cp.procHandle)
+	if err != nil {
+		log.Debugf("Error retrieving exe path for pid %v %v", pe32.Th32ProcessID, err)
+	} else {
+		cp.comm = getFileDescriptionCached(imagePath)
+	}
 	cp.executablePath = winutil.ConvertWindowsString16(pe32.SzExeFile[:])
 	cp.commandLine = cp.executablePath
-	cp.comm = getFileDescriptionCached(cp.executablePath)
 	// we cannot read the command line if the process is protected
 	if !isProtected {
 		commandParams, cmderr := winutil.GetCommandParamsForProcess(cp.procHandle, false)

--- a/releasenotes/notes/fix-image-path-6d580ceae8b5b956.yaml
+++ b/releasenotes/notes/fix-image-path-6d580ceae8b5b956.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed Windows live process file descriptor resolution to use the full executable path.

--- a/releasenotes/notes/fix-image-path-6d580ceae8b5b956.yaml
+++ b/releasenotes/notes/fix-image-path-6d580ceae8b5b956.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fixed Windows live process file descriptor resolution to use the full executable path.
+    Fixed live process file descriptor resolution on Windows to use the full executable path.

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -142,6 +142,13 @@ func assertProcessCommandLineArgs(t require.TestingT, processes []*agentmodel.Pr
 	}
 }
 
+func assertCommProperty(t require.TestingT, processes []*agentmodel.Process, expectedComm string) {
+	for _, proc := range processes {
+		// compare the comm property of the process
+		assert.Containsf(t, proc.Command.Comm, expectedComm, "process comm does not match. Expected %s", expectedComm)
+	}
+}
+
 // assertProcesses asserts that the given processes are collected by the process check
 func assertProcesses(t require.TestingT, procs []*agentmodel.Process, withIOStats bool, process string) {
 	// verify process data is populated


### PR DESCRIPTION
Use Full Image Name for File Description (https://github.com/DataDog/datadog-agent/pull/44726) 

### What does this PR do? 
Gets full path to fix bug in FileDescription grabbing.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2128

### Describe how you validated your changes
Manually ran agent and verified that error are no longer accruing for live processes.
Example of a exe with full path being used now that does not have a FileDescription.
```
2026-01-02 12:00:56 PST | PROCESS | DEBUG | (pkg/process/procutil/process_windows.go:73 in getFileDescriptionCached) | Could not get file description for C:\Program Files\WindowsApps\Microsoft.WindowsStore_22510.1401.4.0_x64__8wekyb3d8bbwe\StoreDesktopExtension.exe: GetFileVersionInfoSizeW failed: The specified resource type cannot be found in the image file.

```

### Additional Notes