### PR TITLE
[ABLD-300] Remove `bazel`'s unpacked deps from GitLab cache

### DIFF
--- a/.gitlab/bazel/defs.yaml
+++ b/.gitlab/bazel/defs.yaml
@@ -19,7 +19,6 @@
       key: bazel-$CI_RUNNER_DESCRIPTION
       paths:
         - .cache/bazel/*/cache
-        - .cache/bazel/*/*/external
         - .cache/pip
       policy: pull-push
       when: on_success


### PR DESCRIPTION
### Motivation
The `external` (sub)directory indeed contains _unpacked_ `bazel` dependencies (~100k files) that are participating in high upload times (~90s) to the GitLab cache due to the slow nature of the underlying storage being configured (S3 bucket as of today).

### What does this PR do?
The present change therefore aims at removing it, given that:
1. one the one hand, this directory can be regenerated on-the-fly from the repository cache,
2. on the other hand, we're anyway successfully leveraging remote caching in CI.

### Additional Notes
Keeping a **minimal** GitLab cache looks like a decent compromise: fewer redundancies, but enough redundancy to operate on transient remote caching issues.