### PR TITLE
Adding ticket ID to last TODO

### DIFF
--- a/pkg/logs/internal/tag/provider.go
+++ b/pkg/logs/internal/tag/provider.go
@@ -60,7 +60,7 @@ func (p *provider) GetTags() []string {
 	p.Do(func() {
 		// Warmup duration
 		// Make sure the tagger collects all the service tags
-		// TODO: remove this once AD and Tagger use the same PodWatcher instance
+		// TODO AGNTLOG-475: remove this once AD and Tagger use the same PodWatcher instance
 		p.clock.Sleep(p.taggerWarmupDuration)
 	})
 


### PR DESCRIPTION
### What does this PR do?
```
grep -r '//\s*TODO' --include="*.go" | grep 'pkg/logs\|comp/logs'
./pkg/logs/tailers/windowsevent/tailer_test.go:	// TODO: https://datadoghq.atlassian.net/browse/WINA-480
./pkg/logs/util/windowsevent/transform.go:	// TODO: compat: binary data is not guaranteed to be a utf-16 string, but go's
./pkg/logs/internal/tag/provider.go:		// TODO: remove this once AD and Tagger use the same PodWatcher instance
```
Adding the [ticket ID](https://datadoghq.atlassian.net/browse/AGNTLOG-475) to the TODO in tag/provider?
ex:
`// TODO AGNTLOG-475: remove this once AD and Tagger use the same PodWatcher instance`

### Motivation
We are almost TODO free!

### Describe how you validated your changes
Linter check

### Additional Notes
