### PR TITLE
[EBPF-1022] gpu: move checkClosedProcess() out of the main consumer loop

### DIFF
--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -315,7 +315,8 @@ func TestConsumerProcessExitViaCheckClosedProcesses(t *testing.T) {
 	// Remove the process from fake procfs (simulate process exit) by just deleting its folder
 	os.RemoveAll(filepath.Join(fakeProcFS, strconv.Itoa(int(pid))))
 
-	// Wait for the process sync ticker to trigger checkClosedProcesses and mark the stream as ended
+	// Wait for the background process checker to discover the closed process and send it through
+	// the processExitChannel, which will then be handled by the main consumer loop
 	require.Eventually(t, func() bool { return stream.ended }, 5*cfg.ScanProcessesInterval, 50*time.Millisecond)
 
 	// Stop the consumer

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -161,14 +161,6 @@ func (ctx *systemContext) removeProcess(pid int) {
 	}
 }
 
-// cleanOld removes any old entries that have not been accessed in a while, to avoid
-// retaining unused data forever
-func (ctx *systemContext) cleanOld() {
-	if ctx.cudaKernelCache != nil {
-		ctx.cudaKernelCache.CleanOld()
-	}
-}
-
 // filterDevicesForContainer filters the available GPU devices for the given
 // container. If the ID is not empty, we check the assignment of GPU resources
 // to the container and return only the devices that are available to the

--- a/pkg/gpu/cuda/kernel_cache.go
+++ b/pkg/gpu/cuda/kernel_cache.go
@@ -317,7 +317,7 @@ func (kc *KernelCache) processRequests() {
 			delete(kc.pidMaps, pid)
 			kc.telemetry.activePIDs.Set(float64(len(kc.pidMaps)))
 		case <-fatbinCleanup.C:
-			kc.CleanOld()
+			kc.cleanOld()
 		case <-handle.C:
 			continue
 		case <-kc.done:
@@ -366,9 +366,9 @@ func (kc *KernelCache) CleanProcessData(pid int) {
 	kc.telemetry.kernelCacheSize.Set(float64(len(kc.cache)))
 }
 
-// CleanOld removes any old entries that have not been accessed in a while.
+// cleanOld removes any old entries that have not been accessed in a while.
 // Should only be called in the processRequests goroutine, to avoid race issues.
-func (kc *KernelCache) CleanOld() {
+func (kc *KernelCache) cleanOld() {
 	maxFatbinAge := 5 * time.Minute
 	fatbinExpirationTime := time.Now().Add(-maxFatbinAge)
 


### PR DESCRIPTION
### What does this PR do?

Move checkClosedProcesses() out of the main consumer loop into a dedicated goroutine to avoid blocking the main loop with /proc scanning, which was consuming ~5% of the loop's time despite only executing every 30 seconds,  potentially causing event losses.

### Motivation

Reduce eBPF event loss and improve performance.

### Describe how you validated your changes

Existing tests passing

### Additional Notes

A call to `systemContext.cleanOld`, which was used only to clean old objects on the CUDA kernel cache, has been removed as it's redundant, the kernel cache has a goroutine responsible for doing that. The corresponding kernel cache function has been unexported to avoid confusion.