### PR TITLE
Fix typo in System Probe's `circuit_breaker` config

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -177,7 +177,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interval", 1*time.Second)
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.per_probe_cpu_limit", 0.1)
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit", 0.5)
-	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breakerinterrupt_overhead", 5*time.Microsecond)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interrupt_overhead", 5*time.Microsecond)
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.

--- a/pkg/config/setup/system_probe_test.go
+++ b/pkg/config/setup/system_probe_test.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package setup
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSystemProbeDefaultConfig tests that InitSystemProbeConfig sets system probe settings correctly
+func TestSystemProbeDefaultConfig(t *testing.T) {
+	cfg := newEmptyMockConf(t)
+	InitSystemProbeConfig(cfg)
+
+	for _, tc := range []struct {
+		key          string
+		defaultValue interface{}
+	}{
+		{
+			key:          "dynamic_instrumentation.circuit_breaker.interval",
+			defaultValue: 1 * time.Second,
+		},
+		{
+			key:          "dynamic_instrumentation.circuit_breaker.per_probe_cpu_limit",
+			defaultValue: 0.1,
+		},
+		{
+			key:          "dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit",
+			defaultValue: 0.5,
+		},
+		{
+			key:          "dynamic_instrumentation.circuit_breaker.interrupt_overhead",
+			defaultValue: 5 * time.Microsecond,
+		},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			switch expected := tc.defaultValue.(type) {
+			case time.Duration:
+				actual := cfg.GetDuration(tc.key)
+				require.NotZero(t, actual, "config key %s must not be zero - may indicate malformed key", tc.key)
+				assert.Equal(t, expected, actual)
+			case float64:
+				assert.Equal(t, expected, cfg.GetFloat64(tc.key))
+			default:
+				t.Fatalf("unsupported type %T for key %s", tc.defaultValue, tc.key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in the configuration key for circuit breaker interrupt overhead and adds a test to prevent similar config key typos in the future.

### Motivation
The config key `dynamic_instrumentation.circuit_breakerinterrupt_overhead` was missing a dot between `circuit_breaker` and `interrupt_overhead`, causing the configuration value to be `nil`.
This resulted in [warnings during integration tests](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1338610170#L791):
```
failed to get configuration value for key "dynamic_instrumentation.circuit_breaker.interrupt_overhead":
unable to cast <nil> of type <nil> to Duration
```

There was no unit test yet validating the circuit breaker configuration, allowing this typo to go undetected.

### Describe how you validated your changes
Newly added unit test passes locally:
`go test -tags test -run TestSystemProbeDefaultConfig ./pkg/config/setup`

### Additional Notes
This bug only affects `main` branch builds since January 6, 2026 (PR #44682).
Release branches (7.75.x and earlier) still use the `join()` form and are not affected (nothing to backport).