### PR TITLE
Add trimpath to stdlib build command args

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -326,7 +326,7 @@ def test(
     test_run_arg = f"-run {test_run_name}" if test_run_name else ""
 
     stdlib_build_cmd = 'go build {verbose} -mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" '
-    stdlib_build_cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} std cmd'
+    stdlib_build_cmd += '-ldflags="{ldflags}" {build_cpus} {race_opt} {trimpath_opt} std cmd'
     rerun_coverage_fix = '--raw-command {cov_test_path}' if coverage else ""
     gotestsum_flags = (
         '{junit_file_flag} {json_flag} --format {gotestsum_format} {rerun_fails} --packages="{packages}" '


### PR DESCRIPTION
### What does this PR do?
Add trimpath to stdlib build command args

### Motivation
Reduce back the duration of test jobs (which increased after merging https://github.com/DataDog/datadog-agent/pull/44522).

`build_standard_lib` explicitly mentions:
> To avoid a perfomance overhead when running tests, we pre-compile the standard library and cache it.
We must use the same build flags as the one we are using when compiling tests to not invalidate the cache.

I guess not having `trimpath` means it gets re-compiled. 

### Describe how you validated your changes

### Additional Notes
