### PR TITLE
Adjust memory allotment values for quality gate experiments

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -9,7 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 300 MiB
+  # Set to 20% higher than the memory_usage check value
+  memory_allotment: 210 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -36,6 +37,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
+      # When updating this, update the memory_allotment in the target section to 20% higher
       upper_bound: "175 MiB"
 
   - name: intake_connections

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -9,7 +9,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 850 MiB
+  # Set to 20% higher than the memory_usage check value
+  memory_allotment: 582 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -57,6 +58,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
+      # When updating this, update the memory_allotment in the target section to 20% higher
       upper_bound: "485 MiB"
 
   - name: intake_connections

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -4,7 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 350 MiB
+  # Set to 20% higher than the memory_usage check value
+  memory_allotment: 264 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -29,6 +30,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
+      # When updating this, update the memory_allotment in the target section to 20% higher
       upper_bound: "220 MiB"
 
   - name: lost_bytes

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -4,7 +4,8 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 5 GiB
+  # Set to 20% higher than the memory_usage check value
+  memory_allotment: 570 MiB
 
   environment:
     DD_API_KEY: a0000001
@@ -31,6 +32,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total collector memory usage."
     bounds:
       series: total_pss_bytes
+      # When updating this, update the memory_allotment in the target section to 20% higher
       upper_bound: 475 MiB
 
   - name: cpu_usage


### PR DESCRIPTION
### What does this PR do?

- adjusts the memory allotment of the experiments to closer match the limits we've set

### Motivation

This change is related to #incident-47337; we are failing memory checks and we are trying to find optimizations. This sets the memory allotment -- essentially, the cgroup memory limit -- closer to the check limit for all quality gates.

### Describe how you validated your changes

Regression detector will run.

### Additional Notes
Relates to https://github.com/DataDog/datadog-agent/pull/44903
