### PR TITLE
fix(get_token): Use the correct default value when reading env

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -19,22 +19,6 @@
     paths:
       - omnibus/vendor/bundle
 
-.setup_macos_github_app:
-  # GitHub App rate-limits are per-app.
-  # This balances the requests made to GitHub between the two apps we have set up.
-  - |
-    if [[ "$(( RANDOM % 2 ))" == "1" ]]; then
-      GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 key_b64) || exit $?; export GITHUB_KEY_B64
-      GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 app_id) || exit $?; export GITHUB_APP_ID
-      GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_1 installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-      echo "Using GitHub App instance 1"
-    else
-      GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 key_b64) || exit $?; export GITHUB_KEY_B64
-      GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 app_id) || exit $?; export GITHUB_APP_ID
-      GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $MACOS_GITHUB_APP_2 installation_id) || exit $?; export GITHUB_INSTALLATION_ID
-      echo "Using GitHub App instance 2"
-    fi
-
 .setup_agent_github_app:
   - GITHUB_KEY_B64=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP key_b64) || exit $?; export GITHUB_KEY_B64
   - GITHUB_APP_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP app_id) || exit $?; export GITHUB_APP_ID

--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -38,6 +38,7 @@ test_kmt_local_setup_macos:
   before_script:
     - !reference [.vault_login]
     - !reference [.aws_retry_config]
+    - !reference [.setup_agent_github_app]
     # Selecting the current Go version
     - |
       eval $(gimme $(cat .go-version))

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -553,6 +553,8 @@ class GithubAPI:
     def get_token_from_app(app_id_env='GITHUB_APP_ID', pkey_env='GITHUB_KEY_B64'):
         app_id = os.environ.get(app_id_env)
         app_key_b64 = os.environ.get(pkey_env)
+        if app_id is None or app_key_b64 is None:
+            raise RuntimeError(f"Missing {app_id_env} or {pkey_env}")
         app_key = base64.b64decode(app_key_b64).decode("ascii")
 
         auth = Auth.AppAuth(app_id, app_key)


### PR DESCRIPTION
### What does this PR do?
- Remove the no more used `datadog-agent-macos-build` Github App reference
- Add the sourcing of the Github App in the `test_kmt_local_setup_macos` (and added this secret in the macos vault)
- Use a real error to prevent unexpected exception [in case the token is not set](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1335941269)
```
 File "/Users/ec2-user/builds/t3_C7z16h/0/DataDog/datadog-agent/tasks/libs/ciproviders/github_api.py", line 556, in get_token_from_app
    app_key = base64.b64decode(app_key_b64).decode("ascii")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ec2-user/Library/Caches/pyapp/distributions/_8485843412347238486/python/lib/python3.12/base64.py", line 83, in b64decode
    s = _bytes_from_decode_data(s)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ec2-user/Library/Caches/pyapp/distributions/_8485843412347238486/python/lib/python3.12/base64.py", line 45, in _bytes_from_decode_data
    raise TypeError("argument should be a bytes-like object or ASCII "
```
### Motivation
Clean code, detected during #incident-47790

### Describe how you validated your changes
[Passed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1338900018) without error on my last pipeline execution

### Additional Notes
