### PR TITLE
[CWS] Use dynamic port to avoid bind to fail

### DIFF
--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -31,13 +31,11 @@ func getFreePort(network string) (int, error) {
 	switch network {
 	case "tcp", "tcp4", "udp", "udp4":
 		addr = "127.0.0.1:0"
-	case "tcp6", "udp6":
-		addr = "[::1]:0"
 	default:
 		addr = "127.0.0.1:0"
 	}
 
-	if network == "udp" || network == "udp4" || network == "udp6" {
+	if network == "udp" || network == "udp4" {
 		conn, err := net.ListenPacket(network, addr)
 		if err != nil {
 			return 0, err
@@ -206,7 +204,7 @@ func TestBindEvent(t *testing.T) {
 	})
 
 	test.RunMultiMode(t, "bind-af-inet6-any-success", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		port, err := getFreePort("tcp6")
+		port, err := getFreePort("tcp")
 		if err != nil {
 			t.Fatalf("failed to get free port: %v", err)
 		}

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -59,7 +59,11 @@ func TestBindEvent(t *testing.T) {
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:         "test_bind_af_inet",
+			ID:         "test_bind_af_inet_udp",
+			Expression: `bind.addr.family == AF_INET && process.file.name in [ "syscall_tester", "testsuite" ] && bind.addr.ip == 0.0.0.0/32`,
+		},
+		{
+			ID:         "test_bind_af_inet_tcp",
 			Expression: `bind.addr.family == AF_INET && process.file.name in [ "syscall_tester", "testsuite" ] && bind.addr.ip == 0.0.0.0/32`,
 		},
 		{
@@ -107,7 +111,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Bind.Protocol, "wrong protocol")
 
 			test.validateBindSchema(t, event)
-		}, "test_bind_af_inet")
+		}, "test_bind_af_inet_tcp")
 	})
 
 	t.Run("bind-af-inet-any-success-tcp-io-uring", func(t *testing.T) {
@@ -171,7 +175,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Bind.Protocol, "wrong protocol")
 
 			test.validateBindSchema(t, event)
-		}, "test_bind_af_inet")
+		}, "test_bind_af_inet_tcp")
 	})
 
 	test.RunMultiMode(t, "bind-af-inet-any-success-udp", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -198,7 +202,7 @@ func TestBindEvent(t *testing.T) {
 			assert.Equal(t, uint16(unix.IPPROTO_UDP), event.Bind.Protocol, "wrong protocol")
 
 			test.validateBindSchema(t, event)
-		}, "test_bind_af_inet")
+		}, "test_bind_af_inet_udp")
 	})
 
 	test.RunMultiMode(t, "bind-af-inet6-any-success", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {

--- a/pkg/security/tests/bind_test.go
+++ b/pkg/security/tests/bind_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strconv"
 	"syscall"
 	"testing"
 
@@ -24,17 +25,46 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
+// getFreePort finds a free port by binding to port 0 and returning the assigned port
+func getFreePort(network string) (int, error) {
+	var addr string
+	switch network {
+	case "tcp", "tcp4", "udp", "udp4":
+		addr = "127.0.0.1:0"
+	case "tcp6", "udp6":
+		addr = "[::1]:0"
+	default:
+		addr = "127.0.0.1:0"
+	}
+
+	if network == "udp" || network == "udp4" || network == "udp6" {
+		conn, err := net.ListenPacket(network, addr)
+		if err != nil {
+			return 0, err
+		}
+		defer conn.Close()
+		return conn.LocalAddr().(*net.UDPAddr).Port, nil
+	}
+
+	listener, err := net.Listen(network, addr)
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
 func TestBindEvent(t *testing.T) {
 	SkipIfNotAvailable(t)
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_bind_af_inet",
-			Expression: `bind.addr.family == AF_INET && process.file.name in [ "syscall_tester", "testsuite" ]`,
+			Expression: `bind.addr.family == AF_INET && process.file.name in [ "syscall_tester", "testsuite" ] && bind.addr.ip == 0.0.0.0/32`,
 		},
 		{
 			ID:         "test_bind_af_inet6",
-			Expression: `bind.addr.family == AF_INET6 && process.file.name == "syscall_tester"`,
+			Expression: `bind.addr.family == AF_INET6 && process.file.name == "syscall_tester" && bind.addr.ip == ::/128`,
 		},
 		{
 			ID:         "test_bind_af_unix",
@@ -54,7 +84,11 @@ func TestBindEvent(t *testing.T) {
 	}
 
 	test.RunMultiMode(t, "bind-af-inet-any-success-tcp", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		args := []string{"bind", "AF_INET", "any", "tcp"}
+		port, err := getFreePort("tcp")
+		if err != nil {
+			t.Fatalf("failed to get free port: %v", err)
+		}
+		args := []string{"bind", "AF_INET", "any", "tcp", strconv.Itoa(port)}
 		envs := []string{}
 
 		test.WaitSignalFromRule(t, func() error {
@@ -67,7 +101,7 @@ func TestBindEvent(t *testing.T) {
 		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Bind.AddrFamily, "wrong address family")
-			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
+			assert.Equal(t, uint16(port), event.Bind.Addr.Port, "wrong address port")
 			assert.Equal(t, string("0.0.0.0/32"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 			assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Bind.Protocol, "wrong protocol")
@@ -92,8 +126,13 @@ func TestBindEvent(t *testing.T) {
 		}
 		defer iour.Close()
 
+		port, err := getFreePort("tcp")
+		if err != nil {
+			t.Fatalf("failed to get free port: %v", err)
+		}
+
 		sa := unix.SockaddrInet4{
-			Port: 4242,
+			Port: port,
 			Addr: [4]byte(net.IPv4(0, 0, 0, 0)),
 		}
 
@@ -126,7 +165,7 @@ func TestBindEvent(t *testing.T) {
 		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Bind.AddrFamily, "wrong address family")
-			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
+			assert.Equal(t, uint16(port), event.Bind.Addr.Port, "wrong address port")
 			assert.Equal(t, string("0.0.0.0/32"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 			assert.Equal(t, uint16(unix.IPPROTO_TCP), event.Bind.Protocol, "wrong protocol")
@@ -136,7 +175,11 @@ func TestBindEvent(t *testing.T) {
 	})
 
 	test.RunMultiMode(t, "bind-af-inet-any-success-udp", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		args := []string{"bind", "AF_INET", "any", "udp"}
+		port, err := getFreePort("udp")
+		if err != nil {
+			t.Fatalf("failed to get free port: %v", err)
+		}
+		args := []string{"bind", "AF_INET", "any", "udp", strconv.Itoa(port)}
 		envs := []string{}
 
 		test.WaitSignalFromRule(t, func() error {
@@ -149,7 +192,7 @@ func TestBindEvent(t *testing.T) {
 		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET), event.Bind.AddrFamily, "wrong address family")
-			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
+			assert.Equal(t, uint16(port), event.Bind.Addr.Port, "wrong address port")
 			assert.Equal(t, string("0.0.0.0/32"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 			assert.Equal(t, uint16(unix.IPPROTO_UDP), event.Bind.Protocol, "wrong protocol")
@@ -159,7 +202,11 @@ func TestBindEvent(t *testing.T) {
 	})
 
 	test.RunMultiMode(t, "bind-af-inet6-any-success", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		args := []string{"bind", "AF_INET6", "any"}
+		port, err := getFreePort("tcp6")
+		if err != nil {
+			t.Fatalf("failed to get free port: %v", err)
+		}
+		args := []string{"bind", "AF_INET6", "any", strconv.Itoa(port)}
 		envs := []string{}
 
 		test.WaitSignalFromRule(t, func() error {
@@ -172,7 +219,7 @@ func TestBindEvent(t *testing.T) {
 		}, func(event *model.Event, _ *rules.Rule) {
 			assert.Equal(t, "bind", event.GetType(), "wrong event type")
 			assert.Equal(t, uint16(unix.AF_INET6), event.Bind.AddrFamily, "wrong address family")
-			assert.Equal(t, uint16(4242), event.Bind.Addr.Port, "wrong address port")
+			assert.Equal(t, uint16(port), event.Bind.Addr.Port, "wrong address port")
 			assert.Equal(t, string("::/128"), event.Bind.Addr.IPNet.String(), "wrong address")
 			assert.Equal(t, int64(0), event.Bind.Retval, "wrong retval")
 

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -646,11 +646,21 @@ int test_accept(int argc, char** argv) {
 
 int test_bind_af_inet(int argc, char** argv) {
 
-    if (argc != 3) {
+    if (argc < 3 || argc > 4) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: an option for the addr in the list: any, custom_ip\n");
         fprintf(stderr, "Arg2: an option for the protocol in the list: tcp, udp\n");
+        fprintf(stderr, "Arg3 (optional): port number (default: 4242)\n");
         return EXIT_FAILURE;
+    }
+
+    int port = 4242;
+    if (argc == 4) {
+        port = atoi(argv[3]);
+        if (port <= 0 || port > 65535) {
+            fprintf(stderr, "Invalid port number: %s\n", argv[3]);
+            return EXIT_FAILURE;
+        }
     }
 
     char* proto = argv[2];
@@ -683,7 +693,7 @@ int test_bind_af_inet(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    addr.sin_port = htons(4242);
+    addr.sin_port = htons(port);
     if (bind(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         perror("Failed to bind port");
         return EXIT_FAILURE;
@@ -700,9 +710,19 @@ int test_bind_af_inet6(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    if (argc != 2) {
+    if (argc < 2 || argc > 3) {
         fprintf(stderr, "Please specify an option in the list: any, custom_ip\n");
+        fprintf(stderr, "Arg2 (optional): port number (default: 4242)\n");
         return EXIT_FAILURE;
+    }
+
+    int port = 4242;
+    if (argc == 3) {
+        port = atoi(argv[2]);
+        if (port <= 0 || port > 65535) {
+            fprintf(stderr, "Invalid port number: %s\n", argv[2]);
+            return EXIT_FAILURE;
+        }
     }
 
     struct sockaddr_in6 addr;
@@ -719,7 +739,7 @@ int test_bind_af_inet6(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    addr.sin6_port = htons(4242);
+    addr.sin6_port = htons(port);
     if (bind(s, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         perror("Failed to bind port");
         return EXIT_FAILURE;


### PR DESCRIPTION
### What does this PR do?
This PR get dynamically a port for bind tests in order to reduce the chances of having the bind to fail and so the test.

### Motivation
Reduce the flakyness of the bind tests.
Should fix this kind of failures : https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1335147423