### PR TITLE
[CWS] Mount resolver refactor

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/exec.h
+++ b/pkg/security/ebpf/c/include/helpers/exec.h
@@ -32,8 +32,6 @@ int __attribute__((always_inline)) handle_exec_event(ctx_t *ctx, struct syscall_
     syscall->exec.file.path_key.mount_id = mount_id;
     set_file_inode(syscall->exec.dentry, &syscall->exec.file, 0);
 
-    inc_mount_ref(mount_id);
-
     // resolve dentry
     syscall->resolver.key = syscall->exec.file.path_key;
     syscall->resolver.dentry = syscall->exec.dentry;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -333,9 +333,7 @@ int __attribute__((always_inline)) handle_do_exit(ctx_t *ctx) {
         // send the entry to maintain userspace cache
         struct exit_event_t event = {};
         struct proc_cache_t *pc = fill_process_context(&event.process);
-        if (pc) {
-            dec_mount_ref(ctx, pc->entry.executable.path_key.mount_id);
-        }
+
         fill_cgroup_context(pc, &event.cgroup);
         fill_span_context(&event.span);
         event.exit_code = (u32)(u64)CTX_PARM1(ctx);
@@ -772,7 +770,6 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
 
             // inherit the parent cgroup context
             fill_cgroup_context(parent_pc, &pc.cgroup);
-            dec_mount_ref(ctx, parent_pc->entry.executable.path_key.mount_id);
         }
     }
 

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -219,9 +219,6 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
         return 0;
     }
 
-    // increase mount ref
-    inc_mount_ref(syscall->open.file.path_key.mount_id);
-
     // check if the syscall was discarded
     if (syscall->state == DISCARDED) {
         return 0;
@@ -329,17 +326,6 @@ int rethook_io_openat2(ctx_t *ctx) {
     }
     syscall->retval = CTX_PARMRET(ctx);
     return _sys_open_ret(ctx, syscall);
-}
-
-HOOK_ENTRY("filp_close")
-int hook_filp_close(ctx_t *ctx) {
-    struct file *file = (struct file *)CTX_PARM1(ctx);
-    u32 mount_id = get_file_mount_id(file);
-    if (mount_id) {
-        dec_mount_ref(ctx, mount_id);
-    }
-
-    return 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/hooks/umount.h
+++ b/pkg/security/ebpf/c/include/hooks/umount.h
@@ -42,8 +42,6 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
 
     send_event(ctx, EVENT_UMOUNT, event);
 
-    umounted(ctx, mount_id);
-
     return 0;
 }
 
@@ -54,6 +52,22 @@ HOOK_SYSCALL_EXIT(umount) {
 
 TAIL_CALL_TRACEPOINT_FNC(handle_sys_umount_exit, struct tracepoint_raw_syscalls_sys_exit_t *args) {
     return sys_umount_ret(args, args->ret);
+}
+
+HOOK_ENTRY("cleanup_mnt")
+int hook_cleanup_mnt(ctx_t *ctx) {
+    struct mount *mnt = (struct mount *)CTX_PARM1(ctx);
+
+    struct mount_released_event_t event = {};
+    event.mount_id = get_mount_mount_id(mnt);
+    event.mount_id_unique = get_mount_mount_id_unique(mnt);
+
+    bump_mount_discarder_revision(event.mount_id);
+    bump_path_id(event.mount_id);
+
+    send_event(ctx, EVENT_MOUNT_RELEASED, event);
+
+    return 0;
 }
 
 #endif

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -66,7 +66,6 @@ BPF_LRU_MAP(cgroup_wait_list, u64, u64, 1) // max entries will be overridden at 
 BPF_LRU_MAP(traced_cgroups_discarded, u64, u8, 512)
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
 BPF_LRU_MAP(bpf_maps, u32, struct bpf_map_t, 4096)
 BPF_LRU_MAP(bpf_progs, u32, struct bpf_prog_t, 4096)
 BPF_LRU_MAP(tgid_fd_map_id, struct bpf_tgid_fd_t, u32, 4096)

--- a/pkg/security/ebpf/c/include/structs/filesystem.h
+++ b/pkg/security/ebpf/c/include/structs/filesystem.h
@@ -7,11 +7,8 @@
 struct mount_released_event_t {
     struct kevent_t event;
     u32 mount_id;
-};
-
-struct mount_ref_t {
-    u32 umounted;
-    s32 counter;
+    u32 __pad;
+    u64 mount_id_unique;
 };
 
 struct mount_fields_t {

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -232,9 +232,6 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_io_openat2"),
 				hookFunc("rethook_io_openat2"),
 			}},
