### PR TITLE
pkg/dyninst/irgen: Skip unknown arm instructions.

### DIFF
--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xd0a4ea", Frameless: false}]
+          Type: 1330 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xd0a52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1329 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xd0a525", Frameless: false}]
+          Type: 1331 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xd0a565", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xd08f2e", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xd08f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd08fe2", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09022", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1228 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xd07320", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1229 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xd07332", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xd07320", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xd07340", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xd07720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xd0a000", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xd0a660", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xd0aaa0", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xd0aae0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xd0aac0", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xd0ab00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testInlinedBBB]
+          Type: 1360 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBCA]
+          Type: 1361 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1360 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1362 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBCB]
+          Type: 1363 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1364 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testInlinedPrint]
+          Type: 1357 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1358 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1357 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1359 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedSq]
+          Type: 1365 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1364 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1366 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1367 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xd08dae", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xd08dee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd08ef3", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd08f33", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xd07500", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xd09253", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xd09293", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xd09462", Frameless: false}]
+          Type: 1306 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xd094a2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xd094f3", Frameless: false}]
+          Type: 1307 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xd09533", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xd0972b", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xd0976b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xd0986e", Frameless: false}]
+          Type: 1311 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xd098ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xd09936", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xd09976", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xd0900e", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xd0904e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xd0922a", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xd0926a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
+          Type: 1253 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
+          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xd0832a", Frameless: false}]
+          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xd08395", Frameless: false}]
+          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa20", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa20", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa20", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xd0aa20", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xd0a600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1231 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xd07520", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xd07560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xd074e0", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xd07fae", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xd07fee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1250 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xd08064"
+            - PC: "0xd080a4"
               Frameless: false
-            - PC: "0xd0809f"
+            - PC: "0xd080df"
               Frameless: false
-            - PC: "0xd08162"
+            - PC: "0xd081a2"
               Frameless: false
-            - PC: "0xd0816c"
+            - PC: "0xd081ac"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xd07e4e", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xd07e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1248 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xd07eb8"
+            - PC: "0xd07ef8"
               Frameless: false
-            - PC: "0xd07ef3"
+            - PC: "0xd07f33"
               Frameless: false
-            - PC: "0xd07f27"
+            - PC: "0xd07f67"
               Frameless: false
-            - PC: "0xd07f59"
+            - PC: "0xd07f99"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xd0884a", Frameless: false}]
+          Type: 1277 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xd0888a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xd088ad", Frameless: false}]
+          Type: 1278 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xd088ed", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xd088ca", Frameless: false}]
+          Type: 1279 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xd0890a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xd0890b", Frameless: false}]
+          Type: 1280 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xd0894b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xd0892a", Frameless: false}]
+          Type: 1281 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xd0896a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xd08966", Frameless: false}]
+          Type: 1282 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xd089a6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xd08a0e", Frameless: false}]
+          Type: 1285 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xd08a4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xd08a8a", Frameless: false}]
+          Type: 1286 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xd08aca", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xd08d4a", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xd08d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xd08d90", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xd08dd0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xd0870a", Frameless: false}]
+          Type: 1273 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xd0874a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xd08766", Frameless: false}]
+          Type: 1274 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xd087a6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xd07dea", Frameless: false}]
+          Type: 1245 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xd07e2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsError]Return
+          Type: 1246 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xd07e1a"
+            - PC: "0xd07e5a"
               Frameless: false
-            - PC: "0xd07e25"
+            - PC: "0xd07e65"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xd07bea", Frameless: false}]
+          Type: 1239 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1238 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xd07c3b", Frameless: false}]
+          Type: 1240 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xd07c7b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xd07d0e", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xd07dc4", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xd07e04", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xd07c6a", Frameless: false}]
+          Type: 1241 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1240 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xd07cdb", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xd07d1b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xd081ae", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xd081ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1252 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xd08291"
+            - PC: "0xd082d1"
               Frameless: false
-            - PC: "0xd0829b"
+            - PC: "0xd082db"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xd0878e", Frameless: false}]
+          Type: 1275 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xd087ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xd08813", Frameless: false}]
+          Type: 1276 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xd08853", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xd0860e", Frameless: false}]
+          Type: 1271 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xd0864e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xd086e5", Frameless: false}]
+          Type: 1272 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xd08725", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xd08b6a", Frameless: false}]
+          Type: 1289 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xd08baa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xd08bcc", Frameless: false}]
+          Type: 1290 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xd08c0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xd0898a", Frameless: false}]
+          Type: 1283 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xd089ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xd089d8", Frameless: false}]
+          Type: 1284 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xd08a18", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xd08cca", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xd08d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xd08d16", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xd08d56", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xd08c6a", Frameless: false}]
+          Type: 1293 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xd08caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xd08cae", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xd08cee", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xd0858a", Frameless: false}]
+          Type: 1269 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xd085ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xd085f1", Frameless: false}]
+          Type: 1270 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xd08631", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xd08bea", Frameless: false}]
+          Type: 1291 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xd08c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xd08c4d", Frameless: false}]
+          Type: 1292 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xd08c8d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xd08aae", Frameless: false}]
+          Type: 1287 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xd08aee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xd08b34", Frameless: false}]
+          Type: 1288 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xd08b74", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xd0a540", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xd0a160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xd084ae", Frameless: false}]
+          Type: 1267 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xd084ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0854e", Frameless: false}]
+          Type: 1268 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xd0858e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xd097ca", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xd0980a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xd0983c", Frameless: false}]
+          Type: 1310 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xd0987c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xd07660", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xd0a920", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1348 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xd0a942", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xd0996e", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xd099ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xd09a1a", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xd09a5a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xd0a7e0", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xd0a820", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1346 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xd0a7fe", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xd0a83e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xd0a7c0", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xd0a800", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xd0a180", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xd0a640", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xd0a680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xd083ce", Frameless: false}]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xd0846f", Frameless: false}]
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xd0a560", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
+          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd0a59e", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xd0a59e", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xd07580", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xd09fe0", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xd0a600", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xd0a640", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xd07540", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xd09a4e", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xd09a8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xd09acc", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xd09b0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5617,281 +5642,300 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0xd07320..0xd07333]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xd07320..0xd07332
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0xd07320..0xd07332
+              Pieces: []
+            - Range: 0xd07332..0xd07333
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0xd07320..0xd07321]
+      OutOfLinePCRanges: [0xd07340..0xd07341]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0xd07320..0xd07321
+            - Range: 0xd07340..0xd07341
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xd074e0..0xd074e1]
+      OutOfLinePCRanges: [0xd07520..0xd07521]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xd074e0..0xd074e1
+            - Range: 0xd07520..0xd07521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xd07500..0xd07501]
+      OutOfLinePCRanges: [0xd07540..0xd07541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0xd07500..0xd07501
+            - Range: 0xd07540..0xd07541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xd07520..0xd07521]
+      OutOfLinePCRanges: [0xd07560..0xd07561]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0xd07520..0xd07521
+            - Range: 0xd07560..0xd07561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xd07540..0xd07541]
+      OutOfLinePCRanges: [0xd07580..0xd07581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xd07540..0xd07541
+            - Range: 0xd07580..0xd07581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xd07580..0xd07581]
+      OutOfLinePCRanges: [0xd075c0..0xd075c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0xd07580..0xd07581
+            - Range: 0xd075c0..0xd075c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xd07660..0xd07661]
+      OutOfLinePCRanges: [0xd076a0..0xd076a1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0xd07660..0xd07661
+            - Range: 0xd076a0..0xd076a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xd076a0..0xd076a1]
+      OutOfLinePCRanges: [0xd076e0..0xd076e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0xd076a0..0xd076a1
+            - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd076a0..0xd076a1
+            - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0xd076e0..0xd076e1]
+      OutOfLinePCRanges: [0xd07720..0xd07721]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0xd076e0..0xd076e1
+            - Range: 0xd07720..0xd07721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xd07be0..0xd07c52]
+      OutOfLinePCRanges: [0xd07c20..0xd07c92]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07be0..0xd07bf2
+            - Range: 0xd07c20..0xd07c32
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07be0..0xd07c3b
+            - Range: 0xd07c20..0xd07c7b
               Pieces: []
-            - Range: 0xd07c3b..0xd07c3c
+            - Range: 0xd07c7b..0xd07c7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c3c..0xd07c52
+            - Range: 0xd07c7c..0xd07c92
               Pieces: []
           Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07bf2..0xd07c05
+            - Range: 0xd07c32..0xd07c45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c05..0xd07c52
+            - Range: 0xd07c45..0xd07c92
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xd07c60..0xd07cf5]
+      OutOfLinePCRanges: [0xd07ca0..0xd07d35]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07c60..0xd07c7a
+            - Range: 0xd07ca0..0xd07cba
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c7a..0xd07cf5
+            - Range: 0xd07cba..0xd07d35
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07c60..0xd07cdb
+            - Range: 0xd07ca0..0xd07d1b
               Pieces: []
-            - Range: 0xd07cdb..0xd07cdc
+            - Range: 0xd07d1b..0xd07d1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07cdc..0xd07cf5
+            - Range: 0xd07d1c..0xd07d35
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd07c7f..0xd07c9c
+            - Range: 0xd07cbf..0xd07cdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07c9c..0xd07cf5
+            - Range: 0xd07cdc..0xd07d35
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xd07d00..0xd07dde]
+      OutOfLinePCRanges: [0xd07d40..0xd07e1e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d00..0xd07d62
+            - Range: 0xd07d40..0xd07da2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d00..0xd07dc4
+            - Range: 0xd07d40..0xd07e04
               Pieces: []
-            - Range: 0xd07dc4..0xd07dc5
+            - Range: 0xd07e04..0xd07e05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd07dc5..0xd07dde
+            - Range: 0xd07e05..0xd07e1e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd07d00..0xd07dde, Pieces: []}]
+          Locations: [{Range: 0xd07d40..0xd07e1e, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07d16..0xd07d67
+            - Range: 0xd07d56..0xd07da7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd07d67..0xd07dde
+            - Range: 0xd07da7..0xd07e1e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd07d2f..0xd07d67
+            - Range: 0xd07d6f..0xd07da7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xd07d67..0xd07dde
+            - Range: 0xd07da7..0xd07e1e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xd07de0..0xd07e3b]
+      OutOfLinePCRanges: [0xd07e20..0xd07e7b]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07de0..0xd07df9
+            - Range: 0xd07e20..0xd07e39
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd07de0..0xd07e1a
+            - Range: 0xd07e20..0xd07e5a
               Pieces: []
-            - Range: 0xd07e1a..0xd07e1b
+            - Range: 0xd07e5a..0xd07e5b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e1b..0xd07e25
+            - Range: 0xd07e5b..0xd07e65
               Pieces: []
-            - Range: 0xd07e25..0xd07e26
+            - Range: 0xd07e65..0xd07e66
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e26..0xd07e3b
+            - Range: 0xd07e66..0xd07e7b
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xd07e40..0xd07f86]
+      OutOfLinePCRanges: [0xd07e80..0xd07fc6]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e40..0xd07e91
+            - Range: 0xd07e80..0xd07ed1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07e91..0xd07e94
+            - Range: 0xd07ed1..0xd07ed4
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07ed7..0xd07ee5
+            - Range: 0xd07f17..0xd07f25
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f00..0xd07f05
+            - Range: 0xd07f40..0xd07f45
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f34..0xd07f39
+            - Range: 0xd07f74..0xd07f79
               Pieces:
                 - Size: 8
                   Op: null
@@ -5901,112 +5945,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd07e40..0xd07e8f
+            - Range: 0xd07e80..0xd07ecf
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07e40..0xd07eb8
+            - Range: 0xd07e80..0xd07ef8
               Pieces: []
-            - Range: 0xd07eb8..0xd07eb9
+            - Range: 0xd07ef8..0xd07ef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07eb9..0xd07ef3
+            - Range: 0xd07ef9..0xd07f33
               Pieces: []
-            - Range: 0xd07ef3..0xd07ef4
+            - Range: 0xd07f33..0xd07f34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07ef4..0xd07f27
+            - Range: 0xd07f34..0xd07f67
               Pieces: []
-            - Range: 0xd07f27..0xd07f28
+            - Range: 0xd07f67..0xd07f68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f28..0xd07f59
+            - Range: 0xd07f68..0xd07f99
               Pieces: []
-            - Range: 0xd07f59..0xd07f5a
+            - Range: 0xd07f99..0xd07f9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07f5a..0xd07f86
+            - Range: 0xd07f9a..0xd07fc6
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0xd07e40..0xd07eb8
+            - Range: 0xd07e80..0xd07ef8
               Pieces: []
-            - Range: 0xd07eb8..0xd07eb9
+            - Range: 0xd07ef8..0xd07ef9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07eb9..0xd07ef3
+            - Range: 0xd07ef9..0xd07f33
               Pieces: []
-            - Range: 0xd07ef3..0xd07ef4
+            - Range: 0xd07f33..0xd07f34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07ef4..0xd07f27
+            - Range: 0xd07f34..0xd07f67
               Pieces: []
-            - Range: 0xd07f27..0xd07f28
+            - Range: 0xd07f67..0xd07f68
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07f28..0xd07f59
+            - Range: 0xd07f68..0xd07f99
               Pieces: []
-            - Range: 0xd07f59..0xd07f5a
+            - Range: 0xd07f99..0xd07f9a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd07f5a..0xd07f86
+            - Range: 0xd07f9a..0xd07fc6
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd07ed7..0xd07ee0
+            - Range: 0xd07f17..0xd07f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xd07fa0..0xd08194]
+      OutOfLinePCRanges: [0xd07fe0..0xd081d4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07fa0..0xd07fff
+            - Range: 0xd07fe0..0xd0803f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd07fff..0xd08002
+            - Range: 0xd0803f..0xd08042
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08002..0xd08194
+            - Range: 0xd08042..0xd081d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6016,941 +6060,941 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd07fa0..0xd08064
+            - Range: 0xd07fe0..0xd080a4
               Pieces: []
-            - Range: 0xd08064..0xd08065
+            - Range: 0xd080a4..0xd080a5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08065..0xd0809f
+            - Range: 0xd080a5..0xd080df
               Pieces: []
-            - Range: 0xd0809f..0xd080a0
+            - Range: 0xd080df..0xd080e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd080a0..0xd08162
+            - Range: 0xd080e0..0xd081a2
               Pieces: []
-            - Range: 0xd08162..0xd08163
+            - Range: 0xd081a2..0xd081a3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08163..0xd0816c
+            - Range: 0xd081a3..0xd081ac
               Pieces: []
-            - Range: 0xd0816c..0xd0816d
+            - Range: 0xd081ac..0xd081ad
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0816d..0xd08194
+            - Range: 0xd081ad..0xd081d4
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd0808a..0xd08090
+            - Range: 0xd080ca..0xd080d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 93 PointerType *int
           Locations:
-            - Range: 0xd08045..0xd08064
+            - Range: 0xd08085..0xd080a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xd081a0..0xd08305]
+      OutOfLinePCRanges: [0xd081e0..0xd08345]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xd081a0..0xd081e0
+            - Range: 0xd081e0..0xd08220
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd081e0..0xd08245
+            - Range: 0xd08220..0xd08285
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd08245..0xd082a1
+            - Range: 0xd08285..0xd082e1
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd082a1..0xd082c1
+            - Range: 0xd082e1..0xd08301
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd082c1..0xd082c8
+            - Range: 0xd08301..0xd08308
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd082c8..0xd08305
+            - Range: 0xd08308..0xd08345
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd081a0..0xd08291
+            - Range: 0xd081e0..0xd082d1
               Pieces: []
-            - Range: 0xd08291..0xd08292
+            - Range: 0xd082d1..0xd082d2
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd08292..0xd0829b
+            - Range: 0xd082d2..0xd082db
               Pieces: []
-            - Range: 0xd0829b..0xd0829c
+            - Range: 0xd082db..0xd082dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0829c..0xd08305
+            - Range: 0xd082dc..0xd08345
               Pieces: []
           Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xd081a0..0xd081e0
+            - Range: 0xd081e0..0xd08220
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd081e0..0xd08235
+            - Range: 0xd08220..0xd08275
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08235..0xd08245
+            - Range: 0xd08275..0xd08285
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08245..0xd08297
+            - Range: 0xd08285..0xd082d7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08297..0xd08299
+            - Range: 0xd082d7..0xd082d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xd08299..0xd0829b
+            - Range: 0xd082d9..0xd082db
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd0829b..0xd08305
+            - Range: 0xd082db..0xd08345
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xd08320..0xd083af]
+      OutOfLinePCRanges: [0xd08360..0xd083ef]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08320..0xd08331
+            - Range: 0xd08360..0xd08371
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08320..0xd08395
+            - Range: 0xd08360..0xd083d5
               Pieces: []
-            - Range: 0xd08395..0xd08396
+            - Range: 0xd083d5..0xd083d6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08396..0xd083af
+            - Range: 0xd083d6..0xd083ef
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xd083c0..0xd08489]
+      OutOfLinePCRanges: [0xd08400..0xd084c9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd083c0..0xd08413
+            - Range: 0xd08400..0xd08453
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd083c0..0xd0846f
+            - Range: 0xd08400..0xd084af
               Pieces: []
-            - Range: 0xd0846f..0xd08470
+            - Range: 0xd084af..0xd084b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08470..0xd08489
+            - Range: 0xd084b0..0xd084c9
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd083c0..0xd0846f
+            - Range: 0xd08400..0xd084af
               Pieces: []
-            - Range: 0xd0846f..0xd08470
+            - Range: 0xd084af..0xd084b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08470..0xd08489
+            - Range: 0xd084b0..0xd084c9
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xd084a0..0xd08568]
+      OutOfLinePCRanges: [0xd084e0..0xd085a8]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084a0..0xd084e5
+            - Range: 0xd084e0..0xd08525
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd084e5..0xd08568
+            - Range: 0xd08525..0xd085a8
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084a0..0xd0854e
+            - Range: 0xd084e0..0xd0858e
               Pieces: []
-            - Range: 0xd0854e..0xd0854f
+            - Range: 0xd0858e..0xd0858f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0854f..0xd08568
+            - Range: 0xd0858f..0xd085a8
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084a0..0xd0854e
+            - Range: 0xd084e0..0xd0858e
               Pieces: []
-            - Range: 0xd0854e..0xd0854f
+            - Range: 0xd0858e..0xd0858f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0854f..0xd08568
+            - Range: 0xd0858f..0xd085a8
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd084a0..0xd0854e
+            - Range: 0xd084e0..0xd0858e
               Pieces: []
-            - Range: 0xd0854e..0xd0854f
+            - Range: 0xd0858e..0xd0858f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0854f..0xd08568
+            - Range: 0xd0858f..0xd085a8
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xd08580..0xd085fe]
+      OutOfLinePCRanges: [0xd085c0..0xd0863e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 97 BaseType int16
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0xd08580..0xd085f1
+            - Range: 0xd085c0..0xd08631
               Pieces: []
-            - Range: 0xd085f1..0xd085f2
+            - Range: 0xd08631..0xd08632
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd085f2..0xd085fe
+            - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xd08600..0xd086f5]
+      OutOfLinePCRanges: [0xd08640..0xd08735]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08600..0xd086f5, Pieces: []}]
+          Locations: [{Range: 0xd08640..0xd08735, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd08600..0xd086e5
+            - Range: 0xd08640..0xd08725
               Pieces: []
-            - Range: 0xd086e5..0xd086e6
+            - Range: 0xd08725..0xd08726
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd086e6..0xd086f5
+            - Range: 0xd08726..0xd08735
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xd08600..0xd086e5
+            - Range: 0xd08640..0xd08725
               Pieces: []
-            - Range: 0xd086e5..0xd086e6
+            - Range: 0xd08725..0xd08726
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xd086e6..0xd086f5
+            - Range: 0xd08726..0xd08735
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xd08700..0xd08773]
+      OutOfLinePCRanges: [0xd08740..0xd087b3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 89 BaseType complex64
-          Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
+          Locations: [{Range: 0xd08740..0xd087b3, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 90 BaseType complex128
-          Locations: [{Range: 0xd08700..0xd08773, Pieces: []}]
+          Locations: [{Range: 0xd08740..0xd087b3, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xd08780..0xd08825]
+      OutOfLinePCRanges: [0xd087c0..0xd08865]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd08780..0xd08813
+            - Range: 0xd087c0..0xd08853
               Pieces: []
-            - Range: 0xd08813..0xd08814
+            - Range: 0xd08853..0xd08854
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xd08814..0xd08825
+            - Range: 0xd08854..0xd08865
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xd08840..0xd088ba]
+      OutOfLinePCRanges: [0xd08880..0xd088fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08840..0xd088ad
+            - Range: 0xd08880..0xd088ed
               Pieces: []
-            - Range: 0xd088ad..0xd088ae
+            - Range: 0xd088ed..0xd088ee
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd088ae..0xd088ba
+            - Range: 0xd088ee..0xd088fa
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xd088c0..0xd08918]
+      OutOfLinePCRanges: [0xd08900..0xd08958]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0xd088c0..0xd0890b
+            - Range: 0xd08900..0xd0894b
               Pieces: []
-            - Range: 0xd0890b..0xd0890c
+            - Range: 0xd0894b..0xd0894c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0890c..0xd08918
+            - Range: 0xd0894c..0xd08958
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xd08920..0xd08973]
+      OutOfLinePCRanges: [0xd08960..0xd089b3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd08920..0xd08966
+            - Range: 0xd08960..0xd089a6
               Pieces: []
-            - Range: 0xd08966..0xd08967
+            - Range: 0xd089a6..0xd089a7
               Pieces: []
-            - Range: 0xd08967..0xd08973
+            - Range: 0xd089a7..0xd089b3
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xd08980..0xd089e7]
+      OutOfLinePCRanges: [0xd089c0..0xd08a27]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0xd08980..0xd089e7, Pieces: []}]
+          Locations: [{Range: 0xd089c0..0xd08a27, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xd08a00..0xd08a9a]
+      OutOfLinePCRanges: [0xd08a40..0xd08ada]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08a00..0xd08a8a
+            - Range: 0xd08a40..0xd08aca
               Pieces: []
-            - Range: 0xd08a8a..0xd08a8b
+            - Range: 0xd08aca..0xd08acb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd08a8b..0xd08a9a
+            - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xd08aa0..0xd08b45]
+      OutOfLinePCRanges: [0xd08ae0..0xd08b85]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0xd08aa0..0xd08b34
+            - Range: 0xd08ae0..0xd08b74
               Pieces: []
-            - Range: 0xd08b34..0xd08b35
+            - Range: 0xd08b74..0xd08b75
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xd08b35..0xd08b45
+            - Range: 0xd08b75..0xd08b85
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xd08b60..0xd08bd9]
+      OutOfLinePCRanges: [0xd08ba0..0xd08c19]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08b60..0xd08bcc
+            - Range: 0xd08ba0..0xd08c0c
               Pieces: []
-            - Range: 0xd08bcc..0xd08bcd
+            - Range: 0xd08c0c..0xd08c0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08bcd..0xd08bd9
+            - Range: 0xd08c0d..0xd08c19
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
+          Locations: [{Range: 0xd08ba0..0xd08c19, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd08b60..0xd08bcc
+            - Range: 0xd08ba0..0xd08c0c
               Pieces: []
-            - Range: 0xd08bcc..0xd08bcd
+            - Range: 0xd08c0c..0xd08c0d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08bcd..0xd08bd9
+            - Range: 0xd08c0d..0xd08c19
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08b60..0xd08bd9, Pieces: []}]
+          Locations: [{Range: 0xd08ba0..0xd08c19, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd08b60..0xd08bcc
+            - Range: 0xd08ba0..0xd08c0c
               Pieces: []
-            - Range: 0xd08bcc..0xd08bcd
+            - Range: 0xd08c0c..0xd08c0d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xd08bcd..0xd08bd9
+            - Range: 0xd08c0d..0xd08c19
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xd08be0..0xd08c5a]
+      OutOfLinePCRanges: [0xd08c20..0xd08c9a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd08be0..0xd08c4d
+            - Range: 0xd08c20..0xd08c8d
               Pieces: []
-            - Range: 0xd08c4d..0xd08c4e
+            - Range: 0xd08c8d..0xd08c8e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xd08c4e..0xd08c5a
+            - Range: 0xd08c8e..0xd08c9a
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xd08c60..0xd08cbb]
+      OutOfLinePCRanges: [0xd08ca0..0xd08cfb]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08c60..0xd08cbb, Pieces: []}]
+          Locations: [{Range: 0xd08ca0..0xd08cfb, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xd08cc0..0xd08d27]
+      OutOfLinePCRanges: [0xd08d00..0xd08d67]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
+          Locations: [{Range: 0xd08d00..0xd08d67, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0xd08cc0..0xd08d27, Pieces: []}]
+          Locations: [{Range: 0xd08d00..0xd08d67, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xd08d40..0xd08d9d]
+      OutOfLinePCRanges: [0xd08d80..0xd08ddd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xd08d40..0xd08d90
+            - Range: 0xd08d80..0xd08dd0
               Pieces: []
-            - Range: 0xd08d90..0xd08d91
+            - Range: 0xd08dd0..0xd08dd1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd08d91..0xd08d9d
+            - Range: 0xd08dd1..0xd08ddd
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xd08d40..0xd08d90
+            - Range: 0xd08d80..0xd08dd0
               Pieces: []
-            - Range: 0xd08d90..0xd08d91
+            - Range: 0xd08dd0..0xd08dd1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd08d91..0xd08d9d
+            - Range: 0xd08dd1..0xd08ddd
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xd08da0..0xd08f05]
+      OutOfLinePCRanges: [0xd08de0..0xd08f45]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd08da0..0xd08f05
+            - Range: 0xd08de0..0xd08f45
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd08da0..0xd08ef3
+            - Range: 0xd08de0..0xd08f33
               Pieces: []
-            - Range: 0xd08ef3..0xd08ef4
+            - Range: 0xd08f33..0xd08f34
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xd08ef4..0xd08f05
+            - Range: 0xd08f34..0xd08f45
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xd08f20..0xd08ff2]
+      OutOfLinePCRanges: [0xd08f60..0xd09032]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08f20..0xd08ff2
+            - Range: 0xd08f60..0xd09032
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd08f20..0xd08fe2
+            - Range: 0xd08f60..0xd09022
               Pieces: []
-            - Range: 0xd08fe2..0xd08fe3
+            - Range: 0xd09022..0xd09023
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd08fe3..0xd08ff2
+            - Range: 0xd09023..0xd09032
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xd09000..0xd0923a]
+      OutOfLinePCRanges: [0xd09040..0xd0927a]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09000..0xd0923a
+            - Range: 0xd09040..0xd0927a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09000..0xd0923a
+            - Range: 0xd09040..0xd0927a
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd09000..0xd0922a
+            - Range: 0xd09040..0xd0926a
               Pieces: []
-            - Range: 0xd0922a..0xd0922b
+            - Range: 0xd0926a..0xd0926b
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xd0922b..0xd0923a
+            - Range: 0xd0926b..0xd0927a
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xd09240..0xd094cf]
+      OutOfLinePCRanges: [0xd09280..0xd0950f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092b0
+            - Range: 0xd09280..0xd092f0
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd092b0..0xd094cf
+            - Range: 0xd092f0..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09240..0xd092f0
+            - Range: 0xd09280..0xd09330
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xd092f0..0xd094cf
+            - Range: 0xd09330..0xd0950f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd09240..0xd09462
+            - Range: 0xd09280..0xd094a2
               Pieces: []
-            - Range: 0xd09462..0xd09463
+            - Range: 0xd094a2..0xd094a3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xd09463..0xd094cf
+            - Range: 0xd094a3..0xd0950f
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xd094e0..0xd097ac]
+      OutOfLinePCRanges: [0xd09520..0xd097ec]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd09542
+            - Range: 0xd09520..0xd09582
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xd09542..0xd097ac
+            - Range: 0xd09582..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd094e0..0xd0958b
+            - Range: 0xd09520..0xd095cb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xd0958b..0xd097ac
+            - Range: 0xd095cb..0xd097ec
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd094e0..0xd097ac
+            - Range: 0xd09520..0xd097ec
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6960,210 +7004,176 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0xd094e0..0xd0972b
+            - Range: 0xd09520..0xd0976b
               Pieces: []
-            - Range: 0xd0972b..0xd0972c
+            - Range: 0xd0976b..0xd0976c
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xd0972c..0xd097ac
+            - Range: 0xd0976c..0xd097ec
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xd097c0..0xd0984c]
+      OutOfLinePCRanges: [0xd09800..0xd0988c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0xd097c0..0xd0984c
+            - Range: 0xd09800..0xd0988c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd097c0..0xd0983c
+            - Range: 0xd09800..0xd0987c
               Pieces: []
-            - Range: 0xd0983c..0xd0983d
+            - Range: 0xd0987c..0xd0987d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd0983d..0xd0984c
+            - Range: 0xd0987d..0xd0988c
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd097c0..0xd0983c
+            - Range: 0xd09800..0xd0987c
               Pieces: []
-            - Range: 0xd0983c..0xd0983d
+            - Range: 0xd0987c..0xd0987d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xd0983d..0xd0984c
+            - Range: 0xd0987d..0xd0988c
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd097c0..0xd0983c
+            - Range: 0xd09800..0xd0987c
               Pieces: []
-            - Range: 0xd0983c..0xd0983d
+            - Range: 0xd0987c..0xd0987d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xd0983d..0xd0984c
+            - Range: 0xd0987d..0xd0988c
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xd09860..0xd0994a]
+      OutOfLinePCRanges: [0xd098a0..0xd0998a]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd09860..0xd0994a
+            - Range: 0xd098a0..0xd0998a
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0xd09860..0xd0994a
+            - Range: 0xd098a0..0xd0998a
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09860..0xd09936
+            - Range: 0xd098a0..0xd09976
               Pieces: []
-            - Range: 0xd09936..0xd09937
+            - Range: 0xd09976..0xd09977
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09937..0xd0994a
+            - Range: 0xd09977..0xd0998a
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0xd09860..0xd09936
+            - Range: 0xd098a0..0xd09976
               Pieces: []
-            - Range: 0xd09936..0xd09937
+            - Range: 0xd09976..0xd09977
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xd09937..0xd0994a
+            - Range: 0xd09977..0xd0998a
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xd09960..0xd09a2b]
+      OutOfLinePCRanges: [0xd099a0..0xd09a6b]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd09960..0xd09a2b
+            - Range: 0xd099a0..0xd09a6b
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09960..0xd09a1a
+            - Range: 0xd099a0..0xd09a5a
               Pieces: []
-            - Range: 0xd09a1a..0xd09a1b
+            - Range: 0xd09a5a..0xd09a5b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09a1b..0xd09a2b
+            - Range: 0xd09a5b..0xd09a6b
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0xd09960..0xd09a1a
+            - Range: 0xd099a0..0xd09a5a
               Pieces: []
-            - Range: 0xd09a1a..0xd09a1b
+            - Range: 0xd09a5a..0xd09a5b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xd09a1b..0xd09a2b
+            - Range: 0xd09a5b..0xd09a6b
               Pieces: []
           Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd099e6..0xd09a2b
+            - Range: 0xd09a26..0xd09a6b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xd09a40..0xd09ae6]
+      OutOfLinePCRanges: [0xd09a80..0xd09b26]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0xd09a40..0xd09ae6, Pieces: []}]
+          Locations: [{Range: 0xd09a80..0xd09b26, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09a40..0xd09a85
+            - Range: 0xd09a80..0xd09ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09a85..0xd09aa7
+            - Range: 0xd09ac5..0xd09ae7
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xd09aa7..0xd09ac2
+            - Range: 0xd09ae7..0xd09b02
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xd09ac2..0xd09ae6
+            - Range: 0xd09b02..0xd09b26
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xd09a40..0xd09acc
+            - Range: 0xd09a80..0xd09b0c
               Pieces: []
-            - Range: 0xd09acc..0xd09acd
+            - Range: 0xd09b0c..0xd09b0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xd09acd..0xd09ae6
+            - Range: 0xd09b0d..0xd09b26
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0xd09a40..0xd09acc
+            - Range: 0xd09a80..0xd09b0c
               Pieces: []
-            - Range: 0xd09acc..0xd09acd
+            - Range: 0xd09b0c..0xd09b0d
               Pieces: []
-            - Range: 0xd09acd..0xd09ae6
+            - Range: 0xd09b0d..0xd09b26
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xd09fe0..0xd09fe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd09fe0..0xd09fe1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xd0a000..0xd0a001]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0a000..0xd0a001
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 130
-      Name: main.testSliceOfSlices
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xd0a020..0xd0a021]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0a020..0xd0a021
               Pieces:
@@ -7174,13 +7184,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
+    - ID: 130
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0a040..0xd0a041]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0xd0a040..0xd0a041
               Pieces:
@@ -7191,19 +7201,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0a040..0xd0a041
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd0a060..0xd0a061]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xd0a060..0xd0a061
               Pieces:
@@ -7214,14 +7218,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0xd0a060..0xd0a061
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
+    - ID: 132
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xd0a080..0xd0a081]
       InlinePCRanges: []
       Variables:
@@ -7243,13 +7241,13 @@ Subprograms:
             - Range: 0xd0a080..0xd0a081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd0a0a0..0xd0a0a1]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 258 GoSliceHeaderType []string
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xd0a0a0..0xd0a0a1
               Pieces:
@@ -7260,21 +7258,67 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a0a0..0xd0a0a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xd0a0c0..0xd0a0c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xd0a0c0..0xd0a0c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xd0a0c0..0xd0a0c1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 258 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xd0a0e0..0xd0a0e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xd0a100..0xd0a101]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 14 BaseType int8
           Locations:
-            - Range: 0xd0a0c0..0xd0a0c1
+            - Range: 0xd0a100..0xd0a101
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xd0a0c0..0xd0a0c1
+            - Range: 0xd0a100..0xd0a101
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7286,50 +7330,16 @@ Subprograms:
         - Name: x
           Type: 15 BaseType uint
           Locations:
-            - Range: 0xd0a0c0..0xd0a0c1
+            - Range: 0xd0a100..0xd0a101
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xd0a0e0..0xd0a0e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xd0a100..0xd0a101]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xd0a100..0xd0a101
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 138
-      Name: main.testSliceEmptyStructs
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0xd0a120..0xd0a121]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 260 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xd0a120..0xd0a121
               Pieces:
@@ -7340,15 +7350,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
-      Name: main.testSubslices
+    - ID: 138
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0a140..0xd0a141]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 252 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xd0a140..0xd0a141
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xd0a160..0xd0a161]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xd0a160..0xd0a161
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xd0a180..0xd0a181]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a140..0xd0a141
+            - Range: 0xd0a180..0xd0a181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7360,7 +7404,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a140..0xd0a141
+            - Range: 0xd0a180..0xd0a181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7372,7 +7416,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xd0a140..0xd0a141
+            - Range: 0xd0a180..0xd0a181
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7381,49 +7425,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0xd0a4e0..0xd0a532]
+      OutOfLinePCRanges: [0xd0a520..0xd0a572]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a4e0..0xd0a525
+            - Range: 0xd0a520..0xd0a565
               Pieces: []
-            - Range: 0xd0a525..0xd0a526
+            - Range: 0xd0a565..0xd0a566
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xd0a526..0xd0a532
+            - Range: 0xd0a566..0xd0a572
               Pieces: []
           Role: Return
-    - ID: 141
+    - ID: 142
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xd0a540..0xd0a541]
+      OutOfLinePCRanges: [0xd0a580..0xd0a581]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a540..0xd0a541
+            - Range: 0xd0a580..0xd0a581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xd0a560..0xd0a561]
+      OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a560..0xd0a561
+            - Range: 0xd0a5a0..0xd0a5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7433,7 +7477,7 @@ Subprograms:
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a560..0xd0a561
+            - Range: 0xd0a5a0..0xd0a5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7443,22 +7487,22 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a560..0xd0a561
+            - Range: 0xd0a5a0..0xd0a5a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xd0a580..0xd0a59f]
+      OutOfLinePCRanges: [0xd0a5c0..0xd0a5df]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xd0a580..0xd0a59f
+            - Range: 0xd0a5c0..0xd0a5df
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7473,60 +7517,30 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
+      OutOfLinePCRanges: [0xd0a5e0..0xd0a5e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xd0a5a0..0xd0a5a1
+            - Range: 0xd0a5e0..0xd0a5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xd0a5c0..0xd0a5c1]
+      OutOfLinePCRanges: [0xd0a600..0xd0a601]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xd0a5c0..0xd0a5c1
+            - Range: 0xd0a600..0xd0a601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xd0a5e0..0xd0a5e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0a5e0..0xd0a5e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xd0a600..0xd0a601]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0xd0a600..0xd0a601
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xd0a620..0xd0a621]
       InlinePCRanges: []
       Variables:
@@ -7540,15 +7554,45 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
-      Name: main.testSubstrings
+    - ID: 148
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xd0a640..0xd0a641]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0a640..0xd0a641
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xd0a660..0xd0a661]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd0a660..0xd0a661
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 150
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xd0a680..0xd0a681]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a640..0xd0a641
+            - Range: 0xd0a680..0xd0a681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7558,7 +7602,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a640..0xd0a641
+            - Range: 0xd0a680..0xd0a681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7568,33 +7612,33 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0xd0a640..0xd0a641
+            - Range: 0xd0a680..0xd0a681
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xd0a7c0..0xd0a7c1]
+      OutOfLinePCRanges: [0xd0a800..0xd0a801]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xd0a7c0..0xd0a7c1
+            - Range: 0xd0a800..0xd0a801
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xd0a7e0..0xd0a7ff]
+      OutOfLinePCRanges: [0xd0a820..0xd0a83f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xd0a7e0..0xd0a7ff
+            - Range: 0xd0a820..0xd0a83f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7609,15 +7653,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0xd0a920..0xd0a943]
+      OutOfLinePCRanges: [0xd0a960..0xd0a983]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0xd0a920..0xd0a943
+            - Range: 0xd0a960..0xd0a983
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7634,38 +7678,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xd0aa20..0xd0aa21]
+      OutOfLinePCRanges: [0xd0aa60..0xd0aa61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xd0aa20..0xd0aa21
+            - Range: 0xd0aa60..0xd0aa61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xd0aaa0..0xd0aaa1]
+      OutOfLinePCRanges: [0xd0aae0..0xd0aae1]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 314 StructureType main.emptyStruct
-          Locations: [{Range: 0xd0aaa0..0xd0aaa1, Pieces: []}]
+          Locations: [{Range: 0xd0aae0..0xd0aae1, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xd0aac0..0xd0aac1]
+      OutOfLinePCRanges: [0xd0ab00..0xd0ab01]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xd0aac0..0xd0aac1
+            - Range: 0xd0ab00..0xd0ab01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04600..0xd04662]
       InlinePCRanges:
@@ -7694,28 +7738,28 @@ Subprograms:
             - Range: 0xd04920..0xd0493a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd048a6..0xd048de]
           RootRanges: [0xd04840..0xd04905]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd049b3..0xd049f1]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04a66..0xd04a9e]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7728,7 +7772,7 @@ Subprograms:
             - Range: 0xd04ac0..0xd04ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10698,10 +10742,10 @@ Types:
       GoKind: 22
       Pointee: 673 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10713,7 +10757,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -10801,7 +10845,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10813,7 +10857,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -10823,11 +10867,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -10839,7 +10883,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -10999,6 +11043,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1228
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1229
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1165
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11080,7 +11166,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1228
+      ID: 1230
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11092,7 +11178,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11102,7 +11188,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11172,7 +11258,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1236
+      ID: 1238
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11184,7 +11270,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11194,7 +11280,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11354,7 +11440,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11366,7 +11452,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11376,7 +11462,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11386,7 +11472,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11396,11 +11482,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11412,7 +11498,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11422,11 +11508,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1344
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11438,7 +11524,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11448,11 +11534,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1354
+      ID: 1356
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11464,7 +11550,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11474,11 +11560,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1355
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11490,7 +11576,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11500,7 +11586,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11766,7 +11852,7 @@ Types:
       ID: 1187
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1358
+      ID: 1360
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1184
@@ -11818,16 +11904,16 @@ Types:
       ID: 1185
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1360
+      ID: 1362
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1361
+      ID: 1363
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1362
+      ID: 1364
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1188
@@ -11836,7 +11922,7 @@ Types:
       ID: 1189
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1355
+      ID: 1357
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11848,7 +11934,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11858,11 +11944,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1359
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11874,7 +11960,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11884,14 +11970,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1358
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1365
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11903,7 +11989,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11913,11 +11999,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1366
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11929,7 +12015,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11939,11 +12025,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1367
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -11955,7 +12041,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -11965,7 +12051,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12125,7 +12211,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12137,7 +12223,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12147,11 +12233,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12163,11 +12249,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1230
+      ID: 1232
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12179,7 +12265,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12189,7 +12275,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12248,7 +12334,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12260,7 +12346,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12270,7 +12356,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12280,7 +12366,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12290,7 +12376,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12300,7 +12386,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12310,7 +12396,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12320,7 +12406,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12330,7 +12416,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12340,7 +12426,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12350,7 +12436,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12360,7 +12446,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12370,7 +12456,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12380,7 +12466,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12390,7 +12476,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12400,7 +12486,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12410,7 +12496,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12420,7 +12506,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12430,11 +12516,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12446,7 +12532,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12970,7 +13056,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12982,7 +13068,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12992,11 +13078,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13008,7 +13094,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13018,11 +13104,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13034,7 +13120,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13044,7 +13130,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13054,7 +13140,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13064,7 +13150,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13074,7 +13160,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13084,7 +13170,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13094,7 +13180,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13104,7 +13190,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13114,7 +13200,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13124,7 +13210,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13134,7 +13220,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13144,7 +13230,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13154,7 +13240,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13164,7 +13250,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13174,7 +13260,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13184,7 +13270,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13194,7 +13280,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13204,11 +13290,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13220,11 +13306,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13236,7 +13322,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13246,7 +13332,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13256,7 +13342,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13266,11 +13352,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13282,7 +13368,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13292,11 +13378,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13308,7 +13394,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13318,7 +13404,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13328,7 +13414,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13338,11 +13424,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13354,11 +13440,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13370,7 +13456,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13380,11 +13466,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13396,7 +13482,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13406,7 +13492,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13416,7 +13502,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13426,23 +13512,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1259
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13458,7 +13528,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13474,11 +13544,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1265
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13490,7 +13576,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13500,11 +13586,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13516,7 +13602,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13526,7 +13612,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13536,7 +13622,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13546,7 +13632,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13556,7 +13642,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13566,33 +13652,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1260
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13608,7 +13668,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13618,7 +13678,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13634,7 +13694,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13644,7 +13704,33 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1266
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13754,32 +13840,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1253
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -13792,7 +13852,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13802,11 +13862,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1255
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1254
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -13818,11 +13904,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13834,7 +13920,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13844,11 +13930,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1351
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13860,7 +13946,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -13870,11 +13956,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1352
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13886,7 +13972,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -13896,10 +13982,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1351
+      ID: 1353
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1354
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13911,7 +13997,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -13921,7 +14007,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1235
+      ID: 1237
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13933,7 +14019,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -13943,7 +14029,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13953,7 +14039,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13963,11 +14049,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -13979,7 +14065,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -13989,7 +14075,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -13999,7 +14085,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14009,11 +14095,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14025,7 +14111,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14035,7 +14121,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14045,7 +14131,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14055,7 +14141,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14065,7 +14151,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14075,11 +14161,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14091,7 +14177,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14101,11 +14187,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14117,7 +14203,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14127,11 +14213,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1233
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14143,7 +14229,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14153,7 +14239,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14183,7 +14269,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1231
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14195,7 +14281,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14205,11 +14291,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1245
+      ID: 1247
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14221,7 +14307,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14231,7 +14317,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14241,7 +14327,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14251,11 +14337,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1246
+      ID: 1248
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14267,7 +14353,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14277,446 +14363,12 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1247
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1248
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1277
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1278
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 247 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1279
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1280
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1275
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1276
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 246 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1283
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1284
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1295
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1296
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1271
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1272
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 89 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 90 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1244
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1241
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1239
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1240
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 93 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1237
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1238
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1249
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -14742,6 +14394,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1250
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1282
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1277
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1278
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1285
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1286
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1297
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1298
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1273
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1274
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 89 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1245
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1246
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1243
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1244
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1241
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1242
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 93 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1239
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1240
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1251
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1252
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14753,14 +14839,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14772,14 +14858,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -14791,7 +14877,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14801,7 +14887,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -14811,7 +14897,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -14821,7 +14907,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -14831,7 +14917,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -14841,7 +14927,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -14851,7 +14937,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -14861,7 +14947,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -14871,7 +14957,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -14881,7 +14967,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -14891,7 +14977,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -14901,7 +14987,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -14911,7 +14997,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -14921,7 +15007,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -14931,7 +15017,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -14941,7 +15027,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -14951,14 +15037,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14970,14 +15056,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14989,7 +15075,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14999,7 +15085,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15009,7 +15095,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15019,7 +15105,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15029,14 +15115,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15048,7 +15134,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15058,14 +15144,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15077,14 +15163,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15096,7 +15182,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15106,7 +15192,7 @@ Types:
             Type: 97 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15116,7 +15202,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15126,7 +15212,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15136,7 +15222,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15146,7 +15232,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15156,7 +15242,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15166,14 +15252,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15185,14 +15271,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15204,7 +15290,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15514,7 +15600,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15526,7 +15612,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15536,7 +15622,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -15670,7 +15756,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15682,7 +15768,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15692,11 +15778,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15708,7 +15794,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -15718,7 +15804,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -15748,7 +15834,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15760,7 +15846,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15770,11 +15856,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15786,7 +15872,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -15796,7 +15882,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15806,11 +15892,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15822,7 +15908,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -15832,11 +15918,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15848,7 +15934,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15858,7 +15944,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15868,7 +15954,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -15898,7 +15984,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1234
+      ID: 1236
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15910,7 +15996,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -15920,11 +16006,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15936,7 +16022,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -15946,7 +16032,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16002,7 +16088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16014,7 +16100,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16024,7 +16110,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16034,7 +16120,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16044,7 +16130,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16074,7 +16160,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16086,7 +16172,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16096,11 +16182,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16112,7 +16198,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16122,11 +16208,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1347
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16138,7 +16224,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16148,14 +16234,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1346
+      ID: 1348
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1344
+      ID: 1346
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16167,7 +16253,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16177,7 +16263,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16207,7 +16293,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1349
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16219,7 +16305,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16229,14 +16315,14 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1348
+      ID: 1350
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16248,7 +16334,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16258,7 +16344,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16268,7 +16354,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16278,7 +16364,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16288,7 +16374,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16298,11 +16384,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1343
+      ID: 1345
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16314,7 +16400,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16324,7 +16410,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16334,7 +16420,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16344,7 +16430,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16354,7 +16440,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16364,11 +16450,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16380,7 +16466,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16390,11 +16476,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16406,7 +16492,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16419,7 +16505,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16432,14 +16518,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16451,7 +16537,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16461,11 +16547,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16477,7 +16563,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16487,7 +16573,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16497,17 +16583,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1333
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1337
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1333
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16519,7 +16605,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16529,7 +16615,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16539,7 +16625,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16549,7 +16635,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16559,7 +16645,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16569,7 +16655,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16729,7 +16815,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1233
+      ID: 1235
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16741,7 +16827,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -16751,11 +16837,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16767,7 +16853,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16777,11 +16863,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16793,7 +16879,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16803,11 +16889,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1232
+      ID: 1234
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16819,7 +16905,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -16829,7 +16915,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16859,7 +16945,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16871,7 +16957,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16881,11 +16967,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16897,7 +16983,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16907,11 +16993,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16923,7 +17009,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -16933,7 +17019,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -16943,7 +17029,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -16953,11 +17039,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -16969,7 +17055,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16979,7 +17065,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24032,9 +24118,9 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1365
+MaxTypeID: 1367
 Issues: []
-GoModuledataInfo: {FirstModuledataAddr: "0x175c760", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcdb92a", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcdb96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcdb965", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcdb9a5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xcda36e", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcda3ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcda422", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda462", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1403 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1404 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xcd8812", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcd8820", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdb440", Frameless: true}]
+          Type: 1493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcdbaa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xcdbee0", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xcdbf20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xcdbf00", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xcdbf40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedBBB]
+          Type: 1535 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testInlinedBCA]
+          Type: 1536 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1535 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1537 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testInlinedBCB]
+          Type: 1538 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1539 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testInlinedPrint]
+          Type: 1532 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1533 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1534 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedSq]
+          Type: 1540 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1539 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1541 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1542 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcda1ce", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcda20e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcda333", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcda373", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcd89e0", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xcda693", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xcda8a2", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcda8e2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xcda933", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcda973", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xcdab6b", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdabab", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xcdacae", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdacee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xcdad7e", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdadbe", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xcda44e", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcda48e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xcda66a", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcda6aa", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
+          Type: 1428 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcd974a", Frameless: false}]
+          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd97b5", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbe60", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbe60", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbe60", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcdbe60", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcdba40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcd89c0", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcd93ee", Frameless: false}]
+          Type: 1424 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcd942e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1425 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xcd94a4"
+            - PC: "0xcd94e4"
               Frameless: false
-            - PC: "0xcd94df"
+            - PC: "0xcd951f"
               Frameless: false
-            - PC: "0xcd95a2"
+            - PC: "0xcd95e2"
               Frameless: false
-            - PC: "0xcd95ac"
+            - PC: "0xcd95ec"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcd928e", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcd92ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1423 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcd92e4"
+            - PC: "0xcd9324"
               Frameless: false
-            - PC: "0xcd9333"
+            - PC: "0xcd9373"
               Frameless: false
-            - PC: "0xcd9367"
+            - PC: "0xcd93a7"
               Frameless: false
-            - PC: "0xcd9399"
+            - PC: "0xcd93d9"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcd9c6a", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcd9caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcd9ccd", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcd9d0d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcd9cea", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcd9d2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcd9d2b", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcd9d6b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcd9d4a", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcd9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcd9d86", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcd9dc6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcd9e2e", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcd9e6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xcd9eaa", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcd9eea", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xcda16a", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcda1aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcda1b0", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcda1f0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcd9b2a", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcd9b6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcd9b86", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcd9bc6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcd922a", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsError]Return
+          Type: 1421 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcd925a"
+            - PC: "0xcd929a"
               Frameless: false
-            - PC: "0xcd9265"
+            - PC: "0xcd92a5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcd902a", Frameless: false}]
+          Type: 1414 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1413 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcd907b", Frameless: false}]
+          Type: 1415 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcd90bb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcd914e", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcd918e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcd9204", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcd9244", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcd90aa", Frameless: false}]
+          Type: 1416 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcd90ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1415 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcd9114", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcd9154", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcd95ee", Frameless: false}]
+          Type: 1426 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcd962e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1427 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcd96cf"
+            - PC: "0xcd970f"
               Frameless: false
-            - PC: "0xcd96d9"
+            - PC: "0xcd9719"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcd9bae", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcd9bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcd9c33", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcd9c73", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcd9a2e", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcd9a6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcd9b07", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcd9b47", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xcd9f8a", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcd9fca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xcd9fec", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcda02c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcd9daa", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcd9dea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcd9df8", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcd9e38", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xcda0ea", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcda12a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xcda136", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcda176", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xcda08a", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcda0ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xcda0ce", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcda10e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcd99aa", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcd99ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcd9a11", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcd9a51", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xcda00a", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcda04a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xcda06d", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcda0ad", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xcd9ece", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcd9f0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xcd9f54", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcd9f94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcdb980", Frameless: true}]
+          Type: 1507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdb5a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcd98ce", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcd990e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd996b", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd99ab", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xcdac0a", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdac4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xcdac7c", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdacbc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcd8b40", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcdbd60", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xcdbd82", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xcdadae", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdadee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xcdae5a", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdae9a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcdbc20", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcdbc60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xcdbc3e", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xcdbc7e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcdbc00", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcdbc40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcdb5c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xcdba80", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xcdbac0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcd97ee", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcd988f", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcdb9a0", Frameless: true}]
+          Type: 1508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
+          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcdb9de", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xcdb9de", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdb420", Frameless: true}]
+          Type: 1492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcdba40", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcdba80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdae8e", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdaece", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdaf0c", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdaf4c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5617,281 +5642,300 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0xcd8800..0xcd8813]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcd8800..0xcd8812
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcd8800..0xcd8812
+              Pieces: []
+            - Range: 0xcd8812..0xcd8813
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcd8800..0xcd8801]
+      OutOfLinePCRanges: [0xcd8820..0xcd8821]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0xcd8800..0xcd8801
+            - Range: 0xcd8820..0xcd8821
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcd89c0..0xcd89c1]
+      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcd89c0..0xcd89c1
+            - Range: 0xcd8a00..0xcd8a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcd89e0..0xcd89e1]
+      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0xcd89e0..0xcd89e1
+            - Range: 0xcd8a20..0xcd8a21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
+      OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0xcd8a00..0xcd8a01
+            - Range: 0xcd8a40..0xcd8a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
+      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcd8a20..0xcd8a21
+            - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
+      OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0xcd8a60..0xcd8a61
+            - Range: 0xcd8aa0..0xcd8aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcd8b40..0xcd8b41]
+      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0xcd8b40..0xcd8b41
+            - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
+      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcd8b80..0xcd8b81
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcd8b80..0xcd8b81
+            - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
+      OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0xcd8bc0..0xcd8bc1
+            - Range: 0xcd8c00..0xcd8c01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcd9020..0xcd9092]
+      OutOfLinePCRanges: [0xcd9060..0xcd90d2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9020..0xcd9032
+            - Range: 0xcd9060..0xcd9072
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9020..0xcd907b
+            - Range: 0xcd9060..0xcd90bb
               Pieces: []
-            - Range: 0xcd907b..0xcd907c
+            - Range: 0xcd90bb..0xcd90bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd907c..0xcd9092
+            - Range: 0xcd90bc..0xcd90d2
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9032..0xcd9045
+            - Range: 0xcd9072..0xcd9085
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9045..0xcd9092
+            - Range: 0xcd9085..0xcd90d2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcd90a0..0xcd912f]
+      OutOfLinePCRanges: [0xcd90e0..0xcd916f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd90a0..0xcd90ba
+            - Range: 0xcd90e0..0xcd90fa
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90ba..0xcd912f
+            - Range: 0xcd90fa..0xcd916f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90a0..0xcd9114
+            - Range: 0xcd90e0..0xcd9154
               Pieces: []
-            - Range: 0xcd9114..0xcd9115
+            - Range: 0xcd9154..0xcd9155
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9115..0xcd912f
+            - Range: 0xcd9155..0xcd916f
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd90bf..0xcd90d9
+            - Range: 0xcd90ff..0xcd9119
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd90d9..0xcd912f
+            - Range: 0xcd9119..0xcd916f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcd9140..0xcd921e]
+      OutOfLinePCRanges: [0xcd9180..0xcd925e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9140..0xcd91a2
+            - Range: 0xcd9180..0xcd91e2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9140..0xcd9204
+            - Range: 0xcd9180..0xcd9244
               Pieces: []
-            - Range: 0xcd9204..0xcd9205
+            - Range: 0xcd9244..0xcd9245
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9205..0xcd921e
+            - Range: 0xcd9245..0xcd925e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9140..0xcd921e, Pieces: []}]
+          Locations: [{Range: 0xcd9180..0xcd925e, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9156..0xcd91a7
+            - Range: 0xcd9196..0xcd91e7
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd91a7..0xcd921e
+            - Range: 0xcd91e7..0xcd925e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd916f..0xcd91a7
+            - Range: 0xcd91af..0xcd91e7
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcd91a7..0xcd921e
+            - Range: 0xcd91e7..0xcd925e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcd9220..0xcd927b]
+      OutOfLinePCRanges: [0xcd9260..0xcd92bb]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd9220..0xcd9239
+            - Range: 0xcd9260..0xcd9279
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd9220..0xcd925a
+            - Range: 0xcd9260..0xcd929a
               Pieces: []
-            - Range: 0xcd925a..0xcd925b
+            - Range: 0xcd929a..0xcd929b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd925b..0xcd9265
+            - Range: 0xcd929b..0xcd92a5
               Pieces: []
-            - Range: 0xcd9265..0xcd9266
+            - Range: 0xcd92a5..0xcd92a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9266..0xcd927b
+            - Range: 0xcd92a6..0xcd92bb
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcd9280..0xcd93c6]
+      OutOfLinePCRanges: [0xcd92c0..0xcd9406]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9280..0xcd92cb
+            - Range: 0xcd92c0..0xcd930b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92cb..0xcd92d6
+            - Range: 0xcd930b..0xcd9316
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9307..0xcd930a
+            - Range: 0xcd9347..0xcd934a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9340..0xcd9345
+            - Range: 0xcd9380..0xcd9385
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9374..0xcd9379
+            - Range: 0xcd93b4..0xcd93b9
               Pieces:
                 - Size: 8
                   Op: null
@@ -5901,112 +5945,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcd9280..0xcd92c3
+            - Range: 0xcd92c0..0xcd9303
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd9280..0xcd92e4
+            - Range: 0xcd92c0..0xcd9324
               Pieces: []
-            - Range: 0xcd92e4..0xcd92e5
+            - Range: 0xcd9324..0xcd9325
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd92e5..0xcd9333
+            - Range: 0xcd9325..0xcd9373
               Pieces: []
-            - Range: 0xcd9333..0xcd9334
+            - Range: 0xcd9373..0xcd9374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9334..0xcd9367
+            - Range: 0xcd9374..0xcd93a7
               Pieces: []
-            - Range: 0xcd9367..0xcd9368
+            - Range: 0xcd93a7..0xcd93a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9368..0xcd9399
+            - Range: 0xcd93a8..0xcd93d9
               Pieces: []
-            - Range: 0xcd9399..0xcd939a
+            - Range: 0xcd93d9..0xcd93da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd939a..0xcd93c6
+            - Range: 0xcd93da..0xcd9406
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcd9280..0xcd92e4
+            - Range: 0xcd92c0..0xcd9324
               Pieces: []
-            - Range: 0xcd92e4..0xcd92e5
+            - Range: 0xcd9324..0xcd9325
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd92e5..0xcd9333
+            - Range: 0xcd9325..0xcd9373
               Pieces: []
-            - Range: 0xcd9333..0xcd9334
+            - Range: 0xcd9373..0xcd9374
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd9334..0xcd9367
+            - Range: 0xcd9374..0xcd93a7
               Pieces: []
-            - Range: 0xcd9367..0xcd9368
+            - Range: 0xcd93a7..0xcd93a8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd9368..0xcd9399
+            - Range: 0xcd93a8..0xcd93d9
               Pieces: []
-            - Range: 0xcd9399..0xcd939a
+            - Range: 0xcd93d9..0xcd93da
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd939a..0xcd93c6
+            - Range: 0xcd93da..0xcd9406
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd92cb..0xcd92d1
+            - Range: 0xcd930b..0xcd9311
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcd93e0..0xcd95d4]
+      OutOfLinePCRanges: [0xcd9420..0xcd9614]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd93e0..0xcd942b
+            - Range: 0xcd9420..0xcd946b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd942b..0xcd9432
+            - Range: 0xcd946b..0xcd9472
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9432..0xcd95d4
+            - Range: 0xcd9472..0xcd9614
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6016,941 +6060,941 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd93e0..0xcd94a4
+            - Range: 0xcd9420..0xcd94e4
               Pieces: []
-            - Range: 0xcd94a4..0xcd94a5
+            - Range: 0xcd94e4..0xcd94e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd94a5..0xcd94df
+            - Range: 0xcd94e5..0xcd951f
               Pieces: []
-            - Range: 0xcd94df..0xcd94e0
+            - Range: 0xcd951f..0xcd9520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd94e0..0xcd95a2
+            - Range: 0xcd9520..0xcd95e2
               Pieces: []
-            - Range: 0xcd95a2..0xcd95a3
+            - Range: 0xcd95e2..0xcd95e3
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd95a3..0xcd95ac
+            - Range: 0xcd95e3..0xcd95ec
               Pieces: []
-            - Range: 0xcd95ac..0xcd95ad
+            - Range: 0xcd95ec..0xcd95ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd95ad..0xcd95d4
+            - Range: 0xcd95ed..0xcd9614
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd94ca..0xcd94d0
+            - Range: 0xcd950a..0xcd9510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 98 PointerType *int
           Locations:
-            - Range: 0xcd9485..0xcd94a4
+            - Range: 0xcd94c5..0xcd94e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcd95e0..0xcd973d]
+      OutOfLinePCRanges: [0xcd9620..0xcd977d]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcd95e0..0xcd9620
+            - Range: 0xcd9620..0xcd9660
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9620..0xcd966e
+            - Range: 0xcd9660..0xcd96ae
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd966e..0xcd96df
+            - Range: 0xcd96ae..0xcd971f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd96df..0xcd96ff
+            - Range: 0xcd971f..0xcd973f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd96ff..0xcd9706
+            - Range: 0xcd973f..0xcd9746
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9706..0xcd973d
+            - Range: 0xcd9746..0xcd977d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd95e0..0xcd96cf
+            - Range: 0xcd9620..0xcd970f
               Pieces: []
-            - Range: 0xcd96cf..0xcd96d0
+            - Range: 0xcd970f..0xcd9710
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd96d0..0xcd96d9
+            - Range: 0xcd9710..0xcd9719
               Pieces: []
-            - Range: 0xcd96d9..0xcd96da
+            - Range: 0xcd9719..0xcd971a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd96da..0xcd973d
+            - Range: 0xcd971a..0xcd977d
               Pieces: []
           Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcd95e0..0xcd9620
+            - Range: 0xcd9620..0xcd9660
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcd9620..0xcd966e
+            - Range: 0xcd9660..0xcd96ae
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd966e..0xcd9675
+            - Range: 0xcd96ae..0xcd96b5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd9675..0xcd96d5
+            - Range: 0xcd96b5..0xcd9715
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -72}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd96d5..0xcd96d7
+            - Range: 0xcd9715..0xcd9717
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcd96d7..0xcd96d9
+            - Range: 0xcd9717..0xcd9719
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd96d9..0xcd973d
+            - Range: 0xcd9719..0xcd977d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcd9740..0xcd97cf]
+      OutOfLinePCRanges: [0xcd9780..0xcd980f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9740..0xcd9751
+            - Range: 0xcd9780..0xcd9791
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9740..0xcd97b5
+            - Range: 0xcd9780..0xcd97f5
               Pieces: []
-            - Range: 0xcd97b5..0xcd97b6
+            - Range: 0xcd97f5..0xcd97f6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd97b6..0xcd97cf
+            - Range: 0xcd97f6..0xcd980f
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcd97e0..0xcd98a9]
+      OutOfLinePCRanges: [0xcd9820..0xcd98e9]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd97e0..0xcd9833
+            - Range: 0xcd9820..0xcd9873
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd97e0..0xcd988f
+            - Range: 0xcd9820..0xcd98cf
               Pieces: []
-            - Range: 0xcd988f..0xcd9890
+            - Range: 0xcd98cf..0xcd98d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9890..0xcd98a9
+            - Range: 0xcd98d0..0xcd98e9
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd97e0..0xcd988f
+            - Range: 0xcd9820..0xcd98cf
               Pieces: []
-            - Range: 0xcd988f..0xcd9890
+            - Range: 0xcd98cf..0xcd98d0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9890..0xcd98a9
+            - Range: 0xcd98d0..0xcd98e9
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcd98c0..0xcd9985]
+      OutOfLinePCRanges: [0xcd9900..0xcd99c5]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd98c0..0xcd9905
+            - Range: 0xcd9900..0xcd9945
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9905..0xcd9985
+            - Range: 0xcd9945..0xcd99c5
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd98c0..0xcd996b
+            - Range: 0xcd9900..0xcd99ab
               Pieces: []
-            - Range: 0xcd996b..0xcd996c
+            - Range: 0xcd99ab..0xcd99ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd996c..0xcd9985
+            - Range: 0xcd99ac..0xcd99c5
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd98c0..0xcd996b
+            - Range: 0xcd9900..0xcd99ab
               Pieces: []
-            - Range: 0xcd996b..0xcd996c
+            - Range: 0xcd99ab..0xcd99ac
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd996c..0xcd9985
+            - Range: 0xcd99ac..0xcd99c5
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd98c0..0xcd996b
+            - Range: 0xcd9900..0xcd99ab
               Pieces: []
-            - Range: 0xcd996b..0xcd996c
+            - Range: 0xcd99ab..0xcd99ac
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd996c..0xcd9985
+            - Range: 0xcd99ac..0xcd99c5
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcd99a0..0xcd9a1e]
+      OutOfLinePCRanges: [0xcd99e0..0xcd9a5e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcd99a0..0xcd9a11
+            - Range: 0xcd99e0..0xcd9a51
               Pieces: []
-            - Range: 0xcd9a11..0xcd9a12
+            - Range: 0xcd9a51..0xcd9a52
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcd9a12..0xcd9a1e
+            - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcd9a20..0xcd9b17]
+      OutOfLinePCRanges: [0xcd9a60..0xcd9b57]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9a20..0xcd9b17, Pieces: []}]
+          Locations: [{Range: 0xcd9a60..0xcd9b57, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd9a20..0xcd9b07
+            - Range: 0xcd9a60..0xcd9b47
               Pieces: []
-            - Range: 0xcd9b07..0xcd9b08
+            - Range: 0xcd9b47..0xcd9b48
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9b08..0xcd9b17
+            - Range: 0xcd9b48..0xcd9b57
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xcd9a20..0xcd9b07
+            - Range: 0xcd9a60..0xcd9b47
               Pieces: []
-            - Range: 0xcd9b07..0xcd9b08
+            - Range: 0xcd9b47..0xcd9b48
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcd9b08..0xcd9b17
+            - Range: 0xcd9b48..0xcd9b57
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcd9b20..0xcd9b93]
+      OutOfLinePCRanges: [0xcd9b60..0xcd9bd3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 94 BaseType complex64
-          Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
+          Locations: [{Range: 0xcd9b60..0xcd9bd3, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 95 BaseType complex128
-          Locations: [{Range: 0xcd9b20..0xcd9b93, Pieces: []}]
+          Locations: [{Range: 0xcd9b60..0xcd9bd3, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcd9ba0..0xcd9c45]
+      OutOfLinePCRanges: [0xcd9be0..0xcd9c85]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcd9ba0..0xcd9c33
+            - Range: 0xcd9be0..0xcd9c73
               Pieces: []
-            - Range: 0xcd9c33..0xcd9c34
+            - Range: 0xcd9c73..0xcd9c74
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9c34..0xcd9c45
+            - Range: 0xcd9c74..0xcd9c85
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcd9c60..0xcd9cda]
+      OutOfLinePCRanges: [0xcd9ca0..0xcd9d1a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcd9c60..0xcd9ccd
+            - Range: 0xcd9ca0..0xcd9d0d
               Pieces: []
-            - Range: 0xcd9ccd..0xcd9cce
+            - Range: 0xcd9d0d..0xcd9d0e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9cce..0xcd9cda
+            - Range: 0xcd9d0e..0xcd9d1a
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcd9ce0..0xcd9d38]
+      OutOfLinePCRanges: [0xcd9d20..0xcd9d78]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0xcd9ce0..0xcd9d2b
+            - Range: 0xcd9d20..0xcd9d6b
               Pieces: []
-            - Range: 0xcd9d2b..0xcd9d2c
+            - Range: 0xcd9d6b..0xcd9d6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9d2c..0xcd9d38
+            - Range: 0xcd9d6c..0xcd9d78
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcd9d40..0xcd9d93]
+      OutOfLinePCRanges: [0xcd9d80..0xcd9dd3]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcd9d40..0xcd9d86
+            - Range: 0xcd9d80..0xcd9dc6
               Pieces: []
-            - Range: 0xcd9d86..0xcd9d87
+            - Range: 0xcd9dc6..0xcd9dc7
               Pieces: []
-            - Range: 0xcd9d87..0xcd9d93
+            - Range: 0xcd9dc7..0xcd9dd3
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcd9da0..0xcd9e07]
+      OutOfLinePCRanges: [0xcd9de0..0xcd9e47]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0xcd9da0..0xcd9e07, Pieces: []}]
+          Locations: [{Range: 0xcd9de0..0xcd9e47, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcd9e20..0xcd9eba]
+      OutOfLinePCRanges: [0xcd9e60..0xcd9efa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9e20..0xcd9eaa
+            - Range: 0xcd9e60..0xcd9eea
               Pieces: []
-            - Range: 0xcd9eaa..0xcd9eab
+            - Range: 0xcd9eea..0xcd9eeb
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9eab..0xcd9eba
+            - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcd9ec0..0xcd9f65]
+      OutOfLinePCRanges: [0xcd9f00..0xcd9fa5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0xcd9ec0..0xcd9f54
+            - Range: 0xcd9f00..0xcd9f94
               Pieces: []
-            - Range: 0xcd9f54..0xcd9f55
+            - Range: 0xcd9f94..0xcd9f95
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcd9f55..0xcd9f65
+            - Range: 0xcd9f95..0xcd9fa5
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcd9f80..0xcd9ff9]
+      OutOfLinePCRanges: [0xcd9fc0..0xcda039]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9f80..0xcd9fec
+            - Range: 0xcd9fc0..0xcda02c
               Pieces: []
-            - Range: 0xcd9fec..0xcd9fed
+            - Range: 0xcda02c..0xcda02d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcd9fed..0xcd9ff9
+            - Range: 0xcda02d..0xcda039
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
+          Locations: [{Range: 0xcd9fc0..0xcda039, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcd9f80..0xcd9fec
+            - Range: 0xcd9fc0..0xcda02c
               Pieces: []
-            - Range: 0xcd9fec..0xcd9fed
+            - Range: 0xcda02c..0xcda02d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcd9fed..0xcd9ff9
+            - Range: 0xcda02d..0xcda039
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcd9f80..0xcd9ff9, Pieces: []}]
+          Locations: [{Range: 0xcd9fc0..0xcda039, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcd9f80..0xcd9fec
+            - Range: 0xcd9fc0..0xcda02c
               Pieces: []
-            - Range: 0xcd9fec..0xcd9fed
+            - Range: 0xcda02c..0xcda02d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcd9fed..0xcd9ff9
+            - Range: 0xcda02d..0xcda039
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcda000..0xcda07a]
+      OutOfLinePCRanges: [0xcda040..0xcda0ba]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcda000..0xcda06d
+            - Range: 0xcda040..0xcda0ad
               Pieces: []
-            - Range: 0xcda06d..0xcda06e
+            - Range: 0xcda0ad..0xcda0ae
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcda06e..0xcda07a
+            - Range: 0xcda0ae..0xcda0ba
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcda080..0xcda0db]
+      OutOfLinePCRanges: [0xcda0c0..0xcda11b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcda080..0xcda0db, Pieces: []}]
+          Locations: [{Range: 0xcda0c0..0xcda11b, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcda0e0..0xcda147]
+      OutOfLinePCRanges: [0xcda120..0xcda187]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
+          Locations: [{Range: 0xcda120..0xcda187, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0xcda0e0..0xcda147, Pieces: []}]
+          Locations: [{Range: 0xcda120..0xcda187, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcda160..0xcda1bd]
+      OutOfLinePCRanges: [0xcda1a0..0xcda1fd]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcda160..0xcda1b0
+            - Range: 0xcda1a0..0xcda1f0
               Pieces: []
-            - Range: 0xcda1b0..0xcda1b1
+            - Range: 0xcda1f0..0xcda1f1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda1b1..0xcda1bd
+            - Range: 0xcda1f1..0xcda1fd
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcda160..0xcda1b0
+            - Range: 0xcda1a0..0xcda1f0
               Pieces: []
-            - Range: 0xcda1b0..0xcda1b1
+            - Range: 0xcda1f0..0xcda1f1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda1b1..0xcda1bd
+            - Range: 0xcda1f1..0xcda1fd
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcda1c0..0xcda345]
+      OutOfLinePCRanges: [0xcda200..0xcda385]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda1c0..0xcda345
+            - Range: 0xcda200..0xcda385
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda1c0..0xcda333
+            - Range: 0xcda200..0xcda373
               Pieces: []
-            - Range: 0xcda333..0xcda334
+            - Range: 0xcda373..0xcda374
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcda334..0xcda345
+            - Range: 0xcda374..0xcda385
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcda360..0xcda432]
+      OutOfLinePCRanges: [0xcda3a0..0xcda472]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcda360..0xcda432
+            - Range: 0xcda3a0..0xcda472
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcda360..0xcda422
+            - Range: 0xcda3a0..0xcda462
               Pieces: []
-            - Range: 0xcda422..0xcda423
+            - Range: 0xcda462..0xcda463
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcda423..0xcda432
+            - Range: 0xcda463..0xcda472
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcda440..0xcda67a]
+      OutOfLinePCRanges: [0xcda480..0xcda6ba]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda440..0xcda67a
+            - Range: 0xcda480..0xcda6ba
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda440..0xcda67a
+            - Range: 0xcda480..0xcda6ba
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda440..0xcda66a
+            - Range: 0xcda480..0xcda6aa
               Pieces: []
-            - Range: 0xcda66a..0xcda66b
+            - Range: 0xcda6aa..0xcda6ab
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcda66b..0xcda67a
+            - Range: 0xcda6ab..0xcda6ba
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcda680..0xcda90f]
+      OutOfLinePCRanges: [0xcda6c0..0xcda94f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda71a
+            - Range: 0xcda6c0..0xcda75a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda71a..0xcda90f
+            - Range: 0xcda75a..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda6f0
+            - Range: 0xcda6c0..0xcda730
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcda6f0..0xcda90f
+            - Range: 0xcda730..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda680..0xcda730
+            - Range: 0xcda6c0..0xcda770
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcda730..0xcda90f
+            - Range: 0xcda770..0xcda94f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcda680..0xcda8a2
+            - Range: 0xcda6c0..0xcda8e2
               Pieces: []
-            - Range: 0xcda8a2..0xcda8a3
+            - Range: 0xcda8e2..0xcda8e3
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcda8a3..0xcda90f
+            - Range: 0xcda8e3..0xcda94f
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcda920..0xcdabec]
+      OutOfLinePCRanges: [0xcda960..0xcdac2c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9b5
+            - Range: 0xcda960..0xcda9f5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcda9b5..0xcdabec
+            - Range: 0xcda9f5..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda982
+            - Range: 0xcda960..0xcda9c2
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcda982..0xcdabec
+            - Range: 0xcda9c2..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcda920..0xcda9cb
+            - Range: 0xcda960..0xcdaa0b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcda9cb..0xcdabec
+            - Range: 0xcdaa0b..0xcdac2c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcda920..0xcdabec
+            - Range: 0xcda960..0xcdac2c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6960,210 +7004,176 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0xcda920..0xcdab6b
+            - Range: 0xcda960..0xcdabab
               Pieces: []
-            - Range: 0xcdab6b..0xcdab6c
+            - Range: 0xcdabab..0xcdabac
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdab6c..0xcdabec
+            - Range: 0xcdabac..0xcdac2c
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdac00..0xcdac8c]
+      OutOfLinePCRanges: [0xcdac40..0xcdaccc]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0xcdac00..0xcdac8c
+            - Range: 0xcdac40..0xcdaccc
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac00..0xcdac7c
+            - Range: 0xcdac40..0xcdacbc
               Pieces: []
-            - Range: 0xcdac7c..0xcdac7d
+            - Range: 0xcdacbc..0xcdacbd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdac7d..0xcdac8c
+            - Range: 0xcdacbd..0xcdaccc
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac00..0xcdac7c
+            - Range: 0xcdac40..0xcdacbc
               Pieces: []
-            - Range: 0xcdac7c..0xcdac7d
+            - Range: 0xcdacbc..0xcdacbd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdac7d..0xcdac8c
+            - Range: 0xcdacbd..0xcdaccc
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdac00..0xcdac7c
+            - Range: 0xcdac40..0xcdacbc
               Pieces: []
-            - Range: 0xcdac7c..0xcdac7d
+            - Range: 0xcdacbc..0xcdacbd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdac7d..0xcdac8c
+            - Range: 0xcdacbd..0xcdaccc
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdaca0..0xcdad8e]
+      OutOfLinePCRanges: [0xcdace0..0xcdadce]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdaca0..0xcdad8e
+            - Range: 0xcdace0..0xcdadce
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0xcdaca0..0xcdad8e
+            - Range: 0xcdace0..0xcdadce
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdaca0..0xcdad7e
+            - Range: 0xcdace0..0xcdadbe
               Pieces: []
-            - Range: 0xcdad7e..0xcdad7f
+            - Range: 0xcdadbe..0xcdadbf
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdad7f..0xcdad8e
+            - Range: 0xcdadbf..0xcdadce
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0xcdaca0..0xcdad7e
+            - Range: 0xcdace0..0xcdadbe
               Pieces: []
-            - Range: 0xcdad7e..0xcdad7f
+            - Range: 0xcdadbe..0xcdadbf
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdad7f..0xcdad8e
+            - Range: 0xcdadbf..0xcdadce
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdada0..0xcdae6b]
+      OutOfLinePCRanges: [0xcdade0..0xcdaeab]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdada0..0xcdae6b
+            - Range: 0xcdade0..0xcdaeab
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdada0..0xcdae5a
+            - Range: 0xcdade0..0xcdae9a
               Pieces: []
-            - Range: 0xcdae5a..0xcdae5b
+            - Range: 0xcdae9a..0xcdae9b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdae5b..0xcdae6b
+            - Range: 0xcdae9b..0xcdaeab
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdada0..0xcdae5a
+            - Range: 0xcdade0..0xcdae9a
               Pieces: []
-            - Range: 0xcdae5a..0xcdae5b
+            - Range: 0xcdae9a..0xcdae9b
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdae5b..0xcdae6b
+            - Range: 0xcdae9b..0xcdaeab
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdae26..0xcdae6b
+            - Range: 0xcdae66..0xcdaeab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdae80..0xcdaf26]
+      OutOfLinePCRanges: [0xcdaec0..0xcdaf66]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0xcdae80..0xcdaf26, Pieces: []}]
+          Locations: [{Range: 0xcdaec0..0xcdaf66, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdae80..0xcdaec5
+            - Range: 0xcdaec0..0xcdaf05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdaec5..0xcdaee7
+            - Range: 0xcdaf05..0xcdaf27
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdaee7..0xcdaefa
+            - Range: 0xcdaf27..0xcdaf3a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdaefa..0xcdaf26
+            - Range: 0xcdaf3a..0xcdaf66
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdae80..0xcdaf0c
+            - Range: 0xcdaec0..0xcdaf4c
               Pieces: []
-            - Range: 0xcdaf0c..0xcdaf0d
+            - Range: 0xcdaf4c..0xcdaf4d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdaf0d..0xcdaf26
+            - Range: 0xcdaf4d..0xcdaf66
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0xcdae80..0xcdaf0c
+            - Range: 0xcdaec0..0xcdaf4c
               Pieces: []
-            - Range: 0xcdaf0c..0xcdaf0d
+            - Range: 0xcdaf4c..0xcdaf4d
               Pieces: []
-            - Range: 0xcdaf0d..0xcdaf26
+            - Range: 0xcdaf4d..0xcdaf66
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdb420..0xcdb421]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdb420..0xcdb421
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdb440..0xcdb441]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdb440..0xcdb441
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 130
-      Name: main.testSliceOfSlices
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdb460..0xcdb461]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdb460..0xcdb461
               Pieces:
@@ -7174,13 +7184,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
+    - ID: 130
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdb480..0xcdb481]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdb480..0xcdb481
               Pieces:
@@ -7191,19 +7201,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdb480..0xcdb481
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcdb4a0..0xcdb4a1
               Pieces:
@@ -7214,14 +7218,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdb4a0..0xcdb4a1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
+    - ID: 132
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
       InlinePCRanges: []
       Variables:
@@ -7243,13 +7241,13 @@ Subprograms:
             - Range: 0xcdb4c0..0xcdb4c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdb4e0..0xcdb4e1]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 261 GoSliceHeaderType []string
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdb4e0..0xcdb4e1
               Pieces:
@@ -7260,21 +7258,67 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdb4e0..0xcdb4e1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdb500..0xcdb501]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdb500..0xcdb501
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdb500..0xcdb501
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdb520..0xcdb521]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 261 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdb520..0xcdb521
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdb540..0xcdb541]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xcdb500..0xcdb501
+            - Range: 0xcdb540..0xcdb541
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdb500..0xcdb501
+            - Range: 0xcdb540..0xcdb541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7286,50 +7330,16 @@ Subprograms:
         - Name: x
           Type: 16 BaseType uint
           Locations:
-            - Range: 0xcdb500..0xcdb501
+            - Range: 0xcdb540..0xcdb541
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdb520..0xcdb521]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdb520..0xcdb521
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdb540..0xcdb541]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdb540..0xcdb541
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 138
-      Name: main.testSliceEmptyStructs
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdb560..0xcdb561]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcdb560..0xcdb561
               Pieces:
@@ -7340,15 +7350,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
-      Name: main.testSubslices
+    - ID: 138
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdb580..0xcdb581]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdb580..0xcdb581
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdb5a0..0xcdb5a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdb5a0..0xcdb5a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcdb5c0..0xcdb5c1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb580..0xcdb581
+            - Range: 0xcdb5c0..0xcdb5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7360,7 +7404,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb580..0xcdb581
+            - Range: 0xcdb5c0..0xcdb5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7372,7 +7416,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdb580..0xcdb581
+            - Range: 0xcdb5c0..0xcdb5c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7381,49 +7425,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0xcdb920..0xcdb972]
+      OutOfLinePCRanges: [0xcdb960..0xcdb9b2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb920..0xcdb965
+            - Range: 0xcdb960..0xcdb9a5
               Pieces: []
-            - Range: 0xcdb965..0xcdb966
+            - Range: 0xcdb9a5..0xcdb9a6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdb966..0xcdb972
+            - Range: 0xcdb9a6..0xcdb9b2
               Pieces: []
           Role: Return
-    - ID: 141
+    - ID: 142
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcdb980..0xcdb981]
+      OutOfLinePCRanges: [0xcdb9c0..0xcdb9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb980..0xcdb981
+            - Range: 0xcdb9c0..0xcdb9c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcdb9a0..0xcdb9a1]
+      OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9a0..0xcdb9a1
+            - Range: 0xcdb9e0..0xcdb9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7433,7 +7477,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9a0..0xcdb9a1
+            - Range: 0xcdb9e0..0xcdb9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7443,22 +7487,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdb9a0..0xcdb9a1
+            - Range: 0xcdb9e0..0xcdb9e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcdb9c0..0xcdb9df]
+      OutOfLinePCRanges: [0xcdba00..0xcdba1f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 266 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcdb9c0..0xcdb9df
+            - Range: 0xcdba00..0xcdba1f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7473,60 +7517,30 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
+      OutOfLinePCRanges: [0xcdba20..0xcdba21]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcdb9e0..0xcdb9e1
+            - Range: 0xcdba20..0xcdba21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcdba00..0xcdba01]
+      OutOfLinePCRanges: [0xcdba40..0xcdba41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcdba00..0xcdba01
+            - Range: 0xcdba40..0xcdba41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcdba20..0xcdba21]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdba20..0xcdba21
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcdba40..0xcdba41]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcdba40..0xcdba41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xcdba60..0xcdba61]
       InlinePCRanges: []
       Variables:
@@ -7540,15 +7554,45 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
-      Name: main.testSubstrings
+    - ID: 148
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcdba80..0xcdba81]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdba80..0xcdba81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcdbaa0..0xcdbaa1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdbaa0..0xcdbaa1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 150
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xcdbac0..0xcdbac1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdba80..0xcdba81
+            - Range: 0xcdbac0..0xcdbac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7558,7 +7602,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdba80..0xcdba81
+            - Range: 0xcdbac0..0xcdbac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7568,33 +7612,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdba80..0xcdba81
+            - Range: 0xcdbac0..0xcdbac1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcdbc00..0xcdbc01]
+      OutOfLinePCRanges: [0xcdbc40..0xcdbc41]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcdbc00..0xcdbc01
+            - Range: 0xcdbc40..0xcdbc41
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcdbc20..0xcdbc3f]
+      OutOfLinePCRanges: [0xcdbc60..0xcdbc7f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcdbc20..0xcdbc3f
+            - Range: 0xcdbc60..0xcdbc7f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7609,15 +7653,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcdbd60..0xcdbd83]
+      OutOfLinePCRanges: [0xcdbda0..0xcdbdc3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0xcdbd60..0xcdbd83
+            - Range: 0xcdbda0..0xcdbdc3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7634,38 +7678,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcdbe60..0xcdbe61]
+      OutOfLinePCRanges: [0xcdbea0..0xcdbea1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcdbe60..0xcdbe61
+            - Range: 0xcdbea0..0xcdbea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xcdbee0..0xcdbee1]
+      OutOfLinePCRanges: [0xcdbf20..0xcdbf21]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 317 StructureType main.emptyStruct
-          Locations: [{Range: 0xcdbee0..0xcdbee1, Pieces: []}]
+          Locations: [{Range: 0xcdbf20..0xcdbf21, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xcdbf00..0xcdbf01]
+      OutOfLinePCRanges: [0xcdbf40..0xcdbf41]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xcdbf00..0xcdbf01
+            - Range: 0xcdbf40..0xcdbf41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5920..0xcd5982]
       InlinePCRanges:
@@ -7694,28 +7738,28 @@ Subprograms:
             - Range: 0xcd5c40..0xcd5c5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5bc6..0xcd5bfe]
           RootRanges: [0xcd5b60..0xcd5c25]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5cd3..0xcd5d11]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5d86..0xcd5dbe]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7728,7 +7772,7 @@ Subprograms:
             - Range: 0xcd5de0..0xcd5de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11003,10 +11047,10 @@ Types:
       GoKind: 22
       Pointee: 810 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11018,7 +11062,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11106,7 +11150,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11118,7 +11162,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11128,11 +11172,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11144,7 +11188,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11304,6 +11348,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1404
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11385,7 +11471,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1403
+      ID: 1405
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11397,7 +11483,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11407,7 +11493,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11477,7 +11563,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1411
+      ID: 1413
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11489,7 +11575,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11499,7 +11585,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11659,7 +11745,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11671,7 +11757,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11681,7 +11767,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11691,7 +11777,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11701,11 +11787,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11717,7 +11803,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11727,11 +11813,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11743,7 +11829,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11753,11 +11839,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11769,7 +11855,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11779,11 +11865,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11795,7 +11881,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11805,7 +11891,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12071,7 +12157,7 @@ Types:
       ID: 1362
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1359
@@ -12123,16 +12209,16 @@ Types:
       ID: 1360
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1363
@@ -12141,7 +12227,7 @@ Types:
       ID: 1364
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12153,7 +12239,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12163,11 +12249,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12179,7 +12265,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12189,14 +12275,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12208,7 +12294,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12218,11 +12304,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12234,7 +12320,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12244,11 +12330,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12260,7 +12346,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12270,7 +12356,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12430,7 +12516,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12442,7 +12528,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12452,11 +12538,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12468,11 +12554,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1405
+      ID: 1407
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12484,7 +12570,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12494,7 +12580,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12553,7 +12639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12565,7 +12651,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12575,7 +12661,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12585,7 +12671,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12595,7 +12681,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12605,7 +12691,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12615,7 +12701,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12625,7 +12711,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12635,7 +12721,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12645,7 +12731,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12655,7 +12741,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12665,7 +12751,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12675,7 +12761,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12685,7 +12771,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12695,7 +12781,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12705,7 +12791,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12715,7 +12801,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12725,7 +12811,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12735,11 +12821,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12751,7 +12837,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13275,7 +13361,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13287,7 +13373,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13297,11 +13383,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13313,7 +13399,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13323,11 +13409,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13339,7 +13425,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13349,7 +13435,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13359,7 +13445,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13369,7 +13455,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13379,7 +13465,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13389,7 +13475,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13399,7 +13485,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13409,7 +13495,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13419,7 +13505,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13429,7 +13515,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13439,7 +13525,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13449,7 +13535,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13459,7 +13545,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13469,7 +13555,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13479,7 +13565,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13489,7 +13575,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13499,7 +13585,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13509,11 +13595,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13525,11 +13611,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13541,7 +13627,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13551,7 +13637,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13561,7 +13647,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13571,11 +13657,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13587,7 +13673,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13597,11 +13683,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13613,7 +13699,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13623,7 +13709,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13633,7 +13719,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13643,11 +13729,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13659,11 +13745,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13675,7 +13761,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13685,11 +13771,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13701,7 +13787,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13711,7 +13797,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13721,7 +13807,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13731,23 +13817,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13763,7 +13833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13779,11 +13849,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1440
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13795,7 +13881,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13805,11 +13891,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13821,7 +13907,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13831,7 +13917,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13841,7 +13927,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13851,7 +13937,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13861,7 +13947,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13871,33 +13957,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13913,7 +13973,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13923,7 +13983,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13939,7 +13999,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13949,7 +14009,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14059,32 +14145,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14097,7 +14157,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14107,11 +14167,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1430
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14123,11 +14209,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14139,7 +14225,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14149,11 +14235,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14165,7 +14251,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14175,11 +14261,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14191,7 +14277,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14201,10 +14287,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14216,7 +14302,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14226,7 +14312,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1410
+      ID: 1412
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14238,7 +14324,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14248,7 +14334,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14258,7 +14344,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14268,11 +14354,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14284,7 +14370,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14294,7 +14380,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14304,7 +14390,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14314,11 +14400,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14330,7 +14416,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14340,7 +14426,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14350,7 +14436,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14360,7 +14446,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14370,7 +14456,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14380,11 +14466,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14396,7 +14482,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14406,11 +14492,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14422,7 +14508,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14432,11 +14518,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1408
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14448,7 +14534,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14458,7 +14544,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14488,7 +14574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1406
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14500,7 +14586,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14510,11 +14596,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1422
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14526,7 +14612,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14536,7 +14622,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14546,7 +14632,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14556,11 +14642,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1423
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14572,7 +14658,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14582,446 +14668,12 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1422
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1423
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1452
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 250 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1450
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1451
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 249 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1458
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1459
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1446
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 94 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 95 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1418
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1419
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1414
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1415
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 98 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1412
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1413
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15047,6 +14699,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1425
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1420
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1421
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1418
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1416
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1417
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 98 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1414
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1427
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15058,14 +15144,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15077,14 +15163,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15096,7 +15182,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15106,7 +15192,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15116,7 +15202,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15126,7 +15212,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15136,7 +15222,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15146,7 +15232,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15156,7 +15242,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15166,7 +15252,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15176,7 +15262,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15186,7 +15272,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15196,7 +15282,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15206,7 +15292,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15216,7 +15302,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15226,7 +15312,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15236,7 +15322,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15246,7 +15332,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15256,14 +15342,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15275,14 +15361,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15294,7 +15380,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15304,7 +15390,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15314,7 +15400,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15324,7 +15410,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15334,14 +15420,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15353,7 +15439,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15363,14 +15449,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15382,14 +15468,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15401,7 +15487,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15411,7 +15497,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15421,7 +15507,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15431,7 +15517,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15441,7 +15527,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15451,7 +15537,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15461,7 +15547,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15471,14 +15557,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15490,14 +15576,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15509,7 +15595,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15819,7 +15905,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15831,7 +15917,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15841,7 +15927,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -15975,7 +16061,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15987,7 +16073,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15997,11 +16083,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16013,7 +16099,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16023,7 +16109,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16053,7 +16139,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16065,7 +16151,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16075,11 +16161,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16091,7 +16177,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16101,7 +16187,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16111,11 +16197,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16127,7 +16213,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16137,11 +16223,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16153,7 +16239,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16163,7 +16249,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16173,7 +16259,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16203,7 +16289,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1409
+      ID: 1411
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16215,7 +16301,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16225,11 +16311,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16241,7 +16327,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16251,7 +16337,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16307,7 +16393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16319,7 +16405,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16329,7 +16415,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16339,7 +16425,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16349,7 +16435,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16379,7 +16465,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16391,7 +16477,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16401,11 +16487,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16417,7 +16503,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16427,11 +16513,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16443,7 +16529,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16453,14 +16539,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16472,7 +16558,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16482,7 +16568,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16512,7 +16598,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16524,7 +16610,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16534,14 +16620,14 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16553,7 +16639,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16563,7 +16649,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16573,7 +16659,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16583,7 +16669,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16593,7 +16679,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16603,11 +16689,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16619,7 +16705,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16629,7 +16715,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16639,7 +16725,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16649,7 +16735,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16659,7 +16745,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16669,11 +16755,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16685,7 +16771,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16695,11 +16781,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16711,7 +16797,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16724,7 +16810,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16737,14 +16823,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16756,7 +16842,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16766,11 +16852,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16782,7 +16868,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16792,7 +16878,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16802,17 +16888,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1508
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1512
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1508
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16824,7 +16910,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16834,7 +16920,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16844,7 +16930,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16854,7 +16940,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16864,7 +16950,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16874,7 +16960,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17034,7 +17120,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1408
+      ID: 1410
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17046,7 +17132,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17056,11 +17142,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17072,7 +17158,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17082,11 +17168,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17098,7 +17184,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17108,11 +17194,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1407
+      ID: 1409
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17124,7 +17210,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17134,7 +17220,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17164,7 +17250,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17176,7 +17262,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17186,11 +17272,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17202,7 +17288,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17212,11 +17298,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17228,7 +17314,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17238,7 +17324,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17248,7 +17334,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17258,11 +17344,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17274,7 +17360,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17284,7 +17370,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -25792,7 +25878,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1540
+MaxTypeID: 1542
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xce014a", Frameless: false}]
+          Type: 1524 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xce018a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xce0185", Frameless: false}]
+          Type: 1525 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xcdebae", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xcdebee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdec62", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdeca2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xcdd092", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcdfc60", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xce0280", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xce0700", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xce0740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xce0720", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xce0760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedBBB]
+          Type: 1554 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedBCA]
+          Type: 1555 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1556 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBCB]
+          Type: 1557 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1558 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testInlinedPrint]
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedSq]
+          Type: 1559 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1558 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1560 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1559 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1561 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdea0e", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdea4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdeb73", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdebb3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xcdd240", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xcdeed3", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xcdef13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xcdf0e2", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xcdf122", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xcdf173", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xcdf1b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xcdf3ab", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xcdf3eb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xcdf4ee", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xcdf52e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xcdf5bf", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xcdf5ff", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xcdec8e", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xcdecce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xcdeeaa", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xcdeeea", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcddf8a", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcddff5", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce0680", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce0680", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce0680", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xce0680", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xce0220", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xce0260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xcdd220", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xcddc2e", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xcddc6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xcddcd5"
+            - PC: "0xcddd15"
               Frameless: false
-            - PC: "0xcddd24"
+            - PC: "0xcddd64"
               Frameless: false
-            - PC: "0xcddde0"
+            - PC: "0xcdde20"
               Frameless: false
-            - PC: "0xcdddea"
+            - PC: "0xcdde2a"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xcddace", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xcddb0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xcddb24"
+            - PC: "0xcddb64"
               Frameless: false
-            - PC: "0xcddb73"
+            - PC: "0xcddbb3"
               Frameless: false
-            - PC: "0xcddba7"
+            - PC: "0xcddbe7"
               Frameless: false
-            - PC: "0xcddbd9"
+            - PC: "0xcddc19"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcde4aa", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcde4ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcde50d", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcde54d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcde52a", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcde56a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcde56b", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcde5ab", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcde58a", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcde5ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcde5c6", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcde606", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcde66e", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcde6ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xcde6ea", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xcde72a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xcde9aa", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcde9ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcde9f0", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcdea30", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcde36a", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcde3c6", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcde406", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xcdda6a", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsError]Return
+          Type: 1440 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xcdda9a"
+            - PC: "0xcddada"
               Frameless: false
-            - PC: "0xcddaa5"
+            - PC: "0xcddae5"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xcdd86a", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xcdd8aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xcdd8bb", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xcdd8fb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xcdd98e", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xcdda44", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xcdda84", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xcdd8ea", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xcdd92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xcdd954", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xcdd994", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcdde2e", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcddeff"
+            - PC: "0xcddf3f"
               Frameless: false
-            - PC: "0xcddf09"
+            - PC: "0xcddf49"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcde3ee", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcde473", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcde4b3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcde26e", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcde2ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcde347", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcde387", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xcde7ca", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xcde80a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xcde82c", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xcde86c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcde5ea", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcde62a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcde638", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcde678", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xcde92a", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xcde96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xcde976", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xcde9b6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xcde8ca", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xcde90a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xcde90e", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xcde94e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcde1ea", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcde22a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcde251", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcde291", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xcde84a", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xcde88a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xcde8ad", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xcde8ed", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xcde70e", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xcde74e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xcde794", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xcde7d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xce01a0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcdfdc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcde10e", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcde14e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde1ad", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde1ed", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xcdf44a", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xcdf48a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xcdf4bc", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xcdf4fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xcdd3a0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xce0580", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1542 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0xce05a2", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xcdf5ee", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xcdf62e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xcdf69c", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xcdf6dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xce0440", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xce0480", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0xce045e", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0xce049e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xce0420", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xce0460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcdfde0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcde02e", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcde0cf", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xce01c0", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xce01fe", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0xce01fe", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xce0200", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xce0200", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcdfc40", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xce0260", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xcdf6ce", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xcdf70e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xcdf74c", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcdf78c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5617,281 +5642,300 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0xcdd080..0xcdd093]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcdd080..0xcdd092
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcdd080..0xcdd092
+              Pieces: []
+            - Range: 0xcdd092..0xcdd093
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0xcdd080..0xcdd081]
+      OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0xcdd080..0xcdd081
+            - Range: 0xcdd0a0..0xcdd0a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xcdd220..0xcdd221]
+      OutOfLinePCRanges: [0xcdd260..0xcdd261]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xcdd220..0xcdd221
+            - Range: 0xcdd260..0xcdd261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xcdd240..0xcdd241]
+      OutOfLinePCRanges: [0xcdd280..0xcdd281]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0xcdd240..0xcdd241
+            - Range: 0xcdd280..0xcdd281
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xcdd260..0xcdd261]
+      OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0xcdd260..0xcdd261
+            - Range: 0xcdd2a0..0xcdd2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xcdd280..0xcdd281]
+      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xcdd280..0xcdd281
+            - Range: 0xcdd2c0..0xcdd2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
+      OutOfLinePCRanges: [0xcdd300..0xcdd301]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0xcdd2c0..0xcdd2c1
+            - Range: 0xcdd300..0xcdd301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xcdd3a0..0xcdd3a1]
+      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0xcdd3a0..0xcdd3a1
+            - Range: 0xcdd3e0..0xcdd3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
+      OutOfLinePCRanges: [0xcdd420..0xcdd421]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xcdd3e0..0xcdd3e1
+            - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdd3e0..0xcdd3e1
+            - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0xcdd420..0xcdd421]
+      OutOfLinePCRanges: [0xcdd460..0xcdd461]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0xcdd420..0xcdd421
+            - Range: 0xcdd460..0xcdd461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xcdd860..0xcdd8d2]
+      OutOfLinePCRanges: [0xcdd8a0..0xcdd912]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd860..0xcdd872
+            - Range: 0xcdd8a0..0xcdd8b2
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd860..0xcdd8bb
+            - Range: 0xcdd8a0..0xcdd8fb
               Pieces: []
-            - Range: 0xcdd8bb..0xcdd8bc
+            - Range: 0xcdd8fb..0xcdd8fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8bc..0xcdd8d2
+            - Range: 0xcdd8fc..0xcdd912
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd872..0xcdd885
+            - Range: 0xcdd8b2..0xcdd8c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd885..0xcdd8d2
+            - Range: 0xcdd8c5..0xcdd912
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xcdd8e0..0xcdd96f]
+      OutOfLinePCRanges: [0xcdd920..0xcdd9af]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd8e0..0xcdd8fa
+            - Range: 0xcdd920..0xcdd93a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd8fa..0xcdd96f
+            - Range: 0xcdd93a..0xcdd9af
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd8e0..0xcdd954
+            - Range: 0xcdd920..0xcdd994
               Pieces: []
-            - Range: 0xcdd954..0xcdd955
+            - Range: 0xcdd994..0xcdd995
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd955..0xcdd96f
+            - Range: 0xcdd995..0xcdd9af
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcdd8ff..0xcdd919
+            - Range: 0xcdd93f..0xcdd959
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdd919..0xcdd96f
+            - Range: 0xcdd959..0xcdd9af
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xcdd980..0xcdda5e]
+      OutOfLinePCRanges: [0xcdd9c0..0xcdda9e]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd980..0xcdd9e2
+            - Range: 0xcdd9c0..0xcdda22
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd980..0xcdda44
+            - Range: 0xcdd9c0..0xcdda84
               Pieces: []
-            - Range: 0xcdda44..0xcdda45
+            - Range: 0xcdda84..0xcdda85
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdda45..0xcdda5e
+            - Range: 0xcdda85..0xcdda9e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcdd980..0xcdda5e, Pieces: []}]
+          Locations: [{Range: 0xcdd9c0..0xcdda9e, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdd996..0xcdd9e7
+            - Range: 0xcdd9d6..0xcdda27
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdd9e7..0xcdda5e
+            - Range: 0xcdda27..0xcdda9e
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcdd9af..0xcdd9e7
+            - Range: 0xcdd9ef..0xcdda27
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xcdd9e7..0xcdda5e
+            - Range: 0xcdda27..0xcdda9e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xcdda60..0xcddabb]
+      OutOfLinePCRanges: [0xcddaa0..0xcddafb]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcdda60..0xcdda79
+            - Range: 0xcddaa0..0xcddab9
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcdda60..0xcdda9a
+            - Range: 0xcddaa0..0xcddada
               Pieces: []
-            - Range: 0xcdda9a..0xcdda9b
+            - Range: 0xcddada..0xcddadb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdda9b..0xcddaa5
+            - Range: 0xcddadb..0xcddae5
               Pieces: []
-            - Range: 0xcddaa5..0xcddaa6
+            - Range: 0xcddae5..0xcddae6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddaa6..0xcddabb
+            - Range: 0xcddae6..0xcddafb
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xcddac0..0xcddc06]
+      OutOfLinePCRanges: [0xcddb00..0xcddc46]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddac0..0xcddb0b
+            - Range: 0xcddb00..0xcddb4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb0b..0xcddb16
+            - Range: 0xcddb4b..0xcddb56
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb47..0xcddb4a
+            - Range: 0xcddb87..0xcddb8a
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb80..0xcddb85
+            - Range: 0xcddbc0..0xcddbc5
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbb4..0xcddbb9
+            - Range: 0xcddbf4..0xcddbf9
               Pieces:
                 - Size: 8
                   Op: null
@@ -5901,112 +5945,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcddac0..0xcddb03
+            - Range: 0xcddb00..0xcddb43
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddac0..0xcddb24
+            - Range: 0xcddb00..0xcddb64
               Pieces: []
-            - Range: 0xcddb24..0xcddb25
+            - Range: 0xcddb64..0xcddb65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb25..0xcddb73
+            - Range: 0xcddb65..0xcddbb3
               Pieces: []
-            - Range: 0xcddb73..0xcddb74
+            - Range: 0xcddbb3..0xcddbb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddb74..0xcddba7
+            - Range: 0xcddbb4..0xcddbe7
               Pieces: []
-            - Range: 0xcddba7..0xcddba8
+            - Range: 0xcddbe7..0xcddbe8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddba8..0xcddbd9
+            - Range: 0xcddbe8..0xcddc19
               Pieces: []
-            - Range: 0xcddbd9..0xcddbda
+            - Range: 0xcddc19..0xcddc1a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddbda..0xcddc06
+            - Range: 0xcddc1a..0xcddc46
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 GoInterfaceType error
           Locations:
-            - Range: 0xcddac0..0xcddb24
+            - Range: 0xcddb00..0xcddb64
               Pieces: []
-            - Range: 0xcddb24..0xcddb25
+            - Range: 0xcddb64..0xcddb65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddb25..0xcddb73
+            - Range: 0xcddb65..0xcddbb3
               Pieces: []
-            - Range: 0xcddb73..0xcddb74
+            - Range: 0xcddbb3..0xcddbb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddb74..0xcddba7
+            - Range: 0xcddbb4..0xcddbe7
               Pieces: []
-            - Range: 0xcddba7..0xcddba8
+            - Range: 0xcddbe7..0xcddbe8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddba8..0xcddbd9
+            - Range: 0xcddbe8..0xcddc19
               Pieces: []
-            - Range: 0xcddbd9..0xcddbda
+            - Range: 0xcddc19..0xcddc1a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcddbda..0xcddc06
+            - Range: 0xcddc1a..0xcddc46
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddb0b..0xcddb11
+            - Range: 0xcddb4b..0xcddb51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xcddc20..0xcdde0e]
+      OutOfLinePCRanges: [0xcddc60..0xcdde4e]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddc20..0xcddc6b
+            - Range: 0xcddc60..0xcddcab
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddc6b..0xcddc72
+            - Range: 0xcddcab..0xcddcb2
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddc72..0xcdde0e
+            - Range: 0xcddcb2..0xcdde4e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6016,941 +6060,941 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcddc20..0xcddcd5
+            - Range: 0xcddc60..0xcddd15
               Pieces: []
-            - Range: 0xcddcd5..0xcddcd6
+            - Range: 0xcddd15..0xcddd16
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddcd6..0xcddd24
+            - Range: 0xcddd16..0xcddd64
               Pieces: []
-            - Range: 0xcddd24..0xcddd25
+            - Range: 0xcddd64..0xcddd65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddd25..0xcddde0
+            - Range: 0xcddd65..0xcdde20
               Pieces: []
-            - Range: 0xcddde0..0xcddde1
+            - Range: 0xcdde20..0xcdde21
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddde1..0xcdddea
+            - Range: 0xcdde21..0xcdde2a
               Pieces: []
-            - Range: 0xcdddea..0xcdddeb
+            - Range: 0xcdde2a..0xcdde2b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdddeb..0xcdde0e
+            - Range: 0xcdde2b..0xcdde4e
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddcc0..0xcddcc6
+            - Range: 0xcddd00..0xcddd06
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0xcddd05..0xcddd24
+            - Range: 0xcddd45..0xcddd64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcdde20..0xcddf74]
+      OutOfLinePCRanges: [0xcdde60..0xcddfb4]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xcdde20..0xcdde60
+            - Range: 0xcdde60..0xcddea0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdde60..0xcddeae
+            - Range: 0xcddea0..0xcddeee
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddeae..0xcddf0f
+            - Range: 0xcddeee..0xcddf4f
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddf0f..0xcddf31
+            - Range: 0xcddf4f..0xcddf71
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf31..0xcddf38
+            - Range: 0xcddf71..0xcddf78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf38..0xcddf74
+            - Range: 0xcddf78..0xcddfb4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdde20..0xcddeff
+            - Range: 0xcdde60..0xcddf3f
               Pieces: []
-            - Range: 0xcddeff..0xcddf00
+            - Range: 0xcddf3f..0xcddf40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddf00..0xcddf09
+            - Range: 0xcddf40..0xcddf49
               Pieces: []
-            - Range: 0xcddf09..0xcddf0a
+            - Range: 0xcddf49..0xcddf4a
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcddf0a..0xcddf74
+            - Range: 0xcddf4a..0xcddfb4
               Pieces: []
           Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0xcdde20..0xcdde60
+            - Range: 0xcdde60..0xcddea0
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcdde60..0xcddeae
+            - Range: 0xcddea0..0xcddeee
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddeae..0xcddeb5
+            - Range: 0xcddeee..0xcddef5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddeb5..0xcddf05
+            - Range: 0xcddef5..0xcddf45
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -56}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf05..0xcddf07
+            - Range: 0xcddf45..0xcddf47
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 8}
-            - Range: 0xcddf07..0xcddf09
+            - Range: 0xcddf47..0xcddf49
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcddf09..0xcddf74
+            - Range: 0xcddf49..0xcddfb4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcddf80..0xcde00f]
+      OutOfLinePCRanges: [0xcddfc0..0xcde04f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddf80..0xcddf91
+            - Range: 0xcddfc0..0xcddfd1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcddf80..0xcddff5
+            - Range: 0xcddfc0..0xcde035
               Pieces: []
-            - Range: 0xcddff5..0xcddff6
+            - Range: 0xcde035..0xcde036
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcddff6..0xcde00f
+            - Range: 0xcde036..0xcde04f
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcde020..0xcde0e9]
+      OutOfLinePCRanges: [0xcde060..0xcde129]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde020..0xcde071
+            - Range: 0xcde060..0xcde0b1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde020..0xcde0cf
+            - Range: 0xcde060..0xcde10f
               Pieces: []
-            - Range: 0xcde0cf..0xcde0d0
+            - Range: 0xcde10f..0xcde110
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde0d0..0xcde0e9
+            - Range: 0xcde110..0xcde129
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde020..0xcde0cf
+            - Range: 0xcde060..0xcde10f
               Pieces: []
-            - Range: 0xcde0cf..0xcde0d0
+            - Range: 0xcde10f..0xcde110
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde0d0..0xcde0e9
+            - Range: 0xcde110..0xcde129
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcde100..0xcde1c7]
+      OutOfLinePCRanges: [0xcde140..0xcde207]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde100..0xcde145
+            - Range: 0xcde140..0xcde185
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde145..0xcde1c7
+            - Range: 0xcde185..0xcde207
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde100..0xcde1ad
+            - Range: 0xcde140..0xcde1ed
               Pieces: []
-            - Range: 0xcde1ad..0xcde1ae
+            - Range: 0xcde1ed..0xcde1ee
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde1ae..0xcde1c7
+            - Range: 0xcde1ee..0xcde207
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde100..0xcde1ad
+            - Range: 0xcde140..0xcde1ed
               Pieces: []
-            - Range: 0xcde1ad..0xcde1ae
+            - Range: 0xcde1ed..0xcde1ee
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde1ae..0xcde1c7
+            - Range: 0xcde1ee..0xcde207
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde100..0xcde1ad
+            - Range: 0xcde140..0xcde1ed
               Pieces: []
-            - Range: 0xcde1ad..0xcde1ae
+            - Range: 0xcde1ed..0xcde1ee
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde1ae..0xcde1c7
+            - Range: 0xcde1ee..0xcde207
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcde1e0..0xcde25e]
+      OutOfLinePCRanges: [0xcde220..0xcde29e]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 104 BaseType int16
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 10 BaseType int32
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 12 BaseType int64
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xcde1e0..0xcde251
+            - Range: 0xcde220..0xcde291
               Pieces: []
-            - Range: 0xcde251..0xcde252
+            - Range: 0xcde291..0xcde292
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde252..0xcde25e
+            - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcde260..0xcde357]
+      OutOfLinePCRanges: [0xcde2a0..0xcde397]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde260..0xcde357, Pieces: []}]
+          Locations: [{Range: 0xcde2a0..0xcde397, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcde260..0xcde347
+            - Range: 0xcde2a0..0xcde387
               Pieces: []
-            - Range: 0xcde347..0xcde348
+            - Range: 0xcde387..0xcde388
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcde348..0xcde357
+            - Range: 0xcde388..0xcde397
               Pieces: []
           Role: Return
         - Name: bothArmAndAmd64
           Type: 15 BaseType float64
           Locations:
-            - Range: 0xcde260..0xcde347
+            - Range: 0xcde2a0..0xcde387
               Pieces: []
-            - Range: 0xcde347..0xcde348
+            - Range: 0xcde387..0xcde388
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcde348..0xcde357
+            - Range: 0xcde388..0xcde397
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcde360..0xcde3d3]
+      OutOfLinePCRanges: [0xcde3a0..0xcde413]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 96 BaseType complex64
-          Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
+          Locations: [{Range: 0xcde3a0..0xcde413, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 97 BaseType complex128
-          Locations: [{Range: 0xcde360..0xcde3d3, Pieces: []}]
+          Locations: [{Range: 0xcde3a0..0xcde413, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcde3e0..0xcde485]
+      OutOfLinePCRanges: [0xcde420..0xcde4c5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcde3e0..0xcde473
+            - Range: 0xcde420..0xcde4b3
               Pieces: []
-            - Range: 0xcde473..0xcde474
+            - Range: 0xcde4b3..0xcde4b4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcde474..0xcde485
+            - Range: 0xcde4b4..0xcde4c5
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcde4a0..0xcde51a]
+      OutOfLinePCRanges: [0xcde4e0..0xcde55a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcde4a0..0xcde50d
+            - Range: 0xcde4e0..0xcde54d
               Pieces: []
-            - Range: 0xcde50d..0xcde50e
+            - Range: 0xcde54d..0xcde54e
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde50e..0xcde51a
+            - Range: 0xcde54e..0xcde55a
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcde520..0xcde578]
+      OutOfLinePCRanges: [0xcde560..0xcde5b8]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0xcde520..0xcde56b
+            - Range: 0xcde560..0xcde5ab
               Pieces: []
-            - Range: 0xcde56b..0xcde56c
+            - Range: 0xcde5ab..0xcde5ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde56c..0xcde578
+            - Range: 0xcde5ac..0xcde5b8
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcde580..0xcde5d3]
+      OutOfLinePCRanges: [0xcde5c0..0xcde613]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xcde580..0xcde5c6
+            - Range: 0xcde5c0..0xcde606
               Pieces: []
-            - Range: 0xcde5c6..0xcde5c7
+            - Range: 0xcde606..0xcde607
               Pieces: []
-            - Range: 0xcde5c7..0xcde5d3
+            - Range: 0xcde607..0xcde613
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcde5e0..0xcde647]
+      OutOfLinePCRanges: [0xcde620..0xcde687]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0xcde5e0..0xcde647, Pieces: []}]
+          Locations: [{Range: 0xcde620..0xcde687, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcde660..0xcde6fa]
+      OutOfLinePCRanges: [0xcde6a0..0xcde73a]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde660..0xcde6ea
+            - Range: 0xcde6a0..0xcde72a
               Pieces: []
-            - Range: 0xcde6ea..0xcde6eb
+            - Range: 0xcde72a..0xcde72b
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcde6eb..0xcde6fa
+            - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xcde700..0xcde7a5]
+      OutOfLinePCRanges: [0xcde740..0xcde7e5]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0xcde700..0xcde794
+            - Range: 0xcde740..0xcde7d4
               Pieces: []
-            - Range: 0xcde794..0xcde795
+            - Range: 0xcde7d4..0xcde7d5
               Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xcde795..0xcde7a5
+            - Range: 0xcde7d5..0xcde7e5
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xcde7c0..0xcde839]
+      OutOfLinePCRanges: [0xcde800..0xcde879]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde7c0..0xcde82c
+            - Range: 0xcde800..0xcde86c
               Pieces: []
-            - Range: 0xcde82c..0xcde82d
+            - Range: 0xcde86c..0xcde86d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde82d..0xcde839
+            - Range: 0xcde86d..0xcde879
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
+          Locations: [{Range: 0xcde800..0xcde879, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcde7c0..0xcde82c
+            - Range: 0xcde800..0xcde86c
               Pieces: []
-            - Range: 0xcde82c..0xcde82d
+            - Range: 0xcde86c..0xcde86d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde82d..0xcde839
+            - Range: 0xcde86d..0xcde879
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde7c0..0xcde839, Pieces: []}]
+          Locations: [{Range: 0xcde800..0xcde879, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcde7c0..0xcde82c
+            - Range: 0xcde800..0xcde86c
               Pieces: []
-            - Range: 0xcde82c..0xcde82d
+            - Range: 0xcde86c..0xcde86d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xcde82d..0xcde839
+            - Range: 0xcde86d..0xcde879
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xcde840..0xcde8ba]
+      OutOfLinePCRanges: [0xcde880..0xcde8fa]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcde840..0xcde8ad
+            - Range: 0xcde880..0xcde8ed
               Pieces: []
-            - Range: 0xcde8ad..0xcde8ae
+            - Range: 0xcde8ed..0xcde8ee
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcde8ae..0xcde8ba
+            - Range: 0xcde8ee..0xcde8fa
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xcde8c0..0xcde91b]
+      OutOfLinePCRanges: [0xcde900..0xcde95b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde8c0..0xcde91b, Pieces: []}]
+          Locations: [{Range: 0xcde900..0xcde95b, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xcde920..0xcde987]
+      OutOfLinePCRanges: [0xcde960..0xcde9c7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
+          Locations: [{Range: 0xcde960..0xcde9c7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 15 BaseType float64
-          Locations: [{Range: 0xcde920..0xcde987, Pieces: []}]
+          Locations: [{Range: 0xcde960..0xcde9c7, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xcde9a0..0xcde9fd]
+      OutOfLinePCRanges: [0xcde9e0..0xcdea3d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xcde9a0..0xcde9f0
+            - Range: 0xcde9e0..0xcdea30
               Pieces: []
-            - Range: 0xcde9f0..0xcde9f1
+            - Range: 0xcdea30..0xcdea31
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcde9f1..0xcde9fd
+            - Range: 0xcdea31..0xcdea3d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xcde9a0..0xcde9f0
+            - Range: 0xcde9e0..0xcdea30
               Pieces: []
-            - Range: 0xcde9f0..0xcde9f1
+            - Range: 0xcdea30..0xcdea31
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcde9f1..0xcde9fd
+            - Range: 0xcdea31..0xcdea3d
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcdea00..0xcdeb85]
+      OutOfLinePCRanges: [0xcdea40..0xcdebc5]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdea00..0xcdeb85
+            - Range: 0xcdea40..0xcdebc5
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdea00..0xcdeb73
+            - Range: 0xcdea40..0xcdebb3
               Pieces: []
-            - Range: 0xcdeb73..0xcdeb74
+            - Range: 0xcdebb3..0xcdebb4
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xcdeb74..0xcdeb85
+            - Range: 0xcdebb4..0xcdebc5
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xcdeba0..0xcdec72]
+      OutOfLinePCRanges: [0xcdebe0..0xcdecb2]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdeba0..0xcdec72
+            - Range: 0xcdebe0..0xcdecb2
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdeba0..0xcdec62
+            - Range: 0xcdebe0..0xcdeca2
               Pieces: []
-            - Range: 0xcdec62..0xcdec63
+            - Range: 0xcdeca2..0xcdeca3
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdec63..0xcdec72
+            - Range: 0xcdeca3..0xcdecb2
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xcdec80..0xcdeeba]
+      OutOfLinePCRanges: [0xcdecc0..0xcdeefa]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdec80..0xcdeeba
+            - Range: 0xcdecc0..0xcdeefa
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdec80..0xcdeeba
+            - Range: 0xcdecc0..0xcdeefa
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdec80..0xcdeeaa
+            - Range: 0xcdecc0..0xcdeeea
               Pieces: []
-            - Range: 0xcdeeaa..0xcdeeab
+            - Range: 0xcdeeea..0xcdeeeb
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xcdeeab..0xcdeeba
+            - Range: 0xcdeeeb..0xcdeefa
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xcdeec0..0xcdf14f]
+      OutOfLinePCRanges: [0xcdef00..0xcdf18f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef5a
+            - Range: 0xcdef00..0xcdef9a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdef5a..0xcdf14f
+            - Range: 0xcdef9a..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef30
+            - Range: 0xcdef00..0xcdef70
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdef30..0xcdf14f
+            - Range: 0xcdef70..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdeec0..0xcdef70
+            - Range: 0xcdef00..0xcdefb0
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xcdef70..0xcdf14f
+            - Range: 0xcdefb0..0xcdf18f
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdeec0..0xcdf0e2
+            - Range: 0xcdef00..0xcdf122
               Pieces: []
-            - Range: 0xcdf0e2..0xcdf0e3
+            - Range: 0xcdf122..0xcdf123
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf0e3..0xcdf14f
+            - Range: 0xcdf123..0xcdf18f
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xcdf160..0xcdf42c]
+      OutOfLinePCRanges: [0xcdf1a0..0xcdf46c]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf1f5
+            - Range: 0xcdf1a0..0xcdf235
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf1f5..0xcdf42c
+            - Range: 0xcdf235..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf1c2
+            - Range: 0xcdf1a0..0xcdf202
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcdf1c2..0xcdf42c
+            - Range: 0xcdf202..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf160..0xcdf20b
+            - Range: 0xcdf1a0..0xcdf24b
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcdf20b..0xcdf42c
+            - Range: 0xcdf24b..0xcdf46c
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcdf160..0xcdf42c
+            - Range: 0xcdf1a0..0xcdf46c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6960,210 +7004,176 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0xcdf160..0xcdf3ab
+            - Range: 0xcdf1a0..0xcdf3eb
               Pieces: []
-            - Range: 0xcdf3ab..0xcdf3ac
+            - Range: 0xcdf3eb..0xcdf3ec
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xcdf3ac..0xcdf42c
+            - Range: 0xcdf3ec..0xcdf46c
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xcdf440..0xcdf4cc]
+      OutOfLinePCRanges: [0xcdf480..0xcdf50c]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0xcdf440..0xcdf4cc
+            - Range: 0xcdf480..0xcdf50c
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf440..0xcdf4bc
+            - Range: 0xcdf480..0xcdf4fc
               Pieces: []
-            - Range: 0xcdf4bc..0xcdf4bd
+            - Range: 0xcdf4fc..0xcdf4fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf4bd..0xcdf4cc
+            - Range: 0xcdf4fd..0xcdf50c
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf440..0xcdf4bc
+            - Range: 0xcdf480..0xcdf4fc
               Pieces: []
-            - Range: 0xcdf4bc..0xcdf4bd
+            - Range: 0xcdf4fc..0xcdf4fd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcdf4bd..0xcdf4cc
+            - Range: 0xcdf4fd..0xcdf50c
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf440..0xcdf4bc
+            - Range: 0xcdf480..0xcdf4fc
               Pieces: []
-            - Range: 0xcdf4bc..0xcdf4bd
+            - Range: 0xcdf4fc..0xcdf4fd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcdf4bd..0xcdf4cc
+            - Range: 0xcdf4fd..0xcdf50c
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xcdf4e0..0xcdf5cf]
+      OutOfLinePCRanges: [0xcdf520..0xcdf60f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdf4e0..0xcdf5cf
+            - Range: 0xcdf520..0xcdf60f
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0xcdf4e0..0xcdf5cf
+            - Range: 0xcdf520..0xcdf60f
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf4e0..0xcdf5bf
+            - Range: 0xcdf520..0xcdf5ff
               Pieces: []
-            - Range: 0xcdf5bf..0xcdf5c0
+            - Range: 0xcdf5ff..0xcdf600
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf5c0..0xcdf5cf
+            - Range: 0xcdf600..0xcdf60f
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0xcdf4e0..0xcdf5bf
+            - Range: 0xcdf520..0xcdf5ff
               Pieces: []
-            - Range: 0xcdf5bf..0xcdf5c0
+            - Range: 0xcdf5ff..0xcdf600
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xcdf5c0..0xcdf5cf
+            - Range: 0xcdf600..0xcdf60f
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xcdf5e0..0xcdf6ac]
+      OutOfLinePCRanges: [0xcdf620..0xcdf6ec]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf5e0..0xcdf6ac
+            - Range: 0xcdf620..0xcdf6ec
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf5e0..0xcdf69c
+            - Range: 0xcdf620..0xcdf6dc
               Pieces: []
-            - Range: 0xcdf69c..0xcdf69d
+            - Range: 0xcdf6dc..0xcdf6dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf69d..0xcdf6ac
+            - Range: 0xcdf6dd..0xcdf6ec
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0xcdf5e0..0xcdf69c
+            - Range: 0xcdf620..0xcdf6dc
               Pieces: []
-            - Range: 0xcdf69c..0xcdf69d
+            - Range: 0xcdf6dc..0xcdf6dd
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xcdf69d..0xcdf6ac
+            - Range: 0xcdf6dd..0xcdf6ec
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf666..0xcdf6ac
+            - Range: 0xcdf6a6..0xcdf6ec
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xcdf6c0..0xcdf766]
+      OutOfLinePCRanges: [0xcdf700..0xcdf7a6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0xcdf6c0..0xcdf766, Pieces: []}]
+          Locations: [{Range: 0xcdf700..0xcdf7a6, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf6c0..0xcdf705
+            - Range: 0xcdf700..0xcdf745
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf705..0xcdf727
+            - Range: 0xcdf745..0xcdf767
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcdf727..0xcdf73a
+            - Range: 0xcdf767..0xcdf77a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xcdf73a..0xcdf766
+            - Range: 0xcdf77a..0xcdf7a6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xcdf6c0..0xcdf74c
+            - Range: 0xcdf700..0xcdf78c
               Pieces: []
-            - Range: 0xcdf74c..0xcdf74d
+            - Range: 0xcdf78c..0xcdf78d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcdf74d..0xcdf766
+            - Range: 0xcdf78d..0xcdf7a6
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0xcdf6c0..0xcdf74c
+            - Range: 0xcdf700..0xcdf78c
               Pieces: []
-            - Range: 0xcdf74c..0xcdf74d
+            - Range: 0xcdf78c..0xcdf78d
               Pieces: []
-            - Range: 0xcdf74d..0xcdf766
+            - Range: 0xcdf78d..0xcdf7a6
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcdfc40..0xcdfc41]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdfc40..0xcdfc41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcdfc60..0xcdfc61]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdfc60..0xcdfc61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 130
-      Name: main.testSliceOfSlices
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdfc80..0xcdfc81
               Pieces:
@@ -7174,13 +7184,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
+    - ID: 130
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcdfca0..0xcdfca1
               Pieces:
@@ -7191,19 +7201,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdfca0..0xcdfca1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcdfcc0..0xcdfcc1
               Pieces:
@@ -7214,14 +7218,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcdfcc0..0xcdfcc1
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
+    - ID: 132
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
       InlinePCRanges: []
       Variables:
@@ -7243,13 +7241,13 @@ Subprograms:
             - Range: 0xcdfce0..0xcdfce1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 263 GoSliceHeaderType []string
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcdfd00..0xcdfd01
               Pieces:
@@ -7260,21 +7258,67 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdfd00..0xcdfd01
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdfd20..0xcdfd21]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcdfd20..0xcdfd21
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcdfd20..0xcdfd21
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 263 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcdfd40..0xcdfd41
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xcdfd20..0xcdfd21
+            - Range: 0xcdfd60..0xcdfd61
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcdfd20..0xcdfd21
+            - Range: 0xcdfd60..0xcdfd61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7286,50 +7330,16 @@ Subprograms:
         - Name: x
           Type: 17 BaseType uint
           Locations:
-            - Range: 0xcdfd20..0xcdfd21
+            - Range: 0xcdfd60..0xcdfd61
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 265 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcdfd40..0xcdfd41
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcdfd60..0xcdfd61
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 138
-      Name: main.testSliceEmptyStructs
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdfd80..0xcdfd81]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 265 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcdfd80..0xcdfd81
               Pieces:
@@ -7340,15 +7350,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
-      Name: main.testSubslices
+    - ID: 138
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdfda0..0xcdfda1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 257 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcdfda0..0xcdfda1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcdfdc0..0xcdfdc1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcdfdc0..0xcdfdc1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcdfde0..0xcdfde1]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfda0..0xcdfda1
+            - Range: 0xcdfde0..0xcdfde1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7360,7 +7404,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfda0..0xcdfda1
+            - Range: 0xcdfde0..0xcdfde1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7372,7 +7416,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcdfda0..0xcdfda1
+            - Range: 0xcdfde0..0xcdfde1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7381,49 +7425,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0xce0140..0xce0192]
+      OutOfLinePCRanges: [0xce0180..0xce01d2]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce0140..0xce0185
+            - Range: 0xce0180..0xce01c5
               Pieces: []
-            - Range: 0xce0185..0xce0186
+            - Range: 0xce01c5..0xce01c6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce0186..0xce0192
+            - Range: 0xce01c6..0xce01d2
               Pieces: []
           Role: Return
-    - ID: 141
+    - ID: 142
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xce01a0..0xce01a1]
+      OutOfLinePCRanges: [0xce01e0..0xce01e1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01a0..0xce01a1
+            - Range: 0xce01e0..0xce01e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xce01c0..0xce01c1]
+      OutOfLinePCRanges: [0xce0200..0xce0201]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01c0..0xce01c1
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7433,7 +7477,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01c0..0xce01c1
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7443,22 +7487,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce01c0..0xce01c1
+            - Range: 0xce0200..0xce0201
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xce01e0..0xce01ff]
+      OutOfLinePCRanges: [0xce0220..0xce023f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 268 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xce01e0..0xce01ff
+            - Range: 0xce0220..0xce023f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7473,60 +7517,30 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xce0200..0xce0201]
+      OutOfLinePCRanges: [0xce0240..0xce0241]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 269 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xce0200..0xce0201
+            - Range: 0xce0240..0xce0241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xce0220..0xce0221]
+      OutOfLinePCRanges: [0xce0260..0xce0261]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xce0220..0xce0221
+            - Range: 0xce0260..0xce0261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xce0240..0xce0241]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xce0240..0xce0241
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xce0260..0xce0261]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xce0260..0xce0261
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xce0280..0xce0281]
       InlinePCRanges: []
       Variables:
@@ -7540,15 +7554,45 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
-      Name: main.testSubstrings
+    - ID: 148
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xce02a0..0xce02a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce02a0..0xce02a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xce02c0..0xce02c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce02c0..0xce02c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 150
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xce02e0..0xce02e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02a0..0xce02a1
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7558,7 +7602,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02a0..0xce02a1
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7568,33 +7612,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xce02a0..0xce02a1
+            - Range: 0xce02e0..0xce02e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xce0420..0xce0421]
+      OutOfLinePCRanges: [0xce0460..0xce0461]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xce0420..0xce0421
+            - Range: 0xce0460..0xce0461
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xce0440..0xce045f]
+      OutOfLinePCRanges: [0xce0480..0xce049f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xce0440..0xce045f
+            - Range: 0xce0480..0xce049f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7609,15 +7653,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0xce0580..0xce05a3]
+      OutOfLinePCRanges: [0xce05c0..0xce05e3]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0xce0580..0xce05a3
+            - Range: 0xce05c0..0xce05e3
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7634,38 +7678,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xce0680..0xce0681]
+      OutOfLinePCRanges: [0xce06c0..0xce06c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xce0680..0xce0681
+            - Range: 0xce06c0..0xce06c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xce0700..0xce0701]
+      OutOfLinePCRanges: [0xce0740..0xce0741]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0xce0700..0xce0701, Pieces: []}]
+          Locations: [{Range: 0xce0740..0xce0741, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xce0720..0xce0721]
+      OutOfLinePCRanges: [0xce0760..0xce0761]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xce0720..0xce0721
+            - Range: 0xce0760..0xce0761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda200..0xcda262]
       InlinePCRanges:
@@ -7694,28 +7738,28 @@ Subprograms:
             - Range: 0xcda520..0xcda53a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda4a6..0xcda4de]
           RootRanges: [0xcda440..0xcda505]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda5b3..0xcda5f1]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda65b..0xcda693]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7728,7 +7772,7 @@ Subprograms:
             - Range: 0xcda6c0..0xcda6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11070,10 +11114,10 @@ Types:
       GoKind: 22
       Pointee: 823 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11085,7 +11129,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11173,7 +11217,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11185,7 +11229,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11195,11 +11239,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11211,7 +11255,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11371,6 +11415,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1359
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11452,7 +11538,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11464,7 +11550,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11474,7 +11560,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11544,7 +11630,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11556,7 +11642,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11566,7 +11652,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11726,7 +11812,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11738,7 +11824,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11748,7 +11834,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11758,7 +11844,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11768,11 +11854,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11784,7 +11870,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11794,11 +11880,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11810,7 +11896,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11820,11 +11906,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1548
+      ID: 1550
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11836,7 +11922,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11846,11 +11932,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1549
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11862,7 +11948,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11872,7 +11958,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12138,7 +12224,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1554
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12190,16 +12276,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1556
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1555
+      ID: 1557
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1556
+      ID: 1558
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12208,7 +12294,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1551
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12220,7 +12306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12230,11 +12316,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12246,7 +12332,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12256,14 +12342,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1552
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1559
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12275,7 +12361,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12285,11 +12371,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1560
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12301,7 +12387,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12311,11 +12397,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1561
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12327,7 +12413,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12337,7 +12423,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12497,7 +12583,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12509,7 +12595,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12519,11 +12605,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12535,11 +12621,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12551,7 +12637,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12561,7 +12647,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12620,7 +12706,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12632,7 +12718,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12642,7 +12728,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12652,7 +12738,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12662,7 +12748,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12672,7 +12758,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12682,7 +12768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12692,7 +12778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12702,7 +12788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12712,7 +12798,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12722,7 +12808,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12732,7 +12818,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12742,7 +12828,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12752,7 +12838,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12762,7 +12848,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12772,7 +12858,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12782,7 +12868,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12792,7 +12878,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12802,11 +12888,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12818,7 +12904,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13342,7 +13428,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13354,7 +13440,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13364,11 +13450,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13380,7 +13466,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13390,11 +13476,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13406,7 +13492,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13416,7 +13502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13426,7 +13512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13436,7 +13522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13446,7 +13532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13456,7 +13542,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13466,7 +13552,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13476,7 +13562,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13486,7 +13572,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13496,7 +13582,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13506,7 +13592,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13516,7 +13602,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13526,7 +13612,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13536,7 +13622,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13546,7 +13632,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13556,7 +13642,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13566,7 +13652,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13576,11 +13662,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13592,11 +13678,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13608,7 +13694,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13618,7 +13704,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13628,7 +13714,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13638,11 +13724,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13654,7 +13740,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13664,11 +13750,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13680,7 +13766,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13690,7 +13776,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13700,7 +13786,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13710,11 +13796,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13726,11 +13812,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13742,7 +13828,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13752,11 +13838,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13768,7 +13854,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13778,7 +13864,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13788,7 +13874,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13798,23 +13884,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13830,7 +13900,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13846,11 +13916,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1459
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13862,7 +13948,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13872,11 +13958,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13888,7 +13974,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13898,7 +13984,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13908,7 +13994,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13918,7 +14004,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13928,7 +14014,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13938,33 +14024,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13980,7 +14040,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13990,7 +14050,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14006,7 +14066,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14016,7 +14076,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14126,32 +14212,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14164,7 +14224,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14174,11 +14234,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1449
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14190,11 +14276,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14206,7 +14292,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14216,11 +14302,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14232,7 +14318,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14242,11 +14328,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14258,7 +14344,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14268,10 +14354,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1545
+      ID: 1547
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1548
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14283,7 +14369,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14293,7 +14379,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14305,7 +14391,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14315,7 +14401,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14325,7 +14411,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14335,11 +14421,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14351,7 +14437,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14361,7 +14447,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14371,7 +14457,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14381,11 +14467,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14397,7 +14483,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14407,7 +14493,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14417,7 +14503,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14427,7 +14513,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14437,7 +14523,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14447,11 +14533,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14463,7 +14549,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14473,11 +14559,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14489,7 +14575,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14499,11 +14585,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14515,7 +14601,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14525,7 +14611,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14555,7 +14641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14567,7 +14653,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14577,11 +14663,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14593,7 +14679,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14603,7 +14689,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14613,7 +14699,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14623,11 +14709,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14639,7 +14725,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14649,446 +14735,12 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1441
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1442
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 252 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1469
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1477
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1489
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1490
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1465
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1466
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 96 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 97 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 15 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1443
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15114,6 +14766,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1444
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1446
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15125,14 +15211,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15144,14 +15230,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15163,7 +15249,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15173,7 +15259,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15183,7 +15269,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15193,7 +15279,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15203,7 +15289,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15213,7 +15299,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15223,7 +15309,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15233,7 +15319,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15243,7 +15329,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15253,7 +15339,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15263,7 +15349,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15273,7 +15359,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15283,7 +15369,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15293,7 +15379,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15303,7 +15389,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15313,7 +15399,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15323,14 +15409,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15342,14 +15428,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15361,7 +15447,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15371,7 +15457,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15381,7 +15467,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15391,7 +15477,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15401,14 +15487,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15420,7 +15506,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15430,14 +15516,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15449,14 +15535,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15468,7 +15554,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15478,7 +15564,7 @@ Types:
             Type: 104 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15488,7 +15574,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15498,7 +15584,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15508,7 +15594,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15518,7 +15604,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15528,7 +15614,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15538,14 +15624,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15557,14 +15643,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15576,7 +15662,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15886,7 +15972,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15898,7 +15984,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15908,7 +15994,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16042,7 +16128,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16054,7 +16140,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16064,11 +16150,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16080,7 +16166,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16090,7 +16176,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16120,7 +16206,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16132,7 +16218,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16142,11 +16228,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16158,7 +16244,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16168,7 +16254,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16178,11 +16264,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16194,7 +16280,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16204,11 +16290,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16220,7 +16306,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16230,7 +16316,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16240,7 +16326,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16270,7 +16356,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16282,7 +16368,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16292,11 +16378,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16308,7 +16394,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16318,7 +16404,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16374,7 +16460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16386,7 +16472,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16396,7 +16482,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16406,7 +16492,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16416,7 +16502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16446,7 +16532,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16458,7 +16544,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16468,11 +16554,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16484,7 +16570,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16494,11 +16580,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16510,7 +16596,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16520,14 +16606,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16539,7 +16625,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16549,7 +16635,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16579,7 +16665,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16591,7 +16677,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16601,14 +16687,14 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16620,7 +16706,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16630,7 +16716,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16640,7 +16726,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16650,7 +16736,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16660,7 +16746,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16670,11 +16756,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16686,7 +16772,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16696,7 +16782,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16706,7 +16792,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16716,7 +16802,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16726,7 +16812,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16736,11 +16822,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16752,7 +16838,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16762,11 +16848,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16778,7 +16864,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16791,7 +16877,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16804,14 +16890,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16823,7 +16909,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16833,11 +16919,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16849,7 +16935,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16859,7 +16945,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16869,17 +16955,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1527
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1529
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1531
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1527
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16891,7 +16977,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16901,7 +16987,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16911,7 +16997,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16921,7 +17007,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16931,7 +17017,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16941,7 +17027,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17101,7 +17187,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17113,7 +17199,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17123,11 +17209,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17139,7 +17225,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17149,11 +17235,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17165,7 +17251,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17175,11 +17261,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17191,7 +17277,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17201,7 +17287,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17231,7 +17317,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17243,7 +17329,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17253,11 +17339,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17269,7 +17355,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17279,11 +17365,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17295,7 +17381,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17305,7 +17391,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17315,7 +17401,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17325,11 +17411,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17341,7 +17427,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17351,7 +17437,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26019,7 +26105,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1559
+MaxTypeID: 1561
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0xcec48a", Frameless: false}]
+          Type: 1524 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0xcec4ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0xcec4c5", Frameless: false}]
+          Type: 1525 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0xcec505", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0xceaeae", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0xceaeee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0xceaf6a", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0xceafaa", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0xce9380", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0xce9392", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -289,11 +314,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0xce9380", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0xce93a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -349,11 +374,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0xce9720", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0xce9760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -496,11 +521,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0xcebfe0", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0xcec020", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -522,11 +547,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0xcec040", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0xcec080", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -549,11 +574,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0xcec600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -570,11 +595,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0xceca00", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0xceca40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -590,11 +615,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0xceca20", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0xceca60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -841,10 +866,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedBBB]
+          Type: 1550 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xce6806", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -879,10 +904,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testInlinedBCA]
+          Type: 1551 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -899,10 +924,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1552 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -916,10 +941,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedBCB]
+          Type: 1553 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -936,10 +961,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1552 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1554 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -954,10 +979,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testInlinedPrint]
+          Type: 1547 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xce656a"
               Frameless: false
@@ -971,7 +996,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1548 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xce65aa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -992,10 +1017,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1549 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xce656e"
               Frameless: false
@@ -1023,10 +1048,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedSq]
+          Type: 1555 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1047,10 +1072,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1556 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1069,10 +1094,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1557 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xce6a6d"
               Frameless: false
@@ -1219,15 +1244,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0xcead2e", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0xcead6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xceae8d", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xceaecd", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1244,11 +1269,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0xce9540", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0xce9580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1352,15 +1377,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0xceb1d3", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0xceb213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0xceb402", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0xceb442", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1843,11 +1868,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1865,11 +1890,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1911,15 +1936,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0xceb493", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0xceb4d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0xceb6c2", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0xceb702", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1980,15 +2005,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0xceb80e", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0xceb84e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0xceb8dd", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0xceb91d", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2014,15 +2039,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0xceaf8e", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0xceafce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0xceb1ab", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0xceb1eb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2043,15 +2068,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea32e", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea3cf", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2122,15 +2147,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcea28a", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea2fb", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2152,15 +2177,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0xcea28a", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea2fb", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2183,11 +2208,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec980", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2207,11 +2232,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec980", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2237,11 +2262,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec980", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2261,11 +2286,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0xcec980", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2287,11 +2312,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0xce9720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2313,11 +2338,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0xcec0c0", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0xcec100", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2339,11 +2364,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0xcec060", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0xcec0a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2373,11 +2398,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0xcec0a0", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2404,11 +2429,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0xcec560", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2425,11 +2450,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0xce9560", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2467,11 +2492,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0xce9520", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0xce9560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2488,22 +2513,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0xce9f2e", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0xce9f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0xce9fd5"
+            - PC: "0xcea015"
               Frameless: false
-            - PC: "0xcea024"
+            - PC: "0xcea064"
               Frameless: false
-            - PC: "0xcea0ef"
+            - PC: "0xcea12f"
               Frameless: false
-            - PC: "0xcea0f9"
+            - PC: "0xcea139"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2526,22 +2551,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0xce9dce", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0xce9e0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0xce9e24"
-              Frameless: false
-            - PC: "0xce9e73"
+            - PC: "0xce9e64"
               Frameless: false
             - PC: "0xce9eb3"
               Frameless: false
-            - PC: "0xce9eef"
+            - PC: "0xce9ef3"
+              Frameless: false
+            - PC: "0xce9f2f"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2563,15 +2588,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0xcea7aa", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0xcea7ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0xcea80f", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0xcea84f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2583,15 +2608,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0xcea82a", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0xcea86a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0xcea86b", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0xcea8ab", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2603,15 +2628,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0xcea88a", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0xcea8ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0xcea8c6", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0xcea906", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2623,15 +2648,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0xcea96e", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0xcea9ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0xcea9ea", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0xceaa2a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2643,15 +2668,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0xceacca", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0xcead0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0xcead10", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0xcead50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2663,15 +2688,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0xcea66a", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0xcea6aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0xcea6c6", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0xcea706", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2684,18 +2709,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0xce9d4a", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0xce9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsError]Return
+          Type: 1440 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0xce9d84"
+            - PC: "0xce9dc4"
               Frameless: false
-            - PC: "0xce9d8e"
+            - PC: "0xce9dce"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2712,15 +2737,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0xce9b4a", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0xce9b8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0xce9b9b", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0xce9bdb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2736,15 +2761,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0xce9c6e", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0xce9cae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0xce9d25", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0xce9d65", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2760,15 +2785,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0xce9bca", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0xce9c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0xce9c34", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0xce9c74", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2785,18 +2810,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0xcea12e", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0xcea16e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0xcea1fd"
+            - PC: "0xcea23d"
               Frameless: false
-            - PC: "0xcea207"
+            - PC: "0xcea247"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2813,15 +2838,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0xcea6ee", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0xcea72e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0xcea783", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0xcea7c3", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2833,15 +2858,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0xcea56e", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0xcea5ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0xcea647", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0xcea687", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2853,15 +2878,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0xceaaea", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0xceab2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0xceab4c", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0xceab8c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2873,15 +2898,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0xcea8ea", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0xcea92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0xcea938", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0xcea978", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2893,15 +2918,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0xceac4a", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0xceac8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0xceac96", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0xceacd6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2913,15 +2938,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0xceabea", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0xceac2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0xceac2e", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0xceac6e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2933,15 +2958,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0xcea4ea", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0xcea52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0xcea551", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0xcea591", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2953,15 +2978,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0xceab6a", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0xceabaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0xceabcf", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0xceac0f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2973,15 +2998,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0xceaa0e", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0xceaa4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0xceaab2", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0xceaaf2", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3028,15 +3053,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea32e", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea3cf", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3304,11 +3329,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0xcec4e0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0xcec520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3430,11 +3455,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0xcec100", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0xcec140", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3451,11 +3476,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0xcec000", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0xcec040", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3492,15 +3517,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0xcea40e", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0xcea44e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea4ad", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea4ed", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3516,15 +3541,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0xceb76a", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0xceb7aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0xceb7de", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0xceb81e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3562,11 +3587,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0xce96a0", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3583,11 +3608,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0xcec080", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0xcec0c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3646,11 +3671,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0xcec8c0", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcec900", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3672,11 +3697,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0xcec020", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0xcec060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3718,15 +3743,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0xceb90e", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0xceb94e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0xceb9c4", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0xceba04", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3768,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0xcec780", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0xcec7c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3763,11 +3788,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0xcec760", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0xcec7a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3820,11 +3845,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0xcec120", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0xcec160", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3859,11 +3884,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0xcec620", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3891,15 +3916,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea32e", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea3cf", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3915,15 +3940,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea32e", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea3cf", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3941,15 +3966,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0xcea32e", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0xcea3cf", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3973,11 +3998,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0xcec500", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0xcec540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4004,11 +4029,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcec520", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4033,11 +4058,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0xcec520", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4064,11 +4089,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcec540", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4093,11 +4118,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0xcec540", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4250,11 +4275,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0xce9600", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4271,11 +4296,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0xcebfc0", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0xcec000", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4292,11 +4317,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4313,11 +4338,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0xce9580", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4355,11 +4380,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4376,11 +4401,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4401,15 +4426,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0xceb9ee", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0xceba2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0xceba6c", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0xcebaac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5599,275 +5624,288 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0xce9380..0xce9393]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xce9380..0xce9392
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xce9380..0xce9392
+              Pieces: []
+            - Range: 0xce9392..0xce9393
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0xce9380..0xce9381]
+      OutOfLinePCRanges: [0xce93a0..0xce93a1]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0xce9380..0xce9381
+            - Range: 0xce93a0..0xce93a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0xce9520..0xce9521]
+      OutOfLinePCRanges: [0xce9560..0xce9561]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0xce9520..0xce9521
+            - Range: 0xce9560..0xce9561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0xce9540..0xce9541]
+      OutOfLinePCRanges: [0xce9580..0xce9581]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0xce9540..0xce9541
+            - Range: 0xce9580..0xce9581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0xce9560..0xce9561]
+      OutOfLinePCRanges: [0xce95a0..0xce95a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0xce9560..0xce9561
+            - Range: 0xce95a0..0xce95a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0xce9580..0xce9581]
+      OutOfLinePCRanges: [0xce95c0..0xce95c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0xce9580..0xce9581
+            - Range: 0xce95c0..0xce95c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0xce95c0..0xce95c1]
+      OutOfLinePCRanges: [0xce9600..0xce9601]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0xce95c0..0xce95c1
+            - Range: 0xce9600..0xce9601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0xce96a0..0xce96a1]
+      OutOfLinePCRanges: [0xce96e0..0xce96e1]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0xce96a0..0xce96a1
+            - Range: 0xce96e0..0xce96e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0xce96e0..0xce96e1]
+      OutOfLinePCRanges: [0xce9720..0xce9721]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0xce96e0..0xce96e1
+            - Range: 0xce9720..0xce9721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xce96e0..0xce96e1
+            - Range: 0xce9720..0xce9721
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0xce9720..0xce9721]
+      OutOfLinePCRanges: [0xce9760..0xce9761]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0xce9720..0xce9721
+            - Range: 0xce9760..0xce9761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0xce9b40..0xce9bb2]
+      OutOfLinePCRanges: [0xce9b80..0xce9bf2]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b40..0xce9b52
+            - Range: 0xce9b80..0xce9b92
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b40..0xce9b9b
+            - Range: 0xce9b80..0xce9bdb
               Pieces: []
-            - Range: 0xce9b9b..0xce9b9c
+            - Range: 0xce9bdb..0xce9bdc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9b9c..0xce9bb2
+            - Range: 0xce9bdc..0xce9bf2
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9b52..0xce9b65
+            - Range: 0xce9b92..0xce9ba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9b65..0xce9bb2
+            - Range: 0xce9ba5..0xce9bf2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0xce9bc0..0xce9c4f]
+      OutOfLinePCRanges: [0xce9c00..0xce9c8f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9bc0..0xce9bda
+            - Range: 0xce9c00..0xce9c1a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9bda..0xce9c4f
+            - Range: 0xce9c1a..0xce9c8f
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xce9bc0..0xce9c34
+            - Range: 0xce9c00..0xce9c74
               Pieces: []
-            - Range: 0xce9c34..0xce9c35
+            - Range: 0xce9c74..0xce9c75
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9c35..0xce9c4f
+            - Range: 0xce9c75..0xce9c8f
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 104 PointerType *int
           Locations:
-            - Range: 0xce9bdf..0xce9bf9
+            - Range: 0xce9c1f..0xce9c39
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9bf9..0xce9c4f
+            - Range: 0xce9c39..0xce9c8f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0xce9c60..0xce9d3f]
+      OutOfLinePCRanges: [0xce9ca0..0xce9d7f]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9c60..0xce9cc3
+            - Range: 0xce9ca0..0xce9d03
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9c60..0xce9d25
+            - Range: 0xce9ca0..0xce9d65
               Pieces: []
-            - Range: 0xce9d25..0xce9d26
+            - Range: 0xce9d65..0xce9d66
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xce9d26..0xce9d3f
+            - Range: 0xce9d66..0xce9d7f
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xce9c60..0xce9d3f, Pieces: []}]
+          Locations: [{Range: 0xce9ca0..0xce9d7f, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0xce9c76..0xce9cc8
+            - Range: 0xce9cb6..0xce9d08
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xce9cc8..0xce9d3f
+            - Range: 0xce9d08..0xce9d7f
               Pieces: [{Size: 8, Op: {CfaOffset: -80}}]
           Role: Local
         - Name: resultFloat
           Type: 13 BaseType float64
           Locations:
-            - Range: 0xce9c8f..0xce9cc8
+            - Range: 0xce9ccf..0xce9d08
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
-            - Range: 0xce9cc8..0xce9d3f
+            - Range: 0xce9d08..0xce9d7f
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0xce9d40..0xce9da4]
+      OutOfLinePCRanges: [0xce9d80..0xce9de4]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xce9d40..0xce9d57
+            - Range: 0xce9d80..0xce9d97
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xce9d40..0xce9d84
+            - Range: 0xce9d80..0xce9dc4
               Pieces: []
-            - Range: 0xce9d84..0xce9d85
+            - Range: 0xce9dc4..0xce9dc5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9d85..0xce9d8e
+            - Range: 0xce9dc5..0xce9dce
               Pieces: []
-            - Range: 0xce9d8e..0xce9d8f
+            - Range: 0xce9dce..0xce9dcf
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9d8f..0xce9da4
+            - Range: 0xce9dcf..0xce9de4
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0xce9dc0..0xce9f1c]
+      OutOfLinePCRanges: [0xce9e00..0xce9f5c]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0xce9dc0..0xce9e0b
+            - Range: 0xce9e00..0xce9e4b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e0b..0xce9e16
+            - Range: 0xce9e4b..0xce9e56
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e47..0xce9e4a
-              Pieces:
-                - Size: 8
-                  Op: null
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e7e..0xce9e85
+            - Range: 0xce9e87..0xce9e8a
               Pieces:
                 - Size: 8
                   Op: null
@@ -5879,1060 +5917,1066 @@ Subprograms:
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: failed
-          Type: 4 BaseType bool
-          Locations:
-            - Range: 0xce9dc0..0xce9e16
-              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xce9dc0..0xce9e24
-              Pieces: []
-            - Range: 0xce9e24..0xce9e25
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e25..0xce9e73
-              Pieces: []
-            - Range: 0xce9e73..0xce9e74
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9e74..0xce9eb3
-              Pieces: []
-            - Range: 0xce9eb3..0xce9eb4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9eb4..0xce9eef
-              Pieces: []
-            - Range: 0xce9eef..0xce9ef0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9ef0..0xce9f1c
-              Pieces: []
-          Role: Return
-        - Name: ~r1
-          Type: 15 GoInterfaceType error
-          Locations:
-            - Range: 0xce9dc0..0xce9e24
-              Pieces: []
-            - Range: 0xce9e24..0xce9e25
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9e25..0xce9e73
-              Pieces: []
-            - Range: 0xce9e73..0xce9e74
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9e74..0xce9eb3
-              Pieces: []
-            - Range: 0xce9eb3..0xce9eb4
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9eb4..0xce9eef
-              Pieces: []
-            - Range: 0xce9eef..0xce9ef0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-            - Range: 0xce9ef0..0xce9f1c
-              Pieces: []
-          Role: Return
-        - Name: val
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce9e0b..0xce9e11
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
-    - ID: 99
-      Name: main.testReturnsAny
-      OutOfLinePCRanges: [0xce9f20..0xcea11d]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xce9f20..0xce9f6b
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9f6b..0xce9f72
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xce9f72..0xcea11d
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-          Role: Parameter
-        - Name: ~r0
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xce9f20..0xce9fd5
-              Pieces: []
-            - Range: 0xce9fd5..0xce9fd6
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xce9fd6..0xcea024
-              Pieces: []
-            - Range: 0xcea024..0xcea025
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea025..0xcea0ef
-              Pieces: []
-            - Range: 0xcea0ef..0xcea0f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea0f0..0xcea0f9
-              Pieces: []
-            - Range: 0xcea0f9..0xcea0fa
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea0fa..0xcea11d
-              Pieces: []
-          Role: Return
-        - Name: val
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xce9fc0..0xce9fc6
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
-        - Name: '&result'
-          Type: 104 PointerType *int
-          Locations:
-            - Range: 0xcea005..0xcea024
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Local
-    - ID: 100
-      Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0xcea120..0xcea274]
-      InlinePCRanges: []
-      Variables:
-        - Name: v
-          Type: 163 GoEmptyInterfaceType interface {}
-          Locations:
-            - Range: 0xcea120..0xcea160
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea160..0xcea1b0
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea1b0..0xcea20d
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea20d..0xcea231
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea231..0xcea238
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea238..0xcea274
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 168 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcea120..0xcea1fd
-              Pieces: []
-            - Range: 0xcea1fd..0xcea1fe
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea1fe..0xcea207
-              Pieces: []
-            - Range: 0xcea207..0xcea208
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea208..0xcea274
-              Pieces: []
-          Role: Return
-        - Name: b
-          Type: 168 GoInterfaceType main.behavior
-          Locations:
-            - Range: 0xcea120..0xcea160
+            - Range: 0xce9efe..0xce9f05
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcea160..0xcea1b0
+          Role: Parameter
+        - Name: failed
+          Type: 4 BaseType bool
+          Locations:
+            - Range: 0xce9e00..0xce9e56
+              Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xce9e00..0xce9e64
+              Pieces: []
+            - Range: 0xce9e64..0xce9e65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea1b0..0xcea1b7
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -56}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea1b7..0xcea203
-              Pieces:
-                - Size: 8
-                  Op: {CfaOffset: -56}
-                - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea203..0xcea205
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce9e65..0xce9eb3
+              Pieces: []
+            - Range: 0xce9eb3..0xce9eb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
-                  Op: {CfaOffset: 8}
-            - Range: 0xcea205..0xcea207
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea207..0xcea274
-              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
-          Role: Local
-    - ID: 101
-      Name: main.testNamedReturn
-      OutOfLinePCRanges: [0xcea280..0xcea315]
-      InlinePCRanges: []
-      Variables:
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea280..0xcea291
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: result
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea280..0xcea2fb
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce9eb4..0xce9ef3
               Pieces: []
-            - Range: 0xcea2fb..0xcea2fc
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea2fc..0xcea315
+            - Range: 0xce9ef3..0xce9ef4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce9ef4..0xce9f2f
               Pieces: []
-          Role: Return
-    - ID: 102
-      Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0xcea320..0xcea3e9]
-      InlinePCRanges: []
-      Variables:
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea320..0xcea372
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-        - Name: result
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea320..0xcea3cf
-              Pieces: []
-            - Range: 0xcea3cf..0xcea3d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea3d0..0xcea3e9
-              Pieces: []
-          Role: Return
-        - Name: result2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea320..0xcea3cf
-              Pieces: []
-            - Range: 0xcea3cf..0xcea3d0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea3d0..0xcea3e9
-              Pieces: []
-          Role: Return
-    - ID: 103
-      Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0xcea400..0xcea4c7]
-      InlinePCRanges: []
-      Variables:
-        - Name: i
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea400..0xcea445
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea445..0xcea4c7
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-          Role: Parameter
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea400..0xcea4ad
-              Pieces: []
-            - Range: 0xcea4ad..0xcea4ae
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea4ae..0xcea4c7
-              Pieces: []
-          Role: Return
-        - Name: result2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea400..0xcea4ad
-              Pieces: []
-            - Range: 0xcea4ad..0xcea4ae
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea4ae..0xcea4c7
-              Pieces: []
-          Role: Return
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea400..0xcea4ad
-              Pieces: []
-            - Range: 0xcea4ad..0xcea4ae
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcea4ae..0xcea4c7
-              Pieces: []
-          Role: Return
-    - ID: 104
-      Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0xcea4e0..0xcea55e]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 20 BaseType int8
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
+            - Range: 0xce9f2f..0xce9f30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce9f30..0xce9f5c
               Pieces: []
           Role: Return
         - Name: ~r1
-          Type: 109 BaseType int16
+          Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0xcea4e0..0xcea551
+            - Range: 0xce9e00..0xce9e64
               Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r2
-          Type: 10 BaseType int32
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r3
-          Type: 12 BaseType int64
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r4
-          Type: 3 BaseType uint8
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r5
-          Type: 6 BaseType uint16
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r6
-          Type: 2 BaseType uint32
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-        - Name: ~r7
-          Type: 8 BaseType uint64
-          Locations:
-            - Range: 0xcea4e0..0xcea551
-              Pieces: []
-            - Range: 0xcea551..0xcea552
-              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcea552..0xcea55e
-              Pieces: []
-          Role: Return
-    - ID: 105
-      Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0xcea560..0xcea657]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r1
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r2
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r3
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r4
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r5
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r6
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r7
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r8
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r9
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r10
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r11
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r12
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r13
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: ~r14
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xcea560..0xcea657, Pieces: []}]
-          Role: Return
-        - Name: onlyOnAmd64_16
-          Type: 13 BaseType float64
-          Locations:
-            - Range: 0xcea560..0xcea647
-              Pieces: []
-            - Range: 0xcea647..0xcea648
-              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xcea648..0xcea657
-              Pieces: []
-          Role: Return
-        - Name: bothArmAndAmd64
-          Type: 13 BaseType float64
-          Locations:
-            - Range: 0xcea560..0xcea647
-              Pieces: []
-            - Range: 0xcea647..0xcea648
-              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0xcea648..0xcea657
-              Pieces: []
-          Role: Return
-    - ID: 106
-      Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0xcea660..0xcea6d3]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 102 BaseType complex64
-          Locations: [{Range: 0xcea660..0xcea6d3, Pieces: []}]
-          Role: Return
-        - Name: ~r1
-          Type: 18 BaseType complex128
-          Locations: [{Range: 0xcea660..0xcea6d3, Pieces: []}]
-          Role: Return
-    - ID: 107
-      Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0xcea6e0..0xcea793]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 256 StructureType main.largeStruct
-          Locations:
-            - Range: 0xcea6e0..0xcea783
-              Pieces: []
-            - Range: 0xcea783..0xcea784
-              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
-            - Range: 0xcea784..0xcea793
-              Pieces: []
-          Role: Return
-    - ID: 108
-      Name: main.testReturnsArray
-      OutOfLinePCRanges: [0xcea7a0..0xcea81c]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 257 ArrayType [3]int
-          Locations:
-            - Range: 0xcea7a0..0xcea80f
-              Pieces: []
-            - Range: 0xcea80f..0xcea810
-              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xcea810..0xcea81c
-              Pieces: []
-          Role: Return
-    - ID: 109
-      Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0xcea820..0xcea878]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 258 ArrayType [1]int
-          Locations:
-            - Range: 0xcea820..0xcea86b
-              Pieces: []
-            - Range: 0xcea86b..0xcea86c
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea86c..0xcea878
-              Pieces: []
-          Role: Return
-    - ID: 110
-      Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0xcea880..0xcea8d3]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 259 ArrayType [0]int
-          Locations:
-            - Range: 0xcea880..0xcea8c6
-              Pieces: []
-            - Range: 0xcea8c6..0xcea8c7
-              Pieces: []
-            - Range: 0xcea8c7..0xcea8d3
-              Pieces: []
-          Role: Return
-    - ID: 111
-      Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0xcea8e0..0xcea947]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0xcea8e0..0xcea947, Pieces: []}]
-          Role: Return
-    - ID: 112
-      Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0xcea960..0xcea9fa]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r1
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r3
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r4
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r5
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r6
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r7
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-        - Name: ~r8
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcea960..0xcea9ea
-              Pieces: []
-            - Range: 0xcea9ea..0xcea9eb
-              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xcea9eb..0xcea9fa
-              Pieces: []
-          Role: Return
-    - ID: 113
-      Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0xceaa00..0xceaac5]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 261 StructureType main.wideStruct
-          Locations:
-            - Range: 0xceaa00..0xceaab2
-              Pieces: []
-            - Range: 0xceaab2..0xceaab3
-              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
-            - Range: 0xceaab3..0xceaac5
-              Pieces: []
-          Role: Return
-    - ID: 114
-      Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0xceaae0..0xceab59]
-      InlinePCRanges: []
-      Variables:
-        - Name: ~r0
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xceaae0..0xceab4c
-              Pieces: []
-            - Range: 0xceab4c..0xceab4d
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceab4d..0xceab59
-              Pieces: []
-          Role: Return
-        - Name: ~r1
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xceaae0..0xceab59, Pieces: []}]
-          Role: Return
-        - Name: ~r2
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xceaae0..0xceab4c
-              Pieces: []
-            - Range: 0xceab4c..0xceab4d
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceab4d..0xceab59
-              Pieces: []
-          Role: Return
-        - Name: ~r3
-          Type: 13 BaseType float64
-          Locations: [{Range: 0xceaae0..0xceab59, Pieces: []}]
-          Role: Return
-        - Name: ~r4
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xceaae0..0xceab4c
-              Pieces: []
-            - Range: 0xceab4c..0xceab4d
+            - Range: 0xce9e64..0xce9e65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0xceab4d..0xceab59
+            - Range: 0xce9e65..0xce9eb3
+              Pieces: []
+            - Range: 0xce9eb3..0xce9eb4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xce9eb4..0xce9ef3
+              Pieces: []
+            - Range: 0xce9ef3..0xce9ef4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xce9ef4..0xce9f2f
+              Pieces: []
+            - Range: 0xce9f2f..0xce9f30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xce9f30..0xce9f5c
+              Pieces: []
+          Role: Return
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xce9e4b..0xce9e51
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+    - ID: 100
+      Name: main.testReturnsAny
+      OutOfLinePCRanges: [0xce9f60..0xcea15d]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xce9f60..0xce9fab
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xce9fab..0xce9fb2
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xce9fb2..0xcea15d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+          Role: Parameter
+        - Name: ~r0
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xce9f60..0xcea015
+              Pieces: []
+            - Range: 0xcea015..0xcea016
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea016..0xcea064
+              Pieces: []
+            - Range: 0xcea064..0xcea065
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea065..0xcea12f
+              Pieces: []
+            - Range: 0xcea12f..0xcea130
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea130..0xcea139
+              Pieces: []
+            - Range: 0xcea139..0xcea13a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea13a..0xcea15d
+              Pieces: []
+          Role: Return
+        - Name: val
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea000..0xcea006
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+        - Name: '&result'
+          Type: 104 PointerType *int
+          Locations:
+            - Range: 0xcea045..0xcea064
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Local
+    - ID: 101
+      Name: main.testReturnsInterface
+      OutOfLinePCRanges: [0xcea160..0xcea2b4]
+      InlinePCRanges: []
+      Variables:
+        - Name: v
+          Type: 163 GoEmptyInterfaceType interface {}
+          Locations:
+            - Range: 0xcea160..0xcea1a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea1a0..0xcea1f0
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcea1f0..0xcea24d
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcea24d..0xcea271
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea271..0xcea278
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea278..0xcea2b4
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 168 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xcea160..0xcea23d
+              Pieces: []
+            - Range: 0xcea23d..0xcea23e
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea23e..0xcea247
+              Pieces: []
+            - Range: 0xcea247..0xcea248
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea248..0xcea2b4
+              Pieces: []
+          Role: Return
+        - Name: b
+          Type: 168 GoInterfaceType main.behavior
+          Locations:
+            - Range: 0xcea160..0xcea1a0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xcea1a0..0xcea1f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea1f0..0xcea1f7
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea1f7..0xcea243
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: -56}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea243..0xcea245
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {CfaOffset: 8}
+            - Range: 0xcea245..0xcea247
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcea247..0xcea2b4
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Local
+    - ID: 102
+      Name: main.testNamedReturn
+      OutOfLinePCRanges: [0xcea2c0..0xcea355]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea2c0..0xcea2d1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea2c0..0xcea33b
+              Pieces: []
+            - Range: 0xcea33b..0xcea33c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea33c..0xcea355
+              Pieces: []
+          Role: Return
+    - ID: 103
+      Name: main.testMultipleNamedReturn
+      OutOfLinePCRanges: [0xcea360..0xcea429]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea360..0xcea3b2
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: result
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea360..0xcea40f
+              Pieces: []
+            - Range: 0xcea40f..0xcea410
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea410..0xcea429
+              Pieces: []
+          Role: Return
+        - Name: result2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea360..0xcea40f
+              Pieces: []
+            - Range: 0xcea40f..0xcea410
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcea410..0xcea429
+              Pieces: []
+          Role: Return
+    - ID: 104
+      Name: main.testSomeNamedReturn
+      OutOfLinePCRanges: [0xcea440..0xcea507]
+      InlinePCRanges: []
+      Variables:
+        - Name: i
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea440..0xcea485
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea485..0xcea507
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea440..0xcea4ed
+              Pieces: []
+            - Range: 0xcea4ed..0xcea4ee
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea4ee..0xcea507
+              Pieces: []
+          Role: Return
+        - Name: result2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea440..0xcea4ed
+              Pieces: []
+            - Range: 0xcea4ed..0xcea4ee
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcea4ee..0xcea507
+              Pieces: []
+          Role: Return
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea440..0xcea4ed
+              Pieces: []
+            - Range: 0xcea4ed..0xcea4ee
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcea4ee..0xcea507
+              Pieces: []
+          Role: Return
+    - ID: 105
+      Name: main.testReturnsPrimitives
+      OutOfLinePCRanges: [0xcea520..0xcea59e]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 20 BaseType int8
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r1
+          Type: 109 BaseType int16
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 2, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r2
+          Type: 10 BaseType int32
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r3
+          Type: 12 BaseType int64
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r4
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r5
+          Type: 6 BaseType uint16
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 2, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r6
+          Type: 2 BaseType uint32
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 4, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+        - Name: ~r7
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0xcea520..0xcea591
+              Pieces: []
+            - Range: 0xcea591..0xcea592
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xcea592..0xcea59e
+              Pieces: []
+          Role: Return
+    - ID: 106
+      Name: main.testReturnsManyFloats
+      OutOfLinePCRanges: [0xcea5a0..0xcea697]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r1
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r2
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r3
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r4
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r5
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r6
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r7
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r8
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r9
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r10
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r11
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r12
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r13
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: ~r14
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xcea5a0..0xcea697, Pieces: []}]
+          Role: Return
+        - Name: onlyOnAmd64_16
+          Type: 13 BaseType float64
+          Locations:
+            - Range: 0xcea5a0..0xcea687
+              Pieces: []
+            - Range: 0xcea687..0xcea688
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+            - Range: 0xcea688..0xcea697
+              Pieces: []
+          Role: Return
+        - Name: bothArmAndAmd64
+          Type: 13 BaseType float64
+          Locations:
+            - Range: 0xcea5a0..0xcea687
+              Pieces: []
+            - Range: 0xcea687..0xcea688
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0xcea688..0xcea697
+              Pieces: []
+          Role: Return
+    - ID: 107
+      Name: main.testReturnsComplex
+      OutOfLinePCRanges: [0xcea6a0..0xcea713]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 102 BaseType complex64
+          Locations: [{Range: 0xcea6a0..0xcea713, Pieces: []}]
+          Role: Return
+        - Name: ~r1
+          Type: 18 BaseType complex128
+          Locations: [{Range: 0xcea6a0..0xcea713, Pieces: []}]
+          Role: Return
+    - ID: 108
+      Name: main.testReturnsLargeStruct
+      OutOfLinePCRanges: [0xcea720..0xcea7d3]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 256 StructureType main.largeStruct
+          Locations:
+            - Range: 0xcea720..0xcea7c3
+              Pieces: []
+            - Range: 0xcea7c3..0xcea7c4
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+            - Range: 0xcea7c4..0xcea7d3
+              Pieces: []
+          Role: Return
+    - ID: 109
+      Name: main.testReturnsArray
+      OutOfLinePCRanges: [0xcea7e0..0xcea85c]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 257 ArrayType [3]int
+          Locations:
+            - Range: 0xcea7e0..0xcea84f
+              Pieces: []
+            - Range: 0xcea84f..0xcea850
+              Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
+            - Range: 0xcea850..0xcea85c
+              Pieces: []
+          Role: Return
+    - ID: 110
+      Name: main.testReturnsArrayOne
+      OutOfLinePCRanges: [0xcea860..0xcea8b8]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 258 ArrayType [1]int
+          Locations:
+            - Range: 0xcea860..0xcea8ab
+              Pieces: []
+            - Range: 0xcea8ab..0xcea8ac
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xcea8ac..0xcea8b8
+              Pieces: []
+          Role: Return
+    - ID: 111
+      Name: main.testReturnsArrayZero
+      OutOfLinePCRanges: [0xcea8c0..0xcea913]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 259 ArrayType [0]int
+          Locations:
+            - Range: 0xcea8c0..0xcea906
+              Pieces: []
+            - Range: 0xcea906..0xcea907
+              Pieces: []
+            - Range: 0xcea907..0xcea913
+              Pieces: []
+          Role: Return
+    - ID: 112
+      Name: main.testReturnsMixedStruct
+      OutOfLinePCRanges: [0xcea920..0xcea987]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 260 StructureType main.mixedStruct
+          Locations: [{Range: 0xcea920..0xcea987, Pieces: []}]
+          Role: Return
+    - ID: 113
+      Name: main.testReturnsBacktrackInt
+      OutOfLinePCRanges: [0xcea9a0..0xceaa3a]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r1
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r3
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r4
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r5
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r6
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r7
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+        - Name: ~r8
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcea9a0..0xceaa2a
+              Pieces: []
+            - Range: 0xceaa2a..0xceaa2b
+              Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
+            - Range: 0xceaa2b..0xceaa3a
+              Pieces: []
+          Role: Return
+    - ID: 114
+      Name: main.testReturnsWideStruct
+      OutOfLinePCRanges: [0xceaa40..0xceab05]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 261 StructureType main.wideStruct
+          Locations:
+            - Range: 0xceaa40..0xceaaf2
+              Pieces: []
+            - Range: 0xceaaf2..0xceaaf3
+              Pieces: [{Size: 88, Op: {CfaOffset: 0}}]
+            - Range: 0xceaaf3..0xceab05
               Pieces: []
           Role: Return
     - ID: 115
+      Name: main.testReturnsMixed
+      OutOfLinePCRanges: [0xceab20..0xceab99]
+      InlinePCRanges: []
+      Variables:
+        - Name: ~r0
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xceab20..0xceab8c
+              Pieces: []
+            - Range: 0xceab8c..0xceab8d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xceab8d..0xceab99
+              Pieces: []
+          Role: Return
+        - Name: ~r1
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xceab20..0xceab99, Pieces: []}]
+          Role: Return
+        - Name: ~r2
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xceab20..0xceab8c
+              Pieces: []
+            - Range: 0xceab8c..0xceab8d
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+            - Range: 0xceab8d..0xceab99
+              Pieces: []
+          Role: Return
+        - Name: ~r3
+          Type: 13 BaseType float64
+          Locations: [{Range: 0xceab20..0xceab99, Pieces: []}]
+          Role: Return
+        - Name: ~r4
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xceab20..0xceab8c
+              Pieces: []
+            - Range: 0xceab8c..0xceab8d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0xceab8d..0xceab99
+              Pieces: []
+          Role: Return
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0xceab60..0xceabdc]
+      OutOfLinePCRanges: [0xceaba0..0xceac1c]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceab60..0xceabcf
+            - Range: 0xceaba0..0xceac0f
               Pieces: []
-            - Range: 0xceabcf..0xceabd0
+            - Range: 0xceac0f..0xceac10
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
-            - Range: 0xceabd0..0xceabdc
+            - Range: 0xceac10..0xceac1c
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0xceabe0..0xceac3b]
+      OutOfLinePCRanges: [0xceac20..0xceac7b]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceabe0..0xceac3b, Pieces: []}]
+          Locations: [{Range: 0xceac20..0xceac7b, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0xceac40..0xceaca7]
+      OutOfLinePCRanges: [0xceac80..0xceace7]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0xceac40..0xceaca7, Pieces: []}]
+          Locations: [{Range: 0xceac80..0xceace7, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 13 BaseType float64
-          Locations: [{Range: 0xceac40..0xceaca7, Pieces: []}]
+          Locations: [{Range: 0xceac80..0xceace7, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0xceacc0..0xcead1d]
+      OutOfLinePCRanges: [0xcead00..0xcead5d]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xceacc0..0xcead10
+            - Range: 0xcead00..0xcead50
               Pieces: []
-            - Range: 0xcead10..0xcead11
+            - Range: 0xcead50..0xcead51
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xcead11..0xcead1d
+            - Range: 0xcead51..0xcead5d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0xceacc0..0xcead10
+            - Range: 0xcead00..0xcead50
               Pieces: []
-            - Range: 0xcead10..0xcead11
+            - Range: 0xcead50..0xcead51
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xcead11..0xcead1d
+            - Range: 0xcead51..0xcead5d
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0xcead20..0xceae9d]
+      OutOfLinePCRanges: [0xcead60..0xceaedd]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcead20..0xceae9d
+            - Range: 0xcead60..0xceaedd
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xcead20..0xceae8d
+            - Range: 0xcead60..0xceaecd
               Pieces: []
-            - Range: 0xceae8d..0xceae8e
+            - Range: 0xceaecd..0xceaece
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
-            - Range: 0xceae8e..0xceae9d
+            - Range: 0xceaece..0xceaedd
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0xceaea0..0xceaf7a]
+      OutOfLinePCRanges: [0xceaee0..0xceafba]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceaea0..0xceaf7a
+            - Range: 0xceaee0..0xceafba
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceaea0..0xceaf6a
+            - Range: 0xceaee0..0xceafaa
               Pieces: []
-            - Range: 0xceaf6a..0xceaf6b
+            - Range: 0xceafaa..0xceafab
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xceaf6b..0xceaf7a
+            - Range: 0xceafab..0xceafba
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0xceaf80..0xceb1bb]
+      OutOfLinePCRanges: [0xceafc0..0xceb1fb]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceaf80..0xceb1bb
+            - Range: 0xceafc0..0xceb1fb
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceaf80..0xceb1bb
+            - Range: 0xceafc0..0xceb1fb
               Pieces: [{Size: 80, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceaf80..0xceb1ab
+            - Range: 0xceafc0..0xceb1eb
               Pieces: []
-            - Range: 0xceb1ab..0xceb1ac
+            - Range: 0xceb1eb..0xceb1ec
               Pieces: [{Size: 80, Op: {CfaOffset: 160}}]
-            - Range: 0xceb1ac..0xceb1bb
+            - Range: 0xceb1ec..0xceb1fb
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0xceb1c0..0xceb46f]
+      OutOfLinePCRanges: [0xceb200..0xceb4af]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb22a
+            - Range: 0xceb200..0xceb26a
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb22a..0xceb46f
+            - Range: 0xceb26a..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb1c0..0xceb287
+            - Range: 0xceb200..0xceb2c7
               Pieces: [{Size: 8, Op: {RegNo: 11, Shift: 0}}]
-            - Range: 0xceb287..0xceb46f
+            - Range: 0xceb2c7..0xceb4af
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb1c0..0xceb402
+            - Range: 0xceb200..0xceb442
               Pieces: []
-            - Range: 0xceb402..0xceb403
+            - Range: 0xceb442..0xceb443
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
-            - Range: 0xceb403..0xceb46f
+            - Range: 0xceb443..0xceb4af
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0xceb480..0xceb745]
+      OutOfLinePCRanges: [0xceb4c0..0xceb785]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 96}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 104}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb4e2
+            - Range: 0xceb4c0..0xceb522
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb4e2..0xceb745
+            - Range: 0xceb522..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 112}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 120}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 128}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 136}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 9, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 144}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb480..0xceb52a
+            - Range: 0xceb4c0..0xceb56a
               Pieces: [{Size: 8, Op: {RegNo: 10, Shift: 0}}]
-            - Range: 0xceb52a..0xceb745
+            - Range: 0xceb56a..0xceb785
               Pieces: [{Size: 8, Op: {CfaOffset: 152}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xceb480..0xceb745
+            - Range: 0xceb4c0..0xceb785
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 0}
@@ -6942,210 +6986,176 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0xceb480..0xceb6c2
+            - Range: 0xceb4c0..0xceb702
               Pieces: []
-            - Range: 0xceb6c2..0xceb6c3
+            - Range: 0xceb702..0xceb703
               Pieces: [{Size: 80, Op: {CfaOffset: 16}}]
-            - Range: 0xceb6c3..0xceb745
+            - Range: 0xceb703..0xceb785
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0xceb760..0xceb7ee]
+      OutOfLinePCRanges: [0xceb7a0..0xceb82e]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0xceb760..0xceb7ee
+            - Range: 0xceb7a0..0xceb82e
               Pieces: [{Size: 40, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb760..0xceb7de
+            - Range: 0xceb7a0..0xceb81e
               Pieces: []
-            - Range: 0xceb7de..0xceb7df
+            - Range: 0xceb81e..0xceb81f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb7df..0xceb7ee
+            - Range: 0xceb81f..0xceb82e
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb760..0xceb7de
+            - Range: 0xceb7a0..0xceb81e
               Pieces: []
-            - Range: 0xceb7de..0xceb7df
+            - Range: 0xceb81e..0xceb81f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0xceb7df..0xceb7ee
+            - Range: 0xceb81f..0xceb82e
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb760..0xceb7de
+            - Range: 0xceb7a0..0xceb81e
               Pieces: []
-            - Range: 0xceb7de..0xceb7df
+            - Range: 0xceb81e..0xceb81f
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0xceb7df..0xceb7ee
+            - Range: 0xceb81f..0xceb82e
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0xceb800..0xceb8ed]
+      OutOfLinePCRanges: [0xceb840..0xceb92d]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb800..0xceb8ed
+            - Range: 0xceb840..0xceb92d
               Pieces: [{Size: 16, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0xceb800..0xceb8ed
+            - Range: 0xceb840..0xceb92d
               Pieces: [{Size: 24, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb800..0xceb8dd
+            - Range: 0xceb840..0xceb91d
               Pieces: []
-            - Range: 0xceb8dd..0xceb8de
+            - Range: 0xceb91d..0xceb91e
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb8de..0xceb8ed
+            - Range: 0xceb91e..0xceb92d
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0xceb800..0xceb8dd
+            - Range: 0xceb840..0xceb91d
               Pieces: []
-            - Range: 0xceb8dd..0xceb8de
+            - Range: 0xceb91d..0xceb91e
               Pieces: [{Size: 16, Op: {CfaOffset: 40}}]
-            - Range: 0xceb8de..0xceb8ed
+            - Range: 0xceb91e..0xceb92d
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0xceb900..0xceb9d4]
+      OutOfLinePCRanges: [0xceb940..0xceba14]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceb900..0xceb9d4
+            - Range: 0xceb940..0xceba14
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb900..0xceb9c4
+            - Range: 0xceb940..0xceba04
               Pieces: []
-            - Range: 0xceb9c4..0xceb9c5
+            - Range: 0xceba04..0xceba05
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceb9c5..0xceb9d4
+            - Range: 0xceba05..0xceba14
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0xceb900..0xceb9c4
+            - Range: 0xceb940..0xceba04
               Pieces: []
-            - Range: 0xceb9c4..0xceb9c5
+            - Range: 0xceba04..0xceba05
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
-            - Range: 0xceb9c5..0xceb9d4
+            - Range: 0xceba05..0xceba14
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb98e..0xceb9d4
+            - Range: 0xceb9ce..0xceba14
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0xceb9e0..0xceba86]
+      OutOfLinePCRanges: [0xceba20..0xcebac6]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0xceb9e0..0xceba86, Pieces: []}]
+          Locations: [{Range: 0xceba20..0xcebac6, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb9e0..0xceba25
+            - Range: 0xceba20..0xceba65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceba25..0xceba47
+            - Range: 0xceba65..0xceba87
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
-            - Range: 0xceba47..0xceba5a
+            - Range: 0xceba87..0xceba9a
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
-            - Range: 0xceba5a..0xceba86
+            - Range: 0xceba9a..0xcebac6
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xceb9e0..0xceba6c
+            - Range: 0xceba20..0xcebaac
               Pieces: []
-            - Range: 0xceba6c..0xceba6d
+            - Range: 0xcebaac..0xcebaad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xceba6d..0xceba86
+            - Range: 0xcebaad..0xcebac6
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0xceb9e0..0xceba6c
+            - Range: 0xceba20..0xcebaac
               Pieces: []
-            - Range: 0xceba6c..0xceba6d
+            - Range: 0xcebaac..0xcebaad
               Pieces: []
-            - Range: 0xceba6d..0xceba86
+            - Range: 0xcebaad..0xcebac6
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0xcebfc0..0xcebfc1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcebfc0..0xcebfc1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0xcebfe0..0xcebfe1]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcebfe0..0xcebfe1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 130
-      Name: main.testSliceOfSlices
+      Name: main.testUintSlice
       OutOfLinePCRanges: [0xcec000..0xcec001]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcec000..0xcec001
               Pieces:
@@ -7156,13 +7166,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
+    - ID: 130
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcec020..0xcec021]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0xcec020..0xcec021
               Pieces:
@@ -7173,19 +7183,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec020..0xcec021
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcec040..0xcec041]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0xcec040..0xcec041
               Pieces:
@@ -7196,14 +7200,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0xcec040..0xcec041
-              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
+    - ID: 132
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0xcec060..0xcec061]
       InlinePCRanges: []
       Variables:
@@ -7225,13 +7223,13 @@ Subprograms:
             - Range: 0xcec060..0xcec061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcec080..0xcec081]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 269 GoSliceHeaderType []string
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0xcec080..0xcec081
               Pieces:
@@ -7242,21 +7240,67 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec080..0xcec081
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcec0a0..0xcec0a1]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0xcec0a0..0xcec0a1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xcec0a0..0xcec0a1
+              Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0xcec0c0..0xcec0c1]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 269 GoSliceHeaderType []string
+          Locations:
+            - Range: 0xcec0c0..0xcec0c1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0xcec0e0..0xcec0e1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 20 BaseType int8
           Locations:
-            - Range: 0xcec0a0..0xcec0a1
+            - Range: 0xcec0e0..0xcec0e1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0xcec0a0..0xcec0a1
+            - Range: 0xcec0e0..0xcec0e1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7268,50 +7312,16 @@ Subprograms:
         - Name: x
           Type: 14 BaseType uint
           Locations:
-            - Range: 0xcec0a0..0xcec0a1
+            - Range: 0xcec0e0..0xcec0e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
-      Name: main.testNilSlice
-      OutOfLinePCRanges: [0xcec0c0..0xcec0c1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 271 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0xcec0c0..0xcec0c1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0xcec0e0..0xcec0e1]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0xcec0e0..0xcec0e1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 138
-      Name: main.testSliceEmptyStructs
+      Name: main.testNilSlice
       OutOfLinePCRanges: [0xcec100..0xcec101]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 271 GoSliceHeaderType []uint16
           Locations:
             - Range: 0xcec100..0xcec101
               Pieces:
@@ -7322,15 +7332,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
-      Name: main.testSubslices
+    - ID: 138
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcec120..0xcec121]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 263 GoSliceHeaderType []uint
+          Locations:
+            - Range: 0xcec120..0xcec121
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0xcec140..0xcec141]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0xcec140..0xcec141
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
+      Name: main.testSubslices
+      OutOfLinePCRanges: [0xcec160..0xcec161]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec120..0xcec121
+            - Range: 0xcec160..0xcec161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7342,7 +7386,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec120..0xcec121
+            - Range: 0xcec160..0xcec161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
@@ -7354,7 +7398,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0xcec120..0xcec121
+            - Range: 0xcec160..0xcec161
               Pieces:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
@@ -7363,49 +7407,49 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0xcec480..0xcec4d2]
+      OutOfLinePCRanges: [0xcec4c0..0xcec512]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec480..0xcec4c5
+            - Range: 0xcec4c0..0xcec505
               Pieces: []
-            - Range: 0xcec4c5..0xcec4c6
+            - Range: 0xcec505..0xcec506
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xcec4c6..0xcec4d2
+            - Range: 0xcec506..0xcec512
               Pieces: []
           Role: Return
-    - ID: 141
+    - ID: 142
       Name: main.testSingleString
-      OutOfLinePCRanges: [0xcec4e0..0xcec4e1]
+      OutOfLinePCRanges: [0xcec520..0xcec521]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec4e0..0xcec4e1
+            - Range: 0xcec520..0xcec521
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 142
+    - ID: 143
       Name: main.testThreeStrings
-      OutOfLinePCRanges: [0xcec500..0xcec501]
+      OutOfLinePCRanges: [0xcec540..0xcec541]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec500..0xcec501
+            - Range: 0xcec540..0xcec541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7415,7 +7459,7 @@ Subprograms:
         - Name: y
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec500..0xcec501
+            - Range: 0xcec540..0xcec541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7425,22 +7469,22 @@ Subprograms:
         - Name: z
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec500..0xcec501
+            - Range: 0xcec540..0xcec541
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0xcec520..0xcec521]
+      OutOfLinePCRanges: [0xcec560..0xcec561]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 274 StructureType main.threeStringStruct
           Locations:
-            - Range: 0xcec520..0xcec521
+            - Range: 0xcec560..0xcec561
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7455,60 +7499,30 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0xcec540..0xcec541]
+      OutOfLinePCRanges: [0xcec580..0xcec581]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 275 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0xcec540..0xcec541
+            - Range: 0xcec580..0xcec581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0xcec560..0xcec561]
+      OutOfLinePCRanges: [0xcec5a0..0xcec5a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 276 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0xcec560..0xcec561
+            - Range: 0xcec5a0..0xcec5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
-      OutOfLinePCRanges: [0xcec580..0xcec581]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcec580..0xcec581
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0xcec5a0..0xcec5a1]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0xcec5a0..0xcec5a1
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+      Name: main.testMassiveString
       OutOfLinePCRanges: [0xcec5c0..0xcec5c1]
       InlinePCRanges: []
       Variables:
@@ -7522,15 +7536,45 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
-      Name: main.testSubstrings
+    - ID: 148
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcec5e0..0xcec5e1]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcec5e0..0xcec5e1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0xcec600..0xcec601]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcec600..0xcec601
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+    - ID: 150
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0xcec620..0xcec621]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5e0..0xcec5e1
+            - Range: 0xcec620..0xcec621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7540,7 +7584,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5e0..0xcec5e1
+            - Range: 0xcec620..0xcec621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7550,33 +7594,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xcec5e0..0xcec5e1
+            - Range: 0xcec620..0xcec621
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0xcec760..0xcec761]
+      OutOfLinePCRanges: [0xcec7a0..0xcec7a1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0xcec760..0xcec761
+            - Range: 0xcec7a0..0xcec7a1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0xcec780..0xcec781]
+      OutOfLinePCRanges: [0xcec7c0..0xcec7c1]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0xcec780..0xcec781
+            - Range: 0xcec7c0..0xcec7c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7591,15 +7635,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0xcec8c0..0xcec8c1]
+      OutOfLinePCRanges: [0xcec900..0xcec901]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0xcec8c0..0xcec8c1
+            - Range: 0xcec900..0xcec901
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7616,38 +7660,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0xcec980..0xcec981]
+      OutOfLinePCRanges: [0xcec9c0..0xcec9c1]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0xcec980..0xcec981
+            - Range: 0xcec9c0..0xcec9c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0xceca00..0xceca01]
+      OutOfLinePCRanges: [0xceca40..0xceca41]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 StructureType main.emptyStruct
-          Locations: [{Range: 0xceca00..0xceca01, Pieces: []}]
+          Locations: [{Range: 0xceca40..0xceca41, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0xceca20..0xceca21]
+      OutOfLinePCRanges: [0xceca60..0xceca61]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 PointerType *main.emptyStruct
           Locations:
-            - Range: 0xceca20..0xceca21
+            - Range: 0xceca60..0xceca61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xce6560..0xce65c2]
       InlinePCRanges:
@@ -7676,28 +7720,28 @@ Subprograms:
             - Range: 0xce6880..0xce689a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6806..0xce683e]
           RootRanges: [0xce67a0..0xce6865]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6913..0xce6951]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce69bb..0xce69f3]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7710,7 +7754,7 @@ Subprograms:
             - Range: 0xce6a20..0xce6a25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11061,10 +11105,10 @@ Types:
       GoKind: 22
       Pointee: 825 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11076,7 +11120,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11164,7 +11208,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11176,7 +11220,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11186,11 +11230,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11202,7 +11246,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11362,6 +11406,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11440,7 +11526,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11452,7 +11538,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11462,7 +11548,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11532,7 +11618,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11544,7 +11630,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11554,7 +11640,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11714,7 +11800,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11726,7 +11812,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11736,7 +11822,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11746,7 +11832,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11756,11 +11842,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11772,7 +11858,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11782,11 +11868,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11798,7 +11884,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11808,11 +11894,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11824,7 +11910,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11834,11 +11920,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11850,7 +11936,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11860,7 +11946,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12126,7 +12212,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1550
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12178,16 +12264,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1551
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1552
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1551
+      ID: 1553
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1554
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12196,7 +12282,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1545
+      ID: 1547
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12208,7 +12294,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12218,11 +12304,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1549
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12234,7 +12320,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12244,14 +12330,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1546
+      ID: 1548
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12263,7 +12349,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12273,11 +12359,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1556
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12289,7 +12375,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12299,11 +12385,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1557
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12315,7 +12401,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12325,7 +12411,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12485,7 +12571,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12497,7 +12583,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12507,11 +12593,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12523,11 +12609,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12539,7 +12625,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12549,7 +12635,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12628,7 +12714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12640,7 +12726,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12650,7 +12736,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12660,7 +12746,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12670,7 +12756,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12680,7 +12766,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12690,7 +12776,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12700,7 +12786,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12710,7 +12796,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12720,7 +12806,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12730,7 +12816,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12740,7 +12826,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12750,7 +12836,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12760,7 +12846,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12770,7 +12856,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12780,7 +12866,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12790,7 +12876,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12800,7 +12886,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12810,11 +12896,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12826,7 +12912,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13350,7 +13436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13362,7 +13448,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13372,11 +13458,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13388,7 +13474,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13398,11 +13484,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13414,7 +13500,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13424,7 +13510,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13434,7 +13520,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13444,7 +13530,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13454,7 +13540,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13464,7 +13550,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13474,7 +13560,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13484,7 +13570,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13494,7 +13580,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13504,7 +13590,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13514,7 +13600,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13524,7 +13610,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13534,7 +13620,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13544,7 +13630,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13554,7 +13640,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13564,7 +13650,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13574,7 +13660,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13584,11 +13670,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13600,11 +13686,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13616,7 +13702,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13626,7 +13712,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13636,7 +13722,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13646,11 +13732,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13662,7 +13748,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13672,11 +13758,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13688,7 +13774,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13698,7 +13784,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13708,7 +13794,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13718,11 +13804,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13734,11 +13820,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13750,7 +13836,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13760,11 +13846,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13776,7 +13862,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13786,7 +13872,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13796,7 +13882,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13806,23 +13892,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13838,7 +13908,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13854,11 +13924,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1459
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13870,7 +13956,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13880,11 +13966,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13896,7 +13982,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13906,7 +13992,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13916,7 +14002,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13926,7 +14012,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13936,7 +14022,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13946,33 +14032,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13988,7 +14048,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13998,7 +14058,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14014,7 +14074,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14024,7 +14084,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14134,32 +14220,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14172,7 +14232,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14182,11 +14242,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1449
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14198,11 +14284,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14214,7 +14300,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14224,11 +14310,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14240,7 +14326,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14250,11 +14336,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14266,7 +14352,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14276,10 +14362,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14291,7 +14377,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14301,7 +14387,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14313,7 +14399,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14323,7 +14409,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14333,7 +14419,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14343,11 +14429,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14359,7 +14445,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14369,7 +14455,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14379,7 +14465,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14389,11 +14475,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14405,7 +14491,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14415,7 +14501,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14425,7 +14511,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14435,7 +14521,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14445,7 +14531,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14455,11 +14541,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14471,7 +14557,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14481,11 +14567,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14497,7 +14583,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14507,11 +14593,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14523,7 +14609,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14533,7 +14619,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14563,7 +14649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14575,7 +14661,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14585,11 +14671,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14601,7 +14687,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14611,7 +14697,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14621,7 +14707,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14631,11 +14717,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14647,7 +14733,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14657,446 +14743,12 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1441
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1442
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 258 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1469
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 257 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1477
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1489
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1490
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1465
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1466
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 102 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 13 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 104 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1443
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15122,6 +14774,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1444
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 258 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 257 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 102 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 13 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 104 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1446
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15133,14 +15219,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15152,14 +15238,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15171,7 +15257,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15181,7 +15267,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15191,7 +15277,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15201,7 +15287,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15211,7 +15297,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15221,7 +15307,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15231,7 +15317,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15241,7 +15327,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15251,7 +15337,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15261,7 +15347,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15271,7 +15357,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15281,7 +15367,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15291,7 +15377,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15301,7 +15387,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15311,7 +15397,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15321,7 +15407,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15331,14 +15417,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15350,14 +15436,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15369,7 +15455,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15379,7 +15465,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15389,7 +15475,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15399,7 +15485,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15409,14 +15495,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15428,7 +15514,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15438,14 +15524,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15457,14 +15543,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15476,7 +15562,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15486,7 +15572,7 @@ Types:
             Type: 109 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15496,7 +15582,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15506,7 +15592,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15516,7 +15602,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15526,7 +15612,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15536,7 +15622,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15546,14 +15632,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15565,14 +15651,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15584,7 +15670,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15894,7 +15980,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15906,7 +15992,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15916,7 +16002,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16050,7 +16136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16062,7 +16148,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16072,11 +16158,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16088,7 +16174,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16098,7 +16184,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16128,7 +16214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16140,7 +16226,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16150,11 +16236,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16166,7 +16252,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16176,7 +16262,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16186,11 +16272,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16202,7 +16288,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16212,11 +16298,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16228,7 +16314,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16238,7 +16324,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16248,7 +16334,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16278,7 +16364,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16290,7 +16376,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16300,11 +16386,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16316,7 +16402,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16326,7 +16412,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16382,7 +16468,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16394,7 +16480,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16404,7 +16490,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16414,7 +16500,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16424,7 +16510,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16454,7 +16540,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16466,7 +16552,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16476,11 +16562,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16492,7 +16578,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16502,11 +16588,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16518,7 +16604,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16528,11 +16614,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16544,7 +16630,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16554,7 +16640,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16584,7 +16670,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16596,7 +16682,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16606,11 +16692,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16622,7 +16708,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16632,7 +16718,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16642,7 +16728,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16652,7 +16738,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16662,7 +16748,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16672,11 +16758,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16688,7 +16774,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16698,7 +16784,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16708,7 +16794,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16718,7 +16804,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16728,7 +16814,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16738,11 +16824,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16754,7 +16840,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16764,11 +16850,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16780,7 +16866,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16793,7 +16879,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16806,14 +16892,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16825,7 +16911,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16835,11 +16921,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16851,7 +16937,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16861,7 +16947,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16871,11 +16957,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16887,7 +16973,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16897,7 +16983,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16907,7 +16993,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16917,7 +17003,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16927,7 +17013,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16937,7 +17023,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17097,7 +17183,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17109,7 +17195,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17119,11 +17205,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17135,7 +17221,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17145,11 +17231,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17161,7 +17247,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17171,11 +17257,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17187,7 +17273,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17197,7 +17283,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17227,7 +17313,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17239,7 +17325,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17249,11 +17335,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17265,7 +17351,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17275,11 +17361,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17291,7 +17377,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17301,7 +17387,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17311,7 +17397,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17321,11 +17407,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17337,7 +17423,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17347,7 +17433,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26009,7 +26095,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.004e+06
       GoKind: 5
-MaxTypeID: 1555
+MaxTypeID: 1557
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x8928a8", Frameless: false}]
+          Type: 1330 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x8928f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1329 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x8928dc", Frameless: false}]
+          Type: 1331 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x89292c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x89160c", Frameless: false}]
+          Type: 1301 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x89165c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x8916a4", Frameless: false}]
+          Type: 1302 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8916f4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1228 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1229 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x88fb6c", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
+          Type: 1230 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88fdd0", Frameless: true}]
+          Type: 1238 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x88fe20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1316 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x8924d0", Frameless: true}]
+          Type: 1318 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x892500", Frameless: true}]
+          Type: 1321 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x892980", Frameless: true}]
+          Type: 1344 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
+          Type: 1355 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x892d50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x892d10", Frameless: true}]
+          Type: 1356 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x892d60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1358 EventRootType Probe[main.testInlinedBBB]
+          Type: 1360 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d878", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1359 EventRootType Probe[main.testInlinedBCA]
+          Type: 1361 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1360 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1362 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBCB]
+          Type: 1363 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1364 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testInlinedPrint]
+          Type: 1357 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1356 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1358 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d630", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1357 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1359 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d5f8"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedSq]
+          Type: 1365 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1364 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1366 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da84", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1367 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dab4"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x891430", Frameless: false}]
+          Type: 1299 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x891480", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x891588", Frameless: false}]
+          Type: 1300 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8915d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88fce0", Frameless: true}]
+          Type: 1232 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x89193c", Frameless: false}]
+          Type: 1305 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x89198c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x891aac", Frameless: false}]
+          Type: 1306 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x891afc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x892960", Frameless: true}]
+          Type: 1341 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x892960", Frameless: true}]
+          Type: 1342 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x891b30", Frameless: false}]
+          Type: 1307 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x891b80", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x891ce0", Frameless: false}]
+          Type: 1308 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x891d30", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x891e0c", Frameless: false}]
+          Type: 1311 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x891e5c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x891eb0", Frameless: false}]
+          Type: 1312 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x891f00", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x8916e0", Frameless: false}]
+          Type: 1303 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x891730", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x8918b0", Frameless: false}]
+          Type: 1304 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x891900", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x890958", Frameless: false}]
+          Type: 1253 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x8909a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a08", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x890958", Frameless: false}]
+          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x8909a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
+          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x890a08", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
+          Type: 1351 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1350 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
+          Type: 1352 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
+          Type: 1353 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892ca0", Frameless: true}]
+          Type: 1354 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88fdb0", Frameless: true}]
+          Type: 1237 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x88fe00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x892540", Frameless: true}]
+          Type: 1325 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x892590", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x892510", Frameless: true}]
+          Type: 1322 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x892530", Frameless: true}]
+          Type: 1324 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x892580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x892950", Frameless: true}]
+          Type: 1340 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1231 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88fcf0", Frameless: true}]
+          Type: 1233 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1229 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88fcd0", Frameless: true}]
+          Type: 1231 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x8905e8", Frameless: false}]
+          Type: 1249 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x890638", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1250 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x890688"
+            - PC: "0x8906d8"
               Frameless: false
-            - PC: "0x8906d0"
+            - PC: "0x890720"
               Frameless: false
-            - PC: "0x890794"
+            - PC: "0x8907e4"
               Frameless: false
-            - PC: "0x8907a8"
+            - PC: "0x8907f8"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x890468", Frameless: false}]
+          Type: 1247 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x8904b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1248 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x8904d4"
+            - PC: "0x890524"
               Frameless: false
-            - PC: "0x890520"
+            - PC: "0x890570"
               Frameless: false
-            - PC: "0x890560"
+            - PC: "0x8905b0"
               Frameless: false
-            - PC: "0x8905a0"
+            - PC: "0x8905f0"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x890e3c", Frameless: false}]
+          Type: 1277 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x890e8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x890e90", Frameless: false}]
+          Type: 1278 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x890ee0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x890ec8", Frameless: false}]
+          Type: 1279 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x890f18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x890f04", Frameless: false}]
+          Type: 1280 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x890f54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x890f38", Frameless: false}]
+          Type: 1281 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x890f88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x890f70", Frameless: false}]
+          Type: 1282 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x890fc0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x891028", Frameless: false}]
+          Type: 1285 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x891078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x89108c", Frameless: false}]
+          Type: 1286 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x8910dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x8913b8", Frameless: false}]
+          Type: 1297 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x891408", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x8913f8", Frameless: false}]
+          Type: 1298 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x891448", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x890ce8", Frameless: false}]
+          Type: 1273 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x890d38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x890d34", Frameless: false}]
+          Type: 1274 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x890d84", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x8903e8", Frameless: false}]
+          Type: 1245 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x890438", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsError]Return
+          Type: 1246 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x890418"
+            - PC: "0x890468"
               Frameless: false
-            - PC: "0x89042c"
+            - PC: "0x89047c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x8901f8", Frameless: false}]
+          Type: 1239 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x890248", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1238 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x89023c", Frameless: false}]
+          Type: 1240 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x89028c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x890318", Frameless: false}]
+          Type: 1243 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x890368", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x8903b0", Frameless: false}]
+          Type: 1244 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x890400", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x890278", Frameless: false}]
+          Type: 1241 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x8902c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1240 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x8902dc", Frameless: false}]
+          Type: 1242 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x89032c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x8907e8", Frameless: false}]
+          Type: 1251 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x890838", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1252 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x8908b8"
+            - PC: "0x890908"
               Frameless: false
-            - PC: "0x8908cc"
+            - PC: "0x89091c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x890d70", Frameless: false}]
+          Type: 1275 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x890dc0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x890e04", Frameless: false}]
+          Type: 1276 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x890e54", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x890c28", Frameless: false}]
+          Type: 1271 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x890c78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x890cac", Frameless: false}]
+          Type: 1272 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x890cfc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x8911a8", Frameless: false}]
+          Type: 1289 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x8911f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x891200", Frameless: false}]
+          Type: 1290 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x891250", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x890fa8", Frameless: false}]
+          Type: 1283 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x890ff8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x890ff0", Frameless: false}]
+          Type: 1284 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x891040", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x891338", Frameless: false}]
+          Type: 1295 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x891388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x89137c", Frameless: false}]
+          Type: 1296 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x8913cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x8912c8", Frameless: false}]
+          Type: 1293 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x891318", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x891308", Frameless: false}]
+          Type: 1294 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x891358", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x890b98", Frameless: false}]
+          Type: 1269 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x890be8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x890bf0", Frameless: false}]
+          Type: 1270 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x890c40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x89123c", Frameless: false}]
+          Type: 1291 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x89128c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x891290", Frameless: false}]
+          Type: 1292 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x8912e0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x8910d0", Frameless: false}]
+          Type: 1287 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x891120", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x891174", Frameless: false}]
+          Type: 1288 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x8911c4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x892900", Frameless: true}]
+          Type: 1332 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x892950", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x892560", Frameless: true}]
+          Type: 1328 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x8924e0", Frameless: true}]
+          Type: 1319 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x890ac8", Frameless: false}]
+          Type: 1267 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x890b18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x890b54", Frameless: false}]
+          Type: 1268 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ba4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x891d68", Frameless: false}]
+          Type: 1309 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x891db8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x891dcc", Frameless: false}]
+          Type: 1310 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x891e1c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88fd90", Frameless: true}]
+          Type: 1236 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x88fde0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x892520", Frameless: true}]
+          Type: 1323 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x892570", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x892c00", Frameless: true}]
+          Type: 1349 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x892c50", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1348 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x892c1c", Frameless: true}]
+          Type: 1350 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x892c6c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x8924f0", Frameless: true}]
+          Type: 1320 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x891eec", Frameless: false}]
+          Type: 1313 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x891f3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x891f7c", Frameless: false}]
+          Type: 1314 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x891fcc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x892b10", Frameless: true}]
+          Type: 1347 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x892b60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1346 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x892b28", Frameless: true}]
+          Type: 1348 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x892b78", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x892b00", Frameless: true}]
+          Type: 1346 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x892b50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x892570", Frameless: true}]
+          Type: 1329 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x892990", Frameless: true}]
+          Type: 1345 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x8909f8", Frameless: false}]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a84", Frameless: false}]
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1331 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x892910", Frameless: true}]
+          Type: 1333 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x892960", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892920", Frameless: true}]
+          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x892970", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1333 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892938", Frameless: true}]
+          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x892988", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892920", Frameless: true}]
+          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x892970", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892938", Frameless: true}]
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x892988", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x892940", Frameless: true}]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x892990", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x892940", Frameless: true}]
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x892990", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
+          Type: 1235 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x88fd70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x8924c0", Frameless: true}]
+          Type: 1317 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x892510", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x892970", Frameless: true}]
+          Type: 1343 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88fd00", Frameless: true}]
+          Type: 1234 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x892550", Frameless: true}]
+          Type: 1326 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x892550", Frameless: true}]
+          Type: 1327 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x891fb8", Frameless: false}]
+          Type: 1315 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x892008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x892024", Frameless: false}]
+          Type: 1316 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x892074", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5619,281 +5644,302 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0x88fb30..0x88fb70]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0x88fb30..0x88fb6c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 10 BaseType uint64
+          Locations:
+            - Range: 0x88fb30..0x88fb6c
+              Pieces: []
+            - Range: 0x88fb6c..0x88fb6d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x88fb6d..0x88fb70
+              Pieces: []
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88fb30..0x88fb40]
+      OutOfLinePCRanges: [0x88fb70..0x88fb80]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0x88fb30..0x88fb40
+            - Range: 0x88fb70..0x88fb80
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88fcd0..0x88fce0]
+      OutOfLinePCRanges: [0x88fd20..0x88fd30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88fcd0..0x88fce0
+            - Range: 0x88fd20..0x88fd30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88fce0..0x88fcf0]
+      OutOfLinePCRanges: [0x88fd30..0x88fd40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0x88fce0..0x88fcf0
+            - Range: 0x88fd30..0x88fd40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88fcf0..0x88fd00]
+      OutOfLinePCRanges: [0x88fd40..0x88fd50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0x88fcf0..0x88fd00
+            - Range: 0x88fd40..0x88fd50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88fd00..0x88fd10]
+      OutOfLinePCRanges: [0x88fd50..0x88fd60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88fd00..0x88fd10
+            - Range: 0x88fd50..0x88fd60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88fd20..0x88fd30]
+      OutOfLinePCRanges: [0x88fd70..0x88fd80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x88fd20..0x88fd30
+            - Range: 0x88fd70..0x88fd80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88fd90..0x88fda0]
+      OutOfLinePCRanges: [0x88fde0..0x88fdf0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x88fd90..0x88fda0
+            - Range: 0x88fde0..0x88fdf0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88fdb0..0x88fdc0]
+      OutOfLinePCRanges: [0x88fe00..0x88fe10]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88fdb0..0x88fdc0
+            - Range: 0x88fe00..0x88fe10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fdb0..0x88fdc0
+            - Range: 0x88fe00..0x88fe10
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88fdd0..0x88fde0]
+      OutOfLinePCRanges: [0x88fe20..0x88fe30]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0x88fdd0..0x88fde0
+            - Range: 0x88fe20..0x88fe30
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x8901e0..0x890260]
+      OutOfLinePCRanges: [0x890230..0x8902b0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8901e0..0x8901fc
+            - Range: 0x890230..0x89024c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8901e0..0x89023c
+            - Range: 0x890230..0x89028c
               Pieces: []
-            - Range: 0x89023c..0x89023d
+            - Range: 0x89028c..0x89028d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89023d..0x890260
+            - Range: 0x89028d..0x8902b0
               Pieces: []
           Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8901fc..0x890208
+            - Range: 0x89024c..0x890258
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890208..0x890260
+            - Range: 0x890258..0x8902b0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x890260..0x890300]
+      OutOfLinePCRanges: [0x8902b0..0x890350]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890260..0x890284
+            - Range: 0x8902b0..0x8902d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890284..0x890300
+            - Range: 0x8902d4..0x890350
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x890260..0x8902dc
+            - Range: 0x8902b0..0x89032c
               Pieces: []
-            - Range: 0x8902dc..0x8902dd
+            - Range: 0x89032c..0x89032d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902dd..0x890300
+            - Range: 0x89032d..0x890350
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x890288..0x8902a4
+            - Range: 0x8902d8..0x8902f4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902a4..0x890300
+            - Range: 0x8902f4..0x890350
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x890300..0x8903d0]
+      OutOfLinePCRanges: [0x890350..0x890420]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890300..0x890358
+            - Range: 0x890350..0x8903a8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890300..0x8903b0
+            - Range: 0x890350..0x890400
               Pieces: []
-            - Range: 0x8903b0..0x8903b1
+            - Range: 0x890400..0x890401
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8903b1..0x8903d0
+            - Range: 0x890401..0x890420
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890300..0x8903d0, Pieces: []}]
+          Locations: [{Range: 0x890350..0x890420, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89031c..0x89035c
+            - Range: 0x89036c..0x8903ac
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x89035c..0x8903d0
+            - Range: 0x8903ac..0x890420
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x89032c..0x89035c
+            - Range: 0x89037c..0x8903ac
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x89035c..0x8903d0
+            - Range: 0x8903ac..0x890420
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x8903d0..0x890450]
+      OutOfLinePCRanges: [0x890420..0x8904a0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8903d0..0x8903f4
+            - Range: 0x890420..0x890444
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x8903d0..0x890418
+            - Range: 0x890420..0x890468
               Pieces: []
-            - Range: 0x890418..0x890419
+            - Range: 0x890468..0x890469
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890419..0x89042c
+            - Range: 0x890469..0x89047c
               Pieces: []
-            - Range: 0x89042c..0x89042d
+            - Range: 0x89047c..0x89047d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89042d..0x890450
+            - Range: 0x89047d..0x8904a0
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x890450..0x8905d0]
+      OutOfLinePCRanges: [0x8904a0..0x890620]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890450..0x8904a8
+            - Range: 0x8904a0..0x8904f8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8904a8..0x8904ac
+            - Range: 0x8904f8..0x8904fc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890504..0x890508
+            - Range: 0x890554..0x890558
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x890534..0x890538
+            - Range: 0x890584..0x890588
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890574..0x890578
+            - Range: 0x8905c4..0x8905c8
               Pieces:
                 - Size: 8
                   Op: null
@@ -5903,112 +5949,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x890450..0x8904a4
+            - Range: 0x8904a0..0x8904f4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890450..0x8904d4
+            - Range: 0x8904a0..0x890524
               Pieces: []
-            - Range: 0x8904d4..0x8904d5
+            - Range: 0x890524..0x890525
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8904d5..0x890520
+            - Range: 0x890525..0x890570
               Pieces: []
-            - Range: 0x890520..0x890521
+            - Range: 0x890570..0x890571
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890521..0x890560
+            - Range: 0x890571..0x8905b0
               Pieces: []
-            - Range: 0x890560..0x890561
+            - Range: 0x8905b0..0x8905b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890561..0x8905a0
+            - Range: 0x8905b1..0x8905f0
               Pieces: []
-            - Range: 0x8905a0..0x8905a1
+            - Range: 0x8905f0..0x8905f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905a1..0x8905d0
+            - Range: 0x8905f1..0x890620
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x890450..0x8904d4
+            - Range: 0x8904a0..0x890524
               Pieces: []
-            - Range: 0x8904d4..0x8904d5
+            - Range: 0x890524..0x890525
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8904d5..0x890520
+            - Range: 0x890525..0x890570
               Pieces: []
-            - Range: 0x890520..0x890521
+            - Range: 0x890570..0x890571
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890521..0x890560
+            - Range: 0x890571..0x8905b0
               Pieces: []
-            - Range: 0x890560..0x890561
+            - Range: 0x8905b0..0x8905b1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890561..0x8905a0
+            - Range: 0x8905b1..0x8905f0
               Pieces: []
-            - Range: 0x8905a0..0x8905a1
+            - Range: 0x8905f0..0x8905f1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8905a1..0x8905d0
+            - Range: 0x8905f1..0x890620
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890504..0x89050c
+            - Range: 0x890554..0x89055c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x8905d0..0x8907d0]
+      OutOfLinePCRanges: [0x890620..0x890820]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8905d0..0x89062c
+            - Range: 0x890620..0x89067c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89062c..0x890630
+            - Range: 0x89067c..0x890680
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890630..0x8907d0
+            - Range: 0x890680..0x890820
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6018,429 +6064,429 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8905d0..0x890688
+            - Range: 0x890620..0x8906d8
               Pieces: []
-            - Range: 0x890688..0x890689
+            - Range: 0x8906d8..0x8906d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890689..0x8906d0
+            - Range: 0x8906d9..0x890720
               Pieces: []
-            - Range: 0x8906d0..0x8906d1
+            - Range: 0x890720..0x890721
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8906d1..0x890794
+            - Range: 0x890721..0x8907e4
               Pieces: []
-            - Range: 0x890794..0x890795
+            - Range: 0x8907e4..0x8907e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890795..0x8907a8
+            - Range: 0x8907e5..0x8907f8
               Pieces: []
-            - Range: 0x8907a8..0x8907a9
+            - Range: 0x8907f8..0x8907f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8907a9..0x8907d0
+            - Range: 0x8907f9..0x890820
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8906bc..0x8906c4
+            - Range: 0x89070c..0x890714
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x89066c..0x890688
+            - Range: 0x8906bc..0x8906d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x8907d0..0x890940]
+      OutOfLinePCRanges: [0x890820..0x890990]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8907d0..0x89080c
+            - Range: 0x890820..0x89085c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89080c..0x89086c
+            - Range: 0x89085c..0x8908bc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89086c..0x8908d8
+            - Range: 0x8908bc..0x890928
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8908d8..0x890900
+            - Range: 0x890928..0x890950
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890900..0x890904
+            - Range: 0x890950..0x890954
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890904..0x890940
+            - Range: 0x890954..0x890990
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8907d0..0x8908b8
+            - Range: 0x890820..0x890908
               Pieces: []
-            - Range: 0x8908b8..0x8908b9
+            - Range: 0x890908..0x890909
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8908b9..0x8908cc
+            - Range: 0x890909..0x89091c
               Pieces: []
-            - Range: 0x8908cc..0x8908cd
+            - Range: 0x89091c..0x89091d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8908cd..0x890940
+            - Range: 0x89091d..0x890990
               Pieces: []
           Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x8907d0..0x89080c
+            - Range: 0x890820..0x89085c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89080c..0x89085c
+            - Range: 0x89085c..0x8908ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89085c..0x89086c
+            - Range: 0x8908ac..0x8908bc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x89086c..0x8908c4
+            - Range: 0x8908bc..0x890914
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908c4..0x8908c8
+            - Range: 0x890914..0x890918
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908c8..0x8908cc
+            - Range: 0x890918..0x89091c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8908cc..0x890940
+            - Range: 0x89091c..0x890990
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x890940..0x8909e0]
+      OutOfLinePCRanges: [0x890990..0x890a30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890940..0x89095c
+            - Range: 0x890990..0x8909ac
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890940..0x8909b8
+            - Range: 0x890990..0x890a08
               Pieces: []
-            - Range: 0x8909b8..0x8909b9
+            - Range: 0x890a08..0x890a09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8909b9..0x8909e0
+            - Range: 0x890a09..0x890a30
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x8909e0..0x890ab0]
+      OutOfLinePCRanges: [0x890a30..0x890b00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8909e0..0x890a30
+            - Range: 0x890a30..0x890a80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8909e0..0x890a84
+            - Range: 0x890a30..0x890ad4
               Pieces: []
-            - Range: 0x890a84..0x890a85
+            - Range: 0x890ad4..0x890ad5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890a85..0x890ab0
+            - Range: 0x890ad5..0x890b00
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8909e0..0x890a84
+            - Range: 0x890a30..0x890ad4
               Pieces: []
-            - Range: 0x890a84..0x890a85
+            - Range: 0x890ad4..0x890ad5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890a85..0x890ab0
+            - Range: 0x890ad5..0x890b00
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x890ab0..0x890b80]
+      OutOfLinePCRanges: [0x890b00..0x890bd0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890ab0..0x890af0
+            - Range: 0x890b00..0x890b40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890af0..0x890b80
+            - Range: 0x890b40..0x890bd0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890ab0..0x890b54
+            - Range: 0x890b00..0x890ba4
               Pieces: []
-            - Range: 0x890b54..0x890b55
+            - Range: 0x890ba4..0x890ba5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890b55..0x890b80
+            - Range: 0x890ba5..0x890bd0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890ab0..0x890b54
+            - Range: 0x890b00..0x890ba4
               Pieces: []
-            - Range: 0x890b54..0x890b55
+            - Range: 0x890ba4..0x890ba5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890b55..0x890b80
+            - Range: 0x890ba5..0x890bd0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890ab0..0x890b54
+            - Range: 0x890b00..0x890ba4
               Pieces: []
-            - Range: 0x890b54..0x890b55
+            - Range: 0x890ba4..0x890ba5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890b55..0x890b80
+            - Range: 0x890ba5..0x890bd0
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x890b80..0x890c10]
+      OutOfLinePCRanges: [0x890bd0..0x890c60]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x890b80..0x890bf0
+            - Range: 0x890bd0..0x890c40
               Pieces: []
-            - Range: 0x890bf0..0x890bf1
+            - Range: 0x890c40..0x890c41
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x890bf1..0x890c10
+            - Range: 0x890c41..0x890c60
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x890c10..0x890cd0]
+      OutOfLinePCRanges: [0x890c60..0x890d20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c10..0x890cd0, Pieces: []}]
+          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x890c10..0x890cac
+            - Range: 0x890c60..0x890cfc
               Pieces: []
-            - Range: 0x890cac..0x890cad
+            - Range: 0x890cfc..0x890cfd
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x890cad..0x890cd0
+            - Range: 0x890cfd..0x890d20
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x890cd0..0x890d50]
+      OutOfLinePCRanges: [0x890d20..0x890da0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
+          Locations: [{Range: 0x890d20..0x890da0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0x890cd0..0x890d50, Pieces: []}]
+          Locations: [{Range: 0x890d20..0x890da0, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x890d50..0x890e20]
+      OutOfLinePCRanges: [0x890da0..0x890e70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x890d50..0x890e04
+            - Range: 0x890da0..0x890e54
               Pieces: []
-            - Range: 0x890e04..0x890e05
+            - Range: 0x890e54..0x890e55
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6462,173 +6508,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x890e05..0x890e20
+            - Range: 0x890e55..0x890e70
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x890e20..0x890eb0]
+      OutOfLinePCRanges: [0x890e70..0x890f00]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x890e20..0x890e90
+            - Range: 0x890e70..0x890ee0
               Pieces: []
-            - Range: 0x890e90..0x890e91
+            - Range: 0x890ee0..0x890ee1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x890e91..0x890eb0
+            - Range: 0x890ee1..0x890f00
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x890eb0..0x890f20]
+      OutOfLinePCRanges: [0x890f00..0x890f70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x890eb0..0x890f04
+            - Range: 0x890f00..0x890f54
               Pieces: []
-            - Range: 0x890f04..0x890f05
+            - Range: 0x890f54..0x890f55
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890f05..0x890f20
+            - Range: 0x890f55..0x890f70
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x890f20..0x890f90]
+      OutOfLinePCRanges: [0x890f70..0x890fe0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x890f20..0x890f70
+            - Range: 0x890f70..0x890fc0
               Pieces: []
-            - Range: 0x890f70..0x890f71
+            - Range: 0x890fc0..0x890fc1
               Pieces: []
-            - Range: 0x890f71..0x890f90
+            - Range: 0x890fc1..0x890fe0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x890f90..0x891010]
+      OutOfLinePCRanges: [0x890fe0..0x891060]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x890f90..0x891010, Pieces: []}]
+          Locations: [{Range: 0x890fe0..0x891060, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x891010..0x8910b0]
+      OutOfLinePCRanges: [0x891060..0x891100]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891010..0x89108c
+            - Range: 0x891060..0x8910dc
               Pieces: []
-            - Range: 0x89108c..0x89108d
+            - Range: 0x8910dc..0x8910dd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x89108d..0x8910b0
+            - Range: 0x8910dd..0x891100
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x8910b0..0x891190]
+      OutOfLinePCRanges: [0x891100..0x8911e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x8910b0..0x891174
+            - Range: 0x891100..0x8911c4
               Pieces: []
-            - Range: 0x891174..0x891175
+            - Range: 0x8911c4..0x8911c5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6652,127 +6698,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x891175..0x891190
+            - Range: 0x8911c5..0x8911e0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x891190..0x891220]
+      OutOfLinePCRanges: [0x8911e0..0x891270]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891190..0x891200
+            - Range: 0x8911e0..0x891250
               Pieces: []
-            - Range: 0x891200..0x891201
+            - Range: 0x891250..0x891251
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891201..0x891220
+            - Range: 0x891251..0x891270
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891190..0x891220, Pieces: []}]
+          Locations: [{Range: 0x8911e0..0x891270, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891190..0x891200
+            - Range: 0x8911e0..0x891250
               Pieces: []
-            - Range: 0x891200..0x891201
+            - Range: 0x891250..0x891251
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891201..0x891220
+            - Range: 0x891251..0x891270
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891190..0x891220, Pieces: []}]
+          Locations: [{Range: 0x8911e0..0x891270, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891190..0x891200
+            - Range: 0x8911e0..0x891250
               Pieces: []
-            - Range: 0x891200..0x891201
+            - Range: 0x891250..0x891251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x891201..0x891220
+            - Range: 0x891251..0x891270
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x891220..0x8912b0]
+      OutOfLinePCRanges: [0x891270..0x891300]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891220..0x891290
+            - Range: 0x891270..0x8912e0
               Pieces: []
-            - Range: 0x891290..0x891291
+            - Range: 0x8912e0..0x8912e1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x891291..0x8912b0
+            - Range: 0x8912e1..0x891300
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x8912b0..0x891320]
+      OutOfLinePCRanges: [0x891300..0x891370]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8912b0..0x891320, Pieces: []}]
+          Locations: [{Range: 0x891300..0x891370, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x891320..0x8913a0]
+      OutOfLinePCRanges: [0x891370..0x8913f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
+          Locations: [{Range: 0x891370..0x8913f0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891320..0x8913a0, Pieces: []}]
+          Locations: [{Range: 0x891370..0x8913f0, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8913a0..0x891410]
+      OutOfLinePCRanges: [0x8913f0..0x891460]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8913a0..0x8913f8
+            - Range: 0x8913f0..0x891448
               Pieces: []
-            - Range: 0x8913f8..0x8913f9
+            - Range: 0x891448..0x891449
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8913f9..0x891410
+            - Range: 0x891449..0x891460
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8913a0..0x8913f8
+            - Range: 0x8913f0..0x891448
               Pieces: []
-            - Range: 0x8913f8..0x8913f9
+            - Range: 0x891448..0x891449
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8913f9..0x891410
+            - Range: 0x891449..0x891460
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x891410..0x8915f0]
+      OutOfLinePCRanges: [0x891460..0x891640]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891410..0x89147c
+            - Range: 0x891460..0x8914cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6794,7 +6840,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x89147c..0x891490
+            - Range: 0x8914cc..0x8914e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6816,7 +6862,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891490..0x891494
+            - Range: 0x8914e0..0x8914e4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6842,9 +6888,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891410..0x891588
+            - Range: 0x891460..0x8915d8
               Pieces: []
-            - Range: 0x891588..0x891589
+            - Range: 0x8915d8..0x8915d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6866,39 +6912,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891589..0x8915f0
+            - Range: 0x8915d9..0x891640
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x8915f0..0x8916c0]
+      OutOfLinePCRanges: [0x891640..0x891710]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x8915f0..0x8916c0
+            - Range: 0x891640..0x891710
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x8915f0..0x8916a4
+            - Range: 0x891640..0x8916f4
               Pieces: []
-            - Range: 0x8916a4..0x8916a5
+            - Range: 0x8916f4..0x8916f5
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8916a5..0x8916c0
+            - Range: 0x8916f5..0x891710
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x8916c0..0x891920]
+      OutOfLinePCRanges: [0x891710..0x891970]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8916c0..0x891730
+            - Range: 0x891710..0x891780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6920,7 +6966,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891730..0x891744
+            - Range: 0x891780..0x891794
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6942,7 +6988,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891744..0x891748
+            - Range: 0x891794..0x891798
               Pieces:
                 - Size: 8
                   Op: null
@@ -6968,15 +7014,15 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8916c0..0x891920
+            - Range: 0x891710..0x891970
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x8916c0..0x8918b0
+            - Range: 0x891710..0x891900
               Pieces: []
-            - Range: 0x8918b0..0x8918b1
+            - Range: 0x891900..0x891901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6998,175 +7044,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8918b1..0x891920
+            - Range: 0x891901..0x891970
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x891920..0x891b10]
+      OutOfLinePCRanges: [0x891970..0x891b60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891920..0x891998
+            - Range: 0x891970..0x8919e8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x891998..0x891b10
+            - Range: 0x8919e8..0x891b60
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891920..0x891aac
+            - Range: 0x891970..0x891afc
               Pieces: []
-            - Range: 0x891aac..0x891aad
+            - Range: 0x891afc..0x891afd
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x891aad..0x891b10
+            - Range: 0x891afd..0x891b60
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x891b10..0x891d50]
+      OutOfLinePCRanges: [0x891b60..0x891da0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891b10..0x891b98
+            - Range: 0x891b60..0x891be8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891b98..0x891d50
+            - Range: 0x891be8..0x891da0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7176,9 +7222,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891b10..0x891ce0
+            - Range: 0x891b60..0x891d30
               Pieces: []
-            - Range: 0x891ce0..0x891ce1
+            - Range: 0x891d30..0x891d31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7200,191 +7246,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891ce1..0x891d50
+            - Range: 0x891d31..0x891da0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x891d50..0x891df0]
+      OutOfLinePCRanges: [0x891da0..0x891e40]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x891d50..0x891df0
+            - Range: 0x891da0..0x891e40
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d50..0x891dcc
+            - Range: 0x891da0..0x891e1c
               Pieces: []
-            - Range: 0x891dcc..0x891dcd
+            - Range: 0x891e1c..0x891e1d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891dcd..0x891df0
+            - Range: 0x891e1d..0x891e40
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d50..0x891dcc
+            - Range: 0x891da0..0x891e1c
               Pieces: []
-            - Range: 0x891dcc..0x891dcd
+            - Range: 0x891e1c..0x891e1d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891dcd..0x891df0
+            - Range: 0x891e1d..0x891e40
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891d50..0x891dcc
+            - Range: 0x891da0..0x891e1c
               Pieces: []
-            - Range: 0x891dcc..0x891dcd
+            - Range: 0x891e1c..0x891e1d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891dcd..0x891df0
+            - Range: 0x891e1d..0x891e40
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x891df0..0x891ed0]
+      OutOfLinePCRanges: [0x891e40..0x891f20]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891df0..0x891ed0
+            - Range: 0x891e40..0x891f20
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891df0..0x891ed0
+            - Range: 0x891e40..0x891f20
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891df0..0x891eb0
+            - Range: 0x891e40..0x891f00
               Pieces: []
-            - Range: 0x891eb0..0x891eb1
+            - Range: 0x891f00..0x891f01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891eb1..0x891ed0
+            - Range: 0x891f01..0x891f20
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891df0..0x891eb0
+            - Range: 0x891e40..0x891f00
               Pieces: []
-            - Range: 0x891eb0..0x891eb1
+            - Range: 0x891f00..0x891f01
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x891eb1..0x891ed0
+            - Range: 0x891f01..0x891f20
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x891ed0..0x891fa0]
+      OutOfLinePCRanges: [0x891f20..0x891ff0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891ed0..0x891fa0
+            - Range: 0x891f20..0x891ff0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ed0..0x891f7c
+            - Range: 0x891f20..0x891fcc
               Pieces: []
-            - Range: 0x891f7c..0x891f7d
+            - Range: 0x891fcc..0x891fcd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891f7d..0x891fa0
+            - Range: 0x891fcd..0x891ff0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891ed0..0x891f7c
+            - Range: 0x891f20..0x891fcc
               Pieces: []
-            - Range: 0x891f7c..0x891f7d
+            - Range: 0x891fcc..0x891fcd
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x891f7d..0x891fa0
+            - Range: 0x891fcd..0x891ff0
               Pieces: []
           Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891f50..0x891fa0
+            - Range: 0x891fa0..0x891ff0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x891fa0..0x892050]
+      OutOfLinePCRanges: [0x891ff0..0x8920a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x891fa0..0x892050, Pieces: []}]
+          Locations: [{Range: 0x891ff0..0x8920a0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891fa0..0x891fe0
+            - Range: 0x891ff0..0x892030
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891fe0..0x891ffc
+            - Range: 0x892030..0x89204c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x891ffc..0x892018
+            - Range: 0x89204c..0x892068
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x892018..0x892050
+            - Range: 0x892068..0x8920a0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891fa0..0x892024
+            - Range: 0x891ff0..0x892074
               Pieces: []
-            - Range: 0x892024..0x892025
+            - Range: 0x892074..0x892075
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892025..0x892050
+            - Range: 0x892075..0x8920a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x891fa0..0x892024
+            - Range: 0x891ff0..0x892074
               Pieces: []
-            - Range: 0x892024..0x892025
+            - Range: 0x892074..0x892075
               Pieces: []
-            - Range: 0x892025..0x892050
+            - Range: 0x892075..0x8920a0
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8924c0..0x8924d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8924c0..0x8924d0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x8924d0..0x8924e0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x892510..0x892520]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8924d0..0x8924e0
+            - Range: 0x892510..0x892520
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7394,98 +7423,12 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 130
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x8924e0..0x8924f0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x8924e0..0x8924f0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x8924f0..0x892500]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x8924f0..0x892500
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x8924f0..0x892500
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x892500..0x892510]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x892500..0x892510
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892500..0x892510
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x892510..0x892520]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x892510..0x892520
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892510..0x892520
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x892520..0x892530]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 258 GoSliceHeaderType []string
+        - Name: u
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0x892520..0x892530
               Pieces:
@@ -7496,21 +7439,124 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x892530..0x892540]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x892530..0x892540
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 132
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x892540..0x892550]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x892540..0x892550
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x892540..0x892550
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x892550..0x892560]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x892550..0x892560
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x892550..0x892560
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x892560..0x892570]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x892560..0x892570
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x892560..0x892570
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x892570..0x892580]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 258 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x892570..0x892580
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x892580..0x892590]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892530..0x892540
+            - Range: 0x892580..0x892590
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x892530..0x892540
+            - Range: 0x892580..0x892590
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7522,35 +7568,18 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x892530..0x892540
+            - Range: 0x892580..0x892590
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x892540..0x892550]
+      OutOfLinePCRanges: [0x892590..0x8925a0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 260 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x892540..0x892550
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x892550..0x892560]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x892550..0x892560
+            - Range: 0x892590..0x8925a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7560,14 +7589,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 138
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x892560..0x892570]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8925a0..0x8925b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892560..0x892570
+            - Range: 0x8925a0..0x8925b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7577,14 +7606,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8925b0..0x8925c0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8925b0..0x8925c0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x892570..0x892580]
+      OutOfLinePCRanges: [0x8925c0..0x8925d0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892570..0x892580
+            - Range: 0x8925c0..0x8925d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7596,7 +7642,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892570..0x892580
+            - Range: 0x8925c0..0x8925d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7608,7 +7654,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x892570..0x892580
+            - Range: 0x8925c0..0x8925d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7617,122 +7663,42 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0x892890..0x892900]
+      OutOfLinePCRanges: [0x8928e0..0x892950]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892890..0x8928dc
+            - Range: 0x8928e0..0x89292c
               Pieces: []
-            - Range: 0x8928dc..0x8928dd
+            - Range: 0x89292c..0x89292d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8928dd..0x892900
+            - Range: 0x89292d..0x892950
               Pieces: []
           Role: Return
-    - ID: 141
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x892900..0x892910]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892900..0x892910
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 142
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x892910..0x892920]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892910..0x892920
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-        - Name: y
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892910..0x892920
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: z
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892910..0x892920
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 143
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x892920..0x892940]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 263 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x892920..0x892940
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 144
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x892940..0x892950]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 264 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x892940..0x892950
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 145
-      Name: main.testOneStringInStructPointer
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x892950..0x892960]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 265 PointerType *main.oneStringStruct
+        - Name: x
+          Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x892950..0x892960
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
+    - ID: 143
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x892960..0x892970]
       InlinePCRanges: []
       Variables:
@@ -7746,15 +7712,80 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
+        - Name: y
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x892960..0x892970
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: z
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x892960..0x892970
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 144
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0x892970..0x892990]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 263 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x892970..0x892990
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 145
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x892990..0x8929a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 264 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x892990..0x8929a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 146
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x8929a0..0x8929b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 265 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x8929a0..0x8929b0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x892970..0x892980]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x8929b0..0x8929c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892970..0x892980
+            - Range: 0x8929b0..0x8929c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7762,14 +7793,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 148
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x892980..0x892990]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x8929c0..0x8929d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892980..0x892990
+            - Range: 0x8929c0..0x8929d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7777,14 +7808,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x8929d0..0x8929e0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x8929d0..0x8929e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 150
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x892990..0x8929a0]
+      OutOfLinePCRanges: [0x8929e0..0x8929f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892990..0x8929a0
+            - Range: 0x8929e0..0x8929f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7794,7 +7840,7 @@ Subprograms:
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892990..0x8929a0
+            - Range: 0x8929e0..0x8929f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7804,33 +7850,33 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892990..0x8929a0
+            - Range: 0x8929e0..0x8929f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x892b00..0x892b10]
+      OutOfLinePCRanges: [0x892b50..0x892b60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x892b00..0x892b10
+            - Range: 0x892b50..0x892b60
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x892b10..0x892b30]
+      OutOfLinePCRanges: [0x892b60..0x892b80]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x892b10..0x892b30
+            - Range: 0x892b60..0x892b80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7845,15 +7891,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0x892c00..0x892c20]
+      OutOfLinePCRanges: [0x892c50..0x892c70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x892c00..0x892c20
+            - Range: 0x892c50..0x892c70
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7870,38 +7916,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x892ca0..0x892cb0]
+      OutOfLinePCRanges: [0x892cf0..0x892d00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x892ca0..0x892cb0
+            - Range: 0x892cf0..0x892d00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x892d00..0x892d10]
+      OutOfLinePCRanges: [0x892d50..0x892d60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 314 StructureType main.emptyStruct
-          Locations: [{Range: 0x892d00..0x892d10, Pieces: []}]
+          Locations: [{Range: 0x892d50..0x892d60, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x892d10..0x892d20]
+      OutOfLinePCRanges: [0x892d60..0x892d70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x892d10..0x892d20
+            - Range: 0x892d60..0x892d70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d5e0..0x88d650]
       InlinePCRanges:
@@ -7930,28 +7976,28 @@ Subprograms:
             - Range: 0x88d8e0..0x88d904
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d878..0x88d8b0]
           RootRanges: [0x88d810..0x88d8e0]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d97c..0x88d9c0]
           RootRanges: [0x88d960..0x88da80]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88da30..0x88da68]
           RootRanges: [0x88d960..0x88da80]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7964,7 +8010,7 @@ Subprograms:
             - Range: 0x88da80..0x88da88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10934,10 +10980,10 @@ Types:
       GoKind: 22
       Pointee: 673 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1329
+      ID: 1331
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10949,7 +10995,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11037,7 +11083,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11049,7 +11095,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11059,11 +11105,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11075,7 +11121,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11235,6 +11281,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1228
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1229
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 10 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1165
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11316,7 +11404,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1228
+      ID: 1230
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11328,7 +11416,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11338,7 +11426,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11408,7 +11496,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1236
+      ID: 1238
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11420,7 +11508,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11430,7 +11518,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11590,7 +11678,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11602,7 +11690,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11612,7 +11700,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11622,7 +11710,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11632,11 +11720,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11648,7 +11736,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11658,11 +11746,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1342
+      ID: 1344
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11674,7 +11762,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11684,11 +11772,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1354
+      ID: 1356
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11700,7 +11788,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11710,11 +11798,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1353
+      ID: 1355
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11726,7 +11814,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11736,7 +11824,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12002,7 +12090,7 @@ Types:
       ID: 1187
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1358
+      ID: 1360
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1184
@@ -12054,16 +12142,16 @@ Types:
       ID: 1185
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1360
+      ID: 1362
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1361
+      ID: 1363
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1362
+      ID: 1364
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1188
@@ -12072,7 +12160,7 @@ Types:
       ID: 1189
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1355
+      ID: 1357
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12084,7 +12172,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12094,11 +12182,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1357
+      ID: 1359
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12110,7 +12198,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12120,14 +12208,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1356
+      ID: 1358
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1363
+      ID: 1365
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12139,7 +12227,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12149,11 +12237,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1364
+      ID: 1366
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12165,7 +12253,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12175,11 +12263,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1365
+      ID: 1367
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12191,7 +12279,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12201,7 +12289,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12361,7 +12449,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1297
+      ID: 1299
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12373,7 +12461,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12383,11 +12471,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1298
+      ID: 1300
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12399,11 +12487,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1230
+      ID: 1232
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12415,7 +12503,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12425,7 +12513,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12484,7 +12572,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12496,7 +12584,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12506,7 +12594,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12516,7 +12604,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12526,7 +12614,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12536,7 +12624,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12546,7 +12634,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12556,7 +12644,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12566,7 +12654,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12576,7 +12664,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12586,7 +12674,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12596,7 +12684,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12606,7 +12694,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12616,7 +12704,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12626,7 +12714,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12636,7 +12724,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12646,7 +12734,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12656,7 +12744,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12666,11 +12754,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12682,7 +12770,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13206,7 +13294,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13218,7 +13306,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13228,11 +13316,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13244,7 +13332,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13254,11 +13342,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13270,7 +13358,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13280,7 +13368,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13290,7 +13378,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13300,7 +13388,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13310,7 +13398,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13320,7 +13408,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13330,7 +13418,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13340,7 +13428,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13350,7 +13438,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13360,7 +13448,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13370,7 +13458,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13380,7 +13468,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13390,7 +13478,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13400,7 +13488,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13410,7 +13498,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13420,7 +13508,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13430,7 +13518,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13440,11 +13528,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13456,11 +13544,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13472,7 +13560,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13482,7 +13570,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13492,7 +13580,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13502,11 +13590,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13518,7 +13606,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13528,11 +13616,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13544,7 +13632,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13554,7 +13642,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13564,7 +13652,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13574,11 +13662,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13590,11 +13678,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1255
+      ID: 1257
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13606,7 +13694,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13616,11 +13704,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13632,7 +13720,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13642,7 +13730,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13652,7 +13740,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13662,23 +13750,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1259
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13694,7 +13766,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13710,11 +13782,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1265
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1258
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13726,7 +13814,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13736,11 +13824,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13752,7 +13840,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13762,7 +13850,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13772,7 +13860,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13782,7 +13870,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13792,7 +13880,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13802,33 +13890,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1260
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13844,7 +13906,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13854,7 +13916,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13870,7 +13932,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13880,7 +13942,33 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1266
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13990,32 +14078,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1251
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1253
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14028,7 +14090,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14038,11 +14100,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1252
+      ID: 1255
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1254
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14054,11 +14142,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1254
+      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14070,7 +14158,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14080,11 +14168,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1351
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14096,7 +14184,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14106,11 +14194,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1350
+      ID: 1352
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14122,7 +14210,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14132,10 +14220,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1351
+      ID: 1353
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1352
+      ID: 1354
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14147,7 +14235,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14157,7 +14245,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1235
+      ID: 1237
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14169,7 +14257,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14179,7 +14267,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14189,7 +14277,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14199,11 +14287,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14215,7 +14303,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14225,7 +14313,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14235,7 +14323,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14245,11 +14333,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14261,7 +14349,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14271,7 +14359,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14281,7 +14369,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14291,7 +14379,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14301,7 +14389,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14311,11 +14399,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14327,7 +14415,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14337,11 +14425,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14353,7 +14441,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14363,11 +14451,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1233
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14379,7 +14467,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14389,7 +14477,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14419,7 +14507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1231
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14431,7 +14519,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14441,11 +14529,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1245
+      ID: 1247
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14457,7 +14545,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14467,7 +14555,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14477,7 +14565,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14487,11 +14575,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1246
+      ID: 1248
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14503,7 +14591,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14513,446 +14601,12 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1247
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1248
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1277
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1278
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 247 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1279
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1280
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1275
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1276
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 246 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1283
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1284
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1295
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1296
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1271
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1272
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 90 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 91 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1244
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1241
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1239
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1240
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 94 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1237
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1238
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1249
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -14978,6 +14632,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1250
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1282
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1277
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1278
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1285
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1286
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1297
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1298
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1273
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1274
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 91 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1245
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1246
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1243
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1244
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1241
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1242
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1239
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1240
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1251
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1252
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14989,14 +15077,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1273
+      ID: 1275
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1274
+      ID: 1276
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15008,14 +15096,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15027,7 +15115,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15037,7 +15125,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15047,7 +15135,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15057,7 +15145,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15067,7 +15155,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15077,7 +15165,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15087,7 +15175,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15097,7 +15185,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15107,7 +15195,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15117,7 +15205,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15127,7 +15215,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15137,7 +15225,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15147,7 +15235,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15157,7 +15245,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15167,7 +15255,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15177,7 +15265,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15187,14 +15275,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1281
+      ID: 1283
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1282
+      ID: 1284
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15206,14 +15294,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15225,7 +15313,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15235,7 +15323,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15245,7 +15333,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15255,7 +15343,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15265,14 +15353,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15284,7 +15372,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15294,14 +15382,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15313,14 +15401,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15332,7 +15420,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15342,7 +15430,7 @@ Types:
             Type: 89 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15352,7 +15440,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15362,7 +15450,7 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15372,7 +15460,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15382,7 +15470,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15392,7 +15480,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15402,14 +15490,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15421,14 +15509,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1285
+      ID: 1287
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1286
+      ID: 1288
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15440,7 +15528,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15750,7 +15838,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15762,7 +15850,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15772,7 +15860,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -15906,7 +15994,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15918,7 +16006,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15928,11 +16016,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15944,7 +16032,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -15954,7 +16042,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -15984,7 +16072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1265
+      ID: 1267
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15996,7 +16084,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16006,11 +16094,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1266
+      ID: 1268
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16022,7 +16110,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16032,7 +16120,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16042,11 +16130,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16058,7 +16146,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16068,11 +16156,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16084,7 +16172,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16094,7 +16182,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16104,7 +16192,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16134,7 +16222,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1234
+      ID: 1236
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16146,7 +16234,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16156,11 +16244,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16172,7 +16260,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16182,7 +16270,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16238,7 +16326,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16250,7 +16338,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16260,7 +16348,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16270,7 +16358,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16280,7 +16368,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16310,7 +16398,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16322,7 +16410,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16332,11 +16420,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16348,7 +16436,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16358,11 +16446,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1347
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16374,7 +16462,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16384,14 +16472,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1346
+      ID: 1348
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1344
+      ID: 1346
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16403,7 +16491,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16413,7 +16501,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16443,7 +16531,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1347
+      ID: 1349
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16455,7 +16543,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16465,14 +16553,14 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1348
+      ID: 1350
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16484,7 +16572,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16494,7 +16582,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16504,7 +16592,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16514,7 +16602,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16524,7 +16612,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16534,11 +16622,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1343
+      ID: 1345
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16550,7 +16638,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16560,7 +16648,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16570,7 +16658,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16580,7 +16668,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16590,7 +16678,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16600,11 +16688,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16616,7 +16704,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16626,11 +16714,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1337
+      ID: 1339
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16642,7 +16730,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16655,7 +16743,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16668,14 +16756,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16687,7 +16775,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16697,11 +16785,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16713,7 +16801,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16723,7 +16811,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16733,17 +16821,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1333
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1335
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1331
+      ID: 1337
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1333
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16755,7 +16843,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16765,7 +16853,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16775,7 +16863,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16785,7 +16873,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16795,7 +16883,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16805,7 +16893,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16965,7 +17053,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1233
+      ID: 1235
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16977,7 +17065,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -16987,11 +17075,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17003,7 +17091,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17013,11 +17101,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17029,7 +17117,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17039,11 +17127,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1232
+      ID: 1234
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17055,7 +17143,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17065,7 +17153,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17095,7 +17183,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17107,7 +17195,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17117,11 +17205,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17133,7 +17221,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17143,11 +17231,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17159,7 +17247,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17169,7 +17257,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17179,7 +17267,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17189,11 +17277,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17205,7 +17293,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17215,7 +17303,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24268,7 +24356,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1365
+MaxTypeID: 1367
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x84fea8", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x84fef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x84fedc", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x84ff2c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x84ecac", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x84ecfc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84ed44", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84ed94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1403 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1404 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x84d31c", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
+          Type: 1405 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x84d320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x84d580", Frameless: true}]
+          Type: 1413 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x84fad0", Frameless: true}]
+          Type: 1493 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x84fb00", Frameless: true}]
+          Type: 1496 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x84ff80", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x84ffd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x850300", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x850350", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x850310", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x850360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testInlinedBBB]
+          Type: 1535 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testInlinedBCA]
+          Type: 1536 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1535 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1537 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testInlinedBCB]
+          Type: 1538 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1539 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testInlinedPrint]
+          Type: 1532 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1533 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1532 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1534 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedSq]
+          Type: 1540 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1539 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1541 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1542 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x84eaf0", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x84eb40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84ec48", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84ec98", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x84d490", Frameless: true}]
+          Type: 1407 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x84d4e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x84efac", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x84effc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x84f118", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x84f168", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x84f180", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x84f1d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x84f32c", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x84f37c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x84f42c", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x84f47c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x84f4d4", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x84f524", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x84ed80", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x84edd0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x84ef50", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x84efa0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
+          Type: 1428 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
+          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x84e028", Frameless: false}]
+          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e088", Frameless: false}]
+          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502a0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502a0", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502a0", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x8502a0", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x84d560", Frameless: true}]
+          Type: 1412 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
+          Type: 1500 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x84fb90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
+          Type: 1497 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
+          Type: 1499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x84fb80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x84ff50", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x84ffa0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x84d4a0", Frameless: true}]
+          Type: 1408 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1404 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x84d480", Frameless: true}]
+          Type: 1406 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x84dcc8", Frameless: false}]
+          Type: 1424 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x84dd18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1425 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x84dd64"
+            - PC: "0x84ddb4"
               Frameless: false
-            - PC: "0x84ddac"
+            - PC: "0x84ddfc"
               Frameless: false
-            - PC: "0x84de70"
+            - PC: "0x84dec0"
               Frameless: false
-            - PC: "0x84de84"
+            - PC: "0x84ded4"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x84db48", Frameless: false}]
+          Type: 1422 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x84db98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1423 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x84db9c"
+            - PC: "0x84dbec"
               Frameless: false
-            - PC: "0x84dc00"
+            - PC: "0x84dc50"
               Frameless: false
-            - PC: "0x84dc40"
+            - PC: "0x84dc90"
               Frameless: false
-            - PC: "0x84dc80"
+            - PC: "0x84dcd0"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x84e4fc", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x84e54c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x84e550", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x84e5a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x84e588", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x84e5d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x84e5c4", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x84e614", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x84e5f8", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x84e648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x84e630", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x84e680", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x84e6e8", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x84e738", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x84e74c", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x84e79c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x84ea78", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x84eac8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x84eab8", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x84eb08", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x84e3a8", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x84e3f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x84e3f4", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x84e444", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x84dac8", Frameless: false}]
+          Type: 1420 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x84db18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsError]Return
+          Type: 1421 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x84daf8"
+            - PC: "0x84db48"
               Frameless: false
-            - PC: "0x84db0c"
+            - PC: "0x84db5c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x84d8d8", Frameless: false}]
+          Type: 1414 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x84d928", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1413 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x84d91c", Frameless: false}]
+          Type: 1415 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x84d96c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x84d9f8", Frameless: false}]
+          Type: 1418 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x84da48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x84da90", Frameless: false}]
+          Type: 1419 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x84dae0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x84d958", Frameless: false}]
+          Type: 1416 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x84d9a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1415 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x84d9b8", Frameless: false}]
+          Type: 1417 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x84da08", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x84dec8", Frameless: false}]
+          Type: 1426 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x84df18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1427 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x84df94"
+            - PC: "0x84dfe4"
               Frameless: false
-            - PC: "0x84dfa8"
+            - PC: "0x84dff8"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x84e430", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x84e480", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x84e4c4", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x84e514", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x84e2e8", Frameless: false}]
+          Type: 1446 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x84e338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x84e36c", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x84e3bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x84e868", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x84e8b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x84e8c0", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x84e910", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x84e668", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x84e6b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x84e6b0", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x84e700", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x84e9f8", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x84ea48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x84ea3c", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x84ea8c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x84e988", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x84e9d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x84e9c8", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x84ea18", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x84e258", Frameless: false}]
+          Type: 1444 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x84e2a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x84e2b0", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x84e300", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x84e8fc", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x84e94c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x84e950", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x84e9a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x84e790", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x84e7e0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x84e834", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x84e884", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x84ff00", Frameless: true}]
+          Type: 1507 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x84ff50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
+          Type: 1503 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x84fbb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x84fae0", Frameless: true}]
+          Type: 1494 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x84e198", Frameless: false}]
+          Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x84e1e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e220", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e270", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x84f388", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x84f3ec", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x84f43c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x84d540", Frameless: true}]
+          Type: 1411 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x84d590", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
+          Type: 1498 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x84fb70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x850200", Frameless: true}]
+          Type: 1524 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x850250", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x85021c", Frameless: true}]
+          Type: 1525 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x85026c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x84faf0", Frameless: true}]
+          Type: 1495 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x84f50c", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x84f55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x84f59c", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x84f5ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x850110", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x850160", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1521 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x850128", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x850178", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x850100", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x850150", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x84fb70", Frameless: true}]
+          Type: 1504 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x84fbc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x84ffe0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x84e0c8", Frameless: false}]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x84e154", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1506 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x84ff10", Frameless: true}]
+          Type: 1508 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
+          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84ff38", Frameless: true}]
+          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x84ff20", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x84ff38", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84ff40", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x84ff40", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
+          Type: 1410 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x84d520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x84fac0", Frameless: true}]
+          Type: 1492 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x84ffc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x84d4b0", Frameless: true}]
+          Type: 1409 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x84d500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
+          Type: 1501 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
+          Type: 1502 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x84f5d8", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x84f628", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x84f640", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x84f690", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5619,281 +5644,302 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0x84d2e0..0x84d320]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x84d2e0..0x84d31c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x84d2e0..0x84d31c
+              Pieces: []
+            - Range: 0x84d31c..0x84d31d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x84d31d..0x84d320
+              Pieces: []
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0x84d2e0..0x84d2f0]
+      OutOfLinePCRanges: [0x84d320..0x84d330]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 241 GoChannelType chan bool
           Locations:
-            - Range: 0x84d2e0..0x84d2f0
+            - Range: 0x84d320..0x84d330
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x84d480..0x84d490]
+      OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x84d480..0x84d490
+            - Range: 0x84d4d0..0x84d4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x84d490..0x84d4a0]
+      OutOfLinePCRanges: [0x84d4e0..0x84d4f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 StructureType main.node
           Locations:
-            - Range: 0x84d490..0x84d4a0
+            - Range: 0x84d4e0..0x84d4f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x84d4a0..0x84d4b0]
+      OutOfLinePCRanges: [0x84d4f0..0x84d500]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 245 PointerType *main.node
           Locations:
-            - Range: 0x84d4a0..0x84d4b0
+            - Range: 0x84d4f0..0x84d500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x84d4b0..0x84d4c0]
+      OutOfLinePCRanges: [0x84d500..0x84d510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x84d4b0..0x84d4c0
+            - Range: 0x84d500..0x84d510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
+      OutOfLinePCRanges: [0x84d520..0x84d530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 PointerType *uint
           Locations:
-            - Range: 0x84d4d0..0x84d4e0
+            - Range: 0x84d520..0x84d530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x84d540..0x84d550]
+      OutOfLinePCRanges: [0x84d590..0x84d5a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 93 PointerType *string
           Locations:
-            - Range: 0x84d540..0x84d550
+            - Range: 0x84d590..0x84d5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x84d560..0x84d570]
+      OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x84d560..0x84d570
+            - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84d560..0x84d570
+            - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0x84d580..0x84d590]
+      OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 246 PointerType *main.t
           Locations:
-            - Range: 0x84d580..0x84d590
+            - Range: 0x84d5d0..0x84d5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x84d8c0..0x84d940]
+      OutOfLinePCRanges: [0x84d910..0x84d990]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d8c0..0x84d8dc
+            - Range: 0x84d910..0x84d92c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d8c0..0x84d91c
+            - Range: 0x84d910..0x84d96c
               Pieces: []
-            - Range: 0x84d91c..0x84d91d
+            - Range: 0x84d96c..0x84d96d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d91d..0x84d940
+            - Range: 0x84d96d..0x84d990
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d8dc..0x84d8e8
+            - Range: 0x84d92c..0x84d938
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d8e8..0x84d940
+            - Range: 0x84d938..0x84d990
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x84d940..0x84d9e0]
+      OutOfLinePCRanges: [0x84d990..0x84da30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d940..0x84d964
+            - Range: 0x84d990..0x84d9b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d964..0x84d9e0
+            - Range: 0x84d9b4..0x84da30
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d940..0x84d9b8
+            - Range: 0x84d990..0x84da08
               Pieces: []
-            - Range: 0x84d9b8..0x84d9b9
+            - Range: 0x84da08..0x84da09
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d9b9..0x84d9e0
+            - Range: 0x84da09..0x84da30
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84d968..0x84d980
+            - Range: 0x84d9b8..0x84d9d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84d980..0x84d9e0
+            - Range: 0x84d9d0..0x84da30
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x84d9e0..0x84dab0]
+      OutOfLinePCRanges: [0x84da30..0x84db00]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d9e0..0x84da38
+            - Range: 0x84da30..0x84da88
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d9e0..0x84da90
+            - Range: 0x84da30..0x84dae0
               Pieces: []
-            - Range: 0x84da90..0x84da91
+            - Range: 0x84dae0..0x84dae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84da91..0x84dab0
+            - Range: 0x84dae1..0x84db00
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84d9e0..0x84dab0, Pieces: []}]
+          Locations: [{Range: 0x84da30..0x84db00, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84d9fc..0x84da3c
+            - Range: 0x84da4c..0x84da8c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84da3c..0x84dab0
+            - Range: 0x84da8c..0x84db00
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84da0c..0x84da3c
+            - Range: 0x84da5c..0x84da8c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x84da3c..0x84dab0
+            - Range: 0x84da8c..0x84db00
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x84dab0..0x84db30]
+      OutOfLinePCRanges: [0x84db00..0x84db80]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84dab0..0x84dad4
+            - Range: 0x84db00..0x84db24
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84dab0..0x84daf8
+            - Range: 0x84db00..0x84db48
               Pieces: []
-            - Range: 0x84daf8..0x84daf9
+            - Range: 0x84db48..0x84db49
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84daf9..0x84db0c
+            - Range: 0x84db49..0x84db5c
               Pieces: []
-            - Range: 0x84db0c..0x84db0d
+            - Range: 0x84db5c..0x84db5d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db0d..0x84db30
+            - Range: 0x84db5d..0x84db80
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x84db30..0x84dcb0]
+      OutOfLinePCRanges: [0x84db80..0x84dd00]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db30..0x84db80
+            - Range: 0x84db80..0x84dbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db80..0x84db84
+            - Range: 0x84dbd0..0x84dbd4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x84dbd4..0x84dbd8
+            - Range: 0x84dc24..0x84dc28
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc14..0x84dc18
+            - Range: 0x84dc64..0x84dc68
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc54..0x84dc58
+            - Range: 0x84dca4..0x84dca8
               Pieces:
                 - Size: 8
                   Op: null
@@ -5903,112 +5949,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84db30..0x84db74
+            - Range: 0x84db80..0x84dbc4
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84db30..0x84db9c
+            - Range: 0x84db80..0x84dbec
               Pieces: []
-            - Range: 0x84db9c..0x84db9d
+            - Range: 0x84dbec..0x84dbed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84db9d..0x84dc00
+            - Range: 0x84dbed..0x84dc50
               Pieces: []
-            - Range: 0x84dc00..0x84dc01
+            - Range: 0x84dc50..0x84dc51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc01..0x84dc40
+            - Range: 0x84dc51..0x84dc90
               Pieces: []
-            - Range: 0x84dc40..0x84dc41
+            - Range: 0x84dc90..0x84dc91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc41..0x84dc80
+            - Range: 0x84dc91..0x84dcd0
               Pieces: []
-            - Range: 0x84dc80..0x84dc81
+            - Range: 0x84dcd0..0x84dcd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dc81..0x84dcb0
+            - Range: 0x84dcd1..0x84dd00
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x84db30..0x84db9c
+            - Range: 0x84db80..0x84dbec
               Pieces: []
-            - Range: 0x84db9c..0x84db9d
+            - Range: 0x84dbec..0x84dbed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84db9d..0x84dc00
+            - Range: 0x84dbed..0x84dc50
               Pieces: []
-            - Range: 0x84dc00..0x84dc01
+            - Range: 0x84dc50..0x84dc51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dc01..0x84dc40
+            - Range: 0x84dc51..0x84dc90
               Pieces: []
-            - Range: 0x84dc40..0x84dc41
+            - Range: 0x84dc90..0x84dc91
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dc41..0x84dc80
+            - Range: 0x84dc91..0x84dcd0
               Pieces: []
-            - Range: 0x84dc80..0x84dc81
+            - Range: 0x84dcd0..0x84dcd1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84dc81..0x84dcb0
+            - Range: 0x84dcd1..0x84dd00
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84db80..0x84db88
+            - Range: 0x84dbd0..0x84dbd8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x84dcb0..0x84deb0]
+      OutOfLinePCRanges: [0x84dd00..0x84df00]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dcb0..0x84dcf8
+            - Range: 0x84dd00..0x84dd48
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dcf8..0x84dd00
+            - Range: 0x84dd48..0x84dd50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dd00..0x84deb0
+            - Range: 0x84dd50..0x84df00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6018,429 +6064,429 @@ Subprograms:
         - Name: ~r0
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84dcb0..0x84dd64
+            - Range: 0x84dd00..0x84ddb4
               Pieces: []
-            - Range: 0x84dd64..0x84dd65
+            - Range: 0x84ddb4..0x84ddb5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dd65..0x84ddac
+            - Range: 0x84ddb5..0x84ddfc
               Pieces: []
-            - Range: 0x84ddac..0x84ddad
+            - Range: 0x84ddfc..0x84ddfd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84ddad..0x84de70
+            - Range: 0x84ddfd..0x84dec0
               Pieces: []
-            - Range: 0x84de70..0x84de71
+            - Range: 0x84dec0..0x84dec1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84de71..0x84de84
+            - Range: 0x84dec1..0x84ded4
               Pieces: []
-            - Range: 0x84de84..0x84de85
+            - Range: 0x84ded4..0x84ded5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84de85..0x84deb0
+            - Range: 0x84ded5..0x84df00
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84dd98..0x84dda0
+            - Range: 0x84dde8..0x84ddf0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 99 PointerType *int
           Locations:
-            - Range: 0x84dd48..0x84dd64
+            - Range: 0x84dd98..0x84ddb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x84deb0..0x84e010]
+      OutOfLinePCRanges: [0x84df00..0x84e060]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 155 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x84deb0..0x84deec
+            - Range: 0x84df00..0x84df3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84deec..0x84df34
+            - Range: 0x84df3c..0x84df84
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84df34..0x84dfb4
+            - Range: 0x84df84..0x84e004
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dfb4..0x84dfdc
+            - Range: 0x84e004..0x84e02c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dfdc..0x84dfe0
+            - Range: 0x84e02c..0x84e030
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dfe0..0x84e010
+            - Range: 0x84e030..0x84e060
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84deb0..0x84df94
+            - Range: 0x84df00..0x84dfe4
               Pieces: []
-            - Range: 0x84df94..0x84df95
+            - Range: 0x84dfe4..0x84dfe5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84df95..0x84dfa8
+            - Range: 0x84dfe5..0x84dff8
               Pieces: []
-            - Range: 0x84dfa8..0x84dfa9
+            - Range: 0x84dff8..0x84dff9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84dfa9..0x84e010
+            - Range: 0x84dff9..0x84e060
               Pieces: []
           Role: Return
         - Name: b
           Type: 160 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x84deb0..0x84deec
+            - Range: 0x84df00..0x84df3c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84deec..0x84df34
+            - Range: 0x84df3c..0x84df84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84df34..0x84df3c
+            - Range: 0x84df84..0x84df8c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84df3c..0x84dfa0
+            - Range: 0x84df8c..0x84dff0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dfa0..0x84dfa4
+            - Range: 0x84dff0..0x84dff4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x84dfa4..0x84dfa8
+            - Range: 0x84dff4..0x84dff8
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x84dfa8..0x84e010
+            - Range: 0x84dff8..0x84e060
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x84e010..0x84e0b0]
+      OutOfLinePCRanges: [0x84e060..0x84e100]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e010..0x84e02c
+            - Range: 0x84e060..0x84e07c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e010..0x84e088
+            - Range: 0x84e060..0x84e0d8
               Pieces: []
-            - Range: 0x84e088..0x84e089
+            - Range: 0x84e0d8..0x84e0d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e089..0x84e0b0
+            - Range: 0x84e0d9..0x84e100
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x84e0b0..0x84e180]
+      OutOfLinePCRanges: [0x84e100..0x84e1d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e0b0..0x84e100
+            - Range: 0x84e100..0x84e150
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e0b0..0x84e154
+            - Range: 0x84e100..0x84e1a4
               Pieces: []
-            - Range: 0x84e154..0x84e155
+            - Range: 0x84e1a4..0x84e1a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e155..0x84e180
+            - Range: 0x84e1a5..0x84e1d0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e0b0..0x84e154
+            - Range: 0x84e100..0x84e1a4
               Pieces: []
-            - Range: 0x84e154..0x84e155
+            - Range: 0x84e1a4..0x84e1a5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e155..0x84e180
+            - Range: 0x84e1a5..0x84e1d0
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x84e180..0x84e240]
+      OutOfLinePCRanges: [0x84e1d0..0x84e290]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e180..0x84e1c0
+            - Range: 0x84e1d0..0x84e210
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e1c0..0x84e240
+            - Range: 0x84e210..0x84e290
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e180..0x84e220
+            - Range: 0x84e1d0..0x84e270
               Pieces: []
-            - Range: 0x84e220..0x84e221
+            - Range: 0x84e270..0x84e271
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e221..0x84e240
+            - Range: 0x84e271..0x84e290
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e180..0x84e220
+            - Range: 0x84e1d0..0x84e270
               Pieces: []
-            - Range: 0x84e220..0x84e221
+            - Range: 0x84e270..0x84e271
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e221..0x84e240
+            - Range: 0x84e271..0x84e290
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e180..0x84e220
+            - Range: 0x84e1d0..0x84e270
               Pieces: []
-            - Range: 0x84e220..0x84e221
+            - Range: 0x84e270..0x84e271
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e221..0x84e240
+            - Range: 0x84e271..0x84e290
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x84e240..0x84e2d0]
+      OutOfLinePCRanges: [0x84e290..0x84e320]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 94 BaseType int16
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x84e240..0x84e2b0
+            - Range: 0x84e290..0x84e300
               Pieces: []
-            - Range: 0x84e2b0..0x84e2b1
+            - Range: 0x84e300..0x84e301
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84e2b1..0x84e2d0
+            - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x84e2d0..0x84e390]
+      OutOfLinePCRanges: [0x84e320..0x84e3e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e2d0..0x84e390, Pieces: []}]
+          Locations: [{Range: 0x84e320..0x84e3e0, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x84e2d0..0x84e36c
+            - Range: 0x84e320..0x84e3bc
               Pieces: []
-            - Range: 0x84e36c..0x84e36d
+            - Range: 0x84e3bc..0x84e3bd
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x84e36d..0x84e390
+            - Range: 0x84e3bd..0x84e3e0
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x84e390..0x84e410]
+      OutOfLinePCRanges: [0x84e3e0..0x84e460]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 95 BaseType complex64
-          Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
+          Locations: [{Range: 0x84e3e0..0x84e460, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 96 BaseType complex128
-          Locations: [{Range: 0x84e390..0x84e410, Pieces: []}]
+          Locations: [{Range: 0x84e3e0..0x84e460, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x84e410..0x84e4e0]
+      OutOfLinePCRanges: [0x84e460..0x84e530]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84e410..0x84e4c4
+            - Range: 0x84e460..0x84e514
               Pieces: []
-            - Range: 0x84e4c4..0x84e4c5
+            - Range: 0x84e514..0x84e515
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6462,173 +6508,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84e4c5..0x84e4e0
+            - Range: 0x84e515..0x84e530
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x84e4e0..0x84e570]
+      OutOfLinePCRanges: [0x84e530..0x84e5c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84e4e0..0x84e550
+            - Range: 0x84e530..0x84e5a0
               Pieces: []
-            - Range: 0x84e550..0x84e551
+            - Range: 0x84e5a0..0x84e5a1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x84e551..0x84e570
+            - Range: 0x84e5a1..0x84e5c0
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x84e570..0x84e5e0]
+      OutOfLinePCRanges: [0x84e5c0..0x84e630]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 ArrayType [1]int
           Locations:
-            - Range: 0x84e570..0x84e5c4
+            - Range: 0x84e5c0..0x84e614
               Pieces: []
-            - Range: 0x84e5c4..0x84e5c5
+            - Range: 0x84e614..0x84e615
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e5c5..0x84e5e0
+            - Range: 0x84e615..0x84e630
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x84e5e0..0x84e650]
+      OutOfLinePCRanges: [0x84e630..0x84e6a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x84e5e0..0x84e630
+            - Range: 0x84e630..0x84e680
               Pieces: []
-            - Range: 0x84e630..0x84e631
+            - Range: 0x84e680..0x84e681
               Pieces: []
-            - Range: 0x84e631..0x84e650
+            - Range: 0x84e681..0x84e6a0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x84e650..0x84e6d0]
+      OutOfLinePCRanges: [0x84e6a0..0x84e720]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 StructureType main.mixedStruct
-          Locations: [{Range: 0x84e650..0x84e6d0, Pieces: []}]
+          Locations: [{Range: 0x84e6a0..0x84e720, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x84e6d0..0x84e770]
+      OutOfLinePCRanges: [0x84e720..0x84e7c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e6d0..0x84e74c
+            - Range: 0x84e720..0x84e79c
               Pieces: []
-            - Range: 0x84e74c..0x84e74d
+            - Range: 0x84e79c..0x84e79d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84e74d..0x84e770
+            - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x84e770..0x84e850]
+      OutOfLinePCRanges: [0x84e7c0..0x84e8a0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 StructureType main.wideStruct
           Locations:
-            - Range: 0x84e770..0x84e834
+            - Range: 0x84e7c0..0x84e884
               Pieces: []
-            - Range: 0x84e834..0x84e835
+            - Range: 0x84e884..0x84e885
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6652,127 +6698,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x84e835..0x84e850
+            - Range: 0x84e885..0x84e8a0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x84e850..0x84e8e0]
+      OutOfLinePCRanges: [0x84e8a0..0x84e930]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e850..0x84e8c0
+            - Range: 0x84e8a0..0x84e910
               Pieces: []
-            - Range: 0x84e8c0..0x84e8c1
+            - Range: 0x84e910..0x84e911
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84e8c1..0x84e8e0
+            - Range: 0x84e911..0x84e930
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
+          Locations: [{Range: 0x84e8a0..0x84e930, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84e850..0x84e8c0
+            - Range: 0x84e8a0..0x84e910
               Pieces: []
-            - Range: 0x84e8c0..0x84e8c1
+            - Range: 0x84e910..0x84e911
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84e8c1..0x84e8e0
+            - Range: 0x84e911..0x84e930
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e850..0x84e8e0, Pieces: []}]
+          Locations: [{Range: 0x84e8a0..0x84e930, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84e850..0x84e8c0
+            - Range: 0x84e8a0..0x84e910
               Pieces: []
-            - Range: 0x84e8c0..0x84e8c1
+            - Range: 0x84e910..0x84e911
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x84e8c1..0x84e8e0
+            - Range: 0x84e911..0x84e930
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x84e8e0..0x84e970]
+      OutOfLinePCRanges: [0x84e930..0x84e9c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84e8e0..0x84e950
+            - Range: 0x84e930..0x84e9a0
               Pieces: []
-            - Range: 0x84e950..0x84e951
+            - Range: 0x84e9a0..0x84e9a1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x84e951..0x84e970
+            - Range: 0x84e9a1..0x84e9c0
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x84e970..0x84e9e0]
+      OutOfLinePCRanges: [0x84e9c0..0x84ea30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e970..0x84e9e0, Pieces: []}]
+          Locations: [{Range: 0x84e9c0..0x84ea30, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x84e9e0..0x84ea60]
+      OutOfLinePCRanges: [0x84ea30..0x84eab0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
+          Locations: [{Range: 0x84ea30..0x84eab0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType float64
-          Locations: [{Range: 0x84e9e0..0x84ea60, Pieces: []}]
+          Locations: [{Range: 0x84ea30..0x84eab0, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x84ea60..0x84ead0]
+      OutOfLinePCRanges: [0x84eab0..0x84eb20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x84ea60..0x84eab8
+            - Range: 0x84eab0..0x84eb08
               Pieces: []
-            - Range: 0x84eab8..0x84eab9
+            - Range: 0x84eb08..0x84eb09
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84eab9..0x84ead0
+            - Range: 0x84eb09..0x84eb20
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x84ea60..0x84eab8
+            - Range: 0x84eab0..0x84eb08
               Pieces: []
-            - Range: 0x84eab8..0x84eab9
+            - Range: 0x84eb08..0x84eb09
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84eab9..0x84ead0
+            - Range: 0x84eb09..0x84eb20
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x84ead0..0x84ec90]
+      OutOfLinePCRanges: [0x84eb20..0x84ece0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84ead0..0x84eb3c
+            - Range: 0x84eb20..0x84eb8c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6794,7 +6840,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84eb3c..0x84eb50
+            - Range: 0x84eb8c..0x84eba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6816,7 +6862,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84eb50..0x84eb54
+            - Range: 0x84eba0..0x84eba4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6842,9 +6888,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84ead0..0x84ec48
+            - Range: 0x84eb20..0x84ec98
               Pieces: []
-            - Range: 0x84ec48..0x84ec49
+            - Range: 0x84ec98..0x84ec99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6866,39 +6912,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ec49..0x84ec90
+            - Range: 0x84ec99..0x84ece0
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x84ec90..0x84ed60]
+      OutOfLinePCRanges: [0x84ece0..0x84edb0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84ec90..0x84ed60
+            - Range: 0x84ece0..0x84edb0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84ec90..0x84ed44
+            - Range: 0x84ece0..0x84ed94
               Pieces: []
-            - Range: 0x84ed44..0x84ed45
+            - Range: 0x84ed94..0x84ed95
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x84ed45..0x84ed60
+            - Range: 0x84ed95..0x84edb0
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x84ed60..0x84ef90]
+      OutOfLinePCRanges: [0x84edb0..0x84efe0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84ed60..0x84edd0
+            - Range: 0x84edb0..0x84ee20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6920,7 +6966,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84edd0..0x84ede4
+            - Range: 0x84ee20..0x84ee34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6942,7 +6988,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ede4..0x84ede8
+            - Range: 0x84ee34..0x84ee38
               Pieces:
                 - Size: 8
                   Op: null
@@ -6968,15 +7014,15 @@ Subprograms:
         - Name: s2
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84ed60..0x84ef90
+            - Range: 0x84edb0..0x84efe0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84ed60..0x84ef50
+            - Range: 0x84edb0..0x84efa0
               Pieces: []
-            - Range: 0x84ef50..0x84ef51
+            - Range: 0x84efa0..0x84efa1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6998,175 +7044,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84ef51..0x84ef90
+            - Range: 0x84efa1..0x84efe0
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x84ef90..0x84f160]
+      OutOfLinePCRanges: [0x84efe0..0x84f1b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84eff4
+            - Range: 0x84efe0..0x84f044
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84eff4..0x84f160
+            - Range: 0x84f044..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84ef90..0x84f008
+            - Range: 0x84efe0..0x84f058
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x84f008..0x84f160
+            - Range: 0x84f058..0x84f1b0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84ef90..0x84f118
+            - Range: 0x84efe0..0x84f168
               Pieces: []
-            - Range: 0x84f118..0x84f119
+            - Range: 0x84f168..0x84f169
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x84f119..0x84f160
+            - Range: 0x84f169..0x84f1b0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x84f160..0x84f370]
+      OutOfLinePCRanges: [0x84f1b0..0x84f3c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1d4
+            - Range: 0x84f1b0..0x84f224
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f1d4..0x84f370
+            - Range: 0x84f224..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84f160..0x84f1e8
+            - Range: 0x84f1b0..0x84f238
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84f1e8..0x84f370
+            - Range: 0x84f238..0x84f3c0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7176,9 +7222,9 @@ Subprograms:
         - Name: ~r0
           Type: 248 StructureType main.largeStruct
           Locations:
-            - Range: 0x84f160..0x84f32c
+            - Range: 0x84f1b0..0x84f37c
               Pieces: []
-            - Range: 0x84f32c..0x84f32d
+            - Range: 0x84f37c..0x84f37d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7200,191 +7246,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x84f32d..0x84f370
+            - Range: 0x84f37d..0x84f3c0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x84f370..0x84f410]
+      OutOfLinePCRanges: [0x84f3c0..0x84f460]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 159 ArrayType [5]int
           Locations:
-            - Range: 0x84f370..0x84f410
+            - Range: 0x84f3c0..0x84f460
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f370..0x84f3ec
+            - Range: 0x84f3c0..0x84f43c
               Pieces: []
-            - Range: 0x84f3ec..0x84f3ed
+            - Range: 0x84f43c..0x84f43d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f3ed..0x84f410
+            - Range: 0x84f43d..0x84f460
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f370..0x84f3ec
+            - Range: 0x84f3c0..0x84f43c
               Pieces: []
-            - Range: 0x84f3ec..0x84f3ed
+            - Range: 0x84f43c..0x84f43d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x84f3ed..0x84f410
+            - Range: 0x84f43d..0x84f460
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f370..0x84f3ec
+            - Range: 0x84f3c0..0x84f43c
               Pieces: []
-            - Range: 0x84f3ec..0x84f3ed
+            - Range: 0x84f43c..0x84f43d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x84f3ed..0x84f410
+            - Range: 0x84f43d..0x84f460
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x84f410..0x84f4f0]
+      OutOfLinePCRanges: [0x84f460..0x84f540]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84f410..0x84f4f0
+            - Range: 0x84f460..0x84f540
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 249 ArrayType [3]int
           Locations:
-            - Range: 0x84f410..0x84f4f0
+            - Range: 0x84f460..0x84f540
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f410..0x84f4d4
+            - Range: 0x84f460..0x84f524
               Pieces: []
-            - Range: 0x84f4d4..0x84f4d5
+            - Range: 0x84f524..0x84f525
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f4d5..0x84f4f0
+            - Range: 0x84f525..0x84f540
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 111 ArrayType [2]int
           Locations:
-            - Range: 0x84f410..0x84f4d4
+            - Range: 0x84f460..0x84f524
               Pieces: []
-            - Range: 0x84f4d4..0x84f4d5
+            - Range: 0x84f524..0x84f525
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x84f4d5..0x84f4f0
+            - Range: 0x84f525..0x84f540
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x84f4f0..0x84f5c0]
+      OutOfLinePCRanges: [0x84f540..0x84f610]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84f4f0..0x84f5c0
+            - Range: 0x84f540..0x84f610
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f4f0..0x84f59c
+            - Range: 0x84f540..0x84f5ec
               Pieces: []
-            - Range: 0x84f59c..0x84f59d
+            - Range: 0x84f5ec..0x84f5ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f59d..0x84f5c0
+            - Range: 0x84f5ed..0x84f610
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 254 StructureType main.structWithArray
           Locations:
-            - Range: 0x84f4f0..0x84f59c
+            - Range: 0x84f540..0x84f5ec
               Pieces: []
-            - Range: 0x84f59c..0x84f59d
+            - Range: 0x84f5ec..0x84f5ed
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x84f59d..0x84f5c0
+            - Range: 0x84f5ed..0x84f610
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f570..0x84f5c0
+            - Range: 0x84f5c0..0x84f610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x84f5c0..0x84f660]
+      OutOfLinePCRanges: [0x84f610..0x84f6b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 251 ArrayType [0]int
-          Locations: [{Range: 0x84f5c0..0x84f660, Pieces: []}]
+          Locations: [{Range: 0x84f610..0x84f6b0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f5c0..0x84f600
+            - Range: 0x84f610..0x84f650
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f600..0x84f61c
+            - Range: 0x84f650..0x84f66c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x84f61c..0x84f624
+            - Range: 0x84f66c..0x84f674
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x84f624..0x84f660
+            - Range: 0x84f674..0x84f6b0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x84f5c0..0x84f640
+            - Range: 0x84f610..0x84f690
               Pieces: []
-            - Range: 0x84f640..0x84f641
+            - Range: 0x84f690..0x84f691
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x84f641..0x84f660
+            - Range: 0x84f691..0x84f6b0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 ArrayType [0]int
           Locations:
-            - Range: 0x84f5c0..0x84f640
+            - Range: 0x84f610..0x84f690
               Pieces: []
-            - Range: 0x84f640..0x84f641
+            - Range: 0x84f690..0x84f691
               Pieces: []
-            - Range: 0x84f641..0x84f660
+            - Range: 0x84f691..0x84f6b0
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x84fac0..0x84fad0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84fac0..0x84fad0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x84fad0..0x84fae0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x84fb10..0x84fb20]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fad0..0x84fae0
+            - Range: 0x84fb10..0x84fb20
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7394,98 +7423,12 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 130
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x84fae0..0x84faf0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 256 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x84fae0..0x84faf0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x84faf0..0x84fb00]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84faf0..0x84fb00
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84faf0..0x84fb00
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x84fb00..0x84fb10]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84fb00..0x84fb10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84fb00..0x84fb10
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x84fb10..0x84fb20]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 258 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x84fb10..0x84fb20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x84fb10..0x84fb20
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x84fb20..0x84fb30]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 261 GoSliceHeaderType []string
+        - Name: u
+          Type: 255 GoSliceHeaderType []uint
           Locations:
             - Range: 0x84fb20..0x84fb30
               Pieces:
@@ -7496,21 +7439,124 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x84fb30..0x84fb40]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 256 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x84fb30..0x84fb40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 132
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x84fb40..0x84fb50]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84fb40..0x84fb50
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84fb40..0x84fb50
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x84fb50..0x84fb60]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84fb50..0x84fb60
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84fb50..0x84fb60
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x84fb60..0x84fb70]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 258 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x84fb60..0x84fb70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x84fb60..0x84fb70
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x84fb70..0x84fb80]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 261 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x84fb70..0x84fb80
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x84fb80..0x84fb90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x84fb30..0x84fb40
+            - Range: 0x84fb80..0x84fb90
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 262 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x84fb30..0x84fb40
+            - Range: 0x84fb80..0x84fb90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7522,35 +7568,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x84fb30..0x84fb40
+            - Range: 0x84fb80..0x84fb90
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x84fb40..0x84fb50]
+      OutOfLinePCRanges: [0x84fb90..0x84fba0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 263 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x84fb40..0x84fb50
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x84fb50..0x84fb60]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x84fb50..0x84fb60
+            - Range: 0x84fb90..0x84fba0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7560,14 +7589,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 138
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x84fb60..0x84fb70]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x84fba0..0x84fbb0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 264 GoSliceHeaderType []struct {}
+          Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb60..0x84fb70
+            - Range: 0x84fba0..0x84fbb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7577,14 +7606,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x84fbb0..0x84fbc0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 264 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x84fbb0..0x84fbc0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x84fb70..0x84fb80]
+      OutOfLinePCRanges: [0x84fbc0..0x84fbd0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb70..0x84fb80
+            - Range: 0x84fbc0..0x84fbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7596,7 +7642,7 @@ Subprograms:
         - Name: bs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb70..0x84fb80
+            - Range: 0x84fbc0..0x84fbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7608,7 +7654,7 @@ Subprograms:
         - Name: cs
           Type: 255 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x84fb70..0x84fb80
+            - Range: 0x84fbc0..0x84fbd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7617,122 +7663,42 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0x84fe90..0x84ff00]
+      OutOfLinePCRanges: [0x84fee0..0x84ff50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84fe90..0x84fedc
+            - Range: 0x84fee0..0x84ff2c
               Pieces: []
-            - Range: 0x84fedc..0x84fedd
+            - Range: 0x84ff2c..0x84ff2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x84fedd..0x84ff00
+            - Range: 0x84ff2d..0x84ff50
               Pieces: []
           Role: Return
-    - ID: 141
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x84ff00..0x84ff10]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84ff00..0x84ff10
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 142
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x84ff10..0x84ff20]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84ff10..0x84ff20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84ff10..0x84ff20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x84ff10..0x84ff20
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 143
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x84ff20..0x84ff40]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 266 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x84ff20..0x84ff40
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 144
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x84ff40..0x84ff50]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 267 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x84ff40..0x84ff50
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 145
-      Name: main.testOneStringInStructPointer
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x84ff50..0x84ff60]
       InlinePCRanges: []
       Variables:
-        - Name: a
-          Type: 268 PointerType *main.oneStringStruct
+        - Name: x
+          Type: 9 GoStringHeaderType string
           Locations:
             - Range: 0x84ff50..0x84ff60
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
+    - ID: 143
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x84ff60..0x84ff70]
       InlinePCRanges: []
       Variables:
@@ -7746,15 +7712,80 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84ff60..0x84ff70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84ff60..0x84ff70
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 144
+      Name: main.testThreeStringsInStruct
+      OutOfLinePCRanges: [0x84ff70..0x84ff90]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 266 StructureType main.threeStringStruct
+          Locations:
+            - Range: 0x84ff70..0x84ff90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 145
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x84ff90..0x84ffa0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 267 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x84ff90..0x84ffa0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 146
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x84ffa0..0x84ffb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 268 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x84ffa0..0x84ffb0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
     - ID: 147
-      Name: main.testUnitializedString
-      OutOfLinePCRanges: [0x84ff70..0x84ff80]
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x84ffb0..0x84ffc0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff70..0x84ff80
+            - Range: 0x84ffb0..0x84ffc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7762,14 +7793,14 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 148
-      Name: main.testEmptyString
-      OutOfLinePCRanges: [0x84ff80..0x84ff90]
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x84ffc0..0x84ffd0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff80..0x84ff90
+            - Range: 0x84ffc0..0x84ffd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7777,14 +7808,29 @@ Subprograms:
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x84ffd0..0x84ffe0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84ffd0..0x84ffe0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 150
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x84ff90..0x84ffa0]
+      OutOfLinePCRanges: [0x84ffe0..0x84fff0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff90..0x84ffa0
+            - Range: 0x84ffe0..0x84fff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7794,7 +7840,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff90..0x84ffa0
+            - Range: 0x84ffe0..0x84fff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7804,33 +7850,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x84ff90..0x84ffa0
+            - Range: 0x84ffe0..0x84fff0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x850100..0x850110]
+      OutOfLinePCRanges: [0x850150..0x850160]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 270 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x850100..0x850110
+            - Range: 0x850150..0x850160
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x850110..0x850130]
+      OutOfLinePCRanges: [0x850160..0x850180]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 283 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x850110..0x850130
+            - Range: 0x850160..0x850180
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7845,15 +7891,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0x850200..0x850220]
+      OutOfLinePCRanges: [0x850250..0x850270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 314 StructureType main.aStruct
           Locations:
-            - Range: 0x850200..0x850220
+            - Range: 0x850250..0x850270
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7870,38 +7916,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x8502a0..0x8502b0]
+      OutOfLinePCRanges: [0x8502f0..0x850300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 315 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x8502a0..0x8502b0
+            - Range: 0x8502f0..0x850300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x850300..0x850310]
+      OutOfLinePCRanges: [0x850350..0x850360]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 317 StructureType main.emptyStruct
-          Locations: [{Range: 0x850300..0x850310, Pieces: []}]
+          Locations: [{Range: 0x850350..0x850360, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x850310..0x850320]
+      OutOfLinePCRanges: [0x850360..0x850370]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 318 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x850310..0x850320
+            - Range: 0x850360..0x850370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84ad00..0x84ad70]
       InlinePCRanges:
@@ -7930,28 +7976,28 @@ Subprograms:
             - Range: 0x84aff0..0x84b014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af98..0x84afd0]
           RootRanges: [0x84af30..0x84aff0]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b08c..0x84b0d0]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b140..0x84b178]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7964,7 +8010,7 @@ Subprograms:
             - Range: 0x84b190..0x84b198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11239,10 +11285,10 @@ Types:
       GoKind: 22
       Pointee: 810 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11254,7 +11300,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11342,7 +11388,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11354,7 +11400,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11364,11 +11410,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11380,7 +11426,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11540,6 +11586,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1404
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1340
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11621,7 +11709,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1403
+      ID: 1405
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11633,7 +11721,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11643,7 +11731,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11713,7 +11801,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1411
+      ID: 1413
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11725,7 +11813,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11735,7 +11823,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11895,7 +11983,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11907,7 +11995,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11917,7 +12005,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11927,7 +12015,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11937,11 +12025,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11953,7 +12041,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11963,11 +12051,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11979,7 +12067,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11989,11 +12077,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12005,7 +12093,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12015,11 +12103,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12031,7 +12119,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12041,7 +12129,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12307,7 +12395,7 @@ Types:
       ID: 1362
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1359
@@ -12359,16 +12447,16 @@ Types:
       ID: 1360
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1363
@@ -12377,7 +12465,7 @@ Types:
       ID: 1364
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12389,7 +12477,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12399,11 +12487,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12415,7 +12503,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12425,14 +12513,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12444,7 +12532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12454,11 +12542,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12470,7 +12558,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12480,11 +12568,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12496,7 +12584,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12506,7 +12594,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12666,7 +12754,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1472
+      ID: 1474
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12678,7 +12766,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12688,11 +12776,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1473
+      ID: 1475
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12704,11 +12792,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1405
+      ID: 1407
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12720,7 +12808,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12730,7 +12818,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12789,7 +12877,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12801,7 +12889,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12811,7 +12899,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12821,7 +12909,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12831,7 +12919,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12841,7 +12929,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12851,7 +12939,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12861,7 +12949,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12871,7 +12959,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12881,7 +12969,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12891,7 +12979,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12901,7 +12989,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12911,7 +12999,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12921,7 +13009,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12931,7 +13019,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12941,7 +13029,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12951,7 +13039,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12961,7 +13049,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12971,11 +13059,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12987,7 +13075,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13511,7 +13599,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13523,7 +13611,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13533,11 +13621,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13549,7 +13637,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13559,11 +13647,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13575,7 +13663,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13585,7 +13673,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13595,7 +13683,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13605,7 +13693,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13615,7 +13703,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13625,7 +13713,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13635,7 +13723,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13645,7 +13733,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13655,7 +13743,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13665,7 +13753,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13675,7 +13763,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13685,7 +13773,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13695,7 +13783,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13705,7 +13793,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13715,7 +13803,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13725,7 +13813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13735,7 +13823,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13745,11 +13833,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13761,11 +13849,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13777,7 +13865,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13787,7 +13875,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13797,7 +13885,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13807,11 +13895,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13823,7 +13911,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13833,11 +13921,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13849,7 +13937,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13859,7 +13947,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13869,7 +13957,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13879,11 +13967,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13895,11 +13983,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13911,7 +13999,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13921,11 +14009,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13937,7 +14025,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13947,7 +14035,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13957,7 +14045,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13967,23 +14055,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13999,7 +14071,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14015,11 +14087,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1440
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14031,7 +14119,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14041,11 +14129,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14057,7 +14145,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14067,7 +14155,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14077,7 +14165,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14087,7 +14175,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14097,7 +14185,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14107,33 +14195,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14149,7 +14211,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14159,7 +14221,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14175,7 +14237,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14185,7 +14247,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14295,32 +14383,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1428
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14333,7 +14395,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14343,11 +14405,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1430
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14359,11 +14447,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14375,7 +14463,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14385,11 +14473,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14401,7 +14489,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14411,11 +14499,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14427,7 +14515,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14437,10 +14525,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14452,7 +14540,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14462,7 +14550,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1410
+      ID: 1412
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14474,7 +14562,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14484,7 +14572,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14494,7 +14582,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14504,11 +14592,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14520,7 +14608,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14530,7 +14618,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14540,7 +14628,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14550,11 +14638,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14566,7 +14654,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14576,7 +14664,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14586,7 +14674,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14596,7 +14684,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14606,7 +14694,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14616,11 +14704,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14632,7 +14720,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14642,11 +14730,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14658,7 +14746,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14668,11 +14756,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1408
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14684,7 +14772,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14694,7 +14782,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14724,7 +14812,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1406
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14736,7 +14824,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14746,11 +14834,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1420
+      ID: 1422
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14762,7 +14850,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14772,7 +14860,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14782,7 +14870,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14792,11 +14880,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1421
+      ID: 1423
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14808,7 +14896,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14818,446 +14906,12 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1422
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1423
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1452
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 250 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1450
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1451
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 249 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1458
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1459
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1446
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 95 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 96 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1418
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1419
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1414
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1415
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1412
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1413
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1424
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15283,6 +14937,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1425
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1452
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1453
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1461
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1449
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1420
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1421
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1418
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1416
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1417
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1414
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1415
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1426
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1427
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15294,14 +15382,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15313,14 +15401,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15332,7 +15420,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15342,7 +15430,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15352,7 +15440,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15362,7 +15450,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15372,7 +15460,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15382,7 +15470,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15392,7 +15480,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15402,7 +15490,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15412,7 +15500,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15422,7 +15510,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15432,7 +15520,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15442,7 +15530,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15452,7 +15540,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15462,7 +15550,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15472,7 +15560,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15482,7 +15570,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15492,14 +15580,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1456
+      ID: 1458
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1457
+      ID: 1459
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15511,14 +15599,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15530,7 +15618,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15540,7 +15628,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15550,7 +15638,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15560,7 +15648,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15570,14 +15658,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15589,7 +15677,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15599,14 +15687,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15618,14 +15706,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15637,7 +15725,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15647,7 +15735,7 @@ Types:
             Type: 94 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15657,7 +15745,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15667,7 +15755,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15677,7 +15765,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15687,7 +15775,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15697,7 +15785,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15707,14 +15795,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15726,14 +15814,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15745,7 +15833,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16055,7 +16143,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16067,7 +16155,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16077,7 +16165,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16211,7 +16299,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16223,7 +16311,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16233,11 +16321,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16249,7 +16337,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16259,7 +16347,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16289,7 +16377,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16301,7 +16389,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16311,11 +16399,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16327,7 +16415,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16337,7 +16425,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16347,11 +16435,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16363,7 +16451,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16373,11 +16461,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16389,7 +16477,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16399,7 +16487,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16409,7 +16497,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16439,7 +16527,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1409
+      ID: 1411
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16451,7 +16539,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16461,11 +16549,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16477,7 +16565,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16487,7 +16575,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16543,7 +16631,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16555,7 +16643,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16565,7 +16653,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16575,7 +16663,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16585,7 +16673,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16615,7 +16703,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16627,7 +16715,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16637,11 +16725,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16653,7 +16741,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16663,11 +16751,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16679,7 +16767,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16689,14 +16777,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16708,7 +16796,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16718,7 +16806,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16748,7 +16836,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16760,7 +16848,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16770,14 +16858,14 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16789,7 +16877,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16799,7 +16887,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16809,7 +16897,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16819,7 +16907,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16829,7 +16917,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16839,11 +16927,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16855,7 +16943,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16865,7 +16953,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16875,7 +16963,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16885,7 +16973,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16895,7 +16983,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16905,11 +16993,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16921,7 +17009,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16931,11 +17019,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16947,7 +17035,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16960,7 +17048,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16973,14 +17061,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16992,7 +17080,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17002,11 +17090,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17018,7 +17106,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17028,7 +17116,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17038,17 +17126,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1508
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1510
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1506
+      ID: 1512
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1508
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17060,7 +17148,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17070,7 +17158,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17080,7 +17168,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17090,7 +17178,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17100,7 +17188,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17110,7 +17198,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17270,7 +17358,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1408
+      ID: 1410
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17282,7 +17370,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17292,11 +17380,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17308,7 +17396,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17318,11 +17406,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17334,7 +17422,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17344,11 +17432,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1407
+      ID: 1409
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17360,7 +17448,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17370,7 +17458,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17400,7 +17488,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17412,7 +17500,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17422,11 +17510,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17438,7 +17526,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17448,11 +17536,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17464,7 +17552,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17474,7 +17562,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17484,7 +17572,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17494,11 +17582,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17510,7 +17598,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17520,7 +17608,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26028,7 +26116,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1540
+MaxTypeID: 1542
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x80c338", Frameless: false}]
+          Type: 1524 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x80c388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x80c368", Frameless: false}]
+          Type: 1525 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x80c3b8", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x80b24c", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x80b29c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80b2d8", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b328", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x809a0c", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -293,11 +318,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x809a10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -353,11 +378,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x809c50", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -500,11 +525,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x80bf90", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -526,11 +551,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x80bfc0", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -553,11 +578,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x80c440", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -574,11 +599,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x80c6f0", Frameless: true}]
+          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x80c740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -594,11 +619,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
+          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x80c750", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -845,10 +870,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1552 EventRootType Probe[main.testInlinedBBB]
+          Type: 1554 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -883,10 +908,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedBCA]
+          Type: 1555 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -903,10 +928,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1556 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -920,10 +945,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBCB]
+          Type: 1557 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -940,10 +965,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1558 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -958,10 +983,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testInlinedPrint]
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -975,7 +1000,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1550 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -996,10 +1021,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -1027,10 +1052,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedSq]
+          Type: 1559 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1051,10 +1076,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1558 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1560 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1073,10 +1098,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1559 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1561 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -1223,15 +1248,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x80b0c0", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x80b110", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80b1e8", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80b238", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1248,11 +1273,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x809b60", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1356,15 +1381,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x80b51c", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x80b56c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x80b65c", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1847,11 +1872,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1869,11 +1894,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1915,15 +1940,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x80b6c0", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x80b710", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x80b848", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x80b898", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1984,15 +2009,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x80b93c", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x80b98c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x80b9d4", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x80ba24", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2018,15 +2043,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x80b310", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x80b360", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x80b4b4", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x80b504", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2047,15 +2072,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2126,15 +2151,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2156,15 +2181,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x80a688", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a6e0", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2187,11 +2212,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2211,11 +2236,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2241,11 +2266,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2265,11 +2290,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x80c6b0", Frameless: true}]
+          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2291,11 +2316,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x809c30", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2317,11 +2342,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x80c000", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x80c050", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2343,11 +2368,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2377,11 +2402,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x80c040", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2408,11 +2433,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x80c3c0", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x80c410", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2429,11 +2454,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x809b70", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2471,11 +2496,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x809b50", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2492,22 +2517,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x80a358", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x80a3e0"
+            - PC: "0x80a430"
               Frameless: false
-            - PC: "0x80a434"
+            - PC: "0x80a484"
               Frameless: false
-            - PC: "0x80a4e4"
+            - PC: "0x80a534"
               Frameless: false
-            - PC: "0x80a4f8"
+            - PC: "0x80a548"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2530,22 +2555,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x80a1e8", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x80a238", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x80a23c"
+            - PC: "0x80a28c"
               Frameless: false
-            - PC: "0x80a298"
+            - PC: "0x80a2e8"
               Frameless: false
-            - PC: "0x80a2d8"
+            - PC: "0x80a328"
               Frameless: false
-            - PC: "0x80a314"
+            - PC: "0x80a364"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2567,15 +2592,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x80ab1c", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x80ab6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x80ab68", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x80abb8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2587,15 +2612,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x80ab98", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x80abe8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x80abd0", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x80ac20", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2607,15 +2632,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x80ac08", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x80ac58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x80ac3c", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x80ac8c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2627,15 +2652,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x80acf8", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x80ad48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x80ad58", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x80ada8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2647,15 +2672,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x80b048", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x80b098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x80b084", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x80b0d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2667,15 +2692,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x80a9d8", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x80aa28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x80aa20", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2688,18 +2713,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x80a168", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x80a1b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsError]Return
+          Type: 1440 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x80a194"
+            - PC: "0x80a1e4"
               Frameless: false
-            - PC: "0x80a1a8"
+            - PC: "0x80a1f8"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2716,15 +2741,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x809f78", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x809fb8", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x80a008", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2740,15 +2765,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x80a098", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x80a0e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x80a124", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x80a174", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2764,15 +2789,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x809ff8", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x80a054", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x80a0a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2789,18 +2814,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x80a538", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x80a588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x80a5f0"
+            - PC: "0x80a640"
               Frameless: false
-            - PC: "0x80a604"
+            - PC: "0x80a654"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2817,15 +2842,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x80aa60", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x80aab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x80aadc", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2837,15 +2862,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x80a928", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x80a978", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x80a9a8", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x80a9f8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2857,15 +2882,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x80ae58", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x80aeac", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x80aefc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2877,15 +2902,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x80ac78", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x80acc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x80acbc", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x80ad0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2897,15 +2922,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x80afd8", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x80b028", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x80b018", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x80b068", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2917,15 +2942,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x80af68", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x80afb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x80afa4", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x80aff4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2937,15 +2962,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x80a898", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x80a8ec", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x80a93c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2957,15 +2982,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x80aeec", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x80af3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x80af38", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x80af88", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2977,15 +3002,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x80ad90", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x80ade0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x80ae1c", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x80ae6c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3032,15 +3057,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3308,11 +3333,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x80c380", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3434,11 +3459,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x80c020", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x80c070", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3455,11 +3480,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x80bfa0", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3496,15 +3521,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x80a7d8", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x80a828", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a85c", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a8ac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3520,15 +3545,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x80b8a8", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x80b8f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x80b900", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x80b950", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3566,11 +3591,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x809c10", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x809c60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3587,11 +3612,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x80c030", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3650,15 +3675,15 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x80c620", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1542 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x80c630", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3680,11 +3705,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x80bfb0", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3726,15 +3751,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x80ba0c", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x80ba5c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x80ba90", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x80bae0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3751,15 +3776,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x80c570", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x80c5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x80c57c", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          InjectionPoints: [{PC: "0x80c5cc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3775,11 +3800,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x80c560", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3832,11 +3857,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x80c030", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x80c080", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3871,11 +3896,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x80c400", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x80c450", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3903,15 +3928,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3927,15 +3952,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3953,15 +3978,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x80a718", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x80a798", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3985,11 +4010,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x80c390", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4016,15 +4041,15 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80c3ac", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4049,15 +4074,15 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x80c3a0", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x80c3ac", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4084,11 +4109,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80c3b0", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4113,11 +4138,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x80c3b0", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4270,11 +4295,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4291,11 +4316,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x80bf80", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4312,11 +4337,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x80c430", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4333,11 +4358,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x809b80", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4375,11 +4400,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4396,11 +4421,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x80c010", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4421,15 +4446,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x80bac8", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x80bb18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80bb28", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x80bb78", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5615,275 +5640,296 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0x8099d0..0x809a10]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x8099d0..0x809a0c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x8099d0..0x809a0c
+              Pieces: []
+            - Range: 0x809a0c..0x809a0d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x809a0d..0x809a10
+              Pieces: []
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8099d0..0x8099e0]
+      OutOfLinePCRanges: [0x809a10..0x809a20]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 243 GoChannelType chan bool
           Locations:
-            - Range: 0x8099d0..0x8099e0
+            - Range: 0x809a10..0x809a20
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x809b50..0x809b60]
+      OutOfLinePCRanges: [0x809ba0..0x809bb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 244 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x809b50..0x809b60
+            - Range: 0x809ba0..0x809bb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x809b60..0x809b70]
+      OutOfLinePCRanges: [0x809bb0..0x809bc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 246 StructureType main.node
           Locations:
-            - Range: 0x809b60..0x809b70
+            - Range: 0x809bb0..0x809bc0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x809b70..0x809b80]
+      OutOfLinePCRanges: [0x809bc0..0x809bd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 247 PointerType *main.node
           Locations:
-            - Range: 0x809b70..0x809b80
+            - Range: 0x809bc0..0x809bd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x809b80..0x809b90]
+      OutOfLinePCRanges: [0x809bd0..0x809be0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x809b80..0x809b90
+            - Range: 0x809bd0..0x809be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x809ba0..0x809bb0]
+      OutOfLinePCRanges: [0x809bf0..0x809c00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 PointerType *uint
           Locations:
-            - Range: 0x809ba0..0x809bb0
+            - Range: 0x809bf0..0x809c00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x809c10..0x809c20]
+      OutOfLinePCRanges: [0x809c60..0x809c70]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 95 PointerType *string
           Locations:
-            - Range: 0x809c10..0x809c20
+            - Range: 0x809c60..0x809c70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x809c30..0x809c40]
+      OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 11 PointerType *bool
           Locations:
-            - Range: 0x809c30..0x809c40
+            - Range: 0x809c80..0x809c90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x809c30..0x809c40
+            - Range: 0x809c80..0x809c90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0x809c50..0x809c60]
+      OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 248 PointerType *main.t
           Locations:
-            - Range: 0x809c50..0x809c60
+            - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x809f60..0x809fe0]
+      OutOfLinePCRanges: [0x809fb0..0x80a030]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809f60..0x809f7c
+            - Range: 0x809fb0..0x809fcc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809f60..0x809fb8
+            - Range: 0x809fb0..0x80a008
               Pieces: []
-            - Range: 0x809fb8..0x809fb9
+            - Range: 0x80a008..0x80a009
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809fb9..0x809fe0
+            - Range: 0x80a009..0x80a030
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809f7c..0x809f88
+            - Range: 0x809fcc..0x809fd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x809f88..0x809fe0
+            - Range: 0x809fd8..0x80a030
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x809fe0..0x80a080]
+      OutOfLinePCRanges: [0x80a030..0x80a0d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x809fe0..0x80a004
+            - Range: 0x80a030..0x80a054
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a004..0x80a080
+            - Range: 0x80a054..0x80a0d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x809fe0..0x80a054
+            - Range: 0x80a030..0x80a0a4
               Pieces: []
-            - Range: 0x80a054..0x80a055
+            - Range: 0x80a0a4..0x80a0a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a055..0x80a080
+            - Range: 0x80a0a5..0x80a0d0
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a008..0x80a020
+            - Range: 0x80a058..0x80a070
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a020..0x80a080
+            - Range: 0x80a070..0x80a0d0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x80a080..0x80a150]
+      OutOfLinePCRanges: [0x80a0d0..0x80a1a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a080..0x80a0d4
+            - Range: 0x80a0d0..0x80a124
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a080..0x80a124
+            - Range: 0x80a0d0..0x80a174
               Pieces: []
-            - Range: 0x80a124..0x80a125
+            - Range: 0x80a174..0x80a175
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a125..0x80a150
+            - Range: 0x80a175..0x80a1a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a080..0x80a150, Pieces: []}]
+          Locations: [{Range: 0x80a0d0..0x80a1a0, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a09c..0x80a0d8
+            - Range: 0x80a0ec..0x80a128
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a0d8..0x80a150
+            - Range: 0x80a128..0x80a1a0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80a0ac..0x80a0d8
+            - Range: 0x80a0fc..0x80a128
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x80a0d8..0x80a150
+            - Range: 0x80a128..0x80a1a0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x80a150..0x80a1d0]
+      OutOfLinePCRanges: [0x80a1a0..0x80a220]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a150..0x80a174
+            - Range: 0x80a1a0..0x80a1c4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a150..0x80a194
+            - Range: 0x80a1a0..0x80a1e4
               Pieces: []
-            - Range: 0x80a194..0x80a195
+            - Range: 0x80a1e4..0x80a1e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a195..0x80a1a8
+            - Range: 0x80a1e5..0x80a1f8
               Pieces: []
-            - Range: 0x80a1a8..0x80a1a9
+            - Range: 0x80a1f8..0x80a1f9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a1a9..0x80a1d0
+            - Range: 0x80a1f9..0x80a220
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x80a1d0..0x80a340]
+      OutOfLinePCRanges: [0x80a220..0x80a390]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a1d0..0x80a220
+            - Range: 0x80a220..0x80a270
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a220..0x80a224
+            - Range: 0x80a270..0x80a274
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x80a2ac..0x80a2b0
+            - Range: 0x80a2fc..0x80a300
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2ec..0x80a2f0
+            - Range: 0x80a33c..0x80a340
               Pieces:
                 - Size: 8
                   Op: null
@@ -5893,112 +5939,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80a1d0..0x80a214
+            - Range: 0x80a220..0x80a264
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a1d0..0x80a23c
+            - Range: 0x80a220..0x80a28c
               Pieces: []
-            - Range: 0x80a23c..0x80a23d
+            - Range: 0x80a28c..0x80a28d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a23d..0x80a298
+            - Range: 0x80a28d..0x80a2e8
               Pieces: []
-            - Range: 0x80a298..0x80a299
+            - Range: 0x80a2e8..0x80a2e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a299..0x80a2d8
+            - Range: 0x80a2e9..0x80a328
               Pieces: []
-            - Range: 0x80a2d8..0x80a2d9
+            - Range: 0x80a328..0x80a329
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a2d9..0x80a314
+            - Range: 0x80a329..0x80a364
               Pieces: []
-            - Range: 0x80a314..0x80a315
+            - Range: 0x80a364..0x80a365
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a315..0x80a340
+            - Range: 0x80a365..0x80a390
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 GoInterfaceType error
           Locations:
-            - Range: 0x80a1d0..0x80a23c
+            - Range: 0x80a220..0x80a28c
               Pieces: []
-            - Range: 0x80a23c..0x80a23d
+            - Range: 0x80a28c..0x80a28d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a23d..0x80a298
+            - Range: 0x80a28d..0x80a2e8
               Pieces: []
-            - Range: 0x80a298..0x80a299
+            - Range: 0x80a2e8..0x80a2e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a299..0x80a2d8
+            - Range: 0x80a2e9..0x80a328
               Pieces: []
-            - Range: 0x80a2d8..0x80a2d9
+            - Range: 0x80a328..0x80a329
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a2d9..0x80a314
+            - Range: 0x80a329..0x80a364
               Pieces: []
-            - Range: 0x80a314..0x80a315
+            - Range: 0x80a364..0x80a365
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80a315..0x80a340
+            - Range: 0x80a365..0x80a390
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a220..0x80a228
+            - Range: 0x80a270..0x80a278
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x80a340..0x80a520]
+      OutOfLinePCRanges: [0x80a390..0x80a570]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a340..0x80a380
+            - Range: 0x80a390..0x80a3d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a380..0x80a388
+            - Range: 0x80a3d0..0x80a3d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a388..0x80a520
+            - Range: 0x80a3d8..0x80a570
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6008,429 +6054,429 @@ Subprograms:
         - Name: ~r0
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a340..0x80a3e0
+            - Range: 0x80a390..0x80a430
               Pieces: []
-            - Range: 0x80a3e0..0x80a3e1
+            - Range: 0x80a430..0x80a431
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a3e1..0x80a434
+            - Range: 0x80a431..0x80a484
               Pieces: []
-            - Range: 0x80a434..0x80a435
+            - Range: 0x80a484..0x80a485
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a435..0x80a4e4
+            - Range: 0x80a485..0x80a534
               Pieces: []
-            - Range: 0x80a4e4..0x80a4e5
+            - Range: 0x80a534..0x80a535
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a4e5..0x80a4f8
+            - Range: 0x80a535..0x80a548
               Pieces: []
-            - Range: 0x80a4f8..0x80a4f9
+            - Range: 0x80a548..0x80a549
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a4f9..0x80a520
+            - Range: 0x80a549..0x80a570
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a3cc..0x80a3d4
+            - Range: 0x80a41c..0x80a424
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 100 PointerType *int
           Locations:
-            - Range: 0x80a418..0x80a434
+            - Range: 0x80a468..0x80a484
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x80a520..0x80a670]
+      OutOfLinePCRanges: [0x80a570..0x80a6c0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 157 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x80a520..0x80a55c
+            - Range: 0x80a570..0x80a5ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a55c..0x80a59c
+            - Range: 0x80a5ac..0x80a5ec
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a59c..0x80a610
+            - Range: 0x80a5ec..0x80a660
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a610..0x80a638
+            - Range: 0x80a660..0x80a688
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a638..0x80a63c
+            - Range: 0x80a688..0x80a68c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a63c..0x80a670
+            - Range: 0x80a68c..0x80a6c0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a520..0x80a5f0
+            - Range: 0x80a570..0x80a640
               Pieces: []
-            - Range: 0x80a5f0..0x80a5f1
+            - Range: 0x80a640..0x80a641
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a5f1..0x80a604
+            - Range: 0x80a641..0x80a654
               Pieces: []
-            - Range: 0x80a604..0x80a605
+            - Range: 0x80a654..0x80a655
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a605..0x80a670
+            - Range: 0x80a655..0x80a6c0
               Pieces: []
           Role: Return
         - Name: b
           Type: 162 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x80a520..0x80a55c
+            - Range: 0x80a570..0x80a5ac
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80a55c..0x80a59c
+            - Range: 0x80a5ac..0x80a5ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a59c..0x80a5a4
+            - Range: 0x80a5ec..0x80a5f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5a4..0x80a5fc
+            - Range: 0x80a5f4..0x80a64c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a5fc..0x80a600
+            - Range: 0x80a64c..0x80a650
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x80a600..0x80a604
+            - Range: 0x80a650..0x80a654
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x80a604..0x80a670
+            - Range: 0x80a654..0x80a6c0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x80a670..0x80a700]
+      OutOfLinePCRanges: [0x80a6c0..0x80a750]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a670..0x80a68c
+            - Range: 0x80a6c0..0x80a6dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a670..0x80a6e0
+            - Range: 0x80a6c0..0x80a730
               Pieces: []
-            - Range: 0x80a6e0..0x80a6e1
+            - Range: 0x80a730..0x80a731
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a6e1..0x80a700
+            - Range: 0x80a731..0x80a750
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x80a700..0x80a7c0]
+      OutOfLinePCRanges: [0x80a750..0x80a810]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a700..0x80a74c
+            - Range: 0x80a750..0x80a79c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a700..0x80a798
+            - Range: 0x80a750..0x80a7e8
               Pieces: []
-            - Range: 0x80a798..0x80a799
+            - Range: 0x80a7e8..0x80a7e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a799..0x80a7c0
+            - Range: 0x80a7e9..0x80a810
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a700..0x80a798
+            - Range: 0x80a750..0x80a7e8
               Pieces: []
-            - Range: 0x80a798..0x80a799
+            - Range: 0x80a7e8..0x80a7e9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a799..0x80a7c0
+            - Range: 0x80a7e9..0x80a810
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x80a7c0..0x80a880]
+      OutOfLinePCRanges: [0x80a810..0x80a8d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a7c0..0x80a7fc
+            - Range: 0x80a810..0x80a84c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a7fc..0x80a880
+            - Range: 0x80a84c..0x80a8d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a7c0..0x80a85c
+            - Range: 0x80a810..0x80a8ac
               Pieces: []
-            - Range: 0x80a85c..0x80a85d
+            - Range: 0x80a8ac..0x80a8ad
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a85d..0x80a880
+            - Range: 0x80a8ad..0x80a8d0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a7c0..0x80a85c
+            - Range: 0x80a810..0x80a8ac
               Pieces: []
-            - Range: 0x80a85c..0x80a85d
+            - Range: 0x80a8ac..0x80a8ad
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a85d..0x80a880
+            - Range: 0x80a8ad..0x80a8d0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80a7c0..0x80a85c
+            - Range: 0x80a810..0x80a8ac
               Pieces: []
-            - Range: 0x80a85c..0x80a85d
+            - Range: 0x80a8ac..0x80a8ad
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a85d..0x80a880
+            - Range: 0x80a8ad..0x80a8d0
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x80a880..0x80a910]
+      OutOfLinePCRanges: [0x80a8d0..0x80a960]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x80a880..0x80a8ec
+            - Range: 0x80a8d0..0x80a93c
               Pieces: []
-            - Range: 0x80a8ec..0x80a8ed
+            - Range: 0x80a93c..0x80a93d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80a8ed..0x80a910
+            - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x80a910..0x80a9c0]
+      OutOfLinePCRanges: [0x80a960..0x80aa10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80a910..0x80a9c0, Pieces: []}]
+          Locations: [{Range: 0x80a960..0x80aa10, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 16 BaseType float64
           Locations:
-            - Range: 0x80a910..0x80a9a8
+            - Range: 0x80a960..0x80a9f8
               Pieces: []
-            - Range: 0x80a9a8..0x80a9a9
+            - Range: 0x80a9f8..0x80a9f9
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80a9a9..0x80a9c0
+            - Range: 0x80a9f9..0x80aa10
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x80a9c0..0x80aa40]
+      OutOfLinePCRanges: [0x80aa10..0x80aa90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 97 BaseType complex64
-          Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
+          Locations: [{Range: 0x80aa10..0x80aa90, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 98 BaseType complex128
-          Locations: [{Range: 0x80a9c0..0x80aa40, Pieces: []}]
+          Locations: [{Range: 0x80aa10..0x80aa90, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x80aa40..0x80ab00]
+      OutOfLinePCRanges: [0x80aa90..0x80ab50]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80aa40..0x80aadc
+            - Range: 0x80aa90..0x80ab2c
               Pieces: []
-            - Range: 0x80aadc..0x80aadd
+            - Range: 0x80ab2c..0x80ab2d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6452,173 +6498,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80aadd..0x80ab00
+            - Range: 0x80ab2d..0x80ab50
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x80ab00..0x80ab80]
+      OutOfLinePCRanges: [0x80ab50..0x80abd0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80ab00..0x80ab68
+            - Range: 0x80ab50..0x80abb8
               Pieces: []
-            - Range: 0x80ab68..0x80ab69
+            - Range: 0x80abb8..0x80abb9
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80ab69..0x80ab80
+            - Range: 0x80abb9..0x80abd0
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x80ab80..0x80abf0]
+      OutOfLinePCRanges: [0x80abd0..0x80ac40]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 252 ArrayType [1]int
           Locations:
-            - Range: 0x80ab80..0x80abd0
+            - Range: 0x80abd0..0x80ac20
               Pieces: []
-            - Range: 0x80abd0..0x80abd1
+            - Range: 0x80ac20..0x80ac21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80abd1..0x80abf0
+            - Range: 0x80ac21..0x80ac40
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x80abf0..0x80ac60]
+      OutOfLinePCRanges: [0x80ac40..0x80acb0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80abf0..0x80ac3c
+            - Range: 0x80ac40..0x80ac8c
               Pieces: []
-            - Range: 0x80ac3c..0x80ac3d
+            - Range: 0x80ac8c..0x80ac8d
               Pieces: []
-            - Range: 0x80ac3d..0x80ac60
+            - Range: 0x80ac8d..0x80acb0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x80ac60..0x80ace0]
+      OutOfLinePCRanges: [0x80acb0..0x80ad30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 254 StructureType main.mixedStruct
-          Locations: [{Range: 0x80ac60..0x80ace0, Pieces: []}]
+          Locations: [{Range: 0x80acb0..0x80ad30, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x80ace0..0x80ad70]
+      OutOfLinePCRanges: [0x80ad30..0x80adc0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ace0..0x80ad58
+            - Range: 0x80ad30..0x80ada8
               Pieces: []
-            - Range: 0x80ad58..0x80ad59
+            - Range: 0x80ada8..0x80ada9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80ad59..0x80ad70
+            - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x80ad70..0x80ae40]
+      OutOfLinePCRanges: [0x80adc0..0x80ae90]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 255 StructureType main.wideStruct
           Locations:
-            - Range: 0x80ad70..0x80ae1c
+            - Range: 0x80adc0..0x80ae6c
               Pieces: []
-            - Range: 0x80ae1c..0x80ae1d
+            - Range: 0x80ae6c..0x80ae6d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6642,127 +6688,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x80ae1d..0x80ae40
+            - Range: 0x80ae6d..0x80ae90
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x80ae40..0x80aed0]
+      OutOfLinePCRanges: [0x80ae90..0x80af20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ae40..0x80aeac
+            - Range: 0x80ae90..0x80aefc
               Pieces: []
-            - Range: 0x80aeac..0x80aead
+            - Range: 0x80aefc..0x80aefd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80aead..0x80aed0
+            - Range: 0x80aefd..0x80af20
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
+          Locations: [{Range: 0x80ae90..0x80af20, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ae40..0x80aeac
+            - Range: 0x80ae90..0x80aefc
               Pieces: []
-            - Range: 0x80aeac..0x80aead
+            - Range: 0x80aefc..0x80aefd
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80aead..0x80aed0
+            - Range: 0x80aefd..0x80af20
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80ae40..0x80aed0, Pieces: []}]
+          Locations: [{Range: 0x80ae90..0x80af20, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80ae40..0x80aeac
+            - Range: 0x80ae90..0x80aefc
               Pieces: []
-            - Range: 0x80aeac..0x80aead
+            - Range: 0x80aefc..0x80aefd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80aead..0x80aed0
+            - Range: 0x80aefd..0x80af20
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x80aed0..0x80af50]
+      OutOfLinePCRanges: [0x80af20..0x80afa0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80aed0..0x80af38
+            - Range: 0x80af20..0x80af88
               Pieces: []
-            - Range: 0x80af38..0x80af39
+            - Range: 0x80af88..0x80af89
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80af39..0x80af50
+            - Range: 0x80af89..0x80afa0
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x80af50..0x80afc0]
+      OutOfLinePCRanges: [0x80afa0..0x80b010]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80af50..0x80afc0, Pieces: []}]
+          Locations: [{Range: 0x80afa0..0x80b010, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x80afc0..0x80b030]
+      OutOfLinePCRanges: [0x80b010..0x80b080]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 18 BaseType float32
-          Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
+          Locations: [{Range: 0x80b010..0x80b080, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 16 BaseType float64
-          Locations: [{Range: 0x80afc0..0x80b030, Pieces: []}]
+          Locations: [{Range: 0x80b010..0x80b080, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x80b030..0x80b0a0]
+      OutOfLinePCRanges: [0x80b080..0x80b0f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x80b030..0x80b084
+            - Range: 0x80b080..0x80b0d4
               Pieces: []
-            - Range: 0x80b084..0x80b085
+            - Range: 0x80b0d4..0x80b0d5
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b085..0x80b0a0
+            - Range: 0x80b0d5..0x80b0f0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x80b030..0x80b084
+            - Range: 0x80b080..0x80b0d4
               Pieces: []
-            - Range: 0x80b084..0x80b085
+            - Range: 0x80b0d4..0x80b0d5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b085..0x80b0a0
+            - Range: 0x80b0d5..0x80b0f0
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x80b0a0..0x80b230]
+      OutOfLinePCRanges: [0x80b0f0..0x80b280]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b0a0..0x80b0f8
+            - Range: 0x80b0f0..0x80b148
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6784,7 +6830,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b0f8..0x80b100
+            - Range: 0x80b148..0x80b150
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6806,7 +6852,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b100..0x80b108
+            - Range: 0x80b150..0x80b158
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6828,7 +6874,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b108..0x80b10c
+            - Range: 0x80b158..0x80b15c
               Pieces:
                 - Size: 8
                   Op: null
@@ -6854,9 +6900,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b0a0..0x80b1e8
+            - Range: 0x80b0f0..0x80b238
               Pieces: []
-            - Range: 0x80b1e8..0x80b1e9
+            - Range: 0x80b238..0x80b239
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6878,39 +6924,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b1e9..0x80b230
+            - Range: 0x80b239..0x80b280
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x80b230..0x80b2f0]
+      OutOfLinePCRanges: [0x80b280..0x80b340]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b230..0x80b2f0
+            - Range: 0x80b280..0x80b340
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b230..0x80b2d8
+            - Range: 0x80b280..0x80b328
               Pieces: []
-            - Range: 0x80b2d8..0x80b2d9
+            - Range: 0x80b328..0x80b329
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80b2d9..0x80b2f0
+            - Range: 0x80b329..0x80b340
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x80b2f0..0x80b500]
+      OutOfLinePCRanges: [0x80b340..0x80b550]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b2f0..0x80b34c
+            - Range: 0x80b340..0x80b39c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6932,7 +6978,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b34c..0x80b354
+            - Range: 0x80b39c..0x80b3a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6954,7 +7000,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b354..0x80b35c
+            - Range: 0x80b3a4..0x80b3ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6976,7 +7022,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b35c..0x80b360
+            - Range: 0x80b3ac..0x80b3b0
               Pieces:
                 - Size: 8
                   Op: null
@@ -7002,15 +7048,15 @@ Subprograms:
         - Name: s2
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b2f0..0x80b500
+            - Range: 0x80b340..0x80b550
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b2f0..0x80b4b4
+            - Range: 0x80b340..0x80b504
               Pieces: []
-            - Range: 0x80b4b4..0x80b4b5
+            - Range: 0x80b504..0x80b505
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7032,175 +7078,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b4b5..0x80b500
+            - Range: 0x80b505..0x80b550
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x80b500..0x80b6a0]
+      OutOfLinePCRanges: [0x80b550..0x80b6f0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b564
+            - Range: 0x80b550..0x80b5b4
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b564..0x80b6a0
+            - Range: 0x80b5b4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b56c
+            - Range: 0x80b550..0x80b5bc
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b56c..0x80b6a0
+            - Range: 0x80b5bc..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b500..0x80b574
+            - Range: 0x80b550..0x80b5c4
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x80b574..0x80b6a0
+            - Range: 0x80b5c4..0x80b6f0
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b500..0x80b65c
+            - Range: 0x80b550..0x80b6ac
               Pieces: []
-            - Range: 0x80b65c..0x80b65d
+            - Range: 0x80b6ac..0x80b6ad
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x80b65d..0x80b6a0
+            - Range: 0x80b6ad..0x80b6f0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x80b6a0..0x80b890]
+      OutOfLinePCRanges: [0x80b6f0..0x80b8e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b714
+            - Range: 0x80b6f0..0x80b764
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b714..0x80b890
+            - Range: 0x80b764..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b71c
+            - Range: 0x80b6f0..0x80b76c
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b71c..0x80b890
+            - Range: 0x80b76c..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80b6a0..0x80b724
+            - Range: 0x80b6f0..0x80b774
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b724..0x80b890
+            - Range: 0x80b774..0x80b8e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7210,9 +7256,9 @@ Subprograms:
         - Name: ~r0
           Type: 250 StructureType main.largeStruct
           Locations:
-            - Range: 0x80b6a0..0x80b848
+            - Range: 0x80b6f0..0x80b898
               Pieces: []
-            - Range: 0x80b848..0x80b849
+            - Range: 0x80b898..0x80b899
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7234,191 +7280,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80b849..0x80b890
+            - Range: 0x80b899..0x80b8e0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x80b890..0x80b920]
+      OutOfLinePCRanges: [0x80b8e0..0x80b970]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 161 ArrayType [5]int
           Locations:
-            - Range: 0x80b890..0x80b920
+            - Range: 0x80b8e0..0x80b970
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b890..0x80b900
+            - Range: 0x80b8e0..0x80b950
               Pieces: []
-            - Range: 0x80b900..0x80b901
+            - Range: 0x80b950..0x80b951
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b901..0x80b920
+            - Range: 0x80b951..0x80b970
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b890..0x80b900
+            - Range: 0x80b8e0..0x80b950
               Pieces: []
-            - Range: 0x80b900..0x80b901
+            - Range: 0x80b950..0x80b951
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80b901..0x80b920
+            - Range: 0x80b951..0x80b970
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b890..0x80b900
+            - Range: 0x80b8e0..0x80b950
               Pieces: []
-            - Range: 0x80b900..0x80b901
+            - Range: 0x80b950..0x80b951
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80b901..0x80b920
+            - Range: 0x80b951..0x80b970
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x80b920..0x80b9f0]
+      OutOfLinePCRanges: [0x80b970..0x80ba40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b920..0x80b9f0
+            - Range: 0x80b970..0x80ba40
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 251 ArrayType [3]int
           Locations:
-            - Range: 0x80b920..0x80b9f0
+            - Range: 0x80b970..0x80ba40
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b920..0x80b9d4
+            - Range: 0x80b970..0x80ba24
               Pieces: []
-            - Range: 0x80b9d4..0x80b9d5
+            - Range: 0x80ba24..0x80ba25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80b9d5..0x80b9f0
+            - Range: 0x80ba25..0x80ba40
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 113 ArrayType [2]int
           Locations:
-            - Range: 0x80b920..0x80b9d4
+            - Range: 0x80b970..0x80ba24
               Pieces: []
-            - Range: 0x80b9d4..0x80b9d5
+            - Range: 0x80ba24..0x80ba25
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x80b9d5..0x80b9f0
+            - Range: 0x80ba25..0x80ba40
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x80b9f0..0x80bab0]
+      OutOfLinePCRanges: [0x80ba40..0x80bb00]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80b9f0..0x80bab0
+            - Range: 0x80ba40..0x80bb00
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80b9f0..0x80ba90
+            - Range: 0x80ba40..0x80bae0
               Pieces: []
-            - Range: 0x80ba90..0x80ba91
+            - Range: 0x80bae0..0x80bae1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80ba91..0x80bab0
+            - Range: 0x80bae1..0x80bb00
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 256 StructureType main.structWithArray
           Locations:
-            - Range: 0x80b9f0..0x80ba90
+            - Range: 0x80ba40..0x80bae0
               Pieces: []
-            - Range: 0x80ba90..0x80ba91
+            - Range: 0x80bae0..0x80bae1
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x80ba91..0x80bab0
+            - Range: 0x80bae1..0x80bb00
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80ba68..0x80bab0
+            - Range: 0x80bab8..0x80bb00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x80bab0..0x80bb50]
+      OutOfLinePCRanges: [0x80bb00..0x80bba0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 ArrayType [0]int
-          Locations: [{Range: 0x80bab0..0x80bb50, Pieces: []}]
+          Locations: [{Range: 0x80bb00..0x80bba0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bab0..0x80baec
+            - Range: 0x80bb00..0x80bb3c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80baec..0x80bb04
+            - Range: 0x80bb3c..0x80bb54
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x80bb04..0x80bb0c
+            - Range: 0x80bb54..0x80bb5c
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x80bb0c..0x80bb50
+            - Range: 0x80bb5c..0x80bba0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80bab0..0x80bb28
+            - Range: 0x80bb00..0x80bb78
               Pieces: []
-            - Range: 0x80bb28..0x80bb29
+            - Range: 0x80bb78..0x80bb79
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80bb29..0x80bb50
+            - Range: 0x80bb79..0x80bba0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 253 ArrayType [0]int
           Locations:
-            - Range: 0x80bab0..0x80bb28
+            - Range: 0x80bb00..0x80bb78
               Pieces: []
-            - Range: 0x80bb28..0x80bb29
+            - Range: 0x80bb78..0x80bb79
               Pieces: []
-            - Range: 0x80bb29..0x80bb50
+            - Range: 0x80bb79..0x80bba0
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x80bf80..0x80bf90]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80bf80..0x80bf90
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x80bf90..0x80bfa0]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80bf90..0x80bfa0
+            - Range: 0x80bfd0..0x80bfe0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7428,98 +7457,12 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 130
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x80bfa0..0x80bfb0]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 258 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x80bfa0..0x80bfb0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x80bfb0..0x80bfc0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x80bfb0..0x80bfc0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80bfb0..0x80bfc0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x80bfc0..0x80bfd0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x80bfc0..0x80bfd0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80bfc0..0x80bfd0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x80bfd0..0x80bfe0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x80bfd0..0x80bfe0
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80bfe0..0x80bff0]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 263 GoSliceHeaderType []string
+        - Name: u
+          Type: 257 GoSliceHeaderType []uint
           Locations:
             - Range: 0x80bfe0..0x80bff0
               Pieces:
@@ -7530,21 +7473,124 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80bff0..0x80c000]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 258 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x80bff0..0x80c000
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 132
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x80c000..0x80c010]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80c000..0x80c010
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80c000..0x80c010
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x80c010..0x80c020]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80c010..0x80c020
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80c010..0x80c020
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x80c020..0x80c030]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 260 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x80c020..0x80c030
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x80c020..0x80c030
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x80c030..0x80c040]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 263 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x80c030..0x80c040
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x80c040..0x80c050]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 17 BaseType int8
           Locations:
-            - Range: 0x80bff0..0x80c000
+            - Range: 0x80c040..0x80c050
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 264 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x80bff0..0x80c000
+            - Range: 0x80c040..0x80c050
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7556,35 +7602,18 @@ Subprograms:
         - Name: x
           Type: 10 BaseType uint
           Locations:
-            - Range: 0x80bff0..0x80c000
+            - Range: 0x80c040..0x80c050
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x80c000..0x80c010]
+      OutOfLinePCRanges: [0x80c050..0x80c060]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 265 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x80c000..0x80c010
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x80c010..0x80c020]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 257 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x80c010..0x80c020
+            - Range: 0x80c050..0x80c060
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7594,14 +7623,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 138
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x80c020..0x80c030]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x80c060..0x80c070]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 266 GoSliceHeaderType []struct {}
+          Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c020..0x80c030
+            - Range: 0x80c060..0x80c070
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7611,14 +7640,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x80c070..0x80c080]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x80c070..0x80c080
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x80c030..0x80c040]
+      OutOfLinePCRanges: [0x80c080..0x80c090]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c030..0x80c040
+            - Range: 0x80c080..0x80c090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7630,7 +7676,7 @@ Subprograms:
         - Name: bs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c030..0x80c040
+            - Range: 0x80c080..0x80c090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7642,7 +7688,7 @@ Subprograms:
         - Name: cs
           Type: 257 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x80c030..0x80c040
+            - Range: 0x80c080..0x80c090
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7651,122 +7697,27 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0x80c320..0x80c380]
+      OutOfLinePCRanges: [0x80c370..0x80c3d0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c320..0x80c368
+            - Range: 0x80c370..0x80c3b8
               Pieces: []
-            - Range: 0x80c368..0x80c369
+            - Range: 0x80c3b8..0x80c3b9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80c369..0x80c380
+            - Range: 0x80c3b9..0x80c3d0
               Pieces: []
           Role: Return
-    - ID: 141
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x80c380..0x80c390]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c380..0x80c390
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 142
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x80c390..0x80c3a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c390..0x80c3a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c390..0x80c3a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x80c390..0x80c3a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 143
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x80c3a0..0x80c3b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 268 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x80c3a0..0x80c3b0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 144
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x80c3b0..0x80c3c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 269 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x80c3b0..0x80c3c0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 145
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x80c3c0..0x80c3d0]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 270 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x80c3c0..0x80c3d0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x80c3d0..0x80c3e0]
       InlinePCRanges: []
       Variables:
@@ -7780,8 +7731,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 147
-      Name: main.testUnitializedString
+    - ID: 143
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80c3e0..0x80c3f0]
       InlinePCRanges: []
       Variables:
@@ -7795,13 +7746,33 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c3e0..0x80c3f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c3e0..0x80c3f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 144
+      Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x80c3f0..0x80c400]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 268 StructureType main.threeStringStruct
           Locations:
             - Range: 0x80c3f0..0x80c400
               Pieces:
@@ -7809,16 +7780,91 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 145
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x80c400..0x80c410]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 269 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x80c400..0x80c410
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 146
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x80c410..0x80c420]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 270 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x80c410..0x80c420
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 147
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x80c420..0x80c430]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c420..0x80c430
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 148
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x80c430..0x80c440]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c430..0x80c440
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x80c440..0x80c450]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x80c440..0x80c450
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 150
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x80c400..0x80c410]
+      OutOfLinePCRanges: [0x80c450..0x80c460]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c400..0x80c410
+            - Range: 0x80c450..0x80c460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7828,7 +7874,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c400..0x80c410
+            - Range: 0x80c450..0x80c460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7838,33 +7884,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x80c400..0x80c410
+            - Range: 0x80c450..0x80c460
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x80c560..0x80c570]
+      OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 272 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x80c560..0x80c570
+            - Range: 0x80c5b0..0x80c5c0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x80c570..0x80c580]
+      OutOfLinePCRanges: [0x80c5c0..0x80c5d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 285 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x80c570..0x80c580
+            - Range: 0x80c5c0..0x80c5d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7879,15 +7925,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0x80c620..0x80c640]
+      OutOfLinePCRanges: [0x80c670..0x80c690]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 316 StructureType main.aStruct
           Locations:
-            - Range: 0x80c620..0x80c640
+            - Range: 0x80c670..0x80c690
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7904,38 +7950,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x80c6b0..0x80c6c0]
+      OutOfLinePCRanges: [0x80c700..0x80c710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 317 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x80c6b0..0x80c6c0
+            - Range: 0x80c700..0x80c710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x80c6f0..0x80c700]
+      OutOfLinePCRanges: [0x80c740..0x80c750]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 319 StructureType main.emptyStruct
-          Locations: [{Range: 0x80c6f0..0x80c700, Pieces: []}]
+          Locations: [{Range: 0x80c740..0x80c750, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x80c700..0x80c710]
+      OutOfLinePCRanges: [0x80c750..0x80c760]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 320 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x80c700..0x80c710
+            - Range: 0x80c750..0x80c760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807520..0x807590]
       InlinePCRanges:
@@ -7964,28 +8010,28 @@ Subprograms:
             - Range: 0x807800..0x807824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8077a4..0x8077d8]
           RootRanges: [0x807740..0x807800]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80788c..0x8078c0, 0x8078c8..0x8078cc]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807930..0x807964]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7998,7 +8044,7 @@ Subprograms:
             - Range: 0x807980..0x807988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11340,10 +11386,10 @@ Types:
       GoKind: 22
       Pointee: 823 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11355,7 +11401,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11443,7 +11489,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11455,7 +11501,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11465,11 +11511,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11481,7 +11527,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11641,6 +11687,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1359
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11722,7 +11810,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11734,7 +11822,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11744,7 +11832,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11814,7 +11902,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11826,7 +11914,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11836,7 +11924,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11996,7 +12084,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12008,7 +12096,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12018,7 +12106,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12028,7 +12116,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12038,11 +12126,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12054,7 +12142,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12064,11 +12152,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12080,7 +12168,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12090,11 +12178,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1548
+      ID: 1550
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12106,7 +12194,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12116,11 +12204,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1549
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12132,7 +12220,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12142,7 +12230,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12408,7 +12496,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1552
+      ID: 1554
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12460,16 +12548,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1556
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1555
+      ID: 1557
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1556
+      ID: 1558
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12478,7 +12566,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1551
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12490,7 +12578,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12500,11 +12588,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1551
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12516,7 +12604,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12526,14 +12614,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1550
+      ID: 1552
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1557
+      ID: 1559
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12545,7 +12633,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12555,11 +12643,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1558
+      ID: 1560
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12571,7 +12659,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12581,11 +12669,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1559
+      ID: 1561
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12597,7 +12685,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12607,7 +12695,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12767,7 +12855,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12779,7 +12867,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12789,11 +12877,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12805,11 +12893,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12821,7 +12909,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12831,7 +12919,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12890,7 +12978,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12902,7 +12990,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12912,7 +13000,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12922,7 +13010,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12932,7 +13020,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12942,7 +13030,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12952,7 +13040,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12962,7 +13050,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12972,7 +13060,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12982,7 +13070,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12992,7 +13080,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13002,7 +13090,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13012,7 +13100,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13022,7 +13110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13032,7 +13120,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13042,7 +13130,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13052,7 +13140,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13062,7 +13150,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13072,11 +13160,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13088,7 +13176,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13612,7 +13700,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13624,7 +13712,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13634,11 +13722,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13650,7 +13738,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13660,11 +13748,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13676,7 +13764,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13686,7 +13774,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13696,7 +13784,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13706,7 +13794,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13716,7 +13804,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13726,7 +13814,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13736,7 +13824,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13746,7 +13834,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13756,7 +13844,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13766,7 +13854,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13776,7 +13864,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13786,7 +13874,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13796,7 +13884,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13806,7 +13894,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13816,7 +13904,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13826,7 +13914,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13836,7 +13924,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13846,11 +13934,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13862,11 +13950,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13878,7 +13966,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13888,7 +13976,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13898,7 +13986,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13908,11 +13996,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13924,7 +14012,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13934,11 +14022,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13950,7 +14038,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13960,7 +14048,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13970,7 +14058,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13980,11 +14068,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13996,11 +14084,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14012,7 +14100,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14022,11 +14110,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14038,7 +14126,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14048,7 +14136,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14058,7 +14146,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14068,23 +14156,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14100,7 +14172,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14116,11 +14188,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1459
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14132,7 +14220,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14142,11 +14230,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14158,7 +14246,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14168,7 +14256,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14178,7 +14266,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14188,7 +14276,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14198,7 +14286,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14208,33 +14296,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14250,7 +14312,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14260,7 +14322,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14276,7 +14338,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14286,7 +14348,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14396,32 +14484,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14434,7 +14496,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14444,11 +14506,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1449
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14460,11 +14548,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14476,7 +14564,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14486,11 +14574,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14502,7 +14590,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14512,11 +14600,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14528,7 +14616,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14538,10 +14626,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1545
+      ID: 1547
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1546
+      ID: 1548
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14553,7 +14641,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14563,7 +14651,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14575,7 +14663,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14585,7 +14673,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14595,7 +14683,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14605,11 +14693,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14621,7 +14709,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14631,7 +14719,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14641,7 +14729,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14651,11 +14739,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14667,7 +14755,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14677,7 +14765,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14687,7 +14775,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14697,7 +14785,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14707,7 +14795,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14717,11 +14805,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14733,7 +14821,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14743,11 +14831,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14759,7 +14847,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14769,11 +14857,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14785,7 +14873,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14795,7 +14883,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14825,7 +14913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14837,7 +14925,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14847,11 +14935,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14863,7 +14951,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14873,7 +14961,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14883,7 +14971,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14893,11 +14981,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14909,7 +14997,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14919,446 +15007,12 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1441
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1442
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 252 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1469
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1477
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1489
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1490
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1465
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1466
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 97 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 98 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 16 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 100 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1443
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15384,6 +15038,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1444
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 98 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 100 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1446
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15395,14 +15483,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15414,14 +15502,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15433,7 +15521,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15443,7 +15531,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15453,7 +15541,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15463,7 +15551,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15473,7 +15561,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15483,7 +15571,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15493,7 +15581,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15503,7 +15591,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15513,7 +15601,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15523,7 +15611,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15533,7 +15621,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15543,7 +15631,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15553,7 +15641,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15563,7 +15651,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15573,7 +15661,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15583,7 +15671,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15593,14 +15681,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15612,14 +15700,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15631,7 +15719,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15641,7 +15729,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15651,7 +15739,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15661,7 +15749,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15671,14 +15759,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15690,7 +15778,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15700,14 +15788,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15719,14 +15807,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15738,7 +15826,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15748,7 +15836,7 @@ Types:
             Type: 96 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15758,7 +15846,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15768,7 +15856,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15778,7 +15866,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15788,7 +15876,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15798,7 +15886,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15808,14 +15896,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15827,14 +15915,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15846,7 +15934,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16156,7 +16244,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16168,7 +16256,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16178,7 +16266,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16312,7 +16400,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16324,7 +16412,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16334,11 +16422,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16350,7 +16438,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16360,7 +16448,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16390,7 +16478,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16402,7 +16490,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16412,11 +16500,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16428,7 +16516,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16438,7 +16526,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16448,11 +16536,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16464,7 +16552,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16474,11 +16562,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16490,7 +16578,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16500,7 +16588,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16510,7 +16598,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16540,7 +16628,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16552,7 +16640,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16562,11 +16650,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16578,7 +16666,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16588,7 +16676,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16644,7 +16732,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16656,7 +16744,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16666,7 +16754,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16676,7 +16764,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16686,7 +16774,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16716,7 +16804,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16728,7 +16816,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16738,11 +16826,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16754,7 +16842,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16764,11 +16852,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16780,7 +16868,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16790,14 +16878,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16809,7 +16897,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16819,7 +16907,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16849,7 +16937,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16861,7 +16949,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16871,14 +16959,14 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16890,7 +16978,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16900,7 +16988,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16910,7 +16998,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16920,7 +17008,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16930,7 +17018,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16940,11 +17028,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16956,7 +17044,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16966,7 +17054,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16976,7 +17064,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16986,7 +17074,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16996,7 +17084,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17006,11 +17094,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17022,7 +17110,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17032,11 +17120,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17048,7 +17136,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17061,7 +17149,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17074,14 +17162,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17093,7 +17181,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17103,11 +17191,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17119,7 +17207,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17129,7 +17217,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17139,17 +17227,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1527
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1529
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1525
+      ID: 1531
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1527
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17161,7 +17249,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17171,7 +17259,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17181,7 +17269,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17191,7 +17279,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17201,7 +17289,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17211,7 +17299,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17371,7 +17459,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17383,7 +17471,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17393,11 +17481,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17409,7 +17497,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17419,11 +17507,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17435,7 +17523,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17445,11 +17533,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17461,7 +17549,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17471,7 +17559,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17501,7 +17589,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17513,7 +17601,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17523,11 +17611,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17539,7 +17627,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17549,11 +17637,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17565,7 +17653,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17575,7 +17663,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17585,7 +17673,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17595,11 +17683,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17611,7 +17699,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17621,7 +17709,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26289,7 +26377,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1559
+MaxTypeID: 1561
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -8,15 +8,15 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x808a88", Frameless: false}]
+          Type: 1524 EventRootType Probe[main.stackC]
+          InjectionPoints: [{PC: "0x808ad8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x808ab8", Frameless: false}]
+          Type: 1525 EventRootType Probe[main.stackC]Return
+          InjectionPoints: [{PC: "0x808b08", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -76,15 +76,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x80798c", Frameless: false}]
+          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          InjectionPoints: [{PC: "0x8079dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x807a20", Frameless: false}]
+          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          InjectionPoints: [{PC: "0x807a70", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -218,6 +218,31 @@ Probes:
               DSL: a
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testAtomicAdd
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testAtomicAdd}
+      tags: ['foo:bar']
+      template: '{x}'
+      segments: [{json: {ref: x}, dsl: x}]
+      captureSnapshot: true
+      subprogram: {subprogram: 85}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          InjectionPoints: [{PC: "0x8060f0", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          InjectionPoints: [{PC: "0x80612c", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: '{x}'
+        Segments:
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 1
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -289,11 +314,11 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x8060f0", Frameless: true}]
+          Type: 1424 EventRootType Probe[main.testChannel]
+          InjectionPoints: [{PC: "0x806130", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -349,11 +374,11 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x806360", Frameless: true}]
+          Type: 1432 EventRootType Probe[main.testCycle]
+          InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -496,11 +521,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1510 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x808700", Frameless: true}]
+          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          InjectionPoints: [{PC: "0x808750", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -522,11 +547,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x808730", Frameless: true}]
+          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          InjectionPoints: [{PC: "0x808780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -549,11 +574,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x808b40", Frameless: true}]
+          Type: 1536 EventRootType Probe[main.testEmptyString]
+          InjectionPoints: [{PC: "0x808b90", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -570,11 +595,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x808df0", Frameless: true}]
+          Type: 1545 EventRootType Probe[main.testEmptyStruct]
+          InjectionPoints: [{PC: "0x808e40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -590,11 +615,11 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
+          Type: 1546 EventRootType Probe[main.testEmptyStructPointer]
+          InjectionPoints: [{PC: "0x808e50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -841,10 +866,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testInlinedBBB]
+          Type: 1550 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x803ee4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -879,10 +904,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testInlinedBCA]
+          Type: 1551 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -899,10 +924,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Line
-          Type: 1550 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1552 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -916,10 +941,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedBCB]
+          Type: 1553 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -936,10 +961,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1552 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1554 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -954,10 +979,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testInlinedPrint]
+          Type: 1547 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -971,7 +996,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1546 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1548 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x803cac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -992,10 +1017,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Line
-          Type: 1547 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1549 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -1023,10 +1048,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedSq]
+          Type: 1555 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1047,10 +1072,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1556 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1069,10 +1094,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1557 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8040f4"
               Frameless: false
@@ -1219,15 +1244,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x807800", Frameless: false}]
+          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x807930", Frameless: false}]
+          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x807980", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1244,11 +1269,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x806270", Frameless: true}]
+          Type: 1426 EventRootType Probe[main.testLinkedList]
+          InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1352,15 +1377,15 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x807c6c", Frameless: false}]
+          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          InjectionPoints: [{PC: "0x807cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x807dc0", Frameless: false}]
+          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          InjectionPoints: [{PC: "0x807e10", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1843,11 +1868,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x808b20", Frameless: true}]
+          Type: 1533 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1865,11 +1890,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x808b20", Frameless: true}]
+          Type: 1534 EventRootType Probe[main.testMassiveString]
+          InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1911,15 +1936,15 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x807e20", Frameless: false}]
+          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          InjectionPoints: [{PC: "0x807e70", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x807fac", Frameless: false}]
+          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          InjectionPoints: [{PC: "0x807ffc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -1980,15 +2005,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x80809c", Frameless: false}]
+          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          InjectionPoints: [{PC: "0x8080ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x808138", Frameless: false}]
+          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          InjectionPoints: [{PC: "0x808188", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2014,15 +2039,15 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x807a60", Frameless: false}]
+          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x807c08", Frameless: false}]
+          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          InjectionPoints: [{PC: "0x807c58", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2043,15 +2068,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e38", Frameless: false}]
+          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806ebc", Frameless: false}]
+          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2122,15 +2147,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x806d98", Frameless: false}]
+          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x806df4", Frameless: false}]
+          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2152,15 +2177,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x806d98", Frameless: false}]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x806df4", Frameless: false}]
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2183,11 +2208,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808db0", Frameless: true}]
+          Type: 1541 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2207,11 +2232,11 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808db0", Frameless: true}]
+          Type: 1542 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2237,11 +2262,11 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808db0", Frameless: true}]
+          Type: 1543 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2261,11 +2286,11 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x808db0", Frameless: true}]
+          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2287,11 +2312,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x806340", Frameless: true}]
+          Type: 1431 EventRootType Probe[main.testNilPointer]
+          InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2313,11 +2338,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x808770", Frameless: true}]
+          Type: 1519 EventRootType Probe[main.testNilSlice]
+          InjectionPoints: [{PC: "0x8087c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2339,11 +2364,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x808740", Frameless: true}]
+          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          InjectionPoints: [{PC: "0x808790", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2373,11 +2398,11 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x808760", Frameless: true}]
+          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          InjectionPoints: [{PC: "0x8087b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2404,11 +2429,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x808b10", Frameless: true}]
+          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
+          InjectionPoints: [{PC: "0x808b60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2425,11 +2450,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x806280", Frameless: true}]
+          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2467,11 +2492,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1423 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x806260", Frameless: true}]
+          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2488,22 +2513,22 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x806a68", Frameless: false}]
+          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          InjectionPoints: [{PC: "0x806ab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x806af0"
+            - PC: "0x806b40"
               Frameless: false
-            - PC: "0x806b44"
+            - PC: "0x806b94"
               Frameless: false
-            - PC: "0x806bfc"
+            - PC: "0x806c4c"
               Frameless: false
-            - PC: "0x806c10"
+            - PC: "0x806c60"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2526,22 +2551,22 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x8068e8", Frameless: false}]
+          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          InjectionPoints: [{PC: "0x806938", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x80693c"
+            - PC: "0x80698c"
               Frameless: false
-            - PC: "0x806998"
+            - PC: "0x8069e8"
               Frameless: false
-            - PC: "0x8069e0"
+            - PC: "0x806a30"
               Frameless: false
-            - PC: "0x806a24"
+            - PC: "0x806a74"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2563,15 +2588,15 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x80723c", Frameless: false}]
+          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          InjectionPoints: [{PC: "0x80728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x80728c", Frameless: false}]
+          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          InjectionPoints: [{PC: "0x8072dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2583,15 +2608,15 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x8072c8", Frameless: false}]
+          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          InjectionPoints: [{PC: "0x807318", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x807300", Frameless: false}]
+          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          InjectionPoints: [{PC: "0x807350", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2603,15 +2628,15 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x807338", Frameless: false}]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          InjectionPoints: [{PC: "0x807388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x80736c", Frameless: false}]
+          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          InjectionPoints: [{PC: "0x8073bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2623,15 +2648,15 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x807428", Frameless: false}]
+          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          InjectionPoints: [{PC: "0x807478", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x807488", Frameless: false}]
+          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          InjectionPoints: [{PC: "0x8074d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2643,15 +2668,15 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x807788", Frameless: false}]
+          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x8077c4", Frameless: false}]
+          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          InjectionPoints: [{PC: "0x807814", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2663,15 +2688,15 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x8070f8", Frameless: false}]
+          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          InjectionPoints: [{PC: "0x807148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x807140", Frameless: false}]
+          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          InjectionPoints: [{PC: "0x807190", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2684,18 +2709,18 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x806868", Frameless: false}]
+          Type: 1439 EventRootType Probe[main.testReturnsError]
+          InjectionPoints: [{PC: "0x8068b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsError]Return
+          Type: 1440 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x80689c"
+            - PC: "0x8068ec"
               Frameless: false
-            - PC: "0x8068b0"
+            - PC: "0x806900"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2712,15 +2737,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x806678", Frameless: false}]
+          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          InjectionPoints: [{PC: "0x8066c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1432 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x8066b8", Frameless: false}]
+          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          InjectionPoints: [{PC: "0x806708", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2736,15 +2761,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x806798", Frameless: false}]
+          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          InjectionPoints: [{PC: "0x8067e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x806828", Frameless: false}]
+          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          InjectionPoints: [{PC: "0x806878", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2760,15 +2785,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x8066f8", Frameless: false}]
+          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          InjectionPoints: [{PC: "0x806748", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x806754", Frameless: false}]
+          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          InjectionPoints: [{PC: "0x8067a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2785,18 +2810,18 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x806c48", Frameless: false}]
+          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          InjectionPoints: [{PC: "0x806c98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x806d00"
+            - PC: "0x806d50"
               Frameless: false
-            - PC: "0x806d14"
+            - PC: "0x806d64"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2813,15 +2838,15 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x807180", Frameless: false}]
+          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          InjectionPoints: [{PC: "0x8071d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x807200", Frameless: false}]
+          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          InjectionPoints: [{PC: "0x807250", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2833,15 +2858,15 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x807048", Frameless: false}]
+          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          InjectionPoints: [{PC: "0x807098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x8070c8", Frameless: false}]
+          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          InjectionPoints: [{PC: "0x807118", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2853,15 +2878,15 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x807588", Frameless: false}]
+          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x8075dc", Frameless: false}]
+          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          InjectionPoints: [{PC: "0x80762c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2873,15 +2898,15 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x8073a8", Frameless: false}]
+          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          InjectionPoints: [{PC: "0x8073f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x8073ec", Frameless: false}]
+          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          InjectionPoints: [{PC: "0x80743c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2893,15 +2918,15 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x807718", Frameless: false}]
+          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          InjectionPoints: [{PC: "0x807768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x807758", Frameless: false}]
+          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          InjectionPoints: [{PC: "0x8077a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2913,15 +2938,15 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x8076a8", Frameless: false}]
+          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          InjectionPoints: [{PC: "0x8076f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x8076e4", Frameless: false}]
+          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          InjectionPoints: [{PC: "0x807734", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2933,15 +2958,15 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x806fb8", Frameless: false}]
+          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          InjectionPoints: [{PC: "0x807008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x80700c", Frameless: false}]
+          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          InjectionPoints: [{PC: "0x80705c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2953,15 +2978,15 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x80761c", Frameless: false}]
+          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          InjectionPoints: [{PC: "0x80766c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x80766c", Frameless: false}]
+          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          InjectionPoints: [{PC: "0x8076bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -2973,15 +2998,15 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x8074c0", Frameless: false}]
+          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          InjectionPoints: [{PC: "0x807510", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x807550", Frameless: false}]
+          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          InjectionPoints: [{PC: "0x8075a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3028,15 +3053,15 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e38", Frameless: false}]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806ebc", Frameless: false}]
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3304,11 +3329,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x808ad0", Frameless: true}]
+          Type: 1526 EventRootType Probe[main.testSingleString]
+          InjectionPoints: [{PC: "0x808b20", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3430,11 +3455,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x808790", Frameless: true}]
+          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          InjectionPoints: [{PC: "0x8087e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3451,11 +3476,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x808710", Frameless: true}]
+          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          InjectionPoints: [{PC: "0x808760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3492,15 +3517,15 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x806ef8", Frameless: false}]
+          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          InjectionPoints: [{PC: "0x806f48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x806f80", Frameless: false}]
+          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          InjectionPoints: [{PC: "0x806fd0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3516,15 +3541,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x808008", Frameless: false}]
+          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          InjectionPoints: [{PC: "0x808058", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x808064", Frameless: false}]
+          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          InjectionPoints: [{PC: "0x8080b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3562,11 +3587,11 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x806320", Frameless: true}]
+          Type: 1430 EventRootType Probe[main.testStringPointer]
+          InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3583,11 +3608,11 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x808750", Frameless: true}]
+          Type: 1517 EventRootType Probe[main.testStringSlice]
+          InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3646,11 +3671,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x808d50", Frameless: true}]
+          Type: 1540 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x808da0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3672,11 +3697,11 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x808720", Frameless: true}]
+          Type: 1514 EventRootType Probe[main.testStructSlice]
+          InjectionPoints: [{PC: "0x808770", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3718,15 +3743,15 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x80816c", Frameless: false}]
+          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          InjectionPoints: [{PC: "0x8081bc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x8081f4", Frameless: false}]
+          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          InjectionPoints: [{PC: "0x808244", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3743,11 +3768,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x808cb0", Frameless: true}]
+          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
+          InjectionPoints: [{PC: "0x808d00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3763,11 +3788,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x808ca0", Frameless: true}]
+          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
+          InjectionPoints: [{PC: "0x808cf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3820,11 +3845,11 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
+          Type: 1523 EventRootType Probe[main.testSubslices]
+          InjectionPoints: [{PC: "0x8087f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3859,11 +3884,11 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x808b50", Frameless: true}]
+          Type: 1537 EventRootType Probe[main.testSubstrings]
+          InjectionPoints: [{PC: "0x808ba0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3891,15 +3916,15 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e38", Frameless: false}]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806ebc", Frameless: false}]
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3915,15 +3940,15 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e38", Frameless: false}]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806ebc", Frameless: false}]
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3941,15 +3966,15 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x806e38", Frameless: false}]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x806ebc", Frameless: false}]
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -3973,11 +3998,11 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1525 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x808ae0", Frameless: true}]
+          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          InjectionPoints: [{PC: "0x808b30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4004,11 +4029,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x808af0", Frameless: true}]
+          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4033,11 +4058,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x808af0", Frameless: true}]
+          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
+          InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4064,11 +4089,11 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x808b00", Frameless: true}]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4093,11 +4118,11 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x808b00", Frameless: true}]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
+          InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4250,11 +4275,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
+          Type: 1429 EventRootType Probe[main.testUintPointer]
+          InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4271,11 +4296,11 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x8086f0", Frameless: true}]
+          Type: 1511 EventRootType Probe[main.testUintSlice]
+          InjectionPoints: [{PC: "0x808740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4292,11 +4317,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x808b30", Frameless: true}]
+          Type: 1535 EventRootType Probe[main.testUnitializedString]
+          InjectionPoints: [{PC: "0x808b80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4313,11 +4338,11 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x806290", Frameless: true}]
+          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4355,11 +4380,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x808780", Frameless: true}]
+          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4376,11 +4401,11 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x808780", Frameless: true}]
+          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4401,15 +4426,15 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x808228", Frameless: false}]
+          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          InjectionPoints: [{PC: "0x808278", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x80828c", Frameless: false}]
+          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          InjectionPoints: [{PC: "0x8082dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -5587,275 +5612,296 @@ Subprograms:
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
     - ID: 85
+      Name: main.testAtomicAdd
+      OutOfLinePCRanges: [0x8060f0..0x806130]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x8060f0..0x80612c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: ~r0
+          Type: 8 BaseType uint64
+          Locations:
+            - Range: 0x8060f0..0x80612c
+              Pieces: []
+            - Range: 0x80612c..0x80612d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x80612d..0x806130
+              Pieces: []
+          Role: Return
+    - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0x8060f0..0x806100]
+      OutOfLinePCRanges: [0x806130..0x806140]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 249 GoChannelType chan bool
           Locations:
-            - Range: 0x8060f0..0x806100
+            - Range: 0x806130..0x806140
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 86
+    - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x806260..0x806270]
+      OutOfLinePCRanges: [0x8062b0..0x8062c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 250 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x806260..0x806270
+            - Range: 0x8062b0..0x8062c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x806270..0x806280]
+      OutOfLinePCRanges: [0x8062c0..0x8062d0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 252 StructureType main.node
           Locations:
-            - Range: 0x806270..0x806280
+            - Range: 0x8062c0..0x8062d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x806280..0x806290]
+      OutOfLinePCRanges: [0x8062d0..0x8062e0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 253 PointerType *main.node
           Locations:
-            - Range: 0x806280..0x806290
+            - Range: 0x8062d0..0x8062e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x806290..0x8062a0]
+      OutOfLinePCRanges: [0x8062e0..0x8062f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x806290..0x8062a0
+            - Range: 0x8062e0..0x8062f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x8062b0..0x8062c0]
+      OutOfLinePCRanges: [0x806300..0x806310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 PointerType *uint
           Locations:
-            - Range: 0x8062b0..0x8062c0
+            - Range: 0x806300..0x806310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x806320..0x806330]
+      OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 101 PointerType *string
           Locations:
-            - Range: 0x806320..0x806330
+            - Range: 0x806370..0x806380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x806340..0x806350]
+      OutOfLinePCRanges: [0x806390..0x8063a0]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 10 PointerType *bool
           Locations:
-            - Range: 0x806340..0x806350
+            - Range: 0x806390..0x8063a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x806340..0x806350
+            - Range: 0x806390..0x8063a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0x806360..0x806370]
+      OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 254 PointerType *main.t
           Locations:
-            - Range: 0x806360..0x806370
+            - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x806660..0x8066e0]
+      OutOfLinePCRanges: [0x8066b0..0x806730]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806660..0x80667c
+            - Range: 0x8066b0..0x8066cc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806660..0x8066b8
+            - Range: 0x8066b0..0x806708
               Pieces: []
-            - Range: 0x8066b8..0x8066b9
+            - Range: 0x806708..0x806709
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8066b9..0x8066e0
+            - Range: 0x806709..0x806730
               Pieces: []
           Role: Return
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80667c..0x806688
+            - Range: 0x8066cc..0x8066d8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806688..0x8066e0
+            - Range: 0x8066d8..0x806730
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x8066e0..0x806780]
+      OutOfLinePCRanges: [0x806730..0x8067d0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8066e0..0x806704
+            - Range: 0x806730..0x806754
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806704..0x806780
+            - Range: 0x806754..0x8067d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x8066e0..0x806754
+            - Range: 0x806730..0x8067a4
               Pieces: []
-            - Range: 0x806754..0x806755
+            - Range: 0x8067a4..0x8067a5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806755..0x806780
+            - Range: 0x8067a5..0x8067d0
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x806708..0x806720
+            - Range: 0x806758..0x806770
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806720..0x806780
+            - Range: 0x806770..0x8067d0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x806780..0x806850]
+      OutOfLinePCRanges: [0x8067d0..0x8068a0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806780..0x8067d8
+            - Range: 0x8067d0..0x806828
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806780..0x806828
+            - Range: 0x8067d0..0x806878
               Pieces: []
-            - Range: 0x806828..0x806829
+            - Range: 0x806878..0x806879
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806829..0x806850
+            - Range: 0x806879..0x8068a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x806780..0x806850, Pieces: []}]
+          Locations: [{Range: 0x8067d0..0x8068a0, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 7 BaseType int
           Locations:
-            - Range: 0x80679c..0x8067dc
+            - Range: 0x8067ec..0x80682c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8067dc..0x806850
+            - Range: 0x80682c..0x8068a0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x8067ac..0x8067dc
+            - Range: 0x8067fc..0x80682c
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x8067dc..0x806850
+            - Range: 0x80682c..0x8068a0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x806850..0x8068d0]
+      OutOfLinePCRanges: [0x8068a0..0x806920]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x806850..0x806870
+            - Range: 0x8068a0..0x8068c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x806850..0x80689c
+            - Range: 0x8068a0..0x8068ec
               Pieces: []
-            - Range: 0x80689c..0x80689d
+            - Range: 0x8068ec..0x8068ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80689d..0x8068b0
+            - Range: 0x8068ed..0x806900
               Pieces: []
-            - Range: 0x8068b0..0x8068b1
+            - Range: 0x806900..0x806901
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8068b1..0x8068d0
+            - Range: 0x806901..0x806920
               Pieces: []
           Role: Return
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x8068d0..0x806a50]
+      OutOfLinePCRanges: [0x806920..0x806aa0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8068d0..0x806920
+            - Range: 0x806920..0x806970
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806920..0x806924
+            - Range: 0x806970..0x806974
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x8069a8..0x8069b0
+            - Range: 0x8069f8..0x806a00
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8069f0..0x8069f8
+            - Range: 0x806a40..0x806a48
               Pieces:
                 - Size: 8
                   Op: null
@@ -5865,112 +5911,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8068d0..0x806928
+            - Range: 0x806920..0x806978
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8068d0..0x80693c
+            - Range: 0x806920..0x80698c
               Pieces: []
-            - Range: 0x80693c..0x80693d
+            - Range: 0x80698c..0x80698d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x80693d..0x806998
+            - Range: 0x80698d..0x8069e8
               Pieces: []
-            - Range: 0x806998..0x806999
+            - Range: 0x8069e8..0x8069e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806999..0x8069e0
+            - Range: 0x8069e9..0x806a30
               Pieces: []
-            - Range: 0x8069e0..0x8069e1
+            - Range: 0x806a30..0x806a31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8069e1..0x806a24
+            - Range: 0x806a31..0x806a74
               Pieces: []
-            - Range: 0x806a24..0x806a25
+            - Range: 0x806a74..0x806a75
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806a25..0x806a50
+            - Range: 0x806a75..0x806aa0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 15 GoInterfaceType error
           Locations:
-            - Range: 0x8068d0..0x80693c
+            - Range: 0x806920..0x80698c
               Pieces: []
-            - Range: 0x80693c..0x80693d
+            - Range: 0x80698c..0x80698d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x80693d..0x806998
+            - Range: 0x80698d..0x8069e8
               Pieces: []
-            - Range: 0x806998..0x806999
+            - Range: 0x8069e8..0x8069e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x806999..0x8069e0
+            - Range: 0x8069e9..0x806a30
               Pieces: []
-            - Range: 0x8069e0..0x8069e1
+            - Range: 0x806a30..0x806a31
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8069e1..0x806a24
+            - Range: 0x806a31..0x806a74
               Pieces: []
-            - Range: 0x806a24..0x806a25
+            - Range: 0x806a74..0x806a75
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x806a25..0x806a50
+            - Range: 0x806a75..0x806aa0
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806920..0x806928
+            - Range: 0x806970..0x806978
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x806a50..0x806c30]
+      OutOfLinePCRanges: [0x806aa0..0x806c80]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806a50..0x806a90
+            - Range: 0x806aa0..0x806ae0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806a90..0x806a98
+            - Range: 0x806ae0..0x806ae8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806a98..0x806c30
+            - Range: 0x806ae8..0x806c80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -5980,429 +6026,429 @@ Subprograms:
         - Name: ~r0
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806a50..0x806af0
+            - Range: 0x806aa0..0x806b40
               Pieces: []
-            - Range: 0x806af0..0x806af1
+            - Range: 0x806b40..0x806b41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806af1..0x806b44
+            - Range: 0x806b41..0x806b94
               Pieces: []
-            - Range: 0x806b44..0x806b45
+            - Range: 0x806b94..0x806b95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806b45..0x806bfc
+            - Range: 0x806b95..0x806c4c
               Pieces: []
-            - Range: 0x806bfc..0x806bfd
+            - Range: 0x806c4c..0x806c4d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806bfd..0x806c10
+            - Range: 0x806c4d..0x806c60
               Pieces: []
-            - Range: 0x806c10..0x806c11
+            - Range: 0x806c60..0x806c61
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806c11..0x806c30
+            - Range: 0x806c61..0x806c80
               Pieces: []
           Role: Return
         - Name: val
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806adc..0x806ae4
+            - Range: 0x806b2c..0x806b34
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 105 PointerType *int
           Locations:
-            - Range: 0x806b28..0x806b44
+            - Range: 0x806b78..0x806b94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x806c30..0x806d80]
+      OutOfLinePCRanges: [0x806c80..0x806dd0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 163 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x806c30..0x806c6c
+            - Range: 0x806c80..0x806cbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806c6c..0x806cb0
+            - Range: 0x806cbc..0x806d00
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806cb0..0x806d20
+            - Range: 0x806d00..0x806d70
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806d20..0x806d48
+            - Range: 0x806d70..0x806d98
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d48..0x806d4c
+            - Range: 0x806d98..0x806d9c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d4c..0x806d80
+            - Range: 0x806d9c..0x806dd0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x806c30..0x806d00
+            - Range: 0x806c80..0x806d50
               Pieces: []
-            - Range: 0x806d00..0x806d01
+            - Range: 0x806d50..0x806d51
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806d01..0x806d14
+            - Range: 0x806d51..0x806d64
               Pieces: []
-            - Range: 0x806d14..0x806d15
+            - Range: 0x806d64..0x806d65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806d15..0x806d80
+            - Range: 0x806d65..0x806dd0
               Pieces: []
           Role: Return
         - Name: b
           Type: 168 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x806c30..0x806c6c
+            - Range: 0x806c80..0x806cbc
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x806c6c..0x806cb0
+            - Range: 0x806cbc..0x806d00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806cb0..0x806cb8
+            - Range: 0x806d00..0x806d08
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806cb8..0x806d0c
+            - Range: 0x806d08..0x806d5c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -48}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d0c..0x806d10
+            - Range: 0x806d5c..0x806d60
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x806d10..0x806d14
+            - Range: 0x806d60..0x806d64
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x806d14..0x806d80
+            - Range: 0x806d64..0x806dd0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x806d80..0x806e20]
+      OutOfLinePCRanges: [0x806dd0..0x806e70]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806d80..0x806d9c
+            - Range: 0x806dd0..0x806dec
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806d80..0x806df4
+            - Range: 0x806dd0..0x806e44
               Pieces: []
-            - Range: 0x806df4..0x806df5
+            - Range: 0x806e44..0x806e45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806df5..0x806e20
+            - Range: 0x806e45..0x806e70
               Pieces: []
           Role: Return
-    - ID: 102
+    - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x806e20..0x806ee0]
+      OutOfLinePCRanges: [0x806e70..0x806f30]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e20..0x806e70
+            - Range: 0x806e70..0x806ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e20..0x806ebc
+            - Range: 0x806e70..0x806f0c
               Pieces: []
-            - Range: 0x806ebc..0x806ebd
+            - Range: 0x806f0c..0x806f0d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806ebd..0x806ee0
+            - Range: 0x806f0d..0x806f30
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806e20..0x806ebc
+            - Range: 0x806e70..0x806f0c
               Pieces: []
-            - Range: 0x806ebc..0x806ebd
+            - Range: 0x806f0c..0x806f0d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806ebd..0x806ee0
+            - Range: 0x806f0d..0x806f30
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x806ee0..0x806fa0]
+      OutOfLinePCRanges: [0x806f30..0x806ff0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806ee0..0x806f20
+            - Range: 0x806f30..0x806f70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806f20..0x806fa0
+            - Range: 0x806f70..0x806ff0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806ee0..0x806f80
+            - Range: 0x806f30..0x806fd0
               Pieces: []
-            - Range: 0x806f80..0x806f81
+            - Range: 0x806fd0..0x806fd1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x806f81..0x806fa0
+            - Range: 0x806fd1..0x806ff0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806ee0..0x806f80
+            - Range: 0x806f30..0x806fd0
               Pieces: []
-            - Range: 0x806f80..0x806f81
+            - Range: 0x806fd0..0x806fd1
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x806f81..0x806fa0
+            - Range: 0x806fd1..0x806ff0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x806ee0..0x806f80
+            - Range: 0x806f30..0x806fd0
               Pieces: []
-            - Range: 0x806f80..0x806f81
+            - Range: 0x806fd0..0x806fd1
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x806f81..0x806fa0
+            - Range: 0x806fd1..0x806ff0
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x806fa0..0x807030]
+      OutOfLinePCRanges: [0x806ff0..0x807080]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 102 BaseType int16
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x806fa0..0x80700c
+            - Range: 0x806ff0..0x80705c
               Pieces: []
-            - Range: 0x80700c..0x80700d
+            - Range: 0x80705c..0x80705d
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x80700d..0x807030
+            - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x807030..0x8070e0]
+      OutOfLinePCRanges: [0x807080..0x807130]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807030..0x8070e0, Pieces: []}]
+          Locations: [{Range: 0x807080..0x807130, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 14 BaseType float64
           Locations:
-            - Range: 0x807030..0x8070c8
+            - Range: 0x807080..0x807118
               Pieces: []
-            - Range: 0x8070c8..0x8070c9
+            - Range: 0x807118..0x807119
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x8070c9..0x8070e0
+            - Range: 0x807119..0x807130
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x8070e0..0x807160]
+      OutOfLinePCRanges: [0x807130..0x8071b0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 103 BaseType complex64
-          Locations: [{Range: 0x8070e0..0x807160, Pieces: []}]
+          Locations: [{Range: 0x807130..0x8071b0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 18 BaseType complex128
-          Locations: [{Range: 0x8070e0..0x807160, Pieces: []}]
+          Locations: [{Range: 0x807130..0x8071b0, Pieces: []}]
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x807160..0x807220]
+      OutOfLinePCRanges: [0x8071b0..0x807270]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807160..0x807200
+            - Range: 0x8071b0..0x807250
               Pieces: []
-            - Range: 0x807200..0x807201
+            - Range: 0x807250..0x807251
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6424,173 +6470,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807201..0x807220
+            - Range: 0x807251..0x807270
               Pieces: []
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x807220..0x8072b0]
+      OutOfLinePCRanges: [0x807270..0x807300]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x807220..0x80728c
+            - Range: 0x807270..0x8072dc
               Pieces: []
-            - Range: 0x80728c..0x80728d
+            - Range: 0x8072dc..0x8072dd
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80728d..0x8072b0
+            - Range: 0x8072dd..0x807300
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x8072b0..0x807320]
+      OutOfLinePCRanges: [0x807300..0x807370]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 258 ArrayType [1]int
           Locations:
-            - Range: 0x8072b0..0x807300
+            - Range: 0x807300..0x807350
               Pieces: []
-            - Range: 0x807300..0x807301
+            - Range: 0x807350..0x807351
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807301..0x807320
+            - Range: 0x807351..0x807370
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x807320..0x807390]
+      OutOfLinePCRanges: [0x807370..0x8073e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x807320..0x80736c
+            - Range: 0x807370..0x8073bc
               Pieces: []
-            - Range: 0x80736c..0x80736d
+            - Range: 0x8073bc..0x8073bd
               Pieces: []
-            - Range: 0x80736d..0x807390
+            - Range: 0x8073bd..0x8073e0
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x807390..0x807410]
+      OutOfLinePCRanges: [0x8073e0..0x807460]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 260 StructureType main.mixedStruct
-          Locations: [{Range: 0x807390..0x807410, Pieces: []}]
+          Locations: [{Range: 0x8073e0..0x807460, Pieces: []}]
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x807410..0x8074a0]
+      OutOfLinePCRanges: [0x807460..0x8074f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807410..0x807488
+            - Range: 0x807460..0x8074d8
               Pieces: []
-            - Range: 0x807488..0x807489
+            - Range: 0x8074d8..0x8074d9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807489..0x8074a0
+            - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x8074a0..0x807570]
+      OutOfLinePCRanges: [0x8074f0..0x8075c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 261 StructureType main.wideStruct
           Locations:
-            - Range: 0x8074a0..0x807550
+            - Range: 0x8074f0..0x8075a0
               Pieces: []
-            - Range: 0x807550..0x807551
+            - Range: 0x8075a0..0x8075a1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6614,127 +6660,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x807551..0x807570
+            - Range: 0x8075a1..0x8075c0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x807570..0x807600]
+      OutOfLinePCRanges: [0x8075c0..0x807650]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807570..0x8075dc
+            - Range: 0x8075c0..0x80762c
               Pieces: []
-            - Range: 0x8075dc..0x8075dd
+            - Range: 0x80762c..0x80762d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8075dd..0x807600
+            - Range: 0x80762d..0x807650
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807570..0x807600, Pieces: []}]
+          Locations: [{Range: 0x8075c0..0x807650, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807570..0x8075dc
+            - Range: 0x8075c0..0x80762c
               Pieces: []
-            - Range: 0x8075dc..0x8075dd
+            - Range: 0x80762c..0x80762d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8075dd..0x807600
+            - Range: 0x80762d..0x807650
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807570..0x807600, Pieces: []}]
+          Locations: [{Range: 0x8075c0..0x807650, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807570..0x8075dc
+            - Range: 0x8075c0..0x80762c
               Pieces: []
-            - Range: 0x8075dc..0x8075dd
+            - Range: 0x80762c..0x80762d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8075dd..0x807600
+            - Range: 0x80762d..0x807650
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x807600..0x807690]
+      OutOfLinePCRanges: [0x807650..0x8076e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x807600..0x80766c
+            - Range: 0x807650..0x8076bc
               Pieces: []
-            - Range: 0x80766c..0x80766d
+            - Range: 0x8076bc..0x8076bd
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x80766d..0x807690
+            - Range: 0x8076bd..0x8076e0
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x807690..0x807700]
+      OutOfLinePCRanges: [0x8076e0..0x807750]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807690..0x807700, Pieces: []}]
+          Locations: [{Range: 0x8076e0..0x807750, Pieces: []}]
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x807700..0x807770]
+      OutOfLinePCRanges: [0x807750..0x8077c0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float32
-          Locations: [{Range: 0x807700..0x807770, Pieces: []}]
+          Locations: [{Range: 0x807750..0x8077c0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 14 BaseType float64
-          Locations: [{Range: 0x807700..0x807770, Pieces: []}]
+          Locations: [{Range: 0x807750..0x8077c0, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x807770..0x8077e0]
+      OutOfLinePCRanges: [0x8077c0..0x807830]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x807770..0x8077c4
+            - Range: 0x8077c0..0x807814
               Pieces: []
-            - Range: 0x8077c4..0x8077c5
+            - Range: 0x807814..0x807815
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8077c5..0x8077e0
+            - Range: 0x807815..0x807830
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x807770..0x8077c4
+            - Range: 0x8077c0..0x807814
               Pieces: []
-            - Range: 0x8077c4..0x8077c5
+            - Range: 0x807814..0x807815
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8077c5..0x8077e0
+            - Range: 0x807815..0x807830
               Pieces: []
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x8077e0..0x807970]
+      OutOfLinePCRanges: [0x807830..0x8079c0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8077e0..0x807814
+            - Range: 0x807830..0x807864
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6756,7 +6802,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807814..0x807844
+            - Range: 0x807864..0x807894
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6778,7 +6824,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807844..0x80784c
+            - Range: 0x807894..0x80789c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6800,7 +6846,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x80784c..0x807850
+            - Range: 0x80789c..0x8078a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -6826,9 +6872,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x8077e0..0x807930
+            - Range: 0x807830..0x807980
               Pieces: []
-            - Range: 0x807930..0x807931
+            - Range: 0x807980..0x807981
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6850,39 +6896,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807931..0x807970
+            - Range: 0x807981..0x8079c0
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x807970..0x807a40]
+      OutOfLinePCRanges: [0x8079c0..0x807a90]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x807970..0x807a40
+            - Range: 0x8079c0..0x807a90
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x807970..0x807a20
+            - Range: 0x8079c0..0x807a70
               Pieces: []
-            - Range: 0x807a20..0x807a21
+            - Range: 0x807a70..0x807a71
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x807a21..0x807a40
+            - Range: 0x807a71..0x807a90
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x807a40..0x807c50]
+      OutOfLinePCRanges: [0x807a90..0x807ca0]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a40..0x807a74
+            - Range: 0x807a90..0x807ac4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6904,7 +6950,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807a74..0x807aa8
+            - Range: 0x807ac4..0x807af8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6926,7 +6972,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807aa8..0x807ab0
+            - Range: 0x807af8..0x807b00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6948,7 +6994,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807ab0..0x807ab4
+            - Range: 0x807b00..0x807b04
               Pieces:
                 - Size: 8
                   Op: null
@@ -6974,15 +7020,15 @@ Subprograms:
         - Name: s2
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a40..0x807c50
+            - Range: 0x807a90..0x807ca0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807a40..0x807c08
+            - Range: 0x807a90..0x807c58
               Pieces: []
-            - Range: 0x807c08..0x807c09
+            - Range: 0x807c58..0x807c59
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7004,175 +7050,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807c09..0x807c50
+            - Range: 0x807c59..0x807ca0
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x807c50..0x807e00]
+      OutOfLinePCRanges: [0x807ca0..0x807e50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807c98
+            - Range: 0x807ca0..0x807ce8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807c98..0x807e00
+            - Range: 0x807ce8..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd0
+            - Range: 0x807ca0..0x807d20
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x807cd0..0x807e00
+            - Range: 0x807d20..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807c50..0x807cd8
+            - Range: 0x807ca0..0x807d28
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x807cd8..0x807e00
+            - Range: 0x807d28..0x807e50
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x807c50..0x807dc0
+            - Range: 0x807ca0..0x807e10
               Pieces: []
-            - Range: 0x807dc0..0x807dc1
+            - Range: 0x807e10..0x807e11
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x807dc1..0x807e00
+            - Range: 0x807e11..0x807e50
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x807e00..0x807ff0]
+      OutOfLinePCRanges: [0x807e50..0x808040]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e4c
+            - Range: 0x807e50..0x807e9c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x807e4c..0x807ff0
+            - Range: 0x807e9c..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e80
+            - Range: 0x807e50..0x807ed0
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x807e80..0x807ff0
+            - Range: 0x807ed0..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x807e00..0x807e88
+            - Range: 0x807e50..0x807ed8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807e88..0x807ff0
+            - Range: 0x807ed8..0x808040
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7182,9 +7228,9 @@ Subprograms:
         - Name: ~r0
           Type: 256 StructureType main.largeStruct
           Locations:
-            - Range: 0x807e00..0x807fac
+            - Range: 0x807e50..0x807ffc
               Pieces: []
-            - Range: 0x807fac..0x807fad
+            - Range: 0x807ffc..0x807ffd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7206,191 +7252,174 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x807fad..0x807ff0
+            - Range: 0x807ffd..0x808040
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x807ff0..0x808080]
+      OutOfLinePCRanges: [0x808040..0x8080d0]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 167 ArrayType [5]int
           Locations:
-            - Range: 0x807ff0..0x808080
+            - Range: 0x808040..0x8080d0
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ff0..0x808064
+            - Range: 0x808040..0x8080b4
               Pieces: []
-            - Range: 0x808064..0x808065
+            - Range: 0x8080b4..0x8080b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808065..0x808080
+            - Range: 0x8080b5..0x8080d0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ff0..0x808064
+            - Range: 0x808040..0x8080b4
               Pieces: []
-            - Range: 0x808064..0x808065
+            - Range: 0x8080b4..0x8080b5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x808065..0x808080
+            - Range: 0x8080b5..0x8080d0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 7 BaseType int
           Locations:
-            - Range: 0x807ff0..0x808064
+            - Range: 0x808040..0x8080b4
               Pieces: []
-            - Range: 0x808064..0x808065
+            - Range: 0x8080b4..0x8080b5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x808065..0x808080
+            - Range: 0x8080b5..0x8080d0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x808080..0x808150]
+      OutOfLinePCRanges: [0x8080d0..0x8081a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x808080..0x808150
+            - Range: 0x8080d0..0x8081a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 257 ArrayType [3]int
           Locations:
-            - Range: 0x808080..0x808150
+            - Range: 0x8080d0..0x8081a0
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808080..0x808138
+            - Range: 0x8080d0..0x808188
               Pieces: []
-            - Range: 0x808138..0x808139
+            - Range: 0x808188..0x808189
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808139..0x808150
+            - Range: 0x808189..0x8081a0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 119 ArrayType [2]int
           Locations:
-            - Range: 0x808080..0x808138
+            - Range: 0x8080d0..0x808188
               Pieces: []
-            - Range: 0x808138..0x808139
+            - Range: 0x808188..0x808189
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x808139..0x808150
+            - Range: 0x808189..0x8081a0
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x808150..0x808210]
+      OutOfLinePCRanges: [0x8081a0..0x808260]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x808150..0x808210
+            - Range: 0x8081a0..0x808260
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808150..0x8081f4
+            - Range: 0x8081a0..0x808244
               Pieces: []
-            - Range: 0x8081f4..0x8081f5
+            - Range: 0x808244..0x808245
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8081f5..0x808210
+            - Range: 0x808245..0x808260
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 262 StructureType main.structWithArray
           Locations:
-            - Range: 0x808150..0x8081f4
+            - Range: 0x8081a0..0x808244
               Pieces: []
-            - Range: 0x8081f4..0x8081f5
+            - Range: 0x808244..0x808245
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8081f5..0x808210
+            - Range: 0x808245..0x808260
               Pieces: []
           Role: Return
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x8081d0..0x808210
+            - Range: 0x808220..0x808260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 127
+    - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x808210..0x8082b0]
+      OutOfLinePCRanges: [0x808260..0x808300]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 259 ArrayType [0]int
-          Locations: [{Range: 0x808210..0x8082b0, Pieces: []}]
+          Locations: [{Range: 0x808260..0x808300, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808210..0x808250
+            - Range: 0x808260..0x8082a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x808250..0x808268
+            - Range: 0x8082a0..0x8082b8
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x808268..0x808270
+            - Range: 0x8082b8..0x8082c0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x808270..0x8082b0
+            - Range: 0x8082c0..0x808300
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x808210..0x80828c
+            - Range: 0x808260..0x8082dc
               Pieces: []
-            - Range: 0x80828c..0x80828d
+            - Range: 0x8082dc..0x8082dd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x80828d..0x8082b0
+            - Range: 0x8082dd..0x808300
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 259 ArrayType [0]int
           Locations:
-            - Range: 0x808210..0x80828c
+            - Range: 0x808260..0x8082dc
               Pieces: []
-            - Range: 0x80828c..0x80828d
+            - Range: 0x8082dc..0x8082dd
               Pieces: []
-            - Range: 0x80828d..0x8082b0
+            - Range: 0x8082dd..0x808300
               Pieces: []
           Role: Return
-    - ID: 128
-      Name: main.testUintSlice
-      OutOfLinePCRanges: [0x8086f0..0x808700]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x8086f0..0x808700
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
     - ID: 129
-      Name: main.testEmptySlice
-      OutOfLinePCRanges: [0x808700..0x808710]
+      Name: main.testUintSlice
+      OutOfLinePCRanges: [0x808740..0x808750]
       InlinePCRanges: []
       Variables:
         - Name: u
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x808700..0x808710
+            - Range: 0x808740..0x808750
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7400,98 +7429,12 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 130
-      Name: main.testSliceOfSlices
-      OutOfLinePCRanges: [0x808710..0x808720]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 264 GoSliceHeaderType [][]uint
-          Locations:
-            - Range: 0x808710..0x808720
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 131
-      Name: main.testStructSlice
-      OutOfLinePCRanges: [0x808720..0x808730]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x808720..0x808730
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808720..0x808730
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 132
-      Name: main.testEmptySliceOfStructs
-      OutOfLinePCRanges: [0x808730..0x808740]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x808730..0x808740
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808730..0x808740
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testNilSliceOfStructs
-      OutOfLinePCRanges: [0x808740..0x808750]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 266 GoSliceHeaderType []main.structWithNoStrings
-          Locations:
-            - Range: 0x808740..0x808750
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-        - Name: a
-          Type: 7 BaseType int
-          Locations:
-            - Range: 0x808740..0x808750
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 134
-      Name: main.testStringSlice
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x808750..0x808760]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 269 GoSliceHeaderType []string
+        - Name: u
+          Type: 263 GoSliceHeaderType []uint
           Locations:
             - Range: 0x808750..0x808760
               Pieces:
@@ -7502,21 +7445,124 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 135
-      Name: main.testNilSliceWithOtherParams
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x808760..0x808770]
+      InlinePCRanges: []
+      Variables:
+        - Name: u
+          Type: 264 GoSliceHeaderType [][]uint
+          Locations:
+            - Range: 0x808760..0x808770
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 132
+      Name: main.testStructSlice
+      OutOfLinePCRanges: [0x808770..0x808780]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x808770..0x808780
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x808770..0x808780
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
+      OutOfLinePCRanges: [0x808780..0x808790]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x808780..0x808790
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x808780..0x808790
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 134
+      Name: main.testNilSliceOfStructs
+      OutOfLinePCRanges: [0x808790..0x8087a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 266 GoSliceHeaderType []main.structWithNoStrings
+          Locations:
+            - Range: 0x808790..0x8087a0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: a
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x808790..0x8087a0
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x8087a0..0x8087b0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 269 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x8087a0..0x8087b0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 136
+      Name: main.testNilSliceWithOtherParams
+      OutOfLinePCRanges: [0x8087b0..0x8087c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 19 BaseType int8
           Locations:
-            - Range: 0x808760..0x808770
+            - Range: 0x8087b0..0x8087c0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 270 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x808760..0x808770
+            - Range: 0x8087b0..0x8087c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7528,35 +7574,18 @@ Subprograms:
         - Name: x
           Type: 11 BaseType uint
           Locations:
-            - Range: 0x808760..0x808770
+            - Range: 0x8087b0..0x8087c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x808770..0x808780]
+      OutOfLinePCRanges: [0x8087c0..0x8087d0]
       InlinePCRanges: []
       Variables:
         - Name: xs
           Type: 271 GoSliceHeaderType []uint16
           Locations:
-            - Range: 0x808770..0x808780
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 137
-      Name: main.testVeryLargeSlice
-      OutOfLinePCRanges: [0x808780..0x808790]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 263 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x808780..0x808790
+            - Range: 0x8087c0..0x8087d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7566,14 +7595,14 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 138
-      Name: main.testSliceEmptyStructs
-      OutOfLinePCRanges: [0x808790..0x8087a0]
+      Name: main.testVeryLargeSlice
+      OutOfLinePCRanges: [0x8087d0..0x8087e0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 272 GoSliceHeaderType []struct {}
+          Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x808790..0x8087a0
+            - Range: 0x8087d0..0x8087e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7583,14 +7612,31 @@ Subprograms:
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
     - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8087e0..0x8087f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 272 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8087e0..0x8087f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+    - ID: 140
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8087a0..0x8087b0]
+      OutOfLinePCRanges: [0x8087f0..0x808800]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087a0..0x8087b0
+            - Range: 0x8087f0..0x808800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7602,7 +7648,7 @@ Subprograms:
         - Name: bs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087a0..0x8087b0
+            - Range: 0x8087f0..0x808800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7614,7 +7660,7 @@ Subprograms:
         - Name: cs
           Type: 263 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8087a0..0x8087b0
+            - Range: 0x8087f0..0x808800
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7623,122 +7669,27 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0x808a70..0x808ad0]
+      OutOfLinePCRanges: [0x808ac0..0x808b20]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808a70..0x808ab8
+            - Range: 0x808ac0..0x808b08
               Pieces: []
-            - Range: 0x808ab8..0x808ab9
+            - Range: 0x808b08..0x808b09
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x808ab9..0x808ad0
+            - Range: 0x808b09..0x808b20
               Pieces: []
           Role: Return
-    - ID: 141
-      Name: main.testSingleString
-      OutOfLinePCRanges: [0x808ad0..0x808ae0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808ad0..0x808ae0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
     - ID: 142
-      Name: main.testThreeStrings
-      OutOfLinePCRanges: [0x808ae0..0x808af0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808ae0..0x808af0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-        - Name: y
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808ae0..0x808af0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-          Role: Parameter
-        - Name: z
-          Type: 9 GoStringHeaderType string
-          Locations:
-            - Range: 0x808ae0..0x808af0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 143
-      Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x808af0..0x808b00]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 274 StructureType main.threeStringStruct
-          Locations:
-            - Range: 0x808af0..0x808b00
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 3, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 4, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 5, Shift: 0}
-          Role: Parameter
-    - ID: 144
-      Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x808b00..0x808b10]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 275 PointerType *main.threeStringStruct
-          Locations:
-            - Range: 0x808b00..0x808b10
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 145
-      Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x808b10..0x808b20]
-      InlinePCRanges: []
-      Variables:
-        - Name: a
-          Type: 276 PointerType *main.oneStringStruct
-          Locations:
-            - Range: 0x808b10..0x808b20
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 146
-      Name: main.testMassiveString
+      Name: main.testSingleString
       OutOfLinePCRanges: [0x808b20..0x808b30]
       InlinePCRanges: []
       Variables:
@@ -7752,8 +7703,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 147
-      Name: main.testUnitializedString
+    - ID: 143
+      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x808b30..0x808b40]
       InlinePCRanges: []
       Variables:
@@ -7767,13 +7718,33 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
-      Name: main.testEmptyString
+        - Name: y
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808b30..0x808b40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+          Role: Parameter
+        - Name: z
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808b30..0x808b40
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 144
+      Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x808b40..0x808b50]
       InlinePCRanges: []
       Variables:
-        - Name: x
-          Type: 9 GoStringHeaderType string
+        - Name: a
+          Type: 274 StructureType main.threeStringStruct
           Locations:
             - Range: 0x808b40..0x808b50
               Pieces:
@@ -7781,16 +7752,91 @@ Subprograms:
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+          Role: Parameter
+    - ID: 145
+      Name: main.testThreeStringsInStructPointer
+      OutOfLinePCRanges: [0x808b50..0x808b60]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 275 PointerType *main.threeStringStruct
+          Locations:
+            - Range: 0x808b50..0x808b60
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 146
+      Name: main.testOneStringInStructPointer
+      OutOfLinePCRanges: [0x808b60..0x808b70]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 276 PointerType *main.oneStringStruct
+          Locations:
+            - Range: 0x808b60..0x808b70
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+    - ID: 147
+      Name: main.testMassiveString
+      OutOfLinePCRanges: [0x808b70..0x808b80]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808b70..0x808b80
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 148
+      Name: main.testUnitializedString
+      OutOfLinePCRanges: [0x808b80..0x808b90]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808b80..0x808b90
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
           Role: Parameter
     - ID: 149
+      Name: main.testEmptyString
+      OutOfLinePCRanges: [0x808b90..0x808ba0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x808b90..0x808ba0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
+    - ID: 150
       Name: main.testSubstrings
-      OutOfLinePCRanges: [0x808b50..0x808b60]
+      OutOfLinePCRanges: [0x808ba0..0x808bb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b50..0x808b60
+            - Range: 0x808ba0..0x808bb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7800,7 +7846,7 @@ Subprograms:
         - Name: b
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b50..0x808b60
+            - Range: 0x808ba0..0x808bb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7810,33 +7856,33 @@ Subprograms:
         - Name: c
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x808b50..0x808b60
+            - Range: 0x808ba0..0x808bb0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x808ca0..0x808cb0]
+      OutOfLinePCRanges: [0x808cf0..0x808d00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 278 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x808ca0..0x808cb0
+            - Range: 0x808cf0..0x808d00
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x808cb0..0x808cc0]
+      OutOfLinePCRanges: [0x808d00..0x808d10]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 291 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x808cb0..0x808cc0
+            - Range: 0x808d00..0x808d10
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7851,15 +7897,15 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0x808d50..0x808d60]
+      OutOfLinePCRanges: [0x808da0..0x808db0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 322 StructureType main.aStruct
           Locations:
-            - Range: 0x808d50..0x808d60
+            - Range: 0x808da0..0x808db0
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7876,38 +7922,38 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x808db0..0x808dc0]
+      OutOfLinePCRanges: [0x808e00..0x808e10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 323 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x808db0..0x808dc0
+            - Range: 0x808e00..0x808e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x808df0..0x808e00]
+      OutOfLinePCRanges: [0x808e40..0x808e50]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 325 StructureType main.emptyStruct
-          Locations: [{Range: 0x808df0..0x808e00, Pieces: []}]
+          Locations: [{Range: 0x808e40..0x808e50, Pieces: []}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x808e00..0x808e10]
+      OutOfLinePCRanges: [0x808e50..0x808e60]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 326 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x808e00..0x808e10
+            - Range: 0x808e50..0x808e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x803c60..0x803cd0]
       InlinePCRanges:
@@ -7936,28 +7982,28 @@ Subprograms:
             - Range: 0x803f40..0x803f64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803ee4..0x803f18]
           RootRanges: [0x803e80..0x803f40]
       Variables: []
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803fcc..0x804000, 0x804008..0x80400c]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x804070..0x8040a4]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7970,7 +8016,7 @@ Subprograms:
             - Range: 0x8040c0..0x8040c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11321,10 +11367,10 @@ Types:
       GoKind: 22
       Pointee: 825 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11336,7 +11382,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: ~r0}
+                  Variable: {subprogram: 141, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11424,7 +11470,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11436,7 +11482,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11446,11 +11492,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11462,7 +11508,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11622,6 +11668,48 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testAtomicAdd]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testAtomicAdd]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
       ID: 1360
       Name: Probe[main.testBigStruct]
       ByteSize: 97
@@ -11700,7 +11788,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11712,7 +11800,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11722,7 +11810,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: c}
+                  Variable: {subprogram: 86, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11792,7 +11880,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11804,7 +11892,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11814,7 +11902,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: t}
+                  Variable: {subprogram: 94, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11974,7 +12062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11986,7 +12074,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11996,7 +12084,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12006,7 +12094,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12016,11 +12104,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12032,7 +12120,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12042,11 +12130,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12058,7 +12146,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12068,11 +12156,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12084,7 +12172,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12094,11 +12182,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12110,7 +12198,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12120,7 +12208,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: e}
+                  Variable: {subprogram: 155, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12386,7 +12474,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1548
+      ID: 1550
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12438,16 +12526,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1549
+      ID: 1551
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1550
+      ID: 1552
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1551
+      ID: 1553
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1554
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12456,7 +12544,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1545
+      ID: 1547
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12468,7 +12556,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12478,11 +12566,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1547
+      ID: 1549
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12494,7 +12582,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12504,14 +12592,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: x}
+                  Variable: {subprogram: 157, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1546
+      ID: 1548
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12523,7 +12611,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12533,11 +12621,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1554
+      ID: 1556
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12549,7 +12637,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12559,11 +12647,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 160, index: 0, name: x}
+                  Variable: {subprogram: 161, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1555
+      ID: 1557
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12575,7 +12663,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12585,7 +12673,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: a}
+                  Variable: {subprogram: 162, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12745,7 +12833,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12757,7 +12845,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12767,11 +12855,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: arg}
+                  Variable: {subprogram: 120, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12783,11 +12871,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r0}
+                  Variable: {subprogram: 120, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12799,7 +12887,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12809,7 +12897,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12888,7 +12976,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12900,7 +12988,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12910,7 +12998,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: a}
+                  Variable: {subprogram: 123, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12920,7 +13008,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12930,7 +13018,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: b}
+                  Variable: {subprogram: 123, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12940,7 +13028,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12950,7 +13038,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: c}
+                  Variable: {subprogram: 123, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12960,7 +13048,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12970,7 +13058,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 3, name: d}
+                  Variable: {subprogram: 123, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12980,7 +13068,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12990,7 +13078,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 4, name: e}
+                  Variable: {subprogram: 123, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13000,7 +13088,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13010,7 +13098,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 5, name: f}
+                  Variable: {subprogram: 123, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13020,7 +13108,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13030,7 +13118,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 6, name: g}
+                  Variable: {subprogram: 123, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13040,7 +13128,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13050,7 +13138,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 7, name: h}
+                  Variable: {subprogram: 123, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13060,7 +13148,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13070,11 +13158,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 8, name: i}
+                  Variable: {subprogram: 123, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13086,7 +13174,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 9, name: ~r0}
+                  Variable: {subprogram: 123, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13610,7 +13698,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13622,7 +13710,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13632,11 +13720,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13648,7 +13736,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13658,11 +13746,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: x}
+                  Variable: {subprogram: 147, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13674,7 +13762,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13684,7 +13772,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13694,7 +13782,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13704,7 +13792,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13714,7 +13802,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13724,7 +13812,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13734,7 +13822,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13744,7 +13832,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13754,7 +13842,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13764,7 +13852,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13774,7 +13862,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13784,7 +13872,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13794,7 +13882,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13804,7 +13892,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13814,7 +13902,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13824,7 +13912,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13834,7 +13922,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13844,11 +13932,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: s}
+                  Variable: {subprogram: 124, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13860,11 +13948,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13876,7 +13964,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13886,7 +13974,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13896,7 +13984,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13906,11 +13994,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13922,7 +14010,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r0}
+                  Variable: {subprogram: 126, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13932,11 +14020,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r1}
+                  Variable: {subprogram: 126, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13948,7 +14036,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13958,7 +14046,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: s1}
+                  Variable: {subprogram: 122, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13968,7 +14056,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13978,11 +14066,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: s2}
+                  Variable: {subprogram: 122, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13994,11 +14082,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 2, name: ~r0}
+                  Variable: {subprogram: 122, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1449
+      ID: 1451
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14010,7 +14098,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14020,11 +14108,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14036,7 +14124,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14046,7 +14134,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14056,7 +14144,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14066,23 +14154,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14098,7 +14170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14114,11 +14186,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1459
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1452
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14130,7 +14218,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14140,11 +14228,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14156,7 +14244,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14166,7 +14254,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14176,7 +14264,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14186,7 +14274,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14196,7 +14284,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14206,33 +14294,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14248,7 +14310,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14258,7 +14320,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14274,7 +14336,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14284,7 +14346,33 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 2, name: result2}
+                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1460
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14394,32 +14482,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1445
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
       ID: 1447
       Name: Probe[main.testNamedReturn]
       ByteSize: 17
@@ -14432,7 +14494,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14442,11 +14504,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: i}
+                  Variable: {subprogram: 102, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1446
+      ID: 1449
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14458,11 +14546,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14474,7 +14562,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14484,11 +14572,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: result}
+                  Variable: {subprogram: 102, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14500,7 +14588,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14510,11 +14598,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14526,7 +14614,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14536,10 +14624,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14551,7 +14639,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14561,7 +14649,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14573,7 +14661,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14583,7 +14671,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14593,7 +14681,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14603,11 +14691,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 1, name: a}
+                  Variable: {subprogram: 93, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14619,7 +14707,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14629,7 +14717,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14639,7 +14727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14649,11 +14737,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14665,7 +14753,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14675,7 +14763,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: a}
+                  Variable: {subprogram: 136, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14685,7 +14773,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14695,7 +14783,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 1, name: s}
+                  Variable: {subprogram: 136, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14705,7 +14793,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14715,11 +14803,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 2, name: x}
+                  Variable: {subprogram: 136, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14731,7 +14819,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14741,11 +14829,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Variable: {subprogram: 137, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14757,7 +14845,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14767,11 +14855,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14783,7 +14871,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14793,7 +14881,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14823,7 +14911,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14835,7 +14923,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14845,11 +14933,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 87, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1439
+      ID: 1441
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14861,7 +14949,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14871,7 +14959,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: v}
+                  Variable: {subprogram: 99, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14881,7 +14969,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14891,11 +14979,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: failed}
+                  Variable: {subprogram: 99, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1440
+      ID: 1442
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14907,7 +14995,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 2, name: ~r0}
+                  Variable: {subprogram: 99, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14917,446 +15005,12 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 3, name: ~r1}
+                  Variable: {subprogram: 99, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1441
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1442
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 258 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1469
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1470
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 257 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1477
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1478
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1489
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1490
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1465
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1466
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 103 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 14 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 105 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1431
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1432
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1443
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15382,6 +15036,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1444
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 258 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1471
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1472
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 257 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1479
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1480
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 113, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1491
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1492
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1467
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1468
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 103 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 14 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 105 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1433
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1434
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1445
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1446
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15393,14 +15481,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15412,14 +15500,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15431,7 +15519,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15441,7 +15529,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15451,7 +15539,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15461,7 +15549,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15471,7 +15559,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15481,7 +15569,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15491,7 +15579,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15501,7 +15589,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15511,7 +15599,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 8, name: ~r8}
+                  Variable: {subprogram: 106, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15521,7 +15609,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 9, name: ~r9}
+                  Variable: {subprogram: 106, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15531,7 +15619,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 10, name: ~r10}
+                  Variable: {subprogram: 106, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15541,7 +15629,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 11, name: ~r11}
+                  Variable: {subprogram: 106, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15551,7 +15639,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 12, name: ~r12}
+                  Variable: {subprogram: 106, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15561,7 +15649,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 13, name: ~r13}
+                  Variable: {subprogram: 106, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15571,7 +15659,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 14, name: ~r14}
+                  Variable: {subprogram: 106, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15581,7 +15669,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15591,14 +15679,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15610,14 +15698,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15629,7 +15717,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15639,7 +15727,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Variable: {subprogram: 115, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15649,7 +15737,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Variable: {subprogram: 115, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15659,7 +15747,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Variable: {subprogram: 115, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15669,14 +15757,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Variable: {subprogram: 115, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15688,7 +15776,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15698,14 +15786,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 1, name: ~r1}
+                  Variable: {subprogram: 118, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15717,14 +15805,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15736,7 +15824,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: ~r0}
+                  Variable: {subprogram: 105, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15746,7 +15834,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r1}
+                  Variable: {subprogram: 105, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15756,7 +15844,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: ~r2}
+                  Variable: {subprogram: 105, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15766,7 +15854,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r3}
+                  Variable: {subprogram: 105, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15776,7 +15864,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 4, name: ~r4}
+                  Variable: {subprogram: 105, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15786,7 +15874,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 5, name: ~r5}
+                  Variable: {subprogram: 105, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15796,7 +15884,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 6, name: ~r6}
+                  Variable: {subprogram: 105, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15806,14 +15894,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 7, name: ~r7}
+                  Variable: {subprogram: 105, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15825,14 +15913,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15844,7 +15932,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16154,7 +16242,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16166,7 +16254,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16176,7 +16264,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: x}
+                  Variable: {subprogram: 142, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16310,7 +16398,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16322,7 +16410,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16332,11 +16420,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16348,7 +16436,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16358,7 +16446,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16388,7 +16476,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16400,7 +16488,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16410,11 +16498,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1460
+      ID: 1462
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16426,7 +16514,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: ~r0}
+                  Variable: {subprogram: 104, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16436,7 +16524,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16446,11 +16534,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 3, name: ~r2}
+                  Variable: {subprogram: 104, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16462,7 +16550,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16472,11 +16560,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: arg}
+                  Variable: {subprogram: 125, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16488,7 +16576,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: ~r0}
+                  Variable: {subprogram: 125, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16498,7 +16586,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: ~r1}
+                  Variable: {subprogram: 125, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16508,7 +16596,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: ~r2}
+                  Variable: {subprogram: 125, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16538,7 +16626,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16550,7 +16638,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16560,11 +16648,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: z}
+                  Variable: {subprogram: 92, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16576,7 +16664,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16586,7 +16674,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: s}
+                  Variable: {subprogram: 135, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16642,7 +16730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16654,7 +16742,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16664,7 +16752,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: xs}
+                  Variable: {subprogram: 132, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16674,7 +16762,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16684,7 +16772,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 1, name: a}
+                  Variable: {subprogram: 132, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16714,7 +16802,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16726,7 +16814,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16736,11 +16824,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: arg}
+                  Variable: {subprogram: 127, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16752,7 +16840,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: ~r0}
+                  Variable: {subprogram: 127, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16762,11 +16850,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r1}
+                  Variable: {subprogram: 127, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16778,7 +16866,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16788,11 +16876,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16804,7 +16892,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16814,7 +16902,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16844,7 +16932,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16856,7 +16944,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16866,11 +16954,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: x}
+                  Variable: {subprogram: 153, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16882,7 +16970,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16892,7 +16980,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: as}
+                  Variable: {subprogram: 140, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16902,7 +16990,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16912,7 +17000,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 1, name: bs}
+                  Variable: {subprogram: 140, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16922,7 +17010,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16932,11 +17020,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 2, name: cs}
+                  Variable: {subprogram: 140, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16948,7 +17036,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16958,7 +17046,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: a}
+                  Variable: {subprogram: 150, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16968,7 +17056,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16978,7 +17066,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 1, name: b}
+                  Variable: {subprogram: 150, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16988,7 +17076,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16998,11 +17086,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 2, name: c}
+                  Variable: {subprogram: 150, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17014,7 +17102,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17024,11 +17112,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17040,7 +17128,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17053,7 +17141,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17066,14 +17154,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17085,7 +17173,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17095,11 +17183,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17111,7 +17199,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17121,7 +17209,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17131,11 +17219,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: a}
+                  Variable: {subprogram: 144, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17147,7 +17235,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17157,7 +17245,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17167,7 +17255,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17177,7 +17265,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: y}
+                  Variable: {subprogram: 143, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17187,7 +17275,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17197,7 +17285,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 2, name: z}
+                  Variable: {subprogram: 143, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17357,7 +17445,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17369,7 +17457,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17379,11 +17467,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17395,7 +17483,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17405,11 +17493,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: u}
+                  Variable: {subprogram: 129, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17421,7 +17509,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17431,11 +17519,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17447,7 +17535,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17457,7 +17545,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: x}
+                  Variable: {subprogram: 90, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17487,7 +17575,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17499,7 +17587,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17509,11 +17597,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17525,7 +17613,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17535,11 +17623,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17551,7 +17639,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17561,7 +17649,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: a}
+                  Variable: {subprogram: 128, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17571,7 +17659,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17581,11 +17669,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: b}
+                  Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17597,7 +17685,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r0}
+                  Variable: {subprogram: 128, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17607,7 +17695,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 3, name: ~r1}
+                  Variable: {subprogram: 128, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26269,7 +26357,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 5
-MaxTypeID: 1555
+MaxTypeID: 1557
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -77,8 +77,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [211-211], [212-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: upp: **int (declared at line 169, available: )
 		Var: self: *main.node (declared at line 172, available: [173-177])
@@ -191,10 +191,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [44-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -225,14 +225,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -792,8 +795,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -68,8 +68,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [211-211], [212-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -180,10 +180,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [44-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -214,14 +214,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -781,8 +784,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -67,8 +67,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [212-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [148-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -179,10 +179,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [30-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [42-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -213,14 +213,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -780,8 +783,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -67,8 +67,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [212-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [148-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -179,10 +179,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [30-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [42-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -213,14 +213,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -780,8 +783,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -77,8 +77,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [211-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: upp: **int (declared at line 169, available: )
 		Var: self: *main.node (declared at line 172, available: [173-177])
@@ -191,10 +191,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [44-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -225,14 +225,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -797,8 +800,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -68,8 +68,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [210-210], [211-212], [214-214])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-141], [143-143], [145-145], [147-151], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -180,10 +180,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [987-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [32-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [44-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -214,14 +214,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -786,8 +789,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -67,8 +67,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [123-219])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-140], [143-143], [145-145], [148-150], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -179,10 +179,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [30-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [42-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -213,14 +213,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -785,8 +788,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -67,8 +67,8 @@ Package: main
 		Scope: 210-214
 			Var: i: int (declared at line 210, available: [123-219])
 	Function: executeMultiParamFuncs (main.executeMultiParamFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [86:118] injectible: [86-87], [100-114], [118-118]
-	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [39:44] injectible: [39-41], [43-44]
-		Var: x: chan bool (declared at line 40, available: [41-43])
+	Function: executeOther (main.executeOther) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [51:56] injectible: [51-56]
+		Var: x: chan bool (declared at line 52, available: [53-54])
 	Function: executePointerFuncs (main.executePointerFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [112:178] injectible: [112-113], [115-115], [117-117], [120-121], [123-126], [130-132], [134-135], [137-140], [143-143], [145-145], [148-150], [155-155], [157-157], [159-160], [162-163], [165-165], [167-168], [170-170], [172-173], [175-178]
 		Var: self: *main.node (declared at line 172, available: [173-177])
 		Var: z: main.spws (declared at line 118, available: )
@@ -179,10 +179,10 @@ Package: main
 	Function: main.WithService.func1 (main.main.WithService.func1) in github.com/DataDog/dd-trace-go/v2@v2.2.3-rc.1/ddtrace/tracer/option.go [986:989] injectible: [986-989]
 		Arg: c: *github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.config (declared at line 986, available: [986-988])
 		Var: name: string (declared at line 987, available: [988-989])
-	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [28:34] injectible: [28-34]
-		Arg: ~r0: uint64 (declared at line 28, available: )
-		Var: n: uint64 (declared at line 33, available: [32-34])
-		Var: b: []uint8 (declared at line 29, available: [30-33])
+	Function: returnGoroutineId (main.returnGoroutineId) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [40:46] injectible: [40-46]
+		Arg: ~r0: uint64 (declared at line 40, available: )
+		Var: n: uint64 (declared at line 45, available: [44-46])
+		Var: b: []uint8 (declared at line 41, available: [42-45])
 	Function: sprintSlice (main.sprintSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [16:17] injectible: [16-17]
 		Arg: x: []int (declared at line 16, available: [16-17])
 		Arg: ~r0: string (declared at line 16, available: )
@@ -213,14 +213,17 @@ Package: main
 		Arg: a: [2]main.nestedStruct (declared at line 82, available: [83-83])
 	Function: testArrayPointer (main.testArrayPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/pointers.go [59:59] injectible: [59-59]
 		Arg: x: *[2]uint (declared at line 59, available: [59-59])
+	Function: testAtomicAdd (main.testAtomicAdd) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [23:23] injectible: [23-23]
+		Arg: x: uint64 (declared at line 19, available: [23-23])
+		Arg: ~r0: uint64 (declared at line 19, available: )
 	Function: testBigStruct (main.testBigStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [82:82] injectible: [82-82]
 		Arg: b: main.bigStruct (declared at line 82, available: [82-82])
 	Function: testBoolArray (main.testBoolArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [26:26] injectible: [26-26]
 		Arg: x: [2]bool (declared at line 26, available: [26-26])
 	Function: testByteArray (main.testByteArray) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [14:14] injectible: [14-14]
 		Arg: x: [2]uint8 (declared at line 14, available: [14-14])
-	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [18:18] injectible: [18-18]
-		Arg: c: chan bool (declared at line 18, available: [18-18])
+	Function: testChannel (main.testChannel) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [30:30] injectible: [30-30]
+		Arg: c: chan bool (declared at line 30, available: [30-30])
 	Function: testCircularType (main.testCircularType) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/complex.go [90:90] injectible: [90-90]
 		Arg: x: main.circularReferenceType (declared at line 90, available: [90-90])
 	Function: testCombinedBool (main.testCombinedBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go [34:34] injectible: [34-34]
@@ -785,8 +788,8 @@ Package: main
 		Arg: a: main.threeStringStruct (declared at line 30, available: [30-30])
 	Function: testThreeStringsInStructPointer (main.testThreeStringsInStructPointer) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/strings.go [34:34] injectible: [34-34]
 		Arg: a: *main.threeStringStruct (declared at line 34, available: [34-34])
-	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [22:22] injectible: [22-22]
-		Arg: t: main.triggerVerifierErrorForTesting (declared at line 22, available: [22-22])
+	Function: testTriggerVerifierError (main.testTriggerVerifierError) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go [34:34] injectible: [34-34]
+		Arg: t: main.triggerVerifierErrorForTesting (declared at line 34, available: [34-34])
 	Function: testTypeAlias (main.testTypeAlias) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/basics.go [73:73] injectible: [73-73]
 		Arg: x: main.typeAlias (declared at line 73, available: [73-73])
 	Function: testUint16Array (main.testUint16Array) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [58:58] injectible: [58-58]

--- a/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
+++ b/pkg/dyninst/testdata/decoded/sample/testAtomicAdd.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.testChannel",
+      "method": "main.testAtomicAdd",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -16,14 +16,14 @@
         "language": "go",
         "stack": [
           {
-            "function": "main.testChannel",
+            "function": "main.testAtomicAdd",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 30
+            "lineNumber": 23
           },
           {
             "function": "main.executeOther",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/other.go",
-            "lineNumber": 53
+            "lineNumber": 54
           },
           {
             "function": "main.main",
@@ -42,30 +42,33 @@
           }
         ],
         "probe": {
-          "id": "testChannel",
+          "id": "testAtomicAdd",
           "location": {
-            "method": "main.testChannel"
+            "method": "main.testAtomicAdd"
           }
         },
         "captures": {
           "entry": {
             "arguments": {
-              "c": {
-                "type": "chan bool",
-                "notCapturedReason": "unimplemented"
+              "x": {
+                "type": "uint64",
+                "value": "1"
+              }
+            }
+          },
+          "return": {
+            "locals": {
+              "~r0": {
+                "type": "uint64",
+                "value": "1"
               }
             }
           }
         }
-      },
-      "evaluationErrors": [
-        {
-          "expr": "@duration",
-          "message": "not available: function has no body"
-        }
-      ]
+      }
     },
     "timestamp": "[ts]",
-    "message": "{chan}"
+    "duration": "[duration]",
+    "message": "1"
   }
 ]

--- a/pkg/dyninst/testprogs/progs/sample/other.go
+++ b/pkg/dyninst/testprogs/progs/sample/other.go
@@ -9,7 +9,19 @@ import (
 	"bytes"
 	"runtime"
 	"strconv"
+	"sync/atomic"
 )
+
+var atomicCounter uint64
+
+//nolint:all
+//go:noinline
+func testAtomicAdd(x uint64) uint64 {
+	// by using using sync/atomic we expect Go to generate ARMv8.1 LSE atomic
+	// instructions (like LDADDAL) on arm64, exercising the LSE detection
+	// in disassembleArm64Function.
+	return atomic.AddUint64(&atomicCounter, x)
+}
 
 type triggerVerifierErrorForTesting byte
 
@@ -39,6 +51,6 @@ func returnGoroutineId() uint64 {
 func executeOther() {
 	x := make(chan bool)
 	testChannel(x)
-
+	testAtomicAdd(1)
 	testTriggerVerifierError(1)
 }

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -200,6 +200,18 @@ probes:
           ref: "x"
         dsl: "x"
     captureSnapshot: true
+  - id: testAtomicAdd
+    type: LOG_PROBE
+    tags:
+      - "foo:bar"
+    where:
+      methodName: main.testAtomicAdd
+    template: "{x}"
+    segments:
+      - json:
+          ref: "x"
+        dsl: "x"
+    captureSnapshot: true
   - id: testSingleString
     type: LOG_PROBE
     tags:


### PR DESCRIPTION
### What does this PR do?

Modified disassembleArm64Function to skip unknown instructions.

### Motivation

The disassembleArm64Function was failing when encountering ARM LSE atomic instructions like LDADDAL, CASAL, and SWP. The golang.org/x/arch/arm64/arm64asm package does not support these instructions. We can safely skip them since they're not used for control flow and don't affect our ability to find RET instructions.

Since instructions are a fixed length (4 bytes) on arm64, we can skip any unknown instruction safely. 

### Describe how you validated your changes

Added a test case which will result in generation of one of these arm instructions.

### Additional Notes
