### PR TITLE
Add a gitlab build pipeline for serverless-init

### DIFF
--- a/.gitlab/serverless-init/Dockerfile
+++ b/.gitlab/serverless-init/Dockerfile
@@ -1,0 +1,52 @@
+# syntax = docker/dockerfile:experimental
+#
+# Builds serverless-init container image (standard, Debian-based) from datadog-agent source
+# This Dockerfile runs from the root of the datadog-agent repository
+#
+# Uses golang:1.25.5 to match the version in datadog-agent's go.work file
+# When go.work is updated, this Dockerfile should be updated to match
+
+# Build stage - compile the binary
+FROM golang:1.25.5 as builder
+ARG EXTENSION_VERSION
+ARG AGENT_VERSION
+ARG CMD_PATH
+ARG BUILD_TAGS
+
+WORKDIR /build
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source files
+COPY . .
+
+# Build the binary
+WORKDIR /build/${CMD_PATH}
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ -z "$AGENT_VERSION" ]; then \
+        go build -ldflags="-w \
+        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    else \
+        go build -ldflags="-w \
+        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
+        -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    fi
+
+RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
+    (echo "agentVersionDefault variable doesn't exist" && exit 1)
+
+# Final image - distroless with shell and datadog-init
+FROM gcr.io/distroless/cc-debian12
+COPY --from=busybox:1.37-uclibc /bin/sh /bin/sh
+
+COPY --from=builder /build/${CMD_PATH}/datadog-agent /datadog-init
+COPY ./.gitlab/serverless-init/serverless_init_dotnet.sh /dotnet.sh
+
+ENTRYPOINT ["/datadog-init"]

--- a/.gitlab/serverless-init/Dockerfile.alpine
+++ b/.gitlab/serverless-init/Dockerfile.alpine
@@ -1,0 +1,53 @@
+# syntax = docker/dockerfile:experimental
+#
+# Builds serverless-init container image (alpine variant) from datadog-agent source
+# This Dockerfile runs from the root of the datadog-agent repository
+#
+# Uses golang:1.25.5-alpine to match the version in datadog-agent's go.work file
+# When go.work is updated, this Dockerfile should be updated to match
+
+# Build stage - compile the binary
+FROM golang:1.25.5-alpine as builder
+ARG EXTENSION_VERSION
+ARG AGENT_VERSION
+ARG CMD_PATH
+ARG BUILD_TAGS
+
+# Install build tools needed for cgo
+RUN apk add --no-cache git make musl-dev gcc
+
+WORKDIR /build
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy source files
+COPY . .
+
+# Build the binary (statically linked for Alpine)
+WORKDIR /build/${CMD_PATH}
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ -z "$AGENT_VERSION" ]; then \
+        go build -ldflags="-w -extldflags '-static' \
+        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION" \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    else \
+        go build -ldflags="-w -extldflags '-static' \
+        -X github.com/DataDog/datadog-agent/pkg/serverless/tags.currentExtensionVersion=$EXTENSION_VERSION \
+        -X github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault=$AGENT_VERSION" \
+        -tags "${BUILD_TAGS}" -o datadog-agent; \
+    fi
+
+RUN go tool nm datadog-agent | grep -w 'github.com/DataDog/datadog-agent/pkg/version.agentVersionDefault' || \
+    (echo "agentVersionDefault variable doesn't exist" && exit 1)
+
+# Final image - minimal scratch with just the static binary
+FROM scratch
+
+COPY --from=builder /build/${CMD_PATH}/datadog-agent /datadog-init
+
+ENTRYPOINT ["/datadog-init"]

--- a/.gitlab/serverless-init/README.md
+++ b/.gitlab/serverless-init/README.md
@@ -1,0 +1,116 @@
+# Serverless-Init Release Pipeline
+
+This directory contains the GitLab CI pipeline for building and releasing serverless-init container images.
+
+## 📋 Overview
+
+The pipeline builds serverless-init binaries and container images for both standard (Debian-based) and Alpine Linux variants, supporting both amd64 and arm64 architectures. Images are published to:
+
+- **registry.datadoghq.com** (Internal Datadog Registry): `registry.datadoghq.com/serverless-init` (prod) or `registry.datadoghq.com/serverless-init-dev` (RC)
+
+The `serverless_init_dotnet.sh` file is also copied into images to help users instrument dotnet code.
+
+## 🚀 Usage
+
+### Releasing a Release Candidate (RC)
+
+1. Go to [GitLab Pipelines](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/new)
+2. Select the branch you want to release from (e.g., `main` or a feature branch)
+3. Choose the pipeline: `.gitlab/serverless-init/release.yml`
+4. Set variables:
+   - `TAG`: Your RC version (e.g., `1.7.8-rc1`)
+   - `LATEST_TAG`: `no`
+   - `BUILD_TAGS`: `serverless otlp zlib zstd` (default)
+   - `AGENT_VERSION`: (optional) specific agent version, or leave empty for default
+5. Run the pipeline
+
+**Results:**
+- `registry.datadoghq.com/serverless-init-dev:1.7.8-rc1`
+- `registry.datadoghq.com/serverless-init-dev:1.7.8-rc1-alpine`
+
+### Testing the RC
+
+Use the [serverless-init-self-monitoring GitLab pipeline](https://gitlab.ddbuild.io/DataDog/serverless-init-self-monitoring/-/pipelines/new) to deploy and test your RC:
+
+1. Set `AGENT_IMAGE` to your RC image (e.g., `registry.datadoghq.com/serverless-init-dev:1.7.8-rc1`)
+2. Set `ENVIRONMENT` to `rc`
+3. Run the pipeline
+4. Monitor the [self-monitoring dashboard](https://ddserverless.datadoghq.com/dashboard/c73-7ff-zpk/azure-gcp-self-monitoring)
+
+### Releasing a Production Version
+
+Once your RC has been validated:
+
+1. **Create a tag** in the datadog-agent repository:
+   ```bash
+   git checkout <branch-used-for-rc>
+   git tag serverless-init-1.7.8
+   git push origin serverless-init-1.7.8
+   ```
+
+2. Go to [GitLab Pipelines](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/new)
+3. Select the tag you just created: `serverless-init-1.7.8`
+4. Choose the pipeline: `.gitlab/serverless-init-release.yml`
+5. Set variables:
+   - `TAG`: Your production version (e.g., `1.7.8`)
+   - `LATEST_TAG`: `yes`
+   - `BUILD_TAGS`: `serverless otlp zlib zstd` (default)
+   - `AGENT_VERSION`: (optional) specific agent version
+6. Run the pipeline
+
+**Results:**
+- `registry.datadoghq.com/serverless-init:1.7.8`
+- `registry.datadoghq.com/serverless-init:1.7.8-alpine`
+- `registry.datadoghq.com/serverless-init:latest`
+- `registry.datadoghq.com/serverless-init:latest-alpine`
+
+### Replicating to Public Registries (ECR, GCR, GAR, Docker Hub)
+
+After releasing to production, replicate images to public registries using the [public-images pipeline](https://gitlab.ddbuild.io/DataDog/public-images/-/pipelines/new).
+
+Run **twice** (once for standard, once for alpine):
+
+**Standard variant:**
+- `IMG_SOURCES`: `registry.datadoghq.com/serverless-init:1.7.8`
+- `IMG_DESTINATIONS`: `serverless-init:1.7.8,serverless-init:latest,serverless-init:1`
+- `IMG_SIGNING`: `false`
+
+**Alpine variant:**
+- `IMG_SOURCES`: `registry.datadoghq.com/serverless-init:1.7.8-alpine`
+- `IMG_DESTINATIONS`: `serverless-init:1.7.8-alpine,serverless-init:latest-alpine,serverless-init:1-alpine`
+- `IMG_SIGNING`: `false`
+
+This replicates images to ECR, GCR, GAR, and Docker Hub.
+
+## 🏗️ Pipeline Architecture
+
+The pipeline runs **2 parallel jobs** that each:
+1. Build the Go binary for amd64 and arm64 (using Docker buildx cross-compilation)
+2. Create the final multi-arch container image
+3. Push to registry.datadoghq.com
+
+**Jobs:**
+- `build-and-publish-standard`: Builds and publishes the standard (Debian) variant
+- `build-and-publish-alpine`: Builds and publishes the Alpine variant
+
+## 🔍 Troubleshooting
+
+### Authentication Issues
+
+If you encounter authentication errors:
+
+1. Verify GitLab CI/CD variables are set correctly (`DD_REGISTRY_TOKEN`, `DD_REGISTRY_USERNAME`)
+2. Check Vault integration - these credentials are typically auto-configured
+3. Ensure you have permission to push to registry.datadoghq.com
+
+### Build Failureswha
+
+- Check that the `TAG` variable is set and follows semantic versioning
+- Verify `BUILD_TAGS` includes required Go build tags: `serverless otlp zlib zstd`
+- Ensure the datadog-agent source code is in a buildable state
+-
+## 📚 Related Documentation
+
+- [Releasing a new version](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3048800938/Releasing+a+new+version) (Confluence)
+- [serverless-init-self-monitoring](https://github.com/DataDog/serverless-init-self-monitoring)
+- [public-images pipeline](https://gitlab.ddbuild.io/DataDog/public-images)

--- a/.gitlab/serverless-init/release.yml
+++ b/.gitlab/serverless-init/release.yml
@@ -1,5 +1,6 @@
 # Serverless-init release pipeline
-# Builds and publishes serverless-init images to registry.datadoghq.com
+# Builds and publishes serverless-init images to registry.ddbuild.io
+# Then triggers downstream pipeline to replicate to registry.datadoghq.com
 #
 # Usage:
 #   For RC: Set tag with -rc suffix (e.g., "1.7.8-rc1"), latestTag: "no"
@@ -36,9 +37,10 @@ variables:
 
 stages:
   - build-and-publish
+  - trigger-registry
 
 # ==================== BUILD AND PUBLISH IMAGES ====================
-# Build multi-arch images and push to registry.datadoghq.com
+# Build multi-arch images and push to registry.ddbuild.io
 
 .build-and-publish-template:
   stage: build-and-publish
@@ -55,8 +57,8 @@ stages:
         exit 1
       fi
     - docker buildx create --use --name multiarch-builder || docker buildx use multiarch-builder
-    # Login to registry.datadoghq.com (uses GitLab's built-in credentials)
-    - echo "$DD_REGISTRY_TOKEN" | docker login registry.datadoghq.com -u "$DD_REGISTRY_USERNAME" --password-stdin
+    # Login to registry.ddbuild.io
+    - !reference [.login_to_docker_readonly]
   script:
     - |
       echo "Building and publishing serverless-init image (${VARIANT_NAME})"
@@ -64,25 +66,30 @@ stages:
       # Determine image names and tags based on release type
       if [ "$LATEST_TAG" = "yes" ]; then
         # Production release - push with version and latest tags
-        DD_REGISTRY_IMAGE="registry.datadoghq.com/serverless-init"
+        DDBUILD_IMAGE="registry.ddbuild.io/ci/datadog-agent/serverless-init"
 
-        TAG_ARGS="-t ${DD_REGISTRY_IMAGE}:${TAG}${IMAGE_SUFFIX}"
-        TAG_ARGS="${TAG_ARGS} -t ${DD_REGISTRY_IMAGE}:latest${IMAGE_SUFFIX}"
+        TAG_ARGS="-t ${DDBUILD_IMAGE}:${TAG}${IMAGE_SUFFIX}"
+        TAG_ARGS="${TAG_ARGS} -t ${DDBUILD_IMAGE}:latest${IMAGE_SUFFIX}"
+        TAG_ARGS="${TAG_ARGS} -t ${DDBUILD_IMAGE}:v${CI_PIPELINE_ID}${IMAGE_SUFFIX}"
 
         echo "📦 Publishing PRODUCTION release:"
-        echo "  - registry.datadoghq.com/serverless-init:${TAG}${IMAGE_SUFFIX}"
-        echo "  - registry.datadoghq.com/serverless-init:latest${IMAGE_SUFFIX}"
+        echo "  - registry.ddbuild.io/ci/datadog-agent/serverless-init:${TAG}${IMAGE_SUFFIX}"
+        echo "  - registry.ddbuild.io/ci/datadog-agent/serverless-init:latest${IMAGE_SUFFIX}"
+        echo "  - registry.ddbuild.io/ci/datadog-agent/serverless-init:v${CI_PIPELINE_ID}${IMAGE_SUFFIX}"
       else
         # Release candidate - push to -dev with version tag
-        DD_REGISTRY_IMAGE="registry.datadoghq.com/serverless-init-dev"
+        DDBUILD_IMAGE="registry.ddbuild.io/ci/datadog-agent/serverless-init-dev"
 
-        TAG_ARGS="-t ${DD_REGISTRY_IMAGE}:${TAG}${IMAGE_SUFFIX}"
+        TAG_ARGS="-t ${DDBUILD_IMAGE}:${TAG}${IMAGE_SUFFIX}"
+        TAG_ARGS="${TAG_ARGS} -t ${DDBUILD_IMAGE}:v${CI_PIPELINE_ID}${IMAGE_SUFFIX}"
 
         echo "🧪 Publishing RELEASE CANDIDATE:"
-        echo "  - registry.datadoghq.com/serverless-init-dev:${TAG}${IMAGE_SUFFIX}"
+        echo "  - registry.ddbuild.io/ci/datadog-agent/serverless-init-dev:${TAG}${IMAGE_SUFFIX}"
+        echo "  - registry.ddbuild.io/ci/datadog-agent/serverless-init-dev:v${CI_PIPELINE_ID}${IMAGE_SUFFIX}"
       fi
 
       # Build and push multi-architecture image to registry
+      # Add labels for registry replication
       docker buildx build \
         --platform linux/amd64,linux/arm64 \
         --build-arg EXTENSION_VERSION="${TAG}" \
@@ -91,10 +98,27 @@ stages:
         --build-arg BUILD_TAGS="${BUILD_TAGS}" \
         -f .gitlab/serverless-init/Dockerfile${ALPINE_SUFFIX} \
         ${TAG_ARGS} \
+        --label "org.opencontainers.image.created=$(date --rfc-3339=seconds)" \
+        --label "org.opencontainers.image.authors=Datadog <package@datadoghq.com>" \
+        --label "org.opencontainers.image.source=https://github.com/DataDog/datadog-agent" \
+        --label "org.opencontainers.image.version=${TAG}" \
+        --label "org.opencontainers.image.revision=${CI_COMMIT_SHA}" \
+        --label "com.datadoghq.tags.pipeline.id=${CI_PIPELINE_ID}" \
+        --label "com.datadoghq.tags.pipeline.url=${CI_PIPELINE_URL}" \
         --push \
         .
 
-      echo "✅ Successfully published ${VARIANT_NAME} image to registry.datadoghq.com!"
+      echo "✅ Successfully published ${VARIANT_NAME} image to registry.ddbuild.io!"
+
+      # Save image information for downstream pipeline trigger
+      mkdir -p image-info
+      echo "${DDBUILD_IMAGE}:${TAG}${IMAGE_SUFFIX}" > image-info/${VARIANT_NAME}-image.txt
+  artifacts:
+    reports:
+      dotenv: image-info/${VARIANT_NAME}-image.txt
+    paths:
+      - image-info/${VARIANT_NAME}-image.txt
+    expire_in: 1 day
 
 build-and-publish-standard:
   extends: .build-and-publish-template
@@ -109,3 +133,71 @@ build-and-publish-alpine:
     ALPINE_SUFFIX: ".alpine"
     IMAGE_SUFFIX: "-alpine"
     VARIANT_NAME: "alpine"
+
+# ==================== TRIGGER REGISTRY REPLICATION ====================
+# Trigger downstream pipeline to replicate images to public registries
+# Separate jobs for standard and alpine variants
+
+trigger-registry-replication-prod-standard:
+  stage: trigger-registry
+  trigger:
+    project: DataDog/public-images
+    strategy: depend
+  rules:
+    - if: '$LATEST_TAG == "yes"'
+      when: on_success
+  dependencies:
+    - build-and-publish-standard
+  variables:
+    IMG_SOURCES: "registry.ddbuild.io/ci/datadog-agent/serverless-init:${TAG}"
+    IMG_DESTINATIONS: "serverless-init:${TAG},serverless-init:latest,serverless-init:1"
+    IMG_SIGNING: "false"
+    IMG_REGISTRIES: "public"
+
+trigger-registry-replication-prod-alpine:
+  stage: trigger-registry
+  trigger:
+    project: DataDog/public-images
+    strategy: depend
+  rules:
+    - if: '$LATEST_TAG == "yes"'
+      when: on_success
+  dependencies:
+    - build-and-publish-alpine
+  variables:
+    IMG_SOURCES: "registry.ddbuild.io/ci/datadog-agent/serverless-init:${TAG}-alpine"
+    IMG_DESTINATIONS: "serverless-init:${TAG}-alpine,serverless-init:latest-alpine,serverless-init:1-alpine"
+    IMG_SIGNING: "false"
+    IMG_REGISTRIES: "public"
+
+trigger-registry-replication-rc-standard:
+  stage: trigger-registry
+  trigger:
+    project: DataDog/public-images
+    strategy: depend
+  rules:
+    - if: '$LATEST_TAG != "yes"'
+      when: on_success
+  dependencies:
+    - build-and-publish-standard
+  variables:
+    IMG_SOURCES: "registry.ddbuild.io/ci/datadog-agent/serverless-init-dev:${TAG}"
+    IMG_DESTINATIONS: "serverless-init-dev:${TAG},serverless-init-dev:latest,serverless-init-dev:1"
+    IMG_SIGNING: "false"
+    IMG_REGISTRIES: "prod"
+
+trigger-registry-replication-rc-alpine:
+  stage: trigger-registry
+  trigger:
+    project: DataDog/public-images
+    strategy: depend
+  rules:
+    - if: '$LATEST_TAG != "yes"'
+      when: on_success
+  dependencies:
+    - build-and-publish-alpine
+  variables:
+    IMG_SOURCES: "registry.ddbuild.io/ci/datadog-agent/serverless-init-dev:${TAG}-alpine"
+    IMG_DESTINATIONS: "serverless-init-dev:${TAG}-alpine,serverless-init-dev:latest-alpine,serverless-init-dev:1-alpine"
+    IMG_SIGNING: "false"
+    IMG_REGISTRIES: "prod"

--- a/.gitlab/serverless-init/release.yml
+++ b/.gitlab/serverless-init/release.yml
@@ -1,0 +1,111 @@
+# Serverless-init release pipeline
+# Builds and publishes serverless-init images to registry.datadoghq.com
+#
+# Usage:
+#   For RC: Set tag with -rc suffix (e.g., "1.7.8-rc1"), latestTag: "no"
+#   For Prod: Set tag without -rc (e.g., "1.7.8"), latestTag: "yes"
+#
+# This pipeline runs from the root of the datadog-agent repository
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - when: never
+
+variables:
+  # User-configurable variables
+  TAG:
+    description: 'Docker image tag (e.g., 1.7.8-rc1 for RC, 1.7.8 for prod)'
+    value: ''
+  LATEST_TAG:
+    description: 'Tag as latest? (yes for prod releases, no for RCs)'
+    value: 'no'
+    options:
+      - 'yes'
+      - 'no'
+  BUILD_TAGS:
+    description: 'Go build tags'
+    value: 'serverless otlp zlib zstd'
+  AGENT_VERSION:
+    description: 'Datadog agent version (optional - defaults to version in code)'
+    value: ''
+
+  # Internal variables
+  DOCKER_BUILDKIT: "1"
+  DOCKER_TLS_CERTDIR: ''
+
+stages:
+  - build-and-publish
+
+# ==================== BUILD AND PUBLISH IMAGES ====================
+# Build multi-arch images and push to registry.datadoghq.com
+
+.build-and-publish-template:
+  stage: build-and-publish
+  image: registry.ddbuild.io/images/docker:27.3.1
+  tags: ['arch:amd64']
+  rules:
+    - if: '$TAG == ""'
+      when: never
+    - when: always
+  before_script:
+    - |
+      if [ "$TAG" = "" ]; then
+        echo "ERROR: TAG variable is required"
+        exit 1
+      fi
+    - docker buildx create --use --name multiarch-builder || docker buildx use multiarch-builder
+    # Login to registry.datadoghq.com (uses GitLab's built-in credentials)
+    - echo "$DD_REGISTRY_TOKEN" | docker login registry.datadoghq.com -u "$DD_REGISTRY_USERNAME" --password-stdin
+  script:
+    - |
+      echo "Building and publishing serverless-init image (${VARIANT_NAME})"
+
+      # Determine image names and tags based on release type
+      if [ "$LATEST_TAG" = "yes" ]; then
+        # Production release - push with version and latest tags
+        DD_REGISTRY_IMAGE="registry.datadoghq.com/serverless-init"
+
+        TAG_ARGS="-t ${DD_REGISTRY_IMAGE}:${TAG}${IMAGE_SUFFIX}"
+        TAG_ARGS="${TAG_ARGS} -t ${DD_REGISTRY_IMAGE}:latest${IMAGE_SUFFIX}"
+
+        echo "📦 Publishing PRODUCTION release:"
+        echo "  - registry.datadoghq.com/serverless-init:${TAG}${IMAGE_SUFFIX}"
+        echo "  - registry.datadoghq.com/serverless-init:latest${IMAGE_SUFFIX}"
+      else
+        # Release candidate - push to -dev with version tag
+        DD_REGISTRY_IMAGE="registry.datadoghq.com/serverless-init-dev"
+
+        TAG_ARGS="-t ${DD_REGISTRY_IMAGE}:${TAG}${IMAGE_SUFFIX}"
+
+        echo "🧪 Publishing RELEASE CANDIDATE:"
+        echo "  - registry.datadoghq.com/serverless-init-dev:${TAG}${IMAGE_SUFFIX}"
+      fi
+
+      # Build and push multi-architecture image to registry
+      docker buildx build \
+        --platform linux/amd64,linux/arm64 \
+        --build-arg EXTENSION_VERSION="${TAG}" \
+        --build-arg AGENT_VERSION="${AGENT_VERSION}" \
+        --build-arg CMD_PATH="cmd/serverless-init" \
+        --build-arg BUILD_TAGS="${BUILD_TAGS}" \
+        -f .gitlab/serverless-init/Dockerfile${ALPINE_SUFFIX} \
+        ${TAG_ARGS} \
+        --push \
+        .
+
+      echo "✅ Successfully published ${VARIANT_NAME} image to registry.datadoghq.com!"
+
+build-and-publish-standard:
+  extends: .build-and-publish-template
+  variables:
+    ALPINE_SUFFIX: ""
+    IMAGE_SUFFIX: ""
+    VARIANT_NAME: "standard"
+
+build-and-publish-alpine:
+  extends: .build-and-publish-template
+  variables:
+    ALPINE_SUFFIX: ".alpine"
+    IMAGE_SUFFIX: "-alpine"
+    VARIANT_NAME: "alpine"

--- a/.gitlab/serverless-init/serverless_init_dotnet.sh
+++ b/.gitlab/serverless-init/serverless_init_dotnet.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Check if Alpine
+if [ -f "/etc/alpine-release" ]; then
+    echo "Alpine images are not supported for .NET automatic instrumentation with serverless-init"
+    exit 1
+fi
+
+# Make sure curl and jq are installed
+apt-get update && apt-get install -y curl jq
+
+ghcurl() {
+  if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Github token provided" >&2
+    curl -sSL -w '{"status_code": %{http_code}}' -H "Authorization: Bearer $GITHUB_TOKEN" "$@" | jq -sre add
+  else
+    echo "Github token not provided" >&2
+    curl -sSL -w '{"status_code": %{http_code}}' "$@" | jq -sre add
+  fi
+}
+
+# Get latest released version of dd-trace-dotnet
+response=$(ghcurl https://api.github.com/repos/DataDog/dd-trace-dotnet/releases/latest)
+sanitized_response=$(echo "$response" | tr -d '\000-\037') # remove control characters from json response
+echo "Status code of version request: $(echo "$sanitized_response" | jq '.status_code')"
+TRACER_VERSION=$(echo "$sanitized_response" | jq -r '.tag_name // empty'  | sed 's/^v//')
+
+if [ -z "$TRACER_VERSION" ]; then
+  echo "Error: Could not determine the tracer version. Exiting." >&2
+  exit 1
+fi
+
+# Download the tracer to the dd_tracer folder
+echo Downloading version "${TRACER_VERSION}" of the .NET tracer into /tmp/datadog-dotnet-apm.tar.gz
+response=$(ghcurl "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz" \
+    -o /tmp/datadog-dotnet-apm.tar.gz)
+echo "Status code of download request: $(echo "$response" | jq '.status_code')"
+
+# Unarchive the tracer and remove the tmp
+mkdir -p /dd_tracer/dotnet
+tar -xzf /tmp/datadog-dotnet-apm.tar.gz -C /dd_tracer/dotnet
+rm /tmp/datadog-dotnet-apm.tar.gz
+
+# Create Log path
+/dd_tracer/dotnet/createLogPath.sh


### PR DESCRIPTION
### What does this PR do?
* Moves the Azure/GCP serverless-init build out of the [lambda extension repository](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/3048800938/Releasing+a+new+version)
* Sends serverless-init builds to [registry.datadoghq.com](https://datadoghq.atlassian.net/wiki/spaces/BARX/pages/5939757800/Onboarding+to+registry.datadoghq.com)
* Uses a goland base image instead of an aws base image to speed up builds
* Builds arm/amd images in one step

**Note:** This would not send images to ghcr, which is where our current rc images live! Breaking change to the dev workflow. 

### Motivation
* Registry.datadoghq.com expects builds to come from a gitlab pipeline instead of a github workflow. Moving the build means not having to manage gitlab tokens in github or github tokens in gitlab.
* Registry.datadoghq.com means no more rate limiting
* Not downloading two versions of go should speed up our builds significantly
* Why use an AWS image for an azure/gcp build?

### Describe how you validated your changes
* Will test with related self-monitoring changes at https://github.com/DataDog/serverless-init-self-monitoring/pull/257

### Additional Notes
* New Confluence: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/6028265986/WIP+New+Flow+Releasing+Serverless-Init+Rc+Prod
