### PR TITLE
Fix parameter name for windows unit test job

### DIFF
--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -161,7 +161,7 @@ Invoke-BuildScript `
             Get-ChildItem -Filter "junit-out-*.xml" -Recurse | ForEach-Object {
                 Copy-Item -Path $_.FullName -Destination C:\mnt
             }
-            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "tototot2"
+            $Env:DATADOG_API_KEY = Get-VaultSecret -parameterName "$Env:API_KEY_ORG2" -ErrorAction Stop
             & dda inv -- -e junit-upload --tgz-path $Env:JUNIT_TAR --result-json C:\mnt\$test_output_file
             if($LASTEXITCODE -ne 0){
                 throw "junit upload failed with exit code $LASTEXITCODE"

--- a/tools/ci/fetch_secret.ps1
+++ b/tools/ci/fetch_secret.ps1
@@ -5,7 +5,7 @@ param (
 )
 
 $retryCount = 0
-$maxRetries = 10
+$maxRetries = 4
 
 # To catch the error message from aws cli
 $ErrorActionPreference = "Continue"


### PR DESCRIPTION
### What does this PR do?

Fix an issue that was introduced in #44337. The issue is that an incorrect parameter is used to fetch the secret. It was meant to be only for tested but was missed when reverting that thing.

The PR also reduces the number of retries, because we the exponential backoff and 10 retries we can end up waiting around 15 minutes on the latest retry. If we need to retry more than 4 times it is very likely that something is not working at all and that retrying more will not help

### Motivation

### Describe how you validated your changes

### Additional Notes
