### PR TITLE
[NDM][SNMP] Always collect ifType for interface metadata

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go
@@ -345,6 +345,17 @@ var TunnelMetadataConfig = profiledefinition.MetadataConfig{
 	},
 }
 
+// RequiredInterfaceFields contains interface metadata fields that must always be collected
+// regardless of what is defined in profiles
+var RequiredInterfaceFields = map[string]profiledefinition.MetadataField{
+	"if_type": {
+		Symbol: profiledefinition.SymbolConfig{
+			OID:  "1.3.6.1.2.1.2.2.1.3",
+			Name: "ifType",
+		},
+	},
+}
+
 // updateMetadataDefinitionWithDefaults will add metadata config for resources
 // that does not have metadata definitions
 func updateMetadataDefinitionWithDefaults(metadataConfig profiledefinition.MetadataConfig, collectTopology bool, collectVPN bool) profiledefinition.MetadataConfig {
@@ -359,6 +370,8 @@ func updateMetadataDefinitionWithDefaults(metadataConfig profiledefinition.Metad
 		mergeMetadata(newConfig, RouteMetadataConfig)
 		mergeMetadata(newConfig, TunnelMetadataConfig)
 	}
+	// Ensure required interface fields are always present
+	ensureRequiredInterfaceFields(newConfig)
 	return newConfig
 }
 
@@ -368,4 +381,17 @@ func mergeMetadata(metadataConfig profiledefinition.MetadataConfig, extraMetadat
 			metadataConfig[resourceName] = resourceConfig
 		}
 	}
+}
+
+// ensureRequiredInterfaceFields adds required interface fields that must always be collected
+// These fields override any user-defined configuration
+func ensureRequiredInterfaceFields(metadataConfig profiledefinition.MetadataConfig) {
+	interfaceConfig := metadataConfig["interface"]
+	if interfaceConfig.Fields == nil {
+		interfaceConfig.Fields = make(map[string]profiledefinition.MetadataField)
+	}
+	for fieldName, field := range RequiredInterfaceFields {
+		interfaceConfig.Fields[fieldName] = field
+	}
+	metadataConfig["interface"] = interfaceConfig
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -305,6 +305,7 @@ func buildNetworkInterfacesMetadata(deviceID string, store *metadata.Store) []de
 			MacAddress:  store.GetColumnAsString("interface.mac_address", strIndex),
 			AdminStatus: devicemetadata.IfAdminStatus(store.GetColumnAsFloat("interface.admin_status", strIndex)),
 			OperStatus:  devicemetadata.IfOperStatus(store.GetColumnAsFloat("interface.oper_status", strIndex)),
+			IfType:      int(store.GetColumnAsFloat("interface.if_type", strIndex)),
 			IDTags:      ifIDTags,
 		}
 		interfaces = append(interfaces, networkInterface)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -276,6 +276,10 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 				"1": valuestore.ResultValue{Value: float64(1)},
 				"2": valuestore.ResultValue{Value: float64(2)},
 			},
+			"1.3.6.1.2.1.2.2.1.3": { // ifType
+				"1": valuestore.ResultValue{Value: float64(6)},  // ethernetCsmacd
+				"2": valuestore.ResultValue{Value: float64(24)}, // softwareLoopback
+			},
 			"1.3.6.1.2.1.31.1.1.1.18": {
 				"1": valuestore.ResultValue{Value: "ifAlias1"},
 				"2": valuestore.ResultValue{Value: ""},
@@ -340,6 +344,12 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.8",
 							Name: "ifOperStatus",
+						},
+					},
+					"if_type": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.3",
+							Name: "ifType",
 						},
 					},
 				},
@@ -407,7 +417,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 			"name": "21",
 			"alias": "ifAlias1",
 			"admin_status": 2,
-			"oper_status": 1
+			"oper_status": 1,
+			"if_type": 6
         },
         {
             "device_id": "1234",
@@ -417,7 +428,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
             "index": 2,
             "name": "22",
 			"admin_status": 2,
-			"oper_status": 2
+			"oper_status": 2,
+			"if_type": 24
         }
     ],
     "diagnoses": [

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -130,6 +130,7 @@ type InterfaceMetadata struct {
 	MacAddress    string        `json:"mac_address,omitempty"`
 	AdminStatus   IfAdminStatus `json:"admin_status,omitempty"`   // IF-MIB ifAdminStatus type is INTEGER
 	OperStatus    IfOperStatus  `json:"oper_status,omitempty"`    // IF-MIB ifOperStatus type is INTEGER
+	IfType        int           `json:"if_type,omitempty"`        // IF-MIB ifType type is INTEGER (IANAifType)
 	MerakiEnabled *bool         `json:"meraki_enabled,omitempty"` // enabled bool for Meraki devices, use a pointer to determine if the value was actually sent
 	MerakiStatus  string        `json:"meraki_status,omitempty"`  // status for Meraki devices
 }

--- a/releasenotes/notes/snmp-collect-iftype-interface-metadata-a78388eb512d94b7.yaml
+++ b/releasenotes/notes/snmp-collect-iftype-interface-metadata-a78388eb512d94b7.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    NDM: The SNMP integration now collects ``ifType`` (OID 1.3.6.1.2.1.2.2.1.3) for all network interfaces
+    and includes it in the interface metadata payload. This field identifies the type of each interface
+    (e.g., ethernetCsmacd, softwareLoopback, tunnel) according to the IANAifType MIB.


### PR DESCRIPTION
## What does this PR do?

This PR collects the `ifType` OID (`1.3.6.1.2.1.2.2.1.3` from IF-MIB), the collected value is added to the interface metadata payload.
It's not open for profile configuration and is always collected regardless of the profile definition.

## Changes

### `pkg/networkdevice/metadata/payload.go`
- Added `IfType` field (`int` type with JSON tag `if_type`) to `InterfaceMetadata` struct

### `pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go`
- Introduced `RequiredInterfaceMetadataConfig` containing the `if_type` field definition with OID `1.3.6.1.2.1.2.2.1.3`
- Added `mergeRequiredMetadataFields()` function that merges metadata at the field level, **overwriting** any user-defined configuration
- This ensures `if_type` is always collected with the standard OID, even if users define their own `if_type` in custom profiles (which they shouldn't)

### `pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go`
- Populate `IfType` field in interface metadata from collected SNMP values

### `pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go`
- Updated tests to include `ifType` values in test data

### `pkg/collector/corechecks/snmp/internal/checkconfig/buildprofile_test.go`
- Added `TestBuildProfile_ifTypeAlwaysCollected` to verify:
  - `if_type` is added to inline profiles
  - `if_type` is added to profiles with interface metadata but no `if_type`
  - User-defined `if_type` configurations are overwritten with the standard OID

## Example Metadata Payload

After this change, the interface metadata payload includes `if_type`:

```json
{
  "collect_timestamp": 1767969770,
  "devices": [
    {
      "description": "Linux 41ba948911b9 4.9.87-linuxkit-aufs ...",
      "device_type": "other",
      "id": "florian2:127.0.0.1",
      "name": "41ba948911b9",
      "profile": "generic-device",
      "status": 1
    }
  ],
  "interfaces": [
    {
      "admin_status": 1,
      "description": "lo",
      "device_id": "florian2:127.0.0.1",
      "id_tags": ["interface:lo"],
      "if_type": 24,
      "index": 1,
      "name": "lo",
      "oper_status": 1
    },
    {
      "admin_status": 2,
      "description": "tunl0",
      "device_id": "florian2:127.0.0.1",
      "id_tags": ["interface:tunl0"],
      "if_type": 131,
      "index": 2,
      "name": "tunl0",
      "oper_status": 2
    },
    {
      "admin_status": 2,
      "description": "ip6tnl0",
      "device_id": "florian2:127.0.0.1",
      "id_tags": ["interface:ip6tnl0"],
      "if_type": 131,
      "index": 3,
      "name": "ip6tnl0",
      "oper_status": 2
    },
    {
      "admin_status": 1,
      "description": "eth0",
      "device_id": "florian2:127.0.0.1",
      "id_tags": ["interface:eth0"],
      "if_type": 6,
      "index": 90,
      "mac_address": "02:42:ac:11:00:02",
      "name": "eth0",
      "oper_status": 1
    }
  ]
}
```

### ifType Values (IANAifType)

| Value | Type |
|-------|------|
| 6 | ethernetCsmacd |
| 24 | softwareLoopback |
| 131 | tunnel |

Full list: https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib

## Testing

- Unit tests added and passing
- Manual testing with fake SNMP device confirmed `if_type` is collected and included in metadata payload