-			&manager.AllOf{Selectors: []manager.ProbesSelector{
-				hookFunc("hook_filp_close"),
-			}},
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_terminate_walk"),
 			}},
@@ -257,6 +254,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 				hookFunc("hook_clone_mnt"),
 				hookFunc("rethook_clone_mnt"),
 				hookFunc("hook_mnt_change_mountpoint"),
+				hookFunc("hook_cleanup_mnt"),
 			}},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				hookFunc("rethook_alloc_vfsmnt"),

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -57,6 +57,12 @@ func getMountProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_cleanup_mnt",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_mnt_change_mountpoint",
 			},
 		},

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -69,12 +69,6 @@ func getOpenProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
-				EBPFFuncName: "hook_filp_close",
-			},
-		},
-		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_terminate_walk",
 			},
 		},

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1666,6 +1666,10 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 			return false
 		}
 
+		if event.MountReleased.MountID == 0 {
+			seclog.Errorf("Requested to delete mount id zero!")
+		}
+
 		// Remove all dentry entries belonging to the mountID
 		p.Resolvers.DentryResolver.DelCacheEntries(event.MountReleased.MountID)
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1232,7 +1232,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid, true)
+		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.Resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1665,7 +1665,6 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 		if !p.regularUnmarshalEvent(&event.MountReleased, eventType, offset, dataLen, data) {
 			return false
 		}
-		p.Resolvers.DentryResolver.DelCacheEntriesForMountID(event.MountReleased.MountID)
 
 		// Delete new mount point from cache
 		if err = p.Resolvers.MountResolver.Delete(event.MountReleased.MountID, event.MountReleased.MountIDUnique); err != nil {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1232,7 +1232,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid)
+		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid, true)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.Resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {
@@ -1665,18 +1665,13 @@ func (p *EBPFProbe) handleEarlyReturnEvents(event *model.Event, offset int, data
 		if !p.regularUnmarshalEvent(&event.MountReleased, eventType, offset, dataLen, data) {
 			return false
 		}
-
-		if event.MountReleased.MountID == 0 {
-			seclog.Errorf("Requested to delete mount id zero!")
-		}
-
-		// Remove all dentry entries belonging to the mountID
-		p.Resolvers.DentryResolver.DelCacheEntries(event.MountReleased.MountID)
+		p.Resolvers.DentryResolver.DelCacheEntriesForMountID(event.MountReleased.MountID)
 
 		// Delete new mount point from cache
-		if err = p.Resolvers.MountResolver.Delete(event.MountReleased.MountID); err != nil {
+		if err = p.Resolvers.MountResolver.Delete(event.MountReleased.MountID, event.MountReleased.MountIDUnique); err != nil {
 			seclog.Tracef("failed to delete mount point %d from cache: %s", event.MountReleased.MountID, err)
 		}
+
 		return false
 	case model.ArgsEnvsEventType:
 		if !p.regularUnmarshalEvent(&event.ArgsEnvs, eventType, offset, dataLen, data) {
@@ -2352,7 +2347,7 @@ func (p *EBPFProbe) handleNewMount(ev *model.Event, m *model.Mount) error {
 	// MNT_DETACH. It then does an exec syscall, that will cause the fd to be closed.
 	// Our dentry resolution of the exec event causes the inode/mount_id to be put in cache,
 	// so we remove all dentry entries belonging to the mountID.
-	p.Resolvers.DentryResolver.DelCacheEntries(m.MountID)
+	p.Resolvers.DentryResolver.DelCacheEntriesForMountID(m.MountID)
 
 	if !m.Detached && ev.GetEventType() != model.FileMoveMountEventType {
 		// Resolve mount point

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -174,8 +174,8 @@ func (dr *Resolver) sendERPCStats() error {
 	return dr.bufferSelector.Put(ebpf.BufferSelectorERPCMonitorKey, dr.activeERPCStatsBuffer)
 }
 
-// DelCacheEntries removes all the entries belonging to a mountID
-func (dr *Resolver) DelCacheEntries(mountID uint32) {
+// DelCacheEntriesForMountID removes all the entries belonging to a mountID
+func (dr *Resolver) DelCacheEntriesForMountID(mountID uint32) {
 	dr.cache.RemoveKey1(mountID)
 }
 

--- a/pkg/security/resolvers/file/resolver_linux.go
+++ b/pkg/security/resolvers/file/resolver_linux.go
@@ -97,7 +97,7 @@ func (r *Resolver) ResolveFileMetadata(event *model.Event, file *model.FileEvent
 		}, nil
 	}
 
-	// add pid one for hash resolution outside of a container
+	// add pid one for hash resolution outside a container
 	process := event.ProcessContext.Process
 	rootPIDs := []uint32{process.Pid, 1}
 	if process.ContainerContext.ContainerID != "" && r.cgroupResolver != nil {

--- a/pkg/security/resolvers/mount/errors.go
+++ b/pkg/security/resolvers/mount/errors.go
@@ -15,7 +15,9 @@ import (
 
 var (
 	// ErrMountUndefined is used when a mount identifier is undefined
-	ErrMountUndefined = errors.New("undefined mountID")
+	ErrMountUndefined = errors.New("undefined mountID (mount id is 0)")
+	// ErrParentMountUndefined is used when a mount identifier of a parent is undefined
+	ErrParentMountUndefined = errors.New("undefined parent mountID (mount id is 0)")
 	// ErrMountLoop is returned when there is a resolution loop
 	ErrMountLoop = errors.New("mount resolution loop")
 	// ErrMountPathEmpty is returned when the resolved mount path is empty

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -22,7 +22,7 @@ type ResolverInterface interface {
 	InsertMoved(m model.Mount) error
 	ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
 	ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMount(mountID uint32, pid uint32, useRedemptionAndSync bool) (*model.Mount, model.MountSource, model.MountOrigin, error)
+	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	ToJSON() ([]byte, error)
 }

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -16,13 +16,13 @@ import (
 type ResolverInterface interface {
 	IsMountIDValid(mountID uint32) (bool, error)
 	SyncCache() error
-	Delete(mountID uint32) error
+	Delete(mountID uint32, mountIDUnique uint64) error
 	ResolveFilesystem(mountID uint32, pid uint32) (string, error)
 	Insert(m model.Mount) error
 	InsertMoved(m model.Mount) error
 	ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
 	ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
+	ResolveMount(mountID uint32, pid uint32, useRedemptionAndSync bool) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	ToJSON() ([]byte, error)
 }

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -203,7 +203,6 @@ func collectUniqueMountNSFDs(procfs string) ([]int, error) {
 		}
 
 		ino, err := getInodeNumFromLink(linkTarget)
-
 		if err != nil {
 			continue
 		}

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -64,7 +64,7 @@ func (mr *NoOpResolver) ResolveMountPath(_ uint32, _ uint32) (string, model.Moun
 }
 
 // ResolveMount returns the mount
-func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32, _ bool) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	return nil, model.MountSourceUnknown, model.MountOriginUnknown, errors.New("not available")
 }
 

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -39,7 +39,7 @@ func (mr *NoOpResolver) SyncCacheFromListMount() error {
 }
 
 // Delete a mount from the cache
-func (mr *NoOpResolver) Delete(_ uint32) error {
+func (mr *NoOpResolver) Delete(_ uint32, _ uint64) error {
 	return nil
 }
 
@@ -64,7 +64,7 @@ func (mr *NoOpResolver) ResolveMountPath(_ uint32, _ uint32) (string, model.Moun
 }
 
 // ResolveMount returns the mount
-func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32, _ bool) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	return nil, model.MountSourceUnknown, model.MountOriginUnknown, errors.New("not available")
 }
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -304,7 +304,6 @@ func (mr *Resolver) ResolveFilesystem(mountID uint32, pid uint32) (string, error
 // Insert a new mount point in the cache
 func (mr *Resolver) Insert(m model.Mount) error {
 	if m.MountID == 0 {
-		seclog.Warnf("Tried to insert a mount with mount id 0")
 		return ErrMountUndefined
 	}
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -35,7 +35,7 @@ import (
 const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
-	redemptionTime                       = 2 * time.Second
+	redemptionTime                       = 5 * time.Second
 	// mounts LRU limit: 100000 mounts
 	mountsLimit = 100000
 )

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -211,7 +211,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	}
 
 	// Update the mount path for all the children
-	mr.walkMountSubtree(mount, true, func(child *model.Mount) {
+	mr.walkMountSubtree(mount, false, func(child *model.Mount) {
 		child.Path = ""
 		_, _, _, _ = mr.getMountPath(child.MountID, 0)
 	})

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -11,13 +11,14 @@ package mount
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"path"
 	"slices"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 
 	"go.uber.org/atomic"
 
@@ -211,64 +212,57 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 		}
 	}
 
-	allChildren, err := mr.getAllChildren(mount)
-	if err != nil {
-		seclog.Warnf("Error getting the list of children for mount id %d. err = %v", mount.MountID, err)
-	}
-
-	for _, child := range allChildren {
+	mr.walkMountSubtree(mount, true, func(child *model.Mount) {
 		child.Path = ""
 		_, _, _, _ = mr.getMountPath(child.MountID, 0)
-	}
+	})
 }
 
-func (mr *Resolver) getAllChildren(mount *model.Mount) (map[uint32]*model.Mount, error) {
-	children := map[uint32]*model.Mount{}
+func (mr *Resolver) walkMountSubtree(mount *model.Mount, lookIntoRedemption bool, cb func(*model.Mount)) {
+	stack := []*model.Mount{mount}
+	visited := make(map[uint32]struct{})
 
-	err := mr.getAllChildrenRecursive(mount, children)
+	var getMount func(uint32) *model.Mount
 
-	return children, err
-}
-
-func (mr *Resolver) getAllChildrenRecursive(mount *model.Mount, mountList map[uint32]*model.Mount) error {
-	if _, existed := mountList[mount.MountID]; existed {
-		return nil
-	}
-	mountList[mount.MountID] = mount
-
-	for _, mountid := range mount.Children {
-		mnt := mr.lookupByMountID(mountid)
-		if mnt != nil {
-			err := mr.getAllChildrenRecursive(mnt, mountList)
-			if err != nil {
-				return err
-			}
-		} else {
-			return fmt.Errorf("could not find mount with the id %d", mountid)
+	if lookIntoRedemption {
+		getMount = func(mountid uint32) *model.Mount {
+			return mr.lookupByMountID(mountid)
+		}
+	} else {
+		getMount = func(mountid uint32) *model.Mount {
+			m, _ := mr.mounts.Get(mountid)
+			return m
 		}
 	}
-	return nil
+
+	for len(stack) > 0 {
+		n := len(stack) - 1
+		curr := stack[n]
+		stack = stack[:n]
+
+		if _, ok := visited[curr.MountID]; ok {
+			continue
+		}
+		visited[curr.MountID] = struct{}{}
+
+		for _, childID := range curr.Children {
+			if child := getMount(childID); child != nil {
+				if _, seen := visited[childID]; !seen {
+					stack = append(stack, child)
+				}
+			}
+		}
+
+		cb(curr)
+	}
 }
 
 func (mr *Resolver) delete(mount *model.Mount) {
 	now := time.Now()
 
-	mr.deleteOne(mount, now)
-
-	openQueue := make([]uint32, 0, openQueuePreAllocSize)
-	openQueue = append(openQueue, mount.MountID)
-
-	for len(openQueue) != 0 {
-		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
-		openQueue = rest
-
-		for child := range mr.mounts.ValuesIter() {
-			if child.ParentPathKey.MountID == curr {
-				openQueue = append(openQueue, child.MountID)
-				mr.deleteOne(child, now)
-			}
-		}
-	}
+	mr.walkMountSubtree(mount, true, func(child *model.Mount) {
+		mr.deleteOne(child, now)
+	})
 }
 
 func (mr *Resolver) deleteOne(curr *model.Mount, now time.Time) {

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -251,8 +251,6 @@ func (mr *Resolver) delete(mount *model.Mount) {
 					break
 				}
 			}
-		} else {
-			seclog.Warnf("inconsistent mount resolver: parent %d for mount %d not found. mount = %+v", mount.ParentPathKey.MountID, mount.MountID, mount)
 		}
 	}
 
@@ -268,6 +266,8 @@ func (mr *Resolver) delete(mount *model.Mount) {
 	if _, exists := mr.dangling.Get(mount.MountID); exists {
 		mr.dangling.Remove(mount.MountID)
 	}
+
+	mr.mounts.Remove(mount.MountID)
 }
 
 // Delete a mount from the cache. Set mountIDUnique to 0 if you don't have a unique mount id.

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -282,7 +282,6 @@ func (mr *Resolver) Delete(mountID uint32, mountIDUnique uint64) error {
 	if exists && (m.MountIDUnique == 0 || mountIDUnique == 0 || m.MountIDUnique == mountIDUnique) {
 		mr.delete(m)
 	} else {
-		seclog.Warnf("tried to delete non-existent mount id %d", mountID)
 		return &ErrMountNotFound{MountID: mountID}
 	}
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -35,7 +35,7 @@ import (
 const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
-	redemptionTime                       = 5 * time.Second
+	redemptionTime                       = 2 * time.Second
 	// mounts LRU limit: 100000 mounts
 	mountsLimit = 100000
 )
@@ -207,15 +207,6 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 			}
 
 			mount.Children = append(mount.Children, mnt.MountID)
-		}
-	}
-
-	for e := range mr.redemption.ValuesIter() {
-		if e.mount.ParentPathKey.MountID == mount.MountID && time.Since(e.insertedAt) <= redemptionTime {
-			if slices.Contains(mount.Children, e.mount.MountID) {
-				continue
-			}
-			mount.Children = append(mount.Children, e.mount.MountID)
 		}
 	}
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -36,8 +36,6 @@ const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
 	redemptionTime                       = 2 * time.Second
-	// should be enough to handle most of in-queue mounts waiting to be deleted
-	openQueuePreAllocSize = 32
 	// mounts LRU limit: 100000 mounts
 	mountsLimit = 100000
 )

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -257,45 +257,59 @@ func (mr *Resolver) walkMountSubtree(mount *model.Mount, lookIntoRedemption bool
 }
 
 func (mr *Resolver) delete(mount *model.Mount) {
-	now := time.Now()
-	toDelete := make([]*model.Mount, 0, 1)
-
-	parent, exists := mr.mounts.Get(mount.ParentPathKey.MountID)
-	if exists {
-		for i := 0; i != len(parent.Children); i++ {
-			if parent.Children[i] == mount.MountID {
-				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
-				break
+	// Remove it as its parents' children
+	// Parent MountID == 0 means that it was a detached mount, no need to update its parent
+	if mount.ParentPathKey.MountID != 0 {
+		parent, exists := mr.mounts.Get(mount.ParentPathKey.MountID)
+		if exists {
+			for i := 0; i != len(parent.Children); i++ {
+				if parent.Children[i] == mount.MountID {
+					parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
+					break
+				}
 			}
+		} else {
+			seclog.Warnf("inconsistent mount resolver: parent %d for mount %d not found. mount = %+v", mount.ParentPathKey.MountID, mount.MountID, mount)
 		}
 	}
 
+	// Iterate over the current mount, its children, the children of their children, etc. and collect for deletion
+	toDelete := make([]*model.Mount, 0, 1)
 	mr.walkMountSubtree(mount, false, func(child *model.Mount) {
 		toDelete = append(toDelete, child)
 	})
 
-	for _, e := range toDelete {
-		entry := redemptionEntry{
-			mount:      e,
-			insertedAt: now,
-		}
-		mr.redemption.Add(e.MountID, &entry)
-		mr.mounts.Remove(e.MountID)
+	// Delete all
+	now := time.Now()
+	for _, mnt := range toDelete {
+		mr.moveToRedemption(mnt, now)
 	}
+
 }
 
-func (mr *Resolver) finalize(mount *model.Mount) {
+func (mr *Resolver) moveToRedemption(mount *model.Mount, time time.Time) {
+	entry := redemptionEntry{
+		mount:      mount,
+		insertedAt: time,
+	}
+	mr.redemption.Add(mount.MountID, &entry)
 	mr.mounts.Remove(mount.MountID)
 }
 
 // Delete a mount from the cache
 func (mr *Resolver) Delete(mountID uint32) error {
+	if mountID == 0 {
+		seclog.Warnf("Trying to delete mountid=0")
+		return fmt.Errorf("Tried to delete mountid=0")
+	}
+
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
 	if m, exists := mr.mounts.Get(mountID); exists {
 		mr.delete(m)
 	} else {
+		seclog.Warnf("tried to delete non-existant mount id %d", m)
 		return &ErrMountNotFound{MountID: mountID}
 	}
 
@@ -318,6 +332,7 @@ func (mr *Resolver) ResolveFilesystem(mountID uint32, pid uint32) (string, error
 // Insert a new mount point in the cache
 func (mr *Resolver) Insert(m model.Mount) error {
 	if m.MountID == 0 {
+		seclog.Warnf("Tried to insert a mount with mount id 0")
 		return ErrMountUndefined
 	}
 
@@ -344,18 +359,13 @@ func (mr *Resolver) InsertMoved(m model.Mount) error {
 }
 
 func (mr *Resolver) insert(m *model.Mount, moved bool) {
-	// umount the previous one if exists
+	// Remove the previous one if exists
 	if prev, ok := mr.mounts.Get(m.MountID); prev != nil && ok {
 		m.Children = prev.Children
-
-		if !moved {
-			// put the prev entry and the all the children in the redemption list
-			mr.delete(prev)
-			// force a finalize on the entry itself as it will be overridden by the new one
-			mr.finalize(prev)
-		}
-	} else if _, ok := mr.redemption.Get(m.MountID); ok {
-		// this will call the eviction function that will call the finalize
+		prev.Children = []uint32{}
+		mr.delete(prev)
+	} else {
+		// Remove this mount id from redemption
 		mr.redemption.Remove(m.MountID)
 	}
 
@@ -605,7 +615,7 @@ func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Re
 	}
 
 	redemption, err := simplelru.NewLRU(1024, func(_ uint32, entry *redemptionEntry) {
-		mr.finalize(entry.mount)
+		mr.mounts.Remove(entry.mount.MountID)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -419,7 +419,7 @@ func TestMountResolver(t *testing.T) {
 					mr.insert(&evt.mount.Mount, false)
 				}
 				if evt.umount != nil {
-					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid)
+					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid, true)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -10,10 +10,8 @@ package mount
 
 import (
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -200,38 +198,6 @@ func TestMountResolver(t *testing.T) {
 			},
 		},
 		{
-			"remove_root",
-			args{
-				[]event{
-					{
-						umount: &model.UmountEvent{
-							MountID: 27,
-						},
-					},
-				},
-				[]testCase{
-					{
-						27,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 27},
-					},
-					{
-						22,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 22},
-					},
-					{
-						31,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 31},
-					},
-				},
-			},
-		},
-		{
 			"container_creation",
 			args{
 				[]event{
@@ -298,43 +264,6 @@ func TestMountResolver(t *testing.T) {
 						0,
 						"/proc",
 						nil,
-					},
-				},
-			},
-		},
-		{
-			"remove_container",
-			args{
-				[]event{
-					{
-						umount: &model.UmountEvent{
-							MountID: 176,
-						},
-					},
-					{
-						umount: &model.UmountEvent{
-							MountID: 638,
-						},
-					},
-				},
-				[]testCase{
-					{
-						176,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 176},
-					},
-					{
-						638,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 638},
-					},
-					{
-						639,
-						0,
-						"",
-						&ErrMountNotFound{MountID: 639},
 					},
 				},
 			},
@@ -416,17 +345,14 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.insert(&evt.mount.Mount, false)
+					mr.insert(&evt.mount.Mount)
 				}
 				if evt.umount != nil {
-					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid, true)
+					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid)
 					if err != nil {
 						t.Fatal(err)
 					}
 					mr.delete(mount)
-
-					// wait end of remption
-					time.Sleep(redemptionTime)
 				}
 			}
 

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -53,7 +53,7 @@ func (r *Resolver) ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDC
 		return nil
 	}
 
-	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid, true)
+	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid)
 	if err != nil {
 		return fmt.Errorf("attribute resolution error: %w", err)
 	}

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -53,7 +53,7 @@ func (r *Resolver) ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDC
 		return nil
 	}
 
-	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid)
+	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid, true)
 	if err != nil {
 		return fmt.Errorf("attribute resolution error: %w", err)
 	}

