### PR TITLE
Fix backport workflow missing GitHub outputs

### DIFF
--- a/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
+++ b/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
@@ -108,9 +108,11 @@ git worktree remove {worktree_path}"""
     # Set outputs
     with open(os.environ["GITHUB_OUTPUT"], "a") as f:
         if original_pr_number:
-            f.write(f"pr_number={original_pr_number}\n")
+            f.write(f"original_pr_number={original_pr_number}\n")
         if base:
             f.write(f"base={base}\n")
+        if merge_commit_sha:
+            f.write(f"merge_commit_sha={merge_commit_sha}\n")
         if original_labels:
             f.write(f"original_labels={','.join(original_labels)}\n")
         if original_title:


### PR DESCRIPTION
### What does this PR do?
Fixes the backport workflow by correcting the GitHub Action outputs in the cherry-pick script.

### Motivation
Recent backport PRs (e.g., #44927) were created with missing information:
- branch name was `backport--to-7.75.x` instead of `backport-<pr_number>-to-7.75.x`.
  **This might prevent parallel backport PRs from being created** (branch name already booked),
- PR body showed `Backport from #.` instead of `Backport <sha> from #<pr_number>`.

This was caused by two bugs in the cherry-pick script:
1. output variable named `pr_number` instead of `original_pr_number` (expected by workflow),
2. missing `merge_commit_sha` output variable.

### Additional Notes
The backport workflow was recently rewritten in #44228.