### PR TITLE
tests: add recent kubernetes versions to deploy on kind

### DIFF
--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -231,7 +231,7 @@ func (e *CommonEnvironment) InfraOSImageIDUseLatest() bool {
 }
 
 func (e *CommonEnvironment) KubernetesVersion() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraKubernetesVersion, "1.32")
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraKubernetesVersion, "1.34")
 }
 
 func (e *CommonEnvironment) KindVersion() string {

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -20,6 +20,14 @@ type KindConfig struct {
 
 // Source: https://github.com/kubernetes-sigs/kind/releases
 var kubeToKindVersion = map[string]KindConfig{
+	"1.34": {
+		KindVersion:      "v0.30.0",
+		NodeImageVersion: "v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a",
+	},
+	"1.33": {
+		KindVersion:      "v0.28.0",
+		NodeImageVersion: "v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2",
+	},
 	"1.32": {
 		KindVersion:      "v0.26.0",
 		NodeImageVersion: "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",

--- a/test/e2e-framework/tasks/aws/kind.py
+++ b/test/e2e-framework/tasks/aws/kind.py
@@ -31,6 +31,7 @@ scenario_name = "aws/kind"
         "cluster_agent_full_image_path": doc.cluster_agent_full_image_path,
         "agent_flavor": doc.agent_flavor,
         "helm_config": doc.helm_config,
+        "kube_version": doc.kubernetes_version,
     }
 )
 def create_kind(
@@ -49,6 +50,7 @@ def create_kind(
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
     helm_config: Optional[str] = None,
+    kube_version: Optional[str] = None,
 ):
     """
     Create a kind environment.
@@ -60,6 +62,7 @@ def create_kind(
         "ddinfra:aws/defaultInstanceType": "t3.xlarge",
         "ddagent:deployWithOperator": bool(install_agent_with_operator),
         "ddtestworkload:deployArgoRollout": install_argorollout,
+        "ddinfra:kubernetesVersion": kube_version,
     }
 
     full_stack_name = deploy(

--- a/test/e2e-framework/tasks/doc.py
+++ b/test/e2e-framework/tasks/doc.py
@@ -40,3 +40,4 @@ local_package: str = "Path to a local package to install, it can be either a fol
 pull_secret_path: str = "Path to the OpenShift pull secret file (required for OpenShift cluster creation)."
 local_chart_path: str = "Path to a local helm chart to install the Datadog Agent."
 latest_ami: str = "Use the latest AMI for the OS and architecture (default False)."
+kubernetes_version: str = "Kubernetes version to use (format v<major>.<minor> example v1.34)"


### PR DESCRIPTION
### What does this PR do?

Add the recent released of kubernetes to deploy a stack using kind.

Sets default kubernetes version to v1.34

### Motivation

### Describe how you validated your changes

after deploying each version

`kubectl get node`

```
NAME                                               STATUS   ROLES           AGE   VERSION
alexandre-lavigne-crayon-test-kind-control-plane   Ready    control-plane   12m   v1.33.0
```
and
```
NAME                                               STATUS   ROLES           AGE     VERSION
alexandre-lavigne-crayon-test-kind-control-plane   Ready    control-plane   3m38s   v1.34.0
```


### Additional Notes

**this upgrades the default kubernetes version to v1.34**
