### PR TITLE
[#incident-47785] Fix notarization UUID on retries

### DIFF
--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -148,7 +148,7 @@ if [ "$SIGN" = true ]; then
             "$dmg_file" | tee /dev/stderr | awk '$1 == "id:" {id=$2} END{if (id) print id; else exit 2}'
     }
     export -f submit_for_notarization
-    SUBMISSION_ID=$(tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" submit_for_notarization "$LATEST_DMG")
+    SUBMISSION_ID=$(tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" submit_for_notarization "$LATEST_DMG" | tail -n1)
     echo "Submission ID: $SUBMISSION_ID"
 
     check_notarization_status() {


### PR DESCRIPTION
### What does this PR do?
When `submit_for_notarization` is retried, multiple UUIDs accumulate in `$SUBMISSION_ID` (one per retry attempt), causing `check_notarization_status` to fail with "must be a valid UUID" error.
=> capture only the last UUID by piping through `tail -n1`, ensuring only last UUID is passed to subsequent `notarytool` commands.

### Motivation
[#incident-47785](https://app.datadoghq.com/incidents/47785).