### PR TITLE
Remove replace directive for protobuf

### DIFF
--- a/internal/tools/proto/go.mod
+++ b/internal/tools/proto/go.mod
@@ -24,5 +24,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace google.golang.org/protobuf v1.36.11 => google.golang.org/protobuf v1.36.11


### PR DESCRIPTION
### What does this PR do?
Remove replace directive for protobuf.

### Motivation
The directive is completely useless, it replaces a version with the same one.

### Describe how you validated your changes
n/a

### Additional Notes
