### PR TITLE
fix: Use Container Image from Pod Spec over Status

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kubelet.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet.go
@@ -217,6 +217,9 @@ func parsePodContainers(
 				log.Debugf("cannot split image name %q: %s", containerSpec.Image, err)
 			}
 
+			// Prefer the image from the spec over the status for the container entity
+			image = podContainer.Image
+
 			podContainer.Image.ID = imageID
 			containerSecurityContext = extractContainerSecurityContext(containerSpec)
 			readinessProbe = extractReadinessProbe(containerSpec)

--- a/comp/core/workloadmeta/collectors/util/kubelet_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubelet_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+)
+
+// TestParseKubeletPods_ImageFromContainerSpec tests that the image from the container spec is used
+func TestParseKubeletPods_ImageFromContainerSpec(t *testing.T) {
+	// The container spec image should be used because it preserves the tag even when a digest is specified
+	pod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "test-pod",
+			Namespace: "default",
+			UID:       "test-uid-123",
+		},
+		Spec: kubelet.Spec{
+			Containers: []kubelet.ContainerSpec{
+				{
+					Name: "test-container",
+					// Spec has tag + digest
+					Image: "nginx:1.23.0@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+				},
+			},
+		},
+		Status: kubelet.Status{
+			Containers: []kubelet.ContainerStatus{
+				{
+					Name: "test-container",
+					ID:   "containerd://abc123",
+					// Status may not have the tag (only digest)
+					Image:   "nginx@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+					ImageID: "docker-pullable://nginx@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0",
+				},
+			},
+		},
+	}
+
+	events := ParseKubeletPods([]*kubelet.Pod{pod}, false)
+
+	// Find the container event
+	var containerEvent *workloadmeta.CollectorEvent
+	for i := range events {
+		if events[i].Entity.GetID().Kind == workloadmeta.KindContainer {
+			containerEvent = &events[i]
+			break
+		}
+	}
+
+	require.NotNil(t, containerEvent)
+	container := containerEvent.Entity.(*workloadmeta.Container)
+
+	// The image should come from the spec, which has the tag
+	assert.Equal(t, "nginx:1.23.0@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0", container.Image.RawName)
+	assert.Equal(t, "nginx", container.Image.Name)
+	assert.Equal(t, "1.23.0", container.Image.Tag, "tag should be preserved from spec")
+	assert.Equal(t, "nginx", container.Image.ShortName)
+}

--- a/releasenotes/notes/container-spec-image-tag-0cf9247cff7970df.yaml
+++ b/releasenotes/notes/container-spec-image-tag-0cf9247cff7970df.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Properly parse the `image_tag` tag when defining a container spec
+    that uses both an image tag and a digest like `nginx:1.23@sha256:xxx`.


### PR DESCRIPTION
### What does this PR do?

Updates workloadmeta parsing to prioritize using the containerSpec image over the containerStatus image in the kubelet's container event. The containers that are embedded within the pod object already use this value. This PR updates the logic so that the individual container entity also uses the containerSpec image.

https://github.com/DataDog/datadog-agent/blob/8a6bc135ab04fc11cf10e186102a25b5593bbe75/comp/core/workloadmeta/collectors/util/kubelet.go#L215-L223

### Motivation

Properly pull the image tag when defined with a sha256 like `alpine:3.23@sha256:865b95`. Previously we would fail to resolve the imageTag like `3.23` and instead default to `latest` both in workloadmeta and tagger.

[CONTP-1185]

### Describe how you validated your changes

Deploy a dummy application with an container image with both a tag and sha:

```
apiVersion: v1
kind: Pod
metadata:
  name: alps-pod
spec:
  containers:
    - name: alps
      image: docker.io/library/alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
      command: ["sleep", "infinity"]
```

Check in `agent workload-list` and `agent tagger-list` the `image_tag` has been properly propogated.

### Additional Notes

Below you can see that the containerStatus drops the imageTag meanwhile the containerSpec mirrors the real podSpec.

ContainerStatus:
```
 containerStatuses:
  - containerID: cri-o://60c34ff88343e947d2dd1a68e733d85d83bfadf6a8783a1ba39fcaeee1a068ce
    image: docker.io/library/alpine@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
    imageID: docker.io/library/alpine@sha256:410dabcd6f1d53f1f4e5c1ce9553efa298ca6bcdd086dfc976b8f659d58b46d2
    lastState: {}
    name: alps
```

ContainerSpec:
```
Containers:
  alps:
    Container ID:  cri-o://60c34ff88343e947d2dd1a68e733d85d83bfadf6a8783a1ba39fcaeee1a068ce
    Image:         docker.io/library/alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
    Image ID:      docker.io/library/alpine@sha256:410dabcd6f1d53f1f4e5c1ce9553efa298ca6bcdd086dfc976b8f659d58b46d2
    Port:          <none>
    Host Port:     <none>
    Command:
      sleep
      infinity
```

When running on previous versions of the agent when outputting a verbose workloadmeta dump via `agent workload-list -v` we can see that the pod entity has the embedded container with the proper image tag meanwhile the standalone container entity has the incorrect latest tag applied.

[CONTP-1185]: https://datadoghq.atlassian.net/browse/CONTP-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