### PR TITLE
[snmp] Always collect ifType for interface metadata

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -305,6 +305,7 @@ func buildNetworkInterfacesMetadata(deviceID string, store *metadata.Store) []de
 			MacAddress:  store.GetColumnAsString("interface.mac_address", strIndex),
 			AdminStatus: devicemetadata.IfAdminStatus(store.GetColumnAsFloat("interface.admin_status", strIndex)),
 			OperStatus:  devicemetadata.IfOperStatus(store.GetColumnAsFloat("interface.oper_status", strIndex)),
+			IfType:      int(store.GetColumnAsFloat("interface.if_type", strIndex)),
 			IDTags:      ifIDTags,
 		}
 		interfaces = append(interfaces, networkInterface)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -276,6 +276,10 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 				"1": valuestore.ResultValue{Value: float64(1)},
 				"2": valuestore.ResultValue{Value: float64(2)},
 			},
+			"1.3.6.1.2.1.2.2.1.3": { // ifType
+				"1": valuestore.ResultValue{Value: float64(6)},  // ethernetCsmacd
+				"2": valuestore.ResultValue{Value: float64(24)}, // softwareLoopback
+			},
 			"1.3.6.1.2.1.31.1.1.1.18": {
 				"1": valuestore.ResultValue{Value: "ifAlias1"},
 				"2": valuestore.ResultValue{Value: ""},
@@ -340,6 +344,12 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.8",
 							Name: "ifOperStatus",
+						},
+					},
+					"if_type": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.3",
+							Name: "ifType",
 						},
 					},
 				},
@@ -407,7 +417,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 			"name": "21",
 			"alias": "ifAlias1",
 			"admin_status": 2,
-			"oper_status": 1
+			"oper_status": 1,
+			"if_type": 6
         },
         {
             "device_id": "1234",
@@ -417,7 +428,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
             "index": 2,
             "name": "22",
 			"admin_status": 2,
-			"oper_status": 2
+			"oper_status": 2,
+			"if_type": 24
         }
     ],
     "diagnoses": [

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -130,6 +130,7 @@ type InterfaceMetadata struct {
 	MacAddress    string        `json:"mac_address,omitempty"`
 	AdminStatus   IfAdminStatus `json:"admin_status,omitempty"`   // IF-MIB ifAdminStatus type is INTEGER
 	OperStatus    IfOperStatus  `json:"oper_status,omitempty"`    // IF-MIB ifOperStatus type is INTEGER
+	IfType        int           `json:"if_type,omitempty"`        // IF-MIB ifType type is INTEGER (IANAifType)
 	MerakiEnabled *bool         `json:"meraki_enabled,omitempty"` // enabled bool for Meraki devices, use a pointer to determine if the value was actually sent
 	MerakiStatus  string        `json:"meraki_status,omitempty"`  // status for Meraki devices
 }


### PR DESCRIPTION
## What does this PR do?

This PR ensures that the `ifType` OID (`1.3.6.1.2.1.2.2.1.3`) is always collected for SNMP interfaces, regardless of user profile configuration.

## Changes

- **`pkg/networkdevice/metadata/payload.go`**: Added `IfType` field (`int` type) to `InterfaceMetadata` struct
- **`pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go`**: 
  - Introduced `RequiredInterfaceFields` map containing the `if_type` OID
  - Added `ensureRequiredInterfaceFields` function that **overwrites** any user-defined `if_type` configuration to ensure consistent collection
- **`pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go`**: Populate `IfType` field in interface metadata
- **`pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go`**: Updated tests to verify `ifType` is included in interface metadata payload

## Motivation

The `ifType` field is essential for network device monitoring to identify the type of each interface (e.g., ethernet, loopback, etc.). This change ensures it is always collected independently of profile definitions.

## Testing

- Unit tests updated and passing
- `go test -tags test ./pkg/collector/corechecks/snmp/internal/checkconfig/...`
- `go test -tags test ./pkg/collector/corechecks/snmp/internal/report/...`