### PR TITLE
Enable local fallback for bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,11 +15,13 @@ common --verbose_failures
 
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --strategy=sandboxed
+common:linux --remote_local_fallback_strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=11.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
+common:macos --remote_local_fallback_strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
@@ -33,9 +35,11 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_cache=grpc://bazel-buildbarn-frontend.ddbuild.io:443
+# Fallback doesn't work for --remote_cache, therefore, setting --remote_executor and --strategy to sandboxed
+# to use cache capabilities in combination with sandboxing.
+common:cache --remote_executor=grpc://bazel-buildbarn-frontend.ddbuild.io:443
 common:cache --remote_instance_name=remote-caching/datadog-agent
-common:cache --remote_local_fallback  # best-effort on transient connection errors (no such host)
+common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --remote_retries=1
 common:cache --remote_timeout=60
 

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -11,7 +11,7 @@ static_quality_gate_agent_msi:
   max_on_disk_size: 982.08 MiB
   max_on_wire_size: 143.02 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 708.35 MiB
+  max_on_disk_size: 708.85 MiB
   max_on_wire_size: 177.66 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 703.96 MiB
@@ -23,7 +23,7 @@ static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 688.44 MiB
   max_on_wire_size: 160.46 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 708.35 MiB
+  max_on_disk_size: 708.85 MiB
   max_on_wire_size: 177.66 MiB
 static_quality_gate_agent_suse_amd64_fips:
   max_on_disk_size: 703.96 MiB


### PR DESCRIPTION
### What does this PR do?
Bazel build shouldn't fail in case buildbarn cluster that serves as a Remote Cache (and Remote Build Execution in the future) is unavailable. We also ensure that bazel chooses sandbox execution strategy and not "local" one which is the default.

This is a backport of #44962

### Motivation
To improve resilience of the CI operations