--- a/pkg/security/secl/model/consts_map_names_linux.go
+++ b/pkg/security/secl/model/consts_map_names_linux.go
@@ -66,7 +66,6 @@ var bpfMapNames = []string{
 	"memfd_tracking",
 	"mmap_flags_appr",
 	"mmap_protection",
-	"mount_ref",
 	"mprotect_req_pr",
 	"mprotect_vm_pro",
 	"netdevice_looku",

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -852,6 +852,7 @@ func deepCopyMount(fieldToCopy Mount) Mount {
 func deepCopyMountReleasedEvent(fieldToCopy MountReleasedEvent) MountReleasedEvent {
 	copied := MountReleasedEvent{}
 	copied.MountID = fieldToCopy.MountID
+	copied.MountIDUnique = fieldToCopy.MountIDUnique
 	return copied
 }
 func deepCopyNetDeviceEvent(fieldToCopy NetDeviceEvent) NetDeviceEvent {

--- a/pkg/security/secl/model/model_helpers_unix.go
+++ b/pkg/security/secl/model/model_helpers_unix.go
@@ -261,6 +261,7 @@ const (
 	MountOriginFsmount                      // MountOriginFsmount mount point info from the fsmount syscall
 	MountOriginOpenTree                     // MountOriginOpenTree mount point created from the open_tree syscall
 	MountOriginListmount                    // MountOriginListmount mount point obtained by calling `listmount`
+	MountOriginMoveMount
 )
 
 // MountSource source of the mount
@@ -283,10 +284,11 @@ var MountSources = [...]string{
 type MountEventSource = uint32
 
 const (
-	MountEventSourceInvalid         MountEventSource = iota // MountEventSourceInvalid the source of the mount event is invalid
-	MountEventSourceMountSyscall                            // MountEventSourceMountSyscall the source of the mount event is the `mount` syscall
-	MountEventSourceFsmountSyscall                          // MountEventSourceFsmountSyscall the source of the mount event is the `fsmount` syscall
-	MountEventSourceOpenTreeSyscall                         // MountEventSourceOpenTreeSyscall the source of the mount event is the `open_tree` syscall
+	MountEventSourceInvalid          MountEventSource = iota // MountEventSourceInvalid the source of the mount event is invalid
+	MountEventSourceMountSyscall                             // MountEventSourceMountSyscall the source of the mount event is the `mount` syscall
+	MountEventSourceFsmountSyscall                           // MountEventSourceFsmountSyscall the source of the mount event is the `fsmount` syscall
+	MountEventSourceOpenTreeSyscall                          // MountEventSourceOpenTreeSyscall the source of the mount event is the `open_tree` syscall
+	MountEventSourceMoveMountSyscall                         // MountEventSourceOpenTreeSyscall the source of the mount event is the `open_tree` syscall
 )
 
 // MountSourceToString returns the string corresponding to a mount source
@@ -303,6 +305,7 @@ var MountOrigins = [...]string{
 	"fsmount",
 	"open_tree",
 	"listmount",
+	"move_mount",
 }
 
 // MountOriginToString returns the string corresponding to a mount origin

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -519,7 +519,8 @@ type InvalidateDentryEvent struct {
 
 // MountReleasedEvent defines a mount released event
 type MountReleasedEvent struct {
-	MountID uint32
+	MountID       uint32
+	MountIDUnique uint64
 }
 
 // LinkEvent represents a link event

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -721,13 +721,14 @@ func UnmarshalBinary(data []byte, binaryUnmarshalers ...BinaryUnmarshaler) (int,
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *MountReleasedEvent) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 4 {
+	if len(data) < 16 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.MountID = binary.NativeEndian.Uint32(data[0:4])
+	e.MountIDUnique = binary.NativeEndian.Uint64(data[8:16])
 
-	return 8, nil
+	return 16, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -493,6 +493,7 @@ func (e *MountEvent) UnmarshalBinary(data []byte) (int, error) {
 	case MountEventSourceMoveMountSyscall:
 		e.Mount.Origin = MountOriginMoveMount
 	}
+	e.Origin = e.Mount.Origin
 	return n + 4, nil
 }
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -485,13 +485,14 @@ func (e *MountEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	switch origin {
 	case MountEventSourceMountSyscall:
-		e.Origin = MountOriginEvent
+		e.Mount.Origin = MountOriginEvent
 	case MountEventSourceOpenTreeSyscall:
-		e.Origin = MountOriginOpenTree
+		e.Mount.Origin = MountOriginOpenTree
 	case MountEventSourceFsmountSyscall:
-		e.Origin = MountOriginFsmount
+		e.Mount.Origin = MountOriginFsmount
+	case MountEventSourceMoveMountSyscall:
+		e.Mount.Origin = MountOriginMoveMount
 	}
-
 	return n + 4, nil
 }
 

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -363,7 +363,7 @@ func testMountSnapshot(t *testing.T) {
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
 		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
 
-		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid, true)
+		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid)
 		if err != nil {
 			t.Error(err)
 			return

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -363,7 +363,7 @@ func testMountSnapshot(t *testing.T) {
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
 		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
 
-		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid)
+		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid, true)
 		if err != nil {
 			t.Error(err)
 			return

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -255,7 +255,7 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
 			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
 			assert.Equal(t, err, nil, "Error resolving mount")
-			assert.Equal(t, len(mount.Children), 2, "Wrong number of child mounts")
+			assert.Equal(t, 2, len(mount.Children), "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -92,7 +92,7 @@ func TestMoveMount(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, submountDir, mountPtr.Path, "Wrong mountpoint path")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
@@ -253,13 +253,13 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
 			assert.Equal(t, err, nil, "Error resolving mount")
 			assert.Equal(t, 2, len(mount.Children), "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {
-				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0)
+				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0, true)
 				assert.Equal(t, err, nil, "Error resolving child mount")
 				assert.True(t, strings.HasPrefix(child.Path, te.submountDirDst), "Path wasn't updated")
 			}

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -92,7 +92,7 @@ func TestMoveMount(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
+			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, submountDir, mountPtr.Path, "Wrong mountpoint path")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
@@ -253,13 +253,13 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0, true)
+			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
 			assert.Equal(t, err, nil, "Error resolving mount")
 			assert.Equal(t, 2, len(mount.Children), "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {
-				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0, true)
+				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0)
 				assert.Equal(t, err, nil, "Error resolving child mount")
 				assert.True(t, strings.HasPrefix(child.Path, te.submountDirDst), "Path wasn't updated")
 			}

--- a/pkg/security/tests/umount_test.go
+++ b/pkg/security/tests/umount_test.go
@@ -48,7 +48,7 @@ func TestUmount(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0, true)
+	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestUmount(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Resolve the mount after detaching, without using redemption or reloading. Should return nil
-	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0, false)
+	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0)
 	if err == nil {
 		t.Fatal("No error")
 	}

--- a/pkg/security/tests/umount_test.go
+++ b/pkg/security/tests/umount_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && functionaltests
+
+// Package tests holds tests related files
+package tests
+
+import (
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TmpMountAtLegacyAPI(dir string) error {
+	return unix.Mount("", dir, "tmpfs", 0, "size=1M")
+}
+
+func TestUmount(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	test, err := newTestModule(t, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	mountDir := t.TempDir()
+	err = TmpMountAtLegacyAPI(mountDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mountID, err := getMountID(mountDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
+
+	if !ok {
+		t.Skip("not supported")
+	}
+
+	time.Sleep(1 * time.Second)
+
+	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mnt == nil {
+		t.Fatal("nil mount")
+	}
+
+	assert.Equal(t, "tmpfs", mnt.FSType)
+
+	err = unix.Unmount(mountDir, syscall.MNT_DETACH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// Resolve the mount after detaching, without using redemption or reloading. Should return nil
+	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0, false)
+	if err == nil {
+		t.Fatal("No error")
+	}
+	if mnt != nil {
+		t.Fatal("mount not nil")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

* When the mount resolver doesn't find a mount, it reloads from procfs/listmount. It was previously using a recursive DFS, now it's using an iterative version that should be lighter on the CPU
* Uses the `cleanup_mnt` hook instead of a reference counter to determine when a mount is finally released
* If available, use unique mount id to double-check if we're deleting the correct mount
* Improved mount tree management mechanism
* Improved delete hot path to use non-recursive tree search
* Remove redemption cache
* Add missing `MountEventSourceMoveMountSyscall`

### Motivation

* Fix performance issues showing on the profiler when a deletion occured
* Improve the way we keep track of removed mounts
* Improve the consistency of the overall mount tree

### Describe how you validated your changes

* Deployed on 2 clusters
* Integration tests

### Additional Notes
