### PR TITLE
[cluster agent][autoscaling] fix target hash check

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -153,12 +153,12 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 				log.Errorf("Error converting Target NodePool: %v", err)
 				return autoscaling.Requeue
 			}
-		}
 
-		// Only create or update if there is no TargetHash (i.e. it is fully Datadog-managed), or if the TargetHash has not changed
-		if !checkTargetHash(npi, targetNp) {
-			log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
-			return autoscaling.NoRequeue
+			// Only create or update if there is no TargetHash (i.e. it is fully Datadog-managed), or if the TargetHash has not changed
+			if !checkTargetHash(npi, targetNp) {
+				log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
+				return autoscaling.NoRequeue
+			}
 		}
 
 		if nodePool == nil {

--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -154,7 +154,7 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 				return autoscaling.Requeue
 			}
 
-			// Only create or update if there is no TargetHash (i.e. it is fully Datadog-managed), or if the TargetHash has not changed
+			// Only create or update if the TargetHash has not changed
 			if !checkTargetHash(npi, targetNp) {
 				log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
 				return autoscaling.NoRequeue
@@ -194,7 +194,7 @@ func checkTargetHash(npi model.NodePoolInternal, targetNp *karpenterv1.NodePool)
 	if targetNp == nil {
 		return false
 	}
-	return npi.TargetHash() == "" || npi.TargetHash() == targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey]
+	return npi.TargetHash() == targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey]
 }
 
 func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInternal, knp *karpenterv1.NodePool) error {

--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -155,7 +155,7 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 			}
 
 			// Only create or update if the TargetHash has not changed
-			if !checkTargetHash(npi, targetNp) {
+			if npi.TargetHash() != targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey] {
 				log.Infof("NodePool: %s TargetHash (%s) has changed since recommendation was generated; no action will be applied.", npi.Name(), npi.TargetHash())
 				return autoscaling.NoRequeue
 			}
@@ -188,13 +188,6 @@ func (c *Controller) syncNodePool(ctx context.Context, name string, nodePool *ka
 	}
 
 	return autoscaling.NoRequeue
-}
-
-func checkTargetHash(npi model.NodePoolInternal, targetNp *karpenterv1.NodePool) bool {
-	if targetNp == nil {
-		return false
-	}
-	return npi.TargetHash() == targetNp.GetAnnotations()[model.KarpenterNodePoolHashAnnotationKey]
 }
 
 func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInternal, knp *karpenterv1.NodePool) error {

--- a/releasenotes/notes/cluster-autoscaling-bugfix-0b0d0a56e9f01141.yaml
+++ b/releasenotes/notes/cluster-autoscaling-bugfix-0b0d0a56e9f01141.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix small bug in Cluster Autoscaling when checking Target Hash value.


### PR DESCRIPTION
### What does this PR do?

Fixes behavior if a target NodePool is not found in the cluster for an inferred NodePool

### Motivation

Fix unintended behavior when patching nodepools

### Describe how you validated your changes

In a test cluster pointing to staging, made sure inferred NodePools could be patched properly

### Additional Notes
