### PR TITLE
Set working directory explicitly to root to reduce issues on windows docker image

### DIFF
--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -39,5 +39,7 @@ COPY entrypoint.exe C:/entrypoint.exe
 ADD entrypoint-ps1 ./entrypoint-ps1
 COPY datadog*.yaml C:/ProgramData/Datadog/
 
+WORKDIR /
+
 ENTRYPOINT ["C:/entrypoint.exe"]
 CMD ["datadogagent"]


### PR DESCRIPTION
### What does this PR do?

This PR explicitly sets the working directory to root (`C:\`) in the Windows Docker image before the entrypoint is executed.

### Motivation

When using the `7.73.1-servercore-ltsc2022` base image, the working directory defaults to `C:\Windows\System32`, which causes the entrypoint to fail with the following error:

```
[ENTRYPOINT][ERROR] directory_iterator::directory_iterator: The system cannot find the path specified.: "entrypoint-ps1"
```

This happens because the entrypoint expects to find the `entrypoint-ps1` directory in the working directory, but it was copied to the image root. Without an explicit `WORKDIR` directive, the container inherits an unexpected working directory, causing the entrypoint to exit with code 1.

### Describe how you validated your changes

- Reproduced the issue with `7.73.1-servercore-ltsc2022` image where the default working directory was `C:\Windows\System32`
- Confirmed that the entrypoint fails without this fix with error: `directory_iterator::directory_iterator: The system cannot find the path specified.: "entrypoint-ps1"`
- Verified that using `docker run -w "/"` as a workaround resolves the issue
- Validated that adding `WORKDIR /` in the Dockerfile permanently fixes the issue without requiring the `-w` flag at runtime

### Additional Notes

This fix ensures the container works correctly out of the box without requiring users to specify the `-w /` flag when running the container. The `entrypoint-ps1` directory is located at the root (`/`), so setting the working directory to `/` allows the entrypoint to find it correctly.
