### PR TITLE
Allow substitutions in dd_agent_expand_template to use values from flags

### DIFF
--- a/bazel/rules/dd_agent_expand_template.bzl
+++ b/bazel/rules/dd_agent_expand_template.bzl
@@ -35,13 +35,15 @@ def _dd_agent_expand_template_impl(ctx):
 
     # Now add local substitutions.
     # For extra oomph, we apply the flag substitutions first. That allows us to
-    # reuse tmplates which migh have <% install_dir %> by declaring a local
+    # reuse tmplates which might have <% install_dir %> by declaring a local
     # substitution   "<% install_dir %>": "{install_dir}".
     # That is an affordance during migration.
+    computed_subs = {}
     for key, value in ctx.attr.substitutions.items():
         for flag, flag_value in subs.items():
             value = value.replace(flag, flag_value)
-        subs[key] = value
+        computed_subs[key] = value
+    subs.update(computed_subs)
 
     # let's add a little flavor. We don't need this today but it will be
     # needed if we expand things like the file name of an artifact and we want

--- a/bazel/rules/dd_agent_expand_template.bzl
+++ b/bazel/rules/dd_agent_expand_template.bzl
@@ -13,25 +13,25 @@ DEFAULT_PRODUCT_DIR = "/opt/datadog-agent"
 
 def _dd_agent_expand_template_impl(ctx):
     # Set up a fallback default.
+    subs = {}
+
     # TODO: should this be different for windows? Or should we have different variables for windows?
-    flag_vars = {}
-    flag_vars["output_config_dir"] = DEFAULT_OUTPUT_CONFIG_DIR
+    subs["{output_config_dir}"] = DEFAULT_OUTPUT_CONFIG_DIR
     if ctx.attr._output_config_dir:
         if BuildSettingInfo in ctx.attr._output_config_dir:
             output_config_dir = ctx.attr._output_config_dir[BuildSettingInfo].value.rstrip("/")
-            flag_vars["output_config_dir"] = output_config_dir
-    flag_vars["install_dir"] = DEFAULT_PRODUCT_DIR
+            subs["{output_config_dir}"] = output_config_dir
+    subs["{install_dir}"] = DEFAULT_PRODUCT_DIR
     if ctx.attr._install_dir:
         if BuildSettingInfo in ctx.attr._install_dir:
             install_dir = ctx.attr._install_dir[BuildSettingInfo].value
-            flag_vars["install_dir"] = install_dir
+            subs["{install_dir}"] = install_dir
 
     # TODO: decide if we should default etc to the output base or relative to install_dir.
     # There are use cases for either. For now, we are relative to the output base.
     # Note that the choice of /etc/datadog-agent seems odd, in that /etc is usually /etc,
     # but this matches what is done in the current product packaging.
-    flag_vars["etc_dir"] = flag_vars["output_config_dir"] + "/etc/datadog-agent"
-    subs = {"{%s}" % key: value for key, value in flag_vars.items()}
+    subs["{etc_dir}"] = subs["{output_config_dir}"] + "/etc/datadog-agent"
 
     # Now add local substitutions.
     # For extra oomph, we apply the flag substitutions first. That allows us to
@@ -39,7 +39,9 @@ def _dd_agent_expand_template_impl(ctx):
     # substitution   "<% install_dir %>": "{install_dir}".
     # That is an affordance during migration.
     for key, value in ctx.attr.substitutions.items():
-        subs[key] = value.format(**flag_vars)
+        for flag, flag_value in subs.items():
+            value = value.replace(flag, flag_value)
+        subs[key] = value
 
     # let's add a little flavor. We don't need this today but it will be
     # needed if we expand things like the file name of an artifact and we want

--- a/bazel/rules/template_expand_test.bzl
+++ b/bazel/rules/template_expand_test.bzl
@@ -108,6 +108,7 @@ def _dd_expand_flags_in_vars_test(name):
         substitutions = {
             "@CAP_INSTALL_DIR@": "{install_dir}",
             "@X@": "{x}",
+            "@NO_CHAINING@": "@CAP_INSTALL_DIR@",
         },
         out = "flags_in_vars_test.out",
     )
@@ -127,6 +128,9 @@ def _flags_in_vars_test_impl(env, target):
     install_dir_actual = env.ctx.attr._install_dir_actual[BuildSettingInfo].value
     biz_val = subject.actual.actions[0].substitutions.get("@CAP_INSTALL_DIR@")
     env.expect.that_str(biz_val).equals(install_dir_actual)
+
+    no_chaining_value = subject.actual.actions[0].substitutions.get("@NO_CHAINING@")
+    env.expect.that_str(no_chaining_value).equals("@CAP_INSTALL_DIR@")
 
     # Since there is no flag for "x", @X@ should pass through unchanged
     value = subject.actual.actions[0].substitutions.get("@X@")

--- a/bazel/rules/template_expand_test.bzl
+++ b/bazel/rules/template_expand_test.bzl
@@ -4,20 +4,28 @@ load("@rules_testing//lib:analysis_test.bzl", "analysis_test", "test_suite")
 load("@rules_testing//lib:util.bzl", "util")
 load(":dd_agent_expand_template.bzl", "dd_agent_expand_template")
 
-def _test_basics(name):
+def template_test_suite(name):
+    test_suite(
+        name = name,
+        tests = [
+            _dd_expand_basics_test,
+            _dd_expand_package_info_test,
+            _dd_expand_flags_in_vars_test,
+        ],
+    )
+
+def _dd_expand_basics_test(name):
     util.helper_target(
         dd_agent_expand_template,
-        name = name + "_subject",
+        name = name + "_basics_test",
         template = "ignored",
         substitutions = {"@BIZ@": "BAZ"},
-        out = "placeholder.out",
-        attributes = json.encode({"owner": "toot"}),
-        prefix = "put/them/here",
+        out = "basics_test.out",
     )
     analysis_test(
         name = name,
-        impl = _test_basics_impl,
-        target = name + "_subject",
+        impl = _basics_test_impl,
+        target = name + "_basics_test",
         attr_values = {
             "expect_cpu": select({
                 "@platforms//cpu:arm64": "arm64",
@@ -30,17 +38,12 @@ def _test_basics(name):
         },
     )
 
-def _test_basics_impl(env, target):
+def _basics_test_impl(env, target):
     subject = env.expect.that_target(target)
-    expect_output_path = target.label.package + "/placeholder.out"
+    expect_output_path = target.label.package + "/basics_test.out"
 
     # Writing the correct output file
     env.expect.that_target(target).default_outputs().contains(expect_output_path)
-
-    # Did we put the right things in the rule_pkg provider.
-    pfi = target[PackageFilesInfo]
-    env.expect.that_dict(pfi.attributes).contains_exactly({"owner": "toot"})
-    env.expect.that_dict(pfi.dest_src_map).keys().contains("put/them/here/placeholder.out")
 
     # Did we built the right substitution dictionary
     # Are all the expected keys here.
@@ -76,10 +79,48 @@ def _test_basics_impl(env, target):
     install_dir_actual = env.ctx.attr._install_dir_actual[BuildSettingInfo].value
     env.expect.that_str(install_dir).equals(install_dir_actual)
 
-def template_test_suite(name):
-    test_suite(
-        name = name,
-        tests = [
-            _test_basics,
-        ],
+def _dd_expand_package_info_test(name):
+    util.helper_target(
+        dd_agent_expand_template,
+        name = name + "_package_info_test",
+        template = "ignored",
+        out = "package_info_test.out",
+        attributes = json.encode({"owner": "toot"}),
+        prefix = "put/them/here",
     )
+    analysis_test(
+        name = name,
+        impl = _package_info_test_impl,
+        target = name + "_package_info_test",
+    )
+
+def _package_info_test_impl(env, target):
+    # Did we put the right things in the rules_pkg provider.
+    pfi = target[PackageFilesInfo]
+    env.expect.that_dict(pfi.attributes).contains_exactly({"owner": "toot"})
+    env.expect.that_dict(pfi.dest_src_map).keys().contains("put/them/here/package_info_test.out")
+
+def _dd_expand_flags_in_vars_test(name):
+    util.helper_target(
+        dd_agent_expand_template,
+        name = name + "_flags_in_vars_test",
+        template = "ignored",
+        substitutions = {"@CAP_INSTALL_DIR@": "{install_dir}"},
+        out = "flags_in_vars_test.out",
+    )
+    analysis_test(
+        name = name,
+        impl = _flags_in_vars_test_impl,
+        target = name + "_flags_in_vars_test",
+        attrs = {
+            "_install_dir_actual": attr.label(default = "@@//:install_dir"),
+        },
+    )
+
+def _flags_in_vars_test_impl(env, target):
+    subject = env.expect.that_target(target)
+
+    # Get the value of install_dir from the current flag setting
+    install_dir_actual = env.ctx.attr._install_dir_actual[BuildSettingInfo].value
+    biz_val = subject.actual.actions[0].substitutions.get("@CAP_INSTALL_DIR@")
+    env.expect.that_str(biz_val).equals(install_dir_actual)

--- a/bazel/rules/template_expand_test.bzl
+++ b/bazel/rules/template_expand_test.bzl
@@ -105,7 +105,10 @@ def _dd_expand_flags_in_vars_test(name):
         dd_agent_expand_template,
         name = name + "_flags_in_vars_test",
         template = "ignored",
-        substitutions = {"@CAP_INSTALL_DIR@": "{install_dir}"},
+        substitutions = {
+            "@CAP_INSTALL_DIR@": "{install_dir}",
+            "@X@": "{x}",
+        },
         out = "flags_in_vars_test.out",
     )
     analysis_test(
@@ -124,3 +127,7 @@ def _flags_in_vars_test_impl(env, target):
     install_dir_actual = env.ctx.attr._install_dir_actual[BuildSettingInfo].value
     biz_val = subject.actual.actions[0].substitutions.get("@CAP_INSTALL_DIR@")
     env.expect.that_str(biz_val).equals(install_dir_actual)
+
+    # Since there is no flag for "x", @X@ should pass through unchanged
+    value = subject.actual.actions[0].substitutions.get("@X@")
+    env.expect.that_str(value).equals("{x}")


### PR DESCRIPTION
Allow substitutions dict in dd_agent_expand_template to use values from flags.

Example:
    substitutions = {"@CMAKE_INSTALL_DIR@": "{install_dir}"},

Motivation: There are many existing .erb and .in templates which use different syntax from "{install_dir}".  This capability allows us to conveniently use those existing templates from both omnibus and bazel during the transition.

Note: "flags" means the flags that dd_agent_expand_template knows about, not any arbitrary flag.

Additional:
 - Changed the test names to be more informative
 - Split the single test into 3 for the distinct parts.