### PR TITLE
feat(host-profiler/converter): infer API/APP keys from agent's config

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 )
@@ -112,4 +113,96 @@ func readFromYamlFile(t *testing.T, yamlContent string) map[string]any {
 	err = converter.Convert(context.Background(), conf)
 	require.NoError(t, err)
 	return conf.ToStringMap()
+}
+
+func readFromYamlFileWithAgent(t *testing.T, yamlContent string, agentConfig config.Component) map[string]any {
+	confRetrieved, err := confmap.NewRetrievedFromYAML([]byte(yamlContent))
+	require.NoError(t, err, "Failed to create retrieved from YAML")
+	conf, err := confRetrieved.AsConf()
+	require.NoError(t, err, "Failed to convert to conf")
+	converter := &converterWithAgent{config: agentConfig}
+	err = converter.Convert(context.Background(), conf)
+	require.NoError(t, err, "Failed to convert config")
+	return conf.ToStringMap()
+}
+
+func TestAPIKeyInferenceAddsKeysWhenMissing(t *testing.T) {
+	yaml := `
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+        - site: datadoghq.com
+processors:
+  cumulativetodelta: {}
+exporters:
+  otlphttp:
+    metrics_endpoint: https://otlp.datad0g.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datad0g.com/v1development/profiles
+    headers:
+      dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+`
+	mockConfig := config.NewMockWithOverrides(t, map[string]interface{}{
+		"api_key": "inferred-api-key",
+		"app_key": "inferred-app-key",
+	})
+
+	conf := readFromYamlFileWithAgent(t, yaml, mockConfig)
+
+	// Verify API keys were added to symbol endpoint
+	receivers := conf["receivers"].(map[string]any)
+	hostprofiler := receivers["hostprofiler"].(map[string]any)
+	symbolUploader := hostprofiler["symbol_uploader"].(map[string]any)
+	endpoints := symbolUploader["symbol_endpoints"].([]any)
+	endpoint := endpoints[0].(map[string]any)
+	require.Equal(t, "inferred-api-key", endpoint["api_key"])
+	require.Equal(t, "inferred-app-key", endpoint["app_key"])
+
+	// Verify API key was added to exporter headers
+	exporters := conf["exporters"].(map[string]any)
+	otlphttp := exporters["otlphttp"].(map[string]any)
+	headers := otlphttp["headers"].(map[string]any)
+	require.Equal(t, "inferred-api-key", headers["dd-api-key"])
+}
+
+func TestAPIKeyInferenceDoesNotOverrideExistingKeys(t *testing.T) {
+	yaml := `
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+        - site: datadoghq.com
+          api_key: existing-symbol-api-key
+          app_key: existing-symbol-app-key
+exporters:
+  otlphttp:
+    metrics_endpoint: https://otlp.datad0g.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datad0g.com/v1development/profiles
+    headers:
+      dd-api-key: existing-exporter-api-key
+      dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
+`
+	mockConfig := config.NewMockWithOverrides(t, map[string]interface{}{
+		"api_key": "inferred-api-key",
+		"app_key": "inferred-app-key",
+	})
+
+	conf := readFromYamlFileWithAgent(t, yaml, mockConfig)
+
+	// Verify existing API keys in symbol endpoint were NOT overridden
+	receivers := conf["receivers"].(map[string]any)
+	hostprofiler := receivers["hostprofiler"].(map[string]any)
+	symbolUploader := hostprofiler["symbol_uploader"].(map[string]any)
+	endpoints := symbolUploader["symbol_endpoints"].([]any)
+	endpoint := endpoints[0].(map[string]any)
+	require.Equal(t, "existing-symbol-api-key", endpoint["api_key"])
+	require.Equal(t, "existing-symbol-app-key", endpoint["app_key"])
+
+	// Verify existing API key in exporter headers was NOT overridden
+	exporters := conf["exporters"].(map[string]any)
+	otlphttp := exporters["otlphttp"].(map[string]any)
+	headers := otlphttp["headers"].(map[string]any)
+	require.Equal(t, "existing-exporter-api-key", headers["dd-api-key"])
 }

--- a/comp/host-profiler/collector/impl/converters/helper.go
+++ b/comp/host-profiler/collector/impl/converters/helper.go
@@ -117,28 +117,16 @@ func getMapStr(confStringMap map[string]any, keys []string) (map[string]any, err
 	return confStringMap, nil
 }
 
-func getSymbolEndpoints(confStringMap map[string]any) []any {
+func getSymbolEndpoints(confStringMap map[string]any) ([]any, error) {
 	symbolUploader, err := getMapStr(confStringMap, []string{"receivers", "hostprofiler", "symbol_uploader"})
 	if err != nil || symbolUploader == nil {
-		return nil
+		return nil, err
 	}
-	endpoints, ok := symbolUploader["symbol_endpoints"].([]any)
-	if !ok {
-		return nil
-	}
+	endpoints := symbolUploader["symbol_endpoints"].([]any)
 
-	return endpoints
+	return endpoints, nil
 }
 
-func getExporterHeaders(confStringMap map[string]any) map[string]any {
-	otlphttp, err := getMapStr(confStringMap, []string{"exporters", "otlphttp"})
-	if err != nil || otlphttp == nil {
-		return nil
-	}
-	headers, ok := otlphttp["headers"].(map[string]any)
-
-	if !ok {
-		return nil
-	}
-	return headers
+func getExporterHeaders(confStringMap map[string]any) (map[string]any, error) {
+	return getMapStr(confStringMap, []string{"exporters", "otlphttp", "headers"})
 }

--- a/comp/host-profiler/collector/impl/converters/helper.go
+++ b/comp/host-profiler/collector/impl/converters/helper.go
@@ -116,3 +116,29 @@ func getMapStr(confStringMap map[string]any, keys []string) (map[string]any, err
 	}
 	return confStringMap, nil
 }
+
+func getSymbolEndpoints(confStringMap map[string]any) []any {
+	symbolUploader, err := getMapStr(confStringMap, []string{"receivers", "hostprofiler", "symbol_uploader"})
+	if err != nil || symbolUploader == nil {
+		return nil
+	}
+	endpoints, ok := symbolUploader["symbol_endpoints"].([]any)
+	if !ok {
+		return nil
+	}
+
+	return endpoints
+}
+
+func getExporterHeaders(confStringMap map[string]any) map[string]any {
+	otlphttp, err := getMapStr(confStringMap, []string{"exporters", "otlphttp"})
+	if err != nil || otlphttp == nil {
+		return nil
+	}
+	headers, ok := otlphttp["headers"].(map[string]any)
+
+	if !ok {
+		return nil
+	}
+	return headers
+}

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -9,6 +9,7 @@
 package collectorimpl
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -49,6 +50,7 @@ type extraFactoriesWithAgentCore struct {
 	ipcComp    ipc.Component
 	traceAgent traceagent.Component
 	log        log.Component
+	config     config.Component
 }
 
 var _ ExtraFactories = (*extraFactoriesWithAgentCore)(nil)
@@ -59,6 +61,7 @@ func NewExtraFactoriesWithAgentCore(
 	hostname hostname.Component, ipcComp ipc.Component,
 	traceAgent traceagent.Component,
 	log log.Component,
+	config config.Component,
 ) ExtraFactories {
 	return extraFactoriesWithAgentCore{
 		tagger:     tagger,
@@ -66,6 +69,7 @@ func NewExtraFactoriesWithAgentCore(
 		ipcComp:    ipcComp,
 		traceAgent: traceAgent,
 		log:        log,
+		config:     config,
 	}
 }
 
@@ -84,7 +88,7 @@ func (e extraFactoriesWithAgentCore) GetProcessors() []processor.Factory {
 
 func (e extraFactoriesWithAgentCore) GetConverters() []confmap.ConverterFactory {
 	return []confmap.ConverterFactory{
-		converters.NewFactoryWithAgent(),
+		converters.NewFactoryWithAgent(e.config),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds API/APP keys to every `hostprofiler::symbol_uploader::symbol_endpoints` receiver and adds API key to `otlphttp::headers` if not already present at conversion time.

### Motivation

Eases deployment requirements.

### Describe how you validated your changes

Added 2 tests:
- adding API/APP keys when missing
- API/APP keys are not overwritten if already present