### PR TITLE
[ABLD-323] Initial version of BUILD files for rtloader

### DIFF
--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,0 +1,32 @@
+# rtloader
+
+load("@rules_license//rules:license.bzl", "license")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+
+package(
+    default_package_metadata = [":license"],
+    default_visibility = ["@@//packages:__subpackages__"],
+)
+
+license(
+    name = "license",
+    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
+    license_text = "LICENSE",
+    visibility = ["//visibility:public"],
+)
+
+pkg_filegroup(
+    name = "all",
+    srcs = [
+        "//rtloader/common:all",
+        "//rtloader/include:all",
+        "//rtloader/rtloader:lib_files",
+        "//rtloader/three:lib_files",
+    ],
+)
+
+pkg_install(
+    name = "install",
+    srcs = ["all"],
+)

--- a/rtloader/common/BUILD.bazel
+++ b/rtloader/common/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+
+package(default_visibility = ["//rtloader:__subpackages__"])
+
+# There is no common library, rtloader and three individually build
+# the .c files.
+exports_files(glob(["**"]))
+
+# This library only exists to create the right -isystem includes paths
+cc_library(
+    name = "headers",
+    hdrs = [
+        "builtins/_util.h",
+        "builtins/aggregator.h",
+        "builtins/containers.h",
+        "builtins/datadog_agent.h",
+        "builtins/kubeutil.h",
+        "builtins/tagger.h",
+        "builtins/util.h",
+        "cgo_free.h",
+        "log.h",
+        "rtloader_mem.h",
+        "stringutils.h",
+    ],
+    includes = [
+        ".",
+        "builtins",
+    ],
+    deps = [
+        "//rtloader/include",
+        "@rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
+# What to install
+pkg_files(
+    name = "all",
+    srcs = [
+        "rtloader_mem.h",
+    ],
+    # relative to {install_dir}
+    prefix = "embedded/include",
+)

--- a/rtloader/defs.bzl
+++ b/rtloader/defs.bzl
@@ -1,0 +1,7 @@
+# common definitions for rtloader build
+
+COMMON_DEFINES = [
+    "NDEBUG",
+    "HAS_BACKTRACE_LIB",
+    "_GLIBCXX_USE_CXX11_ABI=0",
+]

--- a/rtloader/include/BUILD.bazel
+++ b/rtloader/include/BUILD.bazel
@@ -1,0 +1,30 @@
+# rtloader/include
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//rtloader:defs.bzl", "COMMON_DEFINES")
+
+package(default_visibility = ["//rtloader:__subpackages__"])
+
+cc_library(
+    name = "include",
+    hdrs = [
+        "datadog_agent_rtloader.h",
+        "rtloader.h",
+        "rtloader_types.h",
+    ],
+    # We do this because they #include them with <x.h>
+    includes = ["."],
+    local_defines = COMMON_DEFINES,
+)
+
+# What to install.
+pkg_files(
+    name = "all",
+    srcs = [
+        "datadog_agent_rtloader.h",
+        "rtloader_types.h",
+    ],
+    # relative to {install_dir}
+    prefix = "embedded/include",
+)

--- a/rtloader/rtloader/BUILD.bazel
+++ b/rtloader/rtloader/BUILD.bazel
@@ -1,0 +1,145 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
+load("//bazel/rules:so_symlink.bzl", "so_symlink")
+load("//rtloader:defs.bzl", "COMMON_DEFINES")
+
+package(default_visibility = ["//rtloader:__pkg__"])
+
+# This package uses a distinct compatibility level. On linux we see:
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so -> libdatadog-agent-rtloader.so.2
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2 -> libdatadog-agent-rtloader.so.0.1.0
+# On mac
+# $ otool -L /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.0.1.0.dylib
+# /opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.0.1.0.dylib:
+#	@rpath/libdatadog-agent-rtloader.2.dylib (compatibility version 2.0.0, current version 0.1.0)
+#	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1800.105.0)
+#	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
+
+# This may take changes to so_symlink. That should be a distint PR.
+VERSION = "0.1.0"
+
+# SO version is ahead of the actual version because we bumped SO
+# when we dropped python 2 support.
+COMPATIBILITY_VERSION = "2"
+
+dd_agent_expand_template(
+    name = "pc_gen",
+    out = "datadog-agent-rtloader.pc",
+    substitutions = {
+        "@CMAKE_INSTALL_PREFIX@": "{install_dir}/embedded",
+        "@CMAKE_INSTALL_LIBDIR@": "lib",
+        "@CMAKE_INSTALL_INCLUDEDIR@": "include",
+        "@PROJECT_NAME@": "datadog-agent-rtloader",
+        "@PROJECT_VERSION@": "0.1.0",
+        "@PROJECT_DESCRIPTION@": "CPython backend for the Datadog Agent",
+    },
+    template = "datadog-agent-rtloader.pc.in",
+)
+
+cc_library(
+    name = "static",
+    srcs = [
+        "api.cpp",
+        "rtloader.cpp",
+        "//rtloader/common:rtloader_mem.c",
+    ],
+    copts = select({
+        "@platforms//os:windows": [
+            # Static library on windows so we don't have to distribute CRT.
+            "/MT",
+        ],
+        "//conditions:default": ["-O2"],
+    }),
+    includes = ["."],
+    local_defines = COMMON_DEFINES + select({
+        "@platforms//os:windows": [
+            "_hypot=hypot",
+        ],
+        "//conditions:default": [],
+    }),
+    visibility = ["//rtloader:__subpackages__"],
+    deps = [
+        "//rtloader/common:headers",
+        "//rtloader/include",
+    ],
+)
+
+cc_shared_library(
+    name = "datadog-agent-rtloader",
+    user_link_flags = select({
+        "@platforms//os:linux": [
+            "-Wl,-soname,datadog-agent-rtloader.so.%s" % VERSION,
+        ],
+        "@platforms//os:macos": [
+            "-Wl,-install_name,datadog-agent-rtloader.%s.dylib" % VERSION,
+            "-Wl,-current_version,%s" % VERSION,
+            "-Wl,-compatibility_version,%s" % COMPATIBILITY_VERSION,
+        ],
+        "@platforms//os:windows": [
+            # Static library on windows so we don't have to distribute CRT.
+            "/MT",
+        ],
+    }),
+    deps = [":static"],
+)
+
+# TODO: Need to get the linux ones right
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so -> libdatadog-agent-rtloader.so.2
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.0.1.0
+#  ./opt/datadog-agent/embedded/lib/libdatadog-agent-rtloader.so.2 -> libdatadog-agent-rtloader.so.0.1.0
+
+so_symlink(
+    name = "lib_files",
+    src = ":datadog-agent-rtloader",
+    libname = "libdatadog-agent-rtloader",
+    prefix = "embedded",
+    version = COMPATIBILITY_VERSION,
+)
+
+# buildifier: disable=no-effect
+"""
+Remaining work:
+
+# https://cmake.org/cmake/help/latest/module/FindBacktrace.html
+find_package(Backtrace)
+if(Backtrace_FOUND)
+    if(NOT TARGET Backtrace::Backtrace)
+        # for pre-3.30 CMake versions
+        add_library(Backtrace::Backtrace INTERFACE IMPORTED)
+        set_target_properties(Backtrace::Backtrace PROPERTIES
+            INTERFACE_LINK_LIBRARIES "${Backtrace_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${Backtrace_INCLUDE_DIRS}"
+        )
+    endif()
+    target_link_libraries(datadog-agent-rtloader PRIVATE Backtrace::Backtrace)
+    target_compile_definitions(datadog-agent-rtloader PRIVATE HAS_BACKTRACE_LIB)
+endif()
+endif()
+
+-- probably not needed, -m32 comes from the toolchain
+if(ARCH_I386)
+    set_target_properties(datadog-agent-rtloader PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
+endif()
+
+if(NOT WIN32)
+find_library( LIBdl dl )
+endif()
+
+install(TARGETS datadog-agent-rtloader
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION include
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+# Windows builder assumes libdatadog-agent-rtloader.a is located in rtloader/rtloader folder.
+if (WIN32)
+ADD_CUSTOM_COMMAND(
+    TARGET datadog-agent-rtloader
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/libdatadog-agent-rtloader.a ${PROJECT_SOURCE_DIR}/libdatadog-agent-rtloader.a
+)
+endif()
+"""

--- a/rtloader/three/BUILD.bazel
+++ b/rtloader/three/BUILD.bazel
@@ -1,0 +1,149 @@
+load("@pythons_hub//:versions.bzl", "DEFAULT_PYTHON_VERSION")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
+load("//rtloader:defs.bzl", "COMMON_DEFINES")
+
+# opts and defines come from omnibus/config/software/datadog-agent.rb, in
+# the rtloader section. E.g.
+#   dda inv -- -e rtloader.make --install-prefix /opt/datadog-agent/embedded \
+#     --cmake-options '-DCMAKE_CXX_FLAGS:="-D_GLIBCXX_USE_CXX11_ABI=0" \
+#     -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER
+
+# TODO: Figure out what to do with this.
+# project(datadog-agent-three VERSION 0.1.0 DESCRIPTION "CPython backend for the Datadog Agent")
+
+dd_agent_expand_template(
+    name = "constants_gen",
+    out = "constants.h",
+    substitutions = {
+        "@Python3_STDLIB@": "{install_dir}/embedded/lib/python%s" % DEFAULT_PYTHON_VERSION,
+    },
+    template = "constants.h.in",
+)
+
+cc_library(
+    name = "three",
+    srcs = [
+        "three.cpp",
+        "three_mem.cpp",
+        ":constants.h",
+        "//rtloader/common:builtins/_util.c",
+        "//rtloader/common:builtins/_util.h",
+        "//rtloader/common:builtins/aggregator.c",
+        "//rtloader/common:builtins/aggregator.h",
+        "//rtloader/common:builtins/containers.c",
+        "//rtloader/common:builtins/containers.h",
+        "//rtloader/common:builtins/datadog_agent.c",
+        "//rtloader/common:builtins/datadog_agent.h",
+        "//rtloader/common:builtins/kubeutil.c",
+        "//rtloader/common:builtins/kubeutil.h",
+        "//rtloader/common:builtins/tagger.c",
+        "//rtloader/common:builtins/tagger.h",
+        "//rtloader/common:builtins/util.c",
+        "//rtloader/common:builtins/util.h",
+        "//rtloader/common:cgo_free.c",
+        "//rtloader/common:cgo_free.h",
+        "//rtloader/common:log.c",
+        "//rtloader/common:log.h",
+        "//rtloader/common:rtloader_mem.h",
+        "//rtloader/common:stringutils.c",
+        "//rtloader/common:stringutils.h",
+    ],
+    hdrs = [
+        "three.h",
+    ],
+    copts = [
+        "-Wno-unused-function",
+        "-I.",
+        "-O2",
+    ] + select({
+        "@platforms//os:linux": [
+            "-Wsign-compare",
+        ],
+        "@platforms//os:macos": [
+            "-Wno-implicit-function-declaration",
+            "-Wno-int-conversion",
+        ],
+        "@platforms//os:windows": [
+            # TODO: only set if MSVC
+            "/MT",
+        ],
+    }),
+    includes = [
+        ".",
+        "/rtloader/common",
+        "/rtloader/include",
+    ],
+    local_defines = COMMON_DEFINES + select({
+        "@platforms//os:windows": [
+            # TODO: only set if not MSVC. But it might be OK do to anyway.
+            "_hypot=hypot",
+            "DATADOG_AGENT_THREE",
+        ],
+        "//conditions:default": [
+            "DATADOG_AGENT_THREE",
+        ],
+    }),
+    visibility = ["//rtloader:__subpackages__"],
+    deps = [
+        "//rtloader/common:headers",
+        "//rtloader/include",
+        "@rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
+# TODO: We comment this out for now so we can test with bazel build ...
+#cc_shared_library(
+#    name = "datadog-agent-three",
+#    deps = [
+#        ":three",
+#    ],
+#    dynamic_deps = [
+#        # TODO: point to embedded/libpython
+#    ],
+#    visibility = ["//rtloader:__subpackages__"],
+#)
+
+pkg_files(
+    name = "lib_files",
+    srcs = [
+        # TODO: replace with shared lib
+        ":three",
+    ],
+    prefix = "embedded/lib",
+    visibility = ["//rtloader:__subpackages__"],
+)
+
+# buildifier: disable=no-effect
+"""
+
+Remaining  work:
+
+if(WIN32)
+  install(TARGETS datadog-agent-three
+      RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+else()
+  target_compile_options(datadog-agent-three PRIVATE "-Wno-deprecated-register")
+  install(TARGETS datadog-agent-three
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+endif()
+
+if(WIN32)
+  set_target_properties(datadog-agent-three PROPERTIES LINK_FLAGS -static)
+elseif(APPLE)
+  set_target_properties(datadog-agent-three PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
+
+add_compile_definitions(DATADOG_AGENT_THREE)
+target_include_directories(datadog-agent-three PRIVATE .)
+target_include_directories(datadog-agent-three PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/common
+    ${CMAKE_SOURCE_DIR}/common/builtins
+    ${Python3_INCLUDE_DIRS}
+)
+target_link_libraries(datadog-agent-three ${Python3_LIBRARIES} datadog-agent-rtloader)
+"""


### PR DESCRIPTION
This is a rough first cut. It builds the libraries, but they are not the right size.

It also adds a feature to dd_expand_template. (also broken out to #44932)

Next steps:
- get tests to build and pass
   - then start building it in CI
- get demo to work?
- Verify on all 3 OSes (windows flags may need to be added)
- resolve issues with naming .so files (mentioned in BUILD files)
- make the three shared library work.

At that point, we can:
- flip the code in omnibus/config/software/datadog-agent.rb to call bazel
- change dda to call bazel