### PR TITLE
Adjust quality_gate_idle_all_features memory allotment down

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -9,7 +9,7 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 850 MiB
+  memory_allotment: 685 MiB
 
   environment:
     DD_API_KEY: a0000001


### PR DESCRIPTION
### What does this PR do?

This commit is a spike for #incident-47337. It sets the memory allotment -- essentially, the cgroup memory limit -- closer to the check limit.
