### PR TITLE
Fix flakey windows certificate e2e test

### DIFF
--- a/test/new-e2e/tests/windows/components/certificatehost/component.go
+++ b/test/new-e2e/tests/windows/components/certificatehost/component.go
@@ -7,15 +7,14 @@
 package certificatehost
 
 import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/namer"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/remote"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/powershell"
 )
 
 // Manager contains the resources to manage a certificate host setup
@@ -62,7 +61,7 @@ func NewCertificateHost(e *config.CommonEnvironment, host *remote.Host, options 
 		manager.Resources = append(manager.Resources, cmd)
 	}
 
-	// Configure registry for remote access
+	// Configure LocalAccountTokenFilterPolicy to disable UAC remote restrictions for admin accounts
 	cmd, err := host.OS.Runner().Command(manager.namer.ResourceName("set-registry-policy"), &command.Args{
 		Create: pulumi.String(`New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -Force -ErrorAction SilentlyContinue; Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System' -Name LocalAccountTokenFilterPolicy -Value 1 -Type DWORD`),
 	}, deps...)
@@ -72,9 +71,9 @@ func NewCertificateHost(e *config.CommonEnvironment, host *remote.Host, options 
 	deps = append(deps, utils.PulumiDependsOn(cmd))
 	manager.Resources = append(manager.Resources, cmd)
 
-	// Configure firewall to allow SMB
-	cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("configure-firewall"), &command.Args{
-		Create: pulumi.String(`New-NetFirewallRule -DisplayName "Allow SMB TCP 445" -Direction Inbound -Protocol TCP -LocalPort 445 -Action Allow -ErrorAction SilentlyContinue`),
+	// Enable firewall rules for Remote Registry (uses RPC)
+	cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("configure-firewall-remote-registry"), &command.Args{
+		Create: pulumi.String(`Enable-NetFirewallRule -DisplayGroup "Remote Service Management" -ErrorAction SilentlyContinue`),
 	}, deps...)
 	if err != nil {
 		return nil, err
@@ -82,11 +81,46 @@ func NewCertificateHost(e *config.CommonEnvironment, host *remote.Host, options 
 	deps = append(deps, utils.PulumiDependsOn(cmd))
 	manager.Resources = append(manager.Resources, cmd)
 
-	// Start and enable RemoteRegistry service
+	// Grant the test user full control for remote registry access
+	if params.Username != "" {
+		cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("grant-registry-permissions"), &command.Args{
+			Create: pulumi.Sprintf(`
+				$ErrorActionPreference = 'Stop'
+				$computerName = $env:COMPUTERNAME
+				$identity = "$computerName\%s"
+				Write-Output "Granting full registry access for: $identity"
+				
+				# Grant full control on winreg key (controls remote registry access)
+				$winregPath = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurePipeServers\winreg"
+				if (-not (Test-Path $winregPath)) {
+					New-Item -Path $winregPath -Force | Out-Null
+				}
+				$winregAcl = Get-Acl $winregPath
+				$winregRule = New-Object System.Security.AccessControl.RegistryAccessRule($identity, "FullControl", "None", "None", "Allow")
+				$winregAcl.SetAccessRule($winregRule)
+				Set-Acl $winregPath $winregAcl
+				Write-Output "Set FullControl on winreg"
+				
+				# Grant full control on certificate store (with inheritance)
+				$certPath = "HKLM:\SOFTWARE\Microsoft\SystemCertificates"
+				$certAcl = Get-Acl $certPath
+				$certRule = New-Object System.Security.AccessControl.RegistryAccessRule($identity, "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+				$certAcl.SetAccessRule($certRule)
+				Set-Acl $certPath $certAcl
+				Write-Output "Set FullControl on certificate store with inheritance"
+				Write-Output "SUCCESS: Full registry access configured"
+			`, params.Username),
+		}, deps...)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, utils.PulumiDependsOn(cmd))
+		manager.Resources = append(manager.Resources, cmd)
+	}
+
+	// Set RemoteRegistry service to automatic startup and start it
 	cmd, err = host.OS.Runner().Command(manager.namer.ResourceName("start-remote-registry"), &command.Args{
-		Create: pulumi.String(powershell.PsHost().
-			StartService("RemoteRegistry").
-			Compile()),
+		Create: pulumi.String(`Set-Service -Name RemoteRegistry -StartupType Automatic; Start-Service -Name RemoteRegistry`),
 	}, deps...)
 	if err != nil {
 		return nil, err

--- a/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
+++ b/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go
@@ -29,8 +29,14 @@ import (
 )
 
 const (
-	TestUser     = "TestUser"
-	TestPassword = "Test1234#"
+	TestUser           = "TestUser"
+	TestPassword       = "Test1234#"
+	agentBinaryPath    = `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
+	checkConfigPath    = `C:\ProgramData\Datadog\conf.d\windows_certificate.d\conf.yaml`
+	checkName          = "windows_certificate"
+	agentStatusTimeout = 5 * time.Minute
+	checkRunTimeout    = 3 * time.Minute
+	retryInterval      = 10 * time.Second
 )
 
 type multiVMEnv struct {
@@ -88,6 +94,55 @@ func TestRemoteCertificates(t *testing.T) {
 	e2e.Run(t, &multiVMSuite{}, e2e.WithPulumiProvisioner(multiVMEnvProvisioner(), nil))
 }
 
+// waitForServiceRunning waits for a Windows service to be in Running state
+func (v *multiVMSuite) waitForServiceRunning(host *components.RemoteHost, serviceName string, timeout time.Duration) {
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		output, err := windowsCommon.GetServiceStatus(host, serviceName)
+		if err != nil {
+			v.T().Logf("Getting %s status failed: %v", serviceName, err)
+		}
+		assert.NoError(c, err)
+		assert.Contains(c, output, "Running")
+		v.T().Logf("%s status: %s", serviceName, output)
+	}, timeout, retryInterval)
+}
+
+// writeCheckConfigAndRestart writes the check configuration and restarts the agent
+func (v *multiVMSuite) writeCheckConfigAndRestart(host *components.RemoteHost, config string) {
+	v.T().Logf("Check config: %s", config)
+	_, err := host.WriteFile(checkConfigPath, []byte(config))
+	v.Require().NoError(err)
+
+	err = restartAgent(v, host)
+	v.Require().NoError(err)
+}
+
+// waitForAgentCheckRunning waits for the agent to be running and the specified check to be loaded
+func (v *multiVMSuite) waitForAgentCheckRunning(host *components.RemoteHost) {
+	cmd := fmt.Sprintf(`&'%s' status`, agentBinaryPath)
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		output, err := host.Execute(cmd)
+		assert.NoError(c, err)
+		assert.Contains(c, output, checkName)
+		v.T().Logf("Agent status: %s", output)
+	}, agentStatusTimeout, retryInterval)
+}
+
+// runCheckAndWaitForMetric runs the certificate check and waits for the expected metric to appear
+func (v *multiVMSuite) runCheckAndWaitForMetric(host *components.RemoteHost, expectedMetric string) string {
+	cmdCheck := fmt.Sprintf(`&'%s' check %s`, agentBinaryPath, checkName)
+	var output string
+	v.EventuallyWithT(func(c *assert.CollectT) {
+		var err error
+		output, err = host.Execute(cmdCheck)
+		assert.NoError(c, err)
+		assert.Contains(c, output, expectedMetric)
+		assert.NotContains(c, output, "Access is denied")
+		v.T().Logf("Check output: %s", output)
+	}, checkRunTimeout, retryInterval)
+	return output
+}
+
 func (v *multiVMSuite) SetupSuite() {
 	v.BaseSuite.SetupSuite()
 	defer v.CleanupOnSetupFailure()
@@ -96,15 +151,40 @@ func (v *multiVMSuite) SetupSuite() {
 	certificateHost := v.Env().CertificateHost
 
 	// Wait for LanmanServer to be running
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		output, err := windowsCommon.GetServiceStatus(certificateHost, "LanmanServer")
-		if err != nil {
-			v.T().Logf("Getting LanmanServer status failed %v", err)
+	v.waitForServiceRunning(certificateHost, "LanmanServer", 10*time.Minute)
+
+	// Wait for RemoteRegistry service to be running on certificate host
+	v.waitForServiceRunning(certificateHost, "RemoteRegistry", 5*time.Minute)
+
+	// Verify firewall rules for Remote Registry are enabled
+	v.T().Logf("Verifying firewall rules on certificate host")
+	firewallCheck := `Get-NetFirewallRule -DisplayGroup "Remote Service Management" -Enabled True -ErrorAction SilentlyContinue | Select-Object -First 5 -ExpandProperty DisplayName`
+	output, err := certificateHost.Execute(firewallCheck)
+	if err != nil {
+		v.T().Logf("Warning: Could not verify firewall rules: %v", err)
+	} else {
+		v.T().Logf("Enabled firewall rules: %s", output)
+	}
+
+	// Verify registry permissions are set on the certificate host
+	v.T().Logf("Verifying registry permissions for remote access")
+	aclVerifyCmd := fmt.Sprintf(`
+		$computerName = $env:COMPUTERNAME
+		$identity = "$computerName\%s"
+		$winregAcl = Get-Acl "HKLM:\SYSTEM\CurrentControlSet\Control\SecurePipeServers\winreg"
+		$certAcl = Get-Acl "HKLM:\SOFTWARE\Microsoft\SystemCertificates"
+		$winregRule = $winregAcl.Access | Where-Object { $_.IdentityReference -eq $identity }
+		$certRule = $certAcl.Access | Where-Object { $_.IdentityReference -eq $identity }
+		if ($winregRule -and $certRule) {
+			Write-Output "SUCCESS: Registry permissions configured"
+		} else {
+			Write-Output "FAILED: Missing permissions"
 		}
-		assert.NoError(c, err)
-		assert.Contains(c, output, "Running")
-		v.T().Logf("LanmanServer status: %s", output)
-	}, 10*time.Minute, 10*time.Second)
+	`, TestUser)
+	aclOutput, err := certificateHost.Execute(aclVerifyCmd)
+	v.Require().NoError(err)
+	v.T().Logf("Permission check: %s", aclOutput)
+	v.Require().Contains(aclOutput, "SUCCESS", "Registry permissions must be configured")
 
 	// Install the agent
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
@@ -119,6 +199,7 @@ func (v *multiVMSuite) TestGetRemoteCertificate() {
 	agentHost := v.Env().AgentHost
 	certificateHost := v.Env().CertificateHost
 
+	// Configure the check for MY certificate store
 	checkConfig := fmt.Sprintf(`
 init_config:
 instances:
@@ -126,47 +207,26 @@ instances:
     server: %s
     username: %s
     password: %s`, certificateHost.HostOutput.Address, TestUser, TestPassword)
-	v.T().Logf("Check config: %s", checkConfig)
 
-	_, err := agentHost.WriteFile("C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml", []byte(checkConfig))
-	v.Require().NoError(err)
+	v.writeCheckConfigAndRestart(agentHost, checkConfig)
+	v.waitForAgentCheckRunning(agentHost)
 
-	err = restartAgent(v, agentHost)
-	v.Require().NoError(err)
+	// Run the check and wait for metrics
+	output := v.runCheckAndWaitForMetric(agentHost, "windows_certificate.days_remaining")
 
-	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
-	cmd := fmt.Sprintf(`&'%s' status`, agent)
-
-	// Wait for the agent to be running and check that the windows_certificate check is running
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		output, err := agentHost.Execute(cmd)
-		assert.NoError(c, err)
-		assert.Contains(c, output, "windows_certificate")
-		v.T().Logf("Agent status: %s", output)
-	}, 5*time.Minute, 10*time.Second)
-
-	cmdCheck := fmt.Sprintf(`&'%s' check windows_certificate`, agent)
-	certStoreTag := `"certificate_store:MY"`
-	serverTag := fmt.Sprintf(`"server:%s"`, certificateHost.HostOutput.Address)
-	subjectCNTag := `"subject_CN:test_cert"`
-	output, err := agentHost.Execute(cmdCheck)
-	v.Require().NoError(err)
-	v.T().Logf("Check output: %s", output)
-
-	// Assert that the check output returns the metric and service check
+	// Verify all expected metrics and tags
 	v.Require().Contains(output, "windows_certificate.days_remaining")
 	v.Require().Contains(output, "windows_certificate.cert_expiration")
-
-	// Assert that the check output returns the correct metric tags
-	v.Require().Contains(output, certStoreTag)
-	v.Require().Contains(output, serverTag)
-	v.Require().Contains(output, subjectCNTag)
-
+	v.Require().Contains(output, `"certificate_store:MY"`)
+	v.Require().Contains(output, fmt.Sprintf(`"server:%s"`, certificateHost.HostOutput.Address))
+	v.Require().Contains(output, `"subject_CN:test_cert"`)
 }
 
 func (v *multiVMSuite) TestGetRemoteCertificateWithCrl() {
 	agentHost := v.Env().AgentHost
 	certificateHost := v.Env().CertificateHost
+
+	// Configure the check for CA certificate store with CRL monitoring
 	checkConfig := fmt.Sprintf(`
 init_config:
 instances:
@@ -175,60 +235,25 @@ instances:
     username: %s
     password: %s
     enable_crl_monitoring: true`, certificateHost.HostOutput.Address, TestUser, TestPassword)
-	v.T().Logf("Check config: %s", checkConfig)
 
-	_, err := agentHost.WriteFile("C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml", []byte(checkConfig))
-	v.Require().NoError(err)
+	v.writeCheckConfigAndRestart(agentHost, checkConfig)
+	v.waitForAgentCheckRunning(agentHost)
 
-	err = restartAgent(v, agentHost)
-	v.Require().NoError(err)
+	// Run the check and wait for CRL metrics
+	output := v.runCheckAndWaitForMetric(agentHost, "windows_certificate.crl_days_remaining")
 
-	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
-	cmd := fmt.Sprintf(`&'%s' status`, agent)
-
-	// Wait for the agent to be running and check that the windows_certificate check is running
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		output, err := agentHost.Execute(cmd)
-		assert.NoError(c, err)
-		assert.Contains(c, output, "windows_certificate")
-		v.T().Logf("Agent status: %s", output)
-	}, 5*time.Minute, 10*time.Second)
-
-	cmdCheck := fmt.Sprintf(`&'%s' check windows_certificate`, agent)
-	certStoreTag := `"certificate_store:CA"`
-	serverTag := fmt.Sprintf(`"server:%s"`, certificateHost.HostOutput.Address)
-	issuerOUTag := `"crl_issuer_OU:VeriSign Commercial Software Publishers CA"`
-	output, err := agentHost.Execute(cmdCheck)
-	v.Require().NoError(err)
-	v.T().Logf("Check output: %s", output)
-
-	// Assert that the check output returns the metric and service check
+	// Verify all expected CRL metrics and tags
 	v.Require().Contains(output, "windows_certificate.crl_days_remaining")
 	v.Require().Contains(output, "windows_certificate.crl_expiration")
-
-	// Assert that the check output returns the correct metric tags
-	v.Require().Contains(output, certStoreTag)
-	v.Require().Contains(output, serverTag)
-	v.Require().Contains(output, issuerOUTag)
-
+	v.Require().Contains(output, `"certificate_store:CA"`)
+	v.Require().Contains(output, fmt.Sprintf(`"server:%s"`, certificateHost.HostOutput.Address))
+	v.Require().Contains(output, `"crl_issuer_OU:VeriSign Commercial Software Publishers CA"`)
 }
 
 func restartAgent(v *multiVMSuite, host *components.RemoteHost) error {
+	// Ensure the agent is running before restarting it
+	v.waitForServiceRunning(host, "datadogagent", 10*time.Minute)
 
-	// Make sure the agent is running before restarting it
-	v.EventuallyWithT(func(c *assert.CollectT) {
-		output, err := windowsCommon.GetServiceStatus(host, "datadogagent")
-		if err != nil {
-			v.T().Logf("Getting datadogagent status failed %v", err)
-		}
-		assert.NoError(c, err)
-		assert.Contains(c, output, "Running")
-		v.T().Logf("datadogagent status: %s", output)
-	}, 10*time.Minute, 10*time.Second)
-
-	err := windowsCommon.RestartService(host, "datadogagent")
-	if err != nil {
-		return err
-	}
-	return nil
+	// Restart the service
+	return windowsCommon.RestartService(host, "datadogagent")
 }


### PR DESCRIPTION
### What does this PR do?
Updates the Windows Certificate Store e2e tests fix flakey "Access is denied" errors: 

```
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/windows-certificate/windows_certificate_remote_test.go:157
        	            				/usr/local/go/src/runtime/asm_amd64.s:1693
        	Error:      	"\r\n\r\n  Running Checks\r\n  ==============\r\n    \r\n    windows_certificate\r\n    -------------------\r\n      Instance ID: windows_certificate:c530c5bc7281635a [ERROR]\r\n      Configuration Source: file:C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml[0]\r\n      Total Runs: 1\r\n      Metric Samples: Last Run: 0, Total: 0\r\n      Events: Last Run: 0, Total: 0\r\n      Service Checks: Last Run: 0, Total: 0\r\n      Average Execution Time : 41ms\r\n      Last Execution Date : 2026-01-08 17:04:32.692 UTC (1767891872692)\r\n      Last Successful Execution Date : Never\r\n      Error: Access is denied.\r\n      No traceback\r\n  Check Worker Utilization\r\n  ========================\r\n    No worker utilization data available\r\n\n  Metadata\n  ========\n    config.hash: windows_certificate:c530c5bc7281635a\n    config.provider: file\n    config.source: C:\\ProgramData\\Datadog\\conf.d\\windows_certificate.d\\conf.yaml[0]\n\nNOTE:\nThe check command runs in a different user context than the running service\nThis could affect results if the command relies on specific permissions and/or user contexts\n\nCheck has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.\nThis check type has 1 instances. If you're looking for a different check instance, try filtering on a specific one using the --instance-filter flag or set --discovery-min-instances to a higher value\n" does not contain "windows_certificate.days_remaining"
```

These errors point to an access issue to the remote registry so these changes change permissions to allow full access to the certificate store and winreg registry keys.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1578

### Describe how you validated your changes
Check running e2e test

### Additional Notes
