### PR TITLE
fix printk test flake

### DIFF
--- a/pkg/ebpf/ebpftest/trace_pipe_linux.go
+++ b/pkg/ebpf/ebpftest/trace_pipe_linux.go
@@ -79,6 +79,15 @@ func parseTraceLine(raw string) (*TraceEvent, error) {
 	}, nil
 }
 
+// Clear clears all existing entries from `trace_pipe` by writing to the `trace` file.
+func (t *TracePipe) Clear() error {
+	root, err := tracefs.Root()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(root+"/trace", []byte("\n"), 0)
+}
+
 // ReadLine reads a line
 func (t *TracePipe) ReadLine() (*TraceEvent, error) {
 	line, err := t.reader.ReadString('\n')

--- a/pkg/ebpf/ebpftest/trace_pipe_linux.go
+++ b/pkg/ebpf/ebpftest/trace_pipe_linux.go
@@ -55,7 +55,9 @@ func NewTracePipe() (*TracePipe, error) {
 
 // A line from trace_pipe looks like (leading spaces included):
 // `        chromium-15581 [000] d... 92783.722567: : Hello, World!`
-var traceLineRegexp = regexp.MustCompile(`(.{16})-(\d+) +\[(\d{3})\] (.{4,5}) +(\d+\.\d+)\: (.*?)\: (.*)`)
+var traceLineRegexp = regexp.MustCompile(`(.{16})-(\d+) +\[(\d{3})\] (.{4,}) +(\d+\.\d+)\: (.*?)\: (.*)`)
+
+var cpuLostEventsRegexp = regexp.MustCompile(`^CPU:\d+ \[LOST (\d+ )?EVENTS\]`)
 
 func parseTraceLine(raw string) (*TraceEvent, error) {
 	if raw == "\n" {
@@ -63,6 +65,9 @@ func parseTraceLine(raw string) (*TraceEvent, error) {
 	}
 	fields := traceLineRegexp.FindStringSubmatch(raw)
 	if len(fields) != 8 {
+		if cpuLostEventsRegexp.MatchString(raw) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("received unexpected input %q", raw)
 	}
 	pid, _ := strconv.ParseUint(fields[2], 10, 32)

--- a/pkg/ebpf/ebpftest/trace_pipe_linux_test.go
+++ b/pkg/ebpf/ebpftest/trace_pipe_linux_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package ebpftest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracePipeParse(t *testing.T) {
+	lines := []string{
+		`           <...>-2866    [000] d...2.1   590.130406: bpf_trace_printk: hi\n`,
+		`CPU:3 [LOST 497 EVENTS]`,
+		`CPU:3 [LOST EVENTS]`,
+	}
+
+	for _, line := range lines {
+		_, err := parseTraceLine(line)
+		assert.NoError(t, err, "parsing trace line %q", line)
+	}
+}

--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -29,6 +29,7 @@ func TestPatchPrintkNewline(t *testing.T) {
 	require.NoError(t, err)
 
 	tracefsRoot, err := tracefs.Root()
+	require.NoError(t, err)
 	// Check that tracing is on, if it's off we might try to enable it
 	tracingOnPath := tracefsRoot + "/tracing_on"
 	tracingOn, err := os.ReadFile(tracingOnPath)

--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -8,7 +8,6 @@
 package ebpf
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 )
 
@@ -28,10 +28,12 @@ func TestPatchPrintkNewline(t *testing.T) {
 	kernelVersion, err := ebpfkernel.NewKernelVersion()
 	require.NoError(t, err)
 
+	tracefsRoot, err := tracefs.Root()
 	// Check that tracing is on, if it's off we might try to enable it
-	tracingOn, err := os.ReadFile("/sys/kernel/debug/tracing/tracing_on")
+	tracingOnPath := tracefsRoot + "/tracing_on"
+	tracingOn, err := os.ReadFile(tracingOnPath)
 	if err == nil && strings.TrimSpace(string(tracingOn)) != "1" { // Try to continue with the tests even if we cannot read the tracing file
-		if err := os.WriteFile("/sys/kernel/debug/tracing/tracing_on", []byte("1"), 0); err != nil {
+		if err := os.WriteFile(tracingOnPath, []byte("1"), 0); err != nil {
 			t.Skipf("Cannot enable tracing: %s", err)
 		}
 	}
@@ -70,9 +72,8 @@ func TestPatchPrintkNewline(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	tp, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
+	tp, err := ebpftest.NewTracePipe()
 	require.NoError(t, err)
-	traceReader := bufio.NewReader(tp)
 	t.Cleanup(func() { _ = tp.Close() })
 
 	progs, ok, err := mgr.GetProgram(idPair)
@@ -81,7 +82,9 @@ func TestPatchPrintkNewline(t *testing.T) {
 	require.NotNil(t, progs)
 	require.NotEmpty(t, progs)
 
-	// The logdebugtest program is a kprobe on do_vfs_ioctl, so we can use that to trigger the
+	require.NoError(t, tp.Clear())
+
+	// The logdebugtest program is a kprobe on do_vfs_ioctl, so we can use that to trigger
 	// it and check that the output is correct. We do not actually care about the arguments.
 	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(0), 0xfafafefe, uintptr(0)); errno != 0 {
 		// Only valid return value is ENOTTY (invalid ioctl for device) because indeed we
@@ -98,7 +101,7 @@ func TestPatchPrintkNewline(t *testing.T) {
 		"12", "21", "with args: 2+2=4", "with more args and vars: 1+2=3", "with a function call in the argument: 70", "bye",
 	}
 
-	foundLines := []string{}
+	var foundLines []string
 
 	for i, line := range expectedLines {
 		// We allow up to two lines that don't match, to avoid failures with other tests outputting to
@@ -112,12 +115,15 @@ func TestPatchPrintkNewline(t *testing.T) {
 			maxLinesToRead = 1000 // Except for the first line, we might need to flush previous trace pipe output
 		}
 		for readLines := 0; readLines < maxLinesToRead; readLines++ {
-			actualLine, err = traceReader.ReadString('\n')
+			event, err := tp.ReadLine()
 			require.NoError(t, err)
-			foundLines = append(foundLines, actualLine)
 
-			if strings.Contains(actualLine, line) {
-				break
+			if event != nil {
+				actualLine = event.Message
+				foundLines = append(foundLines, event.Raw)
+				if strings.Contains(actualLine, line) {
+					break
+				}
 			}
 		}
 		require.Contains(t, actualLine, line, "line %s not found in output, all lines until now:\n%s", line, strings.Join(foundLines, ""))


### PR DESCRIPTION
### What does this PR do?

Fixes a flake in `TestPatchPrintkNewline` by:
1. Clearing the `trace_pipe` before triggering the `ioctl`
2. Looking at only the message for `strings.Contains`

### Motivation

`printk` output from another test managed to match the first log message `hi` and caused this test to fail on the next message.

### Describe how you validated your changes

Updated tests.

### Additional Notes
