### PR TITLE
diagnose: add forwarder-triage suite

### DIFF
--- a/comp/core/diagnose/def/component.go
+++ b/comp/core/diagnose/def/component.go
@@ -41,6 +41,8 @@ const (
 	PortConflict = "port-conflict"
 	// FirewallScan is the suite name for the firewall-scan suite
 	FirewallScan = "firewall-scan"
+	// ForwarderTriage is the suite name for the forwarder-triage suite
+	ForwarderTriage = "forwarder-triage"
 )
 
 // AllSuites is a list of all available suites
@@ -51,6 +53,7 @@ var AllSuites = []string{
 	EventPlatformConnectivity,
 	PortConflict,
 	FirewallScan,
+	ForwarderTriage,
 }
 
 var catalog *Catalog

--- a/comp/core/diagnose/impl/diagnose.go
+++ b/comp/core/diagnose/impl/diagnose.go
@@ -49,6 +49,9 @@ type diagnoseRegistry struct {
 // NewComponent creates a new diagnose component
 func NewComponent(_ Requires) (Provides, error) {
 	comp := &diagnoseRegistry{}
+
+	diagnose.GetCatalog().Register(diagnose.ForwarderTriage, ForwarderTriageSuite)
+
 	provides := Provides{
 		Comp: comp,
 		APIDiagnose: api.NewAgentEndpointProvider(func(w http.ResponseWriter, r *http.Request) { comp.getDiagnose(w, r) },

--- a/comp/core/diagnose/impl/forwarder_triage.go
+++ b/comp/core/diagnose/impl/forwarder_triage.go
@@ -56,7 +56,7 @@ func ForwarderTriageSuite(cfg diagnose.Config) []diagnose.Diagnosis {
 			Name:        "Forwarder expvar reachable",
 			Category:    "forwarder",
 			Description: "Fetch /debug/vars and parse forwarder expvar",
-			Diagnosis:   fmt.Sprintf("Unable to fetch forwarder expvar from %s", url),
+			Diagnosis:   "Unable to fetch forwarder expvar from " + url,
 			RawError:    err.Error(),
 			Remediation: "Check expvar_port / DD_EXPVAR_PORT, local firewall, and that the Agent is running with expvar enabled.",
 		}}
@@ -75,7 +75,7 @@ func ForwarderTriageSuite(cfg diagnose.Config) []diagnose.Diagnosis {
 			Name:        "Forwarder expvar stable",
 			Category:    "forwarder",
 			Description: "Fetch /debug/vars twice and compute deltas",
-			Diagnosis:   fmt.Sprintf("First fetch succeeded but second fetch failed from %s", url),
+			Diagnosis:   "First fetch succeeded but second fetch failed from " + url,
 			RawError:    err.Error(),
 			Remediation: "If this is intermittent, suspect local resource pressure or network rules affecting the expvar port.",
 		}}
@@ -117,7 +117,6 @@ func expvarURL() string {
 func fetchForwarder(url string) (forwarderSnapshot, error) {
 	client := &http.Client{Timeout: 3 * time.Second}
 
-	// As of Go 1.22, the expvar handler requires GET for /debug/vars.
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return forwarderSnapshot{}, err
@@ -284,7 +283,6 @@ func forwarderHealthDiagnosis(d forwarderDelta, window time.Duration) diagnose.D
 		}
 	}
 
-	// dominance: pick the error class that grew most, deterministically
 	dominantKey := ""
 	dominantVal := 0
 	errKeys := make([]string, 0, len(d.ErrorsByType))
@@ -299,7 +297,6 @@ func forwarderHealthDiagnosis(d forwarderDelta, window time.Duration) diagnose.D
 		}
 	}
 
-	// Fail fast on data loss
 	if d.Dropped > 0 || sumMap(d.DroppedByEndpoint) > 0 {
 		return diagnose.Diagnosis{
 			Status:      diagnose.DiagnosisFail,

--- a/comp/core/diagnose/impl/forwarder_triage.go
+++ b/comp/core/diagnose/impl/forwarder_triage.go
@@ -1,0 +1,419 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package diagnoseimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+
+	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+)
+
+// sleepFn is overridden in unit tests to avoid real waiting.
+var sleepFn = time.Sleep
+
+type forwarderSnapshot struct {
+	APIKeyStatus map[string]string `json:"APIKeyStatus"`
+	Transactions struct {
+		Success int `json:"Success"`
+		Errors  int `json:"Errors"`
+
+		Requeued int `json:"Requeued"`
+		Retried  int `json:"Retried"`
+		Dropped  int `json:"Dropped"`
+
+		RetryQueueSize        int `json:"RetryQueueSize"`
+		HighPriorityQueueFull int `json:"HighPriorityQueueFull"`
+
+		ConnectionEvents struct {
+			ConnectSuccess int `json:"ConnectSuccess"`
+			DNSSuccess     int `json:"DNSSuccess"`
+		} `json:"ConnectionEvents"`
+
+		ErrorsByType         map[string]int `json:"ErrorsByType"`
+		HTTPErrorsByCode     map[string]int `json:"HTTPErrorsByCode"`
+		InputCountByEndpoint map[string]int `json:"InputCountByEndpoint"`
+		RequeuedByEndpoint   map[string]int `json:"RequeuedByEndpoint"`
+		RetriedByEndpoint    map[string]int `json:"RetriedByEndpoint"`
+		DroppedByEndpoint    map[string]int `json:"DroppedByEndpoint"`
+	} `json:"Transactions"`
+}
+
+func ForwarderTriageSuite(cfg diagnose.Config) []diagnose.Diagnosis {
+	url := expvarURL()
+
+	snap1, err := fetchForwarder(url)
+	if err != nil {
+		return []diagnose.Diagnosis{{
+			Status:      diagnose.DiagnosisFail,
+			Name:        "Forwarder expvar reachable",
+			Category:    "forwarder",
+			Description: "Fetch /debug/vars and parse forwarder expvar",
+			Diagnosis:   fmt.Sprintf("Unable to fetch forwarder expvar from %s", url),
+			RawError:    err.Error(),
+			Remediation: "Check expvar_port / DD_EXPVAR_PORT, local firewall, and that the Agent is running with expvar enabled.",
+		}}
+	}
+
+	window := 5 * time.Second
+	if cfg.Verbose {
+		window = 10 * time.Second
+	}
+	sleepFn(window)
+
+	snap2, err := fetchForwarder(url)
+	if err != nil {
+		return []diagnose.Diagnosis{{
+			Status:      diagnose.DiagnosisFail,
+			Name:        "Forwarder expvar stable",
+			Category:    "forwarder",
+			Description: "Fetch /debug/vars twice and compute deltas",
+			Diagnosis:   fmt.Sprintf("First fetch succeeded but second fetch failed from %s", url),
+			RawError:    err.Error(),
+			Remediation: "If this is intermittent, suspect local resource pressure or network rules affecting the expvar port.",
+		}}
+	}
+
+	d := diffForwarder(snap1, snap2)
+
+	diags := make([]diagnose.Diagnosis, 0, 4)
+
+	apiDiag := apiKeyStatusDiagnosis(snap2)
+	diags = append(diags, apiDiag)
+
+	healthDiag := forwarderHealthDiagnosis(d, window)
+	diags = append(diags, healthDiag)
+
+	if cfg.Verbose {
+		// Never emit PASS here if the suite is indicating trouble.
+		detailsStatus := diagnose.DiagnosisSuccess
+		if apiDiag.Status != diagnose.DiagnosisSuccess || healthDiag.Status != diagnose.DiagnosisSuccess {
+			detailsStatus = diagnose.DiagnosisWarning
+		}
+		diags = append(diags, topEndpointsDiagnosis(d, detailsStatus))
+	}
+
+	return diags
+}
+
+func expvarURL() string {
+	if u := os.Getenv("DD_DIAGNOSE_EXPVAR_URL"); u != "" {
+		return u
+	}
+	port := os.Getenv("DD_EXPVAR_PORT")
+	if port == "" {
+		port = "5000"
+	}
+	return fmt.Sprintf("http://127.0.0.1:%s/debug/vars", port)
+}
+
+func fetchForwarder(url string) (forwarderSnapshot, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	// As of Go 1.22, the expvar handler requires GET for /debug/vars.
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return forwarderSnapshot{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return forwarderSnapshot{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return forwarderSnapshot{}, fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+
+	var root map[string]json.RawMessage
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&root); err != nil {
+		return forwarderSnapshot{}, err
+	}
+
+	if raw, ok := root["forwarder"]; ok {
+		var snap forwarderSnapshot
+		if err := json.Unmarshal(raw, &snap); err != nil {
+			return forwarderSnapshot{}, err
+		}
+		return snap, nil
+	}
+
+	rawAll, err := json.Marshal(root)
+	if err != nil {
+		return forwarderSnapshot{}, err
+	}
+
+	var snap forwarderSnapshot
+	if err := json.Unmarshal(rawAll, &snap); err != nil {
+		return forwarderSnapshot{}, fmt.Errorf("no 'forwarder' key and root didn't match forwarder schema: %w", err)
+	}
+	return snap, nil
+}
+
+type forwarderDelta struct {
+	Window time.Duration
+
+	Success int
+	Errors  int
+
+	Dropped  int
+	Retried  int
+	Requeued int
+
+	RetryQueueSizeDelta   int
+	HighPriorityQueueFull int
+
+	ConnectSuccess int
+	DNSSuccess     int
+
+	ErrorsByType     map[string]int
+	HTTPErrorsByCode map[string]int
+
+	RequeuedByEndpoint map[string]int
+	RetriedByEndpoint  map[string]int
+	DroppedByEndpoint  map[string]int
+}
+
+func diffForwarder(a, b forwarderSnapshot) forwarderDelta {
+	d := forwarderDelta{
+		ErrorsByType:       make(map[string]int),
+		HTTPErrorsByCode:   make(map[string]int),
+		RequeuedByEndpoint: make(map[string]int),
+		RetriedByEndpoint:  make(map[string]int),
+		DroppedByEndpoint:  make(map[string]int),
+	}
+
+	d.Success = b.Transactions.Success - a.Transactions.Success
+	d.Errors = b.Transactions.Errors - a.Transactions.Errors
+
+	d.Dropped = b.Transactions.Dropped - a.Transactions.Dropped
+	d.Retried = b.Transactions.Retried - a.Transactions.Retried
+	d.Requeued = b.Transactions.Requeued - a.Transactions.Requeued
+
+	d.RetryQueueSizeDelta = b.Transactions.RetryQueueSize - a.Transactions.RetryQueueSize
+	d.HighPriorityQueueFull = b.Transactions.HighPriorityQueueFull - a.Transactions.HighPriorityQueueFull
+
+	d.ConnectSuccess = b.Transactions.ConnectionEvents.ConnectSuccess - a.Transactions.ConnectionEvents.ConnectSuccess
+	d.DNSSuccess = b.Transactions.ConnectionEvents.DNSSuccess - a.Transactions.ConnectionEvents.DNSSuccess
+
+	for k, vb := range b.Transactions.ErrorsByType {
+		d.ErrorsByType[k] = vb - a.Transactions.ErrorsByType[k]
+	}
+	for k, vb := range b.Transactions.HTTPErrorsByCode {
+		d.HTTPErrorsByCode[k] = vb - a.Transactions.HTTPErrorsByCode[k]
+	}
+	for k, vb := range b.Transactions.RequeuedByEndpoint {
+		d.RequeuedByEndpoint[k] = vb - a.Transactions.RequeuedByEndpoint[k]
+	}
+	for k, vb := range b.Transactions.RetriedByEndpoint {
+		d.RetriedByEndpoint[k] = vb - a.Transactions.RetriedByEndpoint[k]
+	}
+	for k, vb := range b.Transactions.DroppedByEndpoint {
+		d.DroppedByEndpoint[k] = vb - a.Transactions.DroppedByEndpoint[k]
+	}
+
+	return d
+}
+
+func apiKeyStatusDiagnosis(s forwarderSnapshot) diagnose.Diagnosis {
+	if len(s.APIKeyStatus) == 0 {
+		return diagnose.Diagnosis{
+			Status:    diagnose.DiagnosisWarning,
+			Name:      "Forwarder API key status",
+			Category:  "forwarder",
+			Diagnosis: "APIKeyStatus missing from forwarder expvar",
+		}
+	}
+
+	keys := make([]string, 0, len(s.APIKeyStatus))
+	for k := range s.APIKeyStatus {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	k := keys[0]
+	v := s.APIKeyStatus[k]
+
+	if v == "API Key valid" {
+		return diagnose.Diagnosis{
+			Status:    diagnose.DiagnosisSuccess,
+			Name:      "Forwarder API key status",
+			Category:  "forwarder",
+			Diagnosis: fmt.Sprintf("%s: %s", k, v),
+		}
+	}
+
+	return diagnose.Diagnosis{
+		Status:      diagnose.DiagnosisWarning,
+		Name:        "Forwarder API key status",
+		Category:    "forwarder",
+		Diagnosis:   fmt.Sprintf("%s: %s", k, v),
+		Remediation: "If this says it cannot reach validation endpoint, treat as connectivity/proxy/firewall/TLS problem (not a bad key) and run the core connectivity suites.",
+	}
+}
+
+func forwarderHealthDiagnosis(d forwarderDelta, window time.Duration) diagnose.Diagnosis {
+	d.Window = window
+
+	noActivity :=
+		d.Success == 0 &&
+			d.Errors == 0 &&
+			d.Dropped == 0 &&
+			d.Retried == 0 &&
+			d.Requeued == 0 &&
+			d.RetryQueueSizeDelta == 0 &&
+			d.HighPriorityQueueFull == 0 &&
+			sumMap(d.ErrorsByType) == 0 &&
+			sumMap(d.HTTPErrorsByCode) == 0
+
+	if noActivity {
+		return diagnose.Diagnosis{
+			Status:    diagnose.DiagnosisSuccess,
+			Name:      "Forwarder health",
+			Category:  "forwarder",
+			Diagnosis: fmt.Sprintf("No forwarder activity observed over %s (no counter deltas).", window),
+		}
+	}
+
+	// dominance: pick the error class that grew most, deterministically
+	dominantKey := ""
+	dominantVal := 0
+	errKeys := make([]string, 0, len(d.ErrorsByType))
+	for k := range d.ErrorsByType {
+		errKeys = append(errKeys, k)
+	}
+	sort.Strings(errKeys)
+	for _, k := range errKeys {
+		v := d.ErrorsByType[k]
+		if v > dominantVal {
+			dominantKey, dominantVal = k, v
+		}
+	}
+
+	// Fail fast on data loss
+	if d.Dropped > 0 || sumMap(d.DroppedByEndpoint) > 0 {
+		return diagnose.Diagnosis{
+			Status:      diagnose.DiagnosisFail,
+			Name:        "Forwarder health",
+			Category:    "forwarder",
+			Description: "Detect data loss/backpressure/errors from forwarder expvar deltas",
+			Diagnosis:   fmt.Sprintf("Data dropped in last %s (Dropped=%d).", window, d.Dropped),
+			Remediation: "This indicates the Agent is losing payloads. Check network reachability, proxy/TLS, and consider tuning forwarder workers/timeouts if connectivity is flaky.",
+		}
+	}
+
+	if dominantVal > 0 {
+		status := diagnose.DiagnosisFail
+		remediation := "Run `datadog-agent diagnose -v` suites connectivity-datadog-core-endpoints and connectivity-datadog-event-platform, then check proxy/TLS settings and outbound firewall rules."
+
+		if len(d.HTTPErrorsByCode) > 0 && sumMap(d.HTTPErrorsByCode) > 0 {
+			status = diagnose.DiagnosisWarning
+			remediation = "HTTP errors suggest auth/permissions (401/403) or upstream/proxy issues (5xx). Verify api_key, site, and proxy configuration."
+		}
+
+		diag := fmt.Sprintf("Forwarder unhealthy over %s: Success=%d Errors=%d DominantError=%s(%d) Requeued=%d Retried=%d",
+			window, d.Success, d.Errors, dominantKey, dominantVal, d.Requeued, d.Retried)
+
+		md := map[string]string{
+			"errors_by_type_delta":      mustJSON(d.ErrorsByType),
+			"http_errors_by_code_delta": mustJSON(d.HTTPErrorsByCode),
+		}
+
+		return diagnose.Diagnosis{
+			Status:      status,
+			Name:        "Forwarder health",
+			Category:    "forwarder",
+			Description: "Detect data loss/backpressure/errors from forwarder expvar deltas",
+			Diagnosis:   diag,
+			Remediation: remediation,
+			Metadata:    md,
+		}
+	}
+
+	if d.Requeued > 0 || d.Retried > 0 || d.HighPriorityQueueFull > 0 {
+		return diagnose.Diagnosis{
+			Status:      diagnose.DiagnosisWarning,
+			Name:        "Forwarder health",
+			Category:    "forwarder",
+			Diagnosis:   fmt.Sprintf("Forwarder seeing retries/requeues over %s (Requeued=%d Retried=%d HighPriorityQueueFull=%d).", window, d.Requeued, d.Retried, d.HighPriorityQueueFull),
+			Remediation: "This is typically transient connectivity or backpressure. If persistent, review proxy/firewall and consider tuning forwarder settings.",
+		}
+	}
+
+	return diagnose.Diagnosis{
+		Status:    diagnose.DiagnosisSuccess,
+		Name:      "Forwarder health",
+		Category:  "forwarder",
+		Diagnosis: fmt.Sprintf("Forwarder healthy over %s (Success=%d Errors=%d).", window, d.Success, d.Errors),
+	}
+}
+
+func topEndpointsDiagnosis(d forwarderDelta, status diagnose.Status) diagnose.Diagnosis {
+	type endpointCount struct {
+		Endpoint string `json:"endpoint"`
+		Count    int    `json:"count"`
+	}
+
+	tops := make([]endpointCount, 0, len(d.RequeuedByEndpoint))
+	for endpoint, count := range d.RequeuedByEndpoint {
+		if count > 0 {
+			tops = append(tops, endpointCount{Endpoint: endpoint, Count: count})
+		}
+	}
+
+	sort.Slice(tops, func(i, j int) bool { return tops[i].Count > tops[j].Count })
+	if len(tops) > 5 {
+		tops = tops[:5]
+	}
+
+	diagnosisText := "Top endpoints by requeue delta captured in metadata."
+	if status != diagnose.DiagnosisSuccess {
+		diagnosisText = "Forwarder is not healthy; endpoint impact details captured in metadata."
+	}
+	if len(tops) == 0 {
+		if status != diagnose.DiagnosisSuccess {
+			diagnosisText = "Forwarder is not healthy; no endpoint requeues observed in the sampling window."
+		} else {
+			diagnosisText = "No endpoint requeues observed in the sampling window."
+		}
+	}
+
+	return diagnose.Diagnosis{
+		Status:      status,
+		Name:        "Forwarder top impacted endpoints",
+		Category:    "forwarder",
+		Description: "Endpoint-level requeue/retry deltas from forwarder expvar",
+		Diagnosis:   diagnosisText,
+		Metadata: map[string]string{
+			"top_requeued_by_endpoint":   mustJSON(tops),
+			"requeued_by_endpoint_delta": mustJSON(d.RequeuedByEndpoint),
+			"retried_by_endpoint_delta":  mustJSON(d.RetriedByEndpoint),
+			"dropped_by_endpoint_delta":  mustJSON(d.DroppedByEndpoint),
+		},
+	}
+}
+
+func sumMap(m map[string]int) int {
+	s := 0
+	for _, v := range m {
+		s += v
+	}
+	return s
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf(`{"marshal_error":%q}`, err.Error())
+	}
+	return string(b)
+}

--- a/comp/core/diagnose/impl/forwarder_triage_test.go
+++ b/comp/core/diagnose/impl/forwarder_triage_test.go
@@ -52,7 +52,6 @@ func TestTopEndpointsDiagnosis_MetadataShapeAndOrdering(t *testing.T) {
 		t.Fatalf("expected 3 entries, got %d: %#v", len(got), got)
 	}
 
-	// Ordered by descending count: series_v2 (10), intake (7), metadata_v1 (2)
 	if got[0].Endpoint != "series_v2" || got[0].Count != 10 {
 		t.Fatalf("unexpected first entry: %#v", got[0])
 	}
@@ -71,7 +70,7 @@ func TestForwarderTriageSuite_Verbose_UnhealthyAndDetailsWarning(t *testing.T) {
 
 	var calls int64
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		n := atomic.AddInt64(&calls, 1)
 
 		payload := map[string]any{
@@ -142,7 +141,6 @@ func TestForwarderTriageSuite_Verbose_UnhealthyAndDetailsWarning(t *testing.T) {
 		t.Fatalf("unexpected details diagnosis: %#v", diags[2])
 	}
 
-	// Validate health metadata contains expected deltas.
 	rawErrs := diags[1].Metadata["errors_by_type_delta"]
 	var errs map[string]int
 	if err := json.Unmarshal([]byte(rawErrs), &errs); err != nil {
@@ -152,7 +150,6 @@ func TestForwarderTriageSuite_Verbose_UnhealthyAndDetailsWarning(t *testing.T) {
 		t.Fatalf("expected ConnectionErrors delta 10, got %d (%v)", errs["ConnectionErrors"], errs)
 	}
 
-	// Validate details top endpoints metadata is not empty and has shape.
 	rawTop := diags[2].Metadata["top_requeued_by_endpoint"]
 	type endpointCount struct {
 		Endpoint string `json:"endpoint"`
@@ -168,7 +165,7 @@ func TestForwarderTriageSuite_Verbose_UnhealthyAndDetailsWarning(t *testing.T) {
 }
 
 func TestFetchForwarder_ParsesNestedForwarderKey(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		payload := map[string]any{
 			"forwarder": map[string]any{
 				"APIKeyStatus": map[string]string{"k": "API Key valid"},
@@ -193,8 +190,7 @@ func TestFetchForwarder_ParsesNestedForwarderKey(t *testing.T) {
 }
 
 func TestFetchForwarder_FallbackRootObject(t *testing.T) {
-	// Root object looks like the forwarder payload directly (no "forwarder" key).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		payload := map[string]any{
 			"APIKeyStatus": map[string]string{"k": "API Key valid"},
 			"Transactions": map[string]any{

--- a/comp/core/diagnose/impl/forwarder_triage_test.go
+++ b/comp/core/diagnose/impl/forwarder_triage_test.go
@@ -1,0 +1,217 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package diagnoseimpl
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+)
+
+func TestTopEndpointsDiagnosis_MetadataShapeAndOrdering(t *testing.T) {
+	d := forwarderDelta{
+		RequeuedByEndpoint: map[string]int{
+			"series_v2":   10,
+			"metadata_v1": 2,
+			"intake":      7,
+		},
+		RetriedByEndpoint: map[string]int{
+			"series_v2": 3,
+		},
+		DroppedByEndpoint: map[string]int{},
+	}
+
+	diag := topEndpointsDiagnosis(d, diagnose.DiagnosisWarning)
+	if diag.Status != diagnose.DiagnosisWarning {
+		t.Fatalf("expected WARNING, got %v", diag.Status)
+	}
+
+	raw, ok := diag.Metadata["top_requeued_by_endpoint"]
+	if !ok || raw == "" {
+		t.Fatalf("expected top_requeued_by_endpoint metadata to be present")
+	}
+
+	type endpointCount struct {
+		Endpoint string `json:"endpoint"`
+		Count    int    `json:"count"`
+	}
+	var got []endpointCount
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("failed to unmarshal top_requeued_by_endpoint: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %#v", len(got), got)
+	}
+
+	// Ordered by descending count: series_v2 (10), intake (7), metadata_v1 (2)
+	if got[0].Endpoint != "series_v2" || got[0].Count != 10 {
+		t.Fatalf("unexpected first entry: %#v", got[0])
+	}
+	if got[1].Endpoint != "intake" || got[1].Count != 7 {
+		t.Fatalf("unexpected second entry: %#v", got[1])
+	}
+	if got[2].Endpoint != "metadata_v1" || got[2].Count != 2 {
+		t.Fatalf("unexpected third entry: %#v", got[2])
+	}
+}
+
+func TestForwarderTriageSuite_Verbose_UnhealthyAndDetailsWarning(t *testing.T) {
+	origSleep := sleepFn
+	sleepFn = func(_ time.Duration) {}
+	defer func() { sleepFn = origSleep }()
+
+	var calls int64
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt64(&calls, 1)
+
+		payload := map[string]any{
+			"forwarder": map[string]any{
+				"APIKeyStatus": map[string]string{
+					"API key ending with 742ce": "Unable to reach the API Key validation endpoint",
+				},
+				"Transactions": map[string]any{
+					"Success":               0,
+					"Errors":                int(10 * n),
+					"Dropped":               0,
+					"Requeued":              int(50 * n),
+					"Retried":               int(5 * n),
+					"RetryQueueSize":        0,
+					"HighPriorityQueueFull": 0,
+					"ConnectionEvents": map[string]any{
+						"ConnectSuccess": 0,
+						"DNSSuccess":     int(1 * n),
+					},
+					"ErrorsByType": map[string]any{
+						"ConnectionErrors":   int(10 * n),
+						"DNSErrors":          int(1 * n),
+						"SentRequestErrors":  0,
+						"TLSErrors":          0,
+						"WroteRequestErrors": 0,
+					},
+					"HTTPErrorsByCode": map[string]any{},
+					"RequeuedByEndpoint": map[string]any{
+						"series_v2": int(10 * n),
+					},
+					"RetriedByEndpoint": map[string]any{
+						"series_v2": int(3 * n),
+					},
+					"DroppedByEndpoint": map[string]any{},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	prev := os.Getenv("DD_DIAGNOSE_EXPVAR_URL")
+	_ = os.Setenv("DD_DIAGNOSE_EXPVAR_URL", srv.URL)
+	defer func() {
+		if prev == "" {
+			_ = os.Unsetenv("DD_DIAGNOSE_EXPVAR_URL")
+		} else {
+			_ = os.Setenv("DD_DIAGNOSE_EXPVAR_URL", prev)
+		}
+	}()
+
+	diags := ForwarderTriageSuite(diagnose.Config{Verbose: true})
+	if len(diags) != 3 {
+		t.Fatalf("expected 3 diagnoses, got %d: %#v", len(diags), diags)
+	}
+
+	if diags[0].Name != "Forwarder API key status" || diags[0].Status != diagnose.DiagnosisWarning {
+		t.Fatalf("unexpected api key diagnosis: %#v", diags[0])
+	}
+
+	if diags[1].Name != "Forwarder health" || diags[1].Status != diagnose.DiagnosisFail {
+		t.Fatalf("unexpected health diagnosis: %#v", diags[1])
+	}
+
+	if diags[2].Name != "Forwarder top impacted endpoints" || diags[2].Status != diagnose.DiagnosisWarning {
+		t.Fatalf("unexpected details diagnosis: %#v", diags[2])
+	}
+
+	// Validate health metadata contains expected deltas.
+	rawErrs := diags[1].Metadata["errors_by_type_delta"]
+	var errs map[string]int
+	if err := json.Unmarshal([]byte(rawErrs), &errs); err != nil {
+		t.Fatalf("failed to unmarshal errors_by_type_delta: %v", err)
+	}
+	if errs["ConnectionErrors"] != 10 {
+		t.Fatalf("expected ConnectionErrors delta 10, got %d (%v)", errs["ConnectionErrors"], errs)
+	}
+
+	// Validate details top endpoints metadata is not empty and has shape.
+	rawTop := diags[2].Metadata["top_requeued_by_endpoint"]
+	type endpointCount struct {
+		Endpoint string `json:"endpoint"`
+		Count    int    `json:"count"`
+	}
+	var tops []endpointCount
+	if err := json.Unmarshal([]byte(rawTop), &tops); err != nil {
+		t.Fatalf("failed to unmarshal top_requeued_by_endpoint: %v", err)
+	}
+	if len(tops) != 1 || tops[0].Endpoint != "series_v2" || tops[0].Count != 10 {
+		t.Fatalf("unexpected tops: %#v", tops)
+	}
+}
+
+func TestFetchForwarder_ParsesNestedForwarderKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{
+			"forwarder": map[string]any{
+				"APIKeyStatus": map[string]string{"k": "API Key valid"},
+				"Transactions": map[string]any{
+					"Success": 1,
+					"Errors":  0,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	snap, err := fetchForwarder(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Transactions.Success != 1 {
+		t.Fatalf("expected Success=1, got %d", snap.Transactions.Success)
+	}
+}
+
+func TestFetchForwarder_FallbackRootObject(t *testing.T) {
+	// Root object looks like the forwarder payload directly (no "forwarder" key).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload := map[string]any{
+			"APIKeyStatus": map[string]string{"k": "API Key valid"},
+			"Transactions": map[string]any{
+				"Success": 2,
+				"Errors":  3,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer srv.Close()
+
+	snap, err := fetchForwarder(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snap.Transactions.Success != 2 || snap.Transactions.Errors != 3 {
+		t.Fatalf("unexpected transactions: success=%d errors=%d", snap.Transactions.Success, snap.Transactions.Errors)
+	}
+}

--- a/comp/core/diagnose/local/local.go
+++ b/comp/core/diagnose/local/local.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	diagnose "github.com/DataDog/datadog-agent/comp/core/diagnose/def"
+	diagnoseimpl "github.com/DataDog/datadog-agent/comp/core/diagnose/impl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
@@ -57,6 +58,9 @@ func Run(
 		},
 		diagnose.CoreEndpointsConnectivity: func(diagCfg diagnose.Config) []diagnose.Diagnosis {
 			return connectivity.Diagnose(diagCfg, log)
+		},
+		diagnose.ForwarderTriage: func(diagCfg diagnose.Config) []diagnose.Diagnosis {
+			return diagnoseimpl.ForwarderTriageSuite(diagCfg)
 		},
 	}
 

--- a/releasenotes/notes/forwarder-triage-b2c255f24c3b64d5.yaml
+++ b/releasenotes/notes/forwarder-triage-b2c255f24c3b64d5.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add a new `forwarder-triage` diagnose suite that reads the forwarder expvar (`/debug/vars`) twice and reports
+    API key validation status, forwarder health (errors/retries/requeues/drops), and the most impacted endpoints.


### PR DESCRIPTION
What does this PR do?
---------------------

Adds a new diagnose suite, `forwarder-triage`, to summarize forwarder health using expvar data from `/debug/vars`. The suite:

-   Reports forwarder API key validation status (`forwarder.APIKeyStatus`)

-   Computes forwarder deltas over a short sampling window to detect errors/retries/requeues/drops

-   In verbose mode, reports endpoint-level impact details (top requeued endpoints) and avoids misleading PASS output when the suite is unhealthy

Motivation
----------

Forwarder failure is a frequent root cause of "Agent not sending data". Existing diagnose suites focus on endpoint connectivity but don't provide a compact, forwarder-centric symptom summary (errors/retries/requeues/drops) with a direct remediation pointer. This suite provides that triage and directs users to the core connectivity suites when symptoms indicate transport issues.

How did you validate your changes?
----------------------------------

-   Unit tests:

    -   `go test -tags=clusterchecks,kubeapiserver,test,kubelet,podwatcher ./comp/core/diagnose/impl`

-   Manual:

    -   Local execution:

        -   `./bin/agent/agent -c "$CFG" diagnose all --local --include forwarder-triage --verbose --json`

    -   Agent-process execution (no `--local`):

        -   `./bin/agent/agent -c "$CFG" diagnose all --include forwarder-triage --verbose --json`

    -   Verified delta-based behavior against an incrementing mock expvar server (expected FAIL/WARNING signals)

Possible Drawbacks / Trade-offs
-------------------------------

-   Requires two expvar reads with a sampling window (~5s, ~10s in verbose), which adds latency to this suite run by design.

-   If expvar is disabled/unreachable, the suite fails with explicit remediation.

Additional Notes
----------------

-   Verbose "top impacted endpoints" output is WARNING when the suite is unhealthy to avoid misleading PASS output.