### PR TITLE
Add `//go:build test` tag to remaining files in `pkg/util/testutil`

### DIFF
--- a/pkg/util/testutil/doc.go
+++ b/pkg/util/testutil/doc.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package testutil provides various helper functions for tests.
+//
+// Most files in this package require the 'test' build tag to be accessible.
+// Import this package with -tags=test when running tests.
+package testutil

--- a/pkg/util/testutil/elements.go
+++ b/pkg/util/testutil/elements.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.Datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package testutil
 
 import (

--- a/pkg/util/testutil/error.go
+++ b/pkg/util/testutil/error.go
@@ -5,7 +5,6 @@
 
 //go:build test
 
-// Package testutil provides various helper functions for tests
 package testutil
 
 // ErrorString is a simple error implementation that can be used in tests

--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.Datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 // Package flake marks an instance of [testing.TB](https://pkg.go.dev/testing#TB) as flake.
 // Use [flake.Mark] to mark a known flake test.
 // Use `skip-flake` to control the behavior, or set the environment variable `SKIP_FLAKE`.

--- a/pkg/util/testutil/flake/parse.go
+++ b/pkg/util/testutil/flake/parse.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build test
+
 package flake
 
 import (

--- a/pkg/util/testutil/fuzz.go
+++ b/pkg/util/testutil/fuzz.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.Datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package testutil provides various helper functions for tests
+//go:build test
+
 package testutil
 
 import (

--- a/pkg/util/testutil/gobuild.go
+++ b/pkg/util/testutil/gobuild.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package testutil provides utilities for testing.
+//go:build test
+
 package testutil
 
 import (

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -5,7 +5,6 @@
 
 //go:build test
 
-// Package testutil provides general test utilities
 package testutil
 
 import (

--- a/pkg/util/testutil/tempfolder.go
+++ b/pkg/util/testutil/tempfolder.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package testutil
 
 import (

--- a/pkg/util/testutil/timeout.go
+++ b/pkg/util/testutil/timeout.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package testutil
 
 import (

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -746,6 +746,7 @@ def ninja_build_dependencies(ctx: Context, nw: NinjaWriter, kmt_paths: KMTPaths,
         variables={
             "go": go_path,
             "chdir": "cd test/new-e2e/system-probe/test-json-review/",
+            "tags": "-tags=test",
             "env": env_str,
         },
     )

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -106,6 +106,8 @@ def build_binaries(
     Build E2E test binaries for all test packages to be reused across test jobs.
     This pre-builds all test binaries to optimize CI pipeline performance.
     """
+    if "test" not in tags:
+        tags = tags + ["test"]
 
     if parallel == 0:
         parallel = multiprocessing.cpu_count()
@@ -267,6 +269,8 @@ def run(
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
     """
+    if "test" not in tags:
+        tags = tags + ["test"]
 
     if shutil.which("pulumi") is None:
         raise Exit(


### PR DESCRIPTION
### What does this PR do?
Add `//go:build test` directive to a few files below `pkg/util/testutil` that were missing it: `elements.go`, `fuzz.go`, `gobuild.go`, `tempfolder.go`, `timeout.go`, and files in the `flake/` subdirectory (`flake.go`, `parse.go`).

Add `-tag:test` to a few custom test runners to have them behave like `go test`.

### Motivation
This ensures consistency within the `pkg/util/testutil` package, where other files (`error.go`, `patternscanner.go`, `docker/*.go`) already have the `//go:build test` tag.

Without this tag, these utility files could potentially be included in production builds if accidentally imported from non-test code. The tag provides an additional safety layer by ensuring the Go build system excludes these test-only utilities from production binaries.

### Additional Notes
The `doc.go` stub file is necessary because:
- `pkg/linters/components/pkgconfigusage` depends on `testutil` for its tests,
- `golangci-lint custom` runs `go mod tidy` which resolves ALL dependencies, including test dependencies,
- `go mod tidy` does not respect build tags, so without `doc.go`, the package would appear empty.

The directive isn't necessary (redundant) for `_test.go` files:
- https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies
- https://pkg.go.dev/testing