### PR TITLE
:window: Disable `bazel` diagnostics on unresolvable remote cache

### DIFF
--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -58,7 +58,7 @@ set "bazel_exit=!errorlevel!"
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
 set "should_diagnose=1"
-for %%c in (0 1 3 36) do if !bazel_exit!==%%c set "should_diagnose=0"
+for %%c in (0 1 3 34 36) do if !bazel_exit!==%%c set "should_diagnose=0"
 if !should_diagnose!==1 (
   >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (


### PR DESCRIPTION
### What does this PR do?
Stop diagnosing `bazel` internals on unresolvable remote cache server.

### Motivation
Diagnosing `bazel` internals on DNS resolution errors doesn't help, example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1341962866