### PR TITLE
[#incident-47881] Update buildbarn frontend endpoint

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,7 +37,7 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Fallback doesn't work for --remote_cache, therefore, setting --remote_executor and --strategy to sandboxed
 # to use cache capabilities in combination with sandboxing.
 common:cache --remote_executor=grpcs://buildbarn-frontend.us1.ddbuild.io:443
-common:cache --remote_instance_name=remote-caching/datadog-agent
+common:cache --remote_instance_name=ci/datadog-agent
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --remote_retries=1
 common:cache --remote_timeout=60

--- a/.bazelrc
+++ b/.bazelrc
@@ -36,7 +36,7 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
 # Fallback doesn't work for --remote_cache, therefore, setting --remote_executor and --strategy to sandboxed
 # to use cache capabilities in combination with sandboxing.
-common:cache --remote_executor=grpc://bazel-buildbarn-frontend.ddbuild.io:443
+common:cache --remote_executor=grpcs://buildbarn-frontend.us1.ddbuild.io:443
 common:cache --remote_instance_name=remote-caching/datadog-agent
 common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
 common:cache --remote_retries=1


### PR DESCRIPTION
### What does this PR do?
- Update buildbarn endpoint to the newly created routing domain
- Update protocol to grpcs since the new endpoint now requires TLS encryption

### Motivation
Solve [#incident-47881](https://app.datadoghq.com/incidents/47881).

### Describe how you validated your changes
I managed to successfully run `bazel build` from my laptop with the following configuration
```
build:rbe-macbook --remote_cache=grpcs://buildbarn-frontend.us1.ddbuild.io:443
build:rbe-macbook --remote_executor=grpcs://buildbarn-frontend.us1.ddbuild.io:443
build:rbe-macbook --remote_instance_name=ci/shared
build:rbe-macbook --remote_timeout=600
build:rbe-macbook --remote_upload_local_results=true
build:rbe-macbook --extra_execution_platforms=//platforms:x86_64-unknown-linux
build:rbe-macbook --host_platform=//platforms:x86_64-unknown-linux
build:rbe-macbook --platforms=//platforms:x86_64-unknown-linux
build:rbe-macbook --jobs=50
```

```zsh
~/go/src/github.com/DataDog/buildbarn-test  ronan.garet/…-from-laptop !2  bazel build //... --config=rbe-macbook --verbose_failures                                        8 ✘  1m 34s 
INFO: Invocation ID: 499c5f6e-ec9a-425f-9b15-fea8646fd0fd
INFO: Analyzed 6 targets (0 packages loaded, 0 targets configured).
INFO: Found 6 targets...
INFO: Elapsed time: 9.568s, Critical Path: 9.33s
INFO: 58 processes: 7 action cache hit, 2 remote cache hit, 1 internal, 55 remote.
INFO: Build completed successfully, 58 total actions
```