### PR TITLE
fix deploy kind with kubernetes v1.35 on kind

### DIFF
--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -235,7 +235,7 @@ func (e *CommonEnvironment) KubernetesVersion() string {
 }
 
 func (e *CommonEnvironment) KindVersion() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraKindVersion, "v0.30.0")
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraKindVersion, "v0.31.0")
 }
 
 func (e *CommonEnvironment) KubeNodeURL() string {

--- a/test/e2e-framework/components/kubernetes/cilium/hosts.toml
+++ b/test/e2e-framework/components/kubernetes/cilium/hosts.toml
@@ -1,0 +1,8 @@
+server = "https://docker.io"
+
+[host."https://mirror.gcr.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://docker.io"]
+  capabilities = ["pull", "resolve"]

--- a/test/e2e-framework/components/kubernetes/cilium/kind-cluster-v1.35+.yaml
+++ b/test/e2e-framework/components/kubernetes/cilium/kind-cluster-v1.35+.yaml
@@ -1,0 +1,24 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /proc
+    containerPath: /host/proc
+  - hostPath: ./certs.d
+    containerPath: "/etc/containerd/certs.d"
+- role: worker
+  extraMounts:
+  - hostPath: /proc
+    containerPath: /host/proc
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+networking:
+  apiServerAddress: "0.0.0.0"
+  apiServerPort: 8443
+  disableDefaultCNI: true
+{{if .KubeProxyReplacement}}
+  kubeProxyMode: "none"
+{{end}}

--- a/test/e2e-framework/components/kubernetes/cilium/kind.go
+++ b/test/e2e-framework/components/kubernetes/cilium/kind.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"gopkg.in/yaml.v3"
 
@@ -25,14 +26,29 @@ import (
 //go:embed kind-cilium-cluster.yaml
 var kindCilumClusterFS embed.FS
 
-func kindKubeClusterConfigFromCiliumParams(params *Params) (string, error) {
+//go:embed kind-cluster-v1.35+.yaml
+var kindCiliumV135ClusterFS embed.FS
+
+//go:embed hosts.toml
+var containerdDockerioHostConfig string
+
+func kindKubeClusterConfigFromCiliumParams(params *Params, kubeVersion string) (string, error) {
 	o := struct {
 		KubeProxyReplacement bool
 	}{
 		KubeProxyReplacement: params.hasKubeProxyReplacement(),
 	}
 
-	kindCiliumClusterTemplate, err := template.ParseFS(kindCilumClusterFS, "kind-cilium-cluster.yaml")
+	var kindCiliumCluster embed.FS = kindCilumClusterFS
+	if index := strings.Index(kubeVersion, "@"); index != -1 {
+		kubeVersion = kubeVersion[:index]
+	}
+
+	if semver.MustParse(kubeVersion).GreaterThanEqual(semver.MustParse("v1.35.0")) {
+		kindCiliumCluster = kindCiliumV135ClusterFS
+	}
+
+	kindCiliumClusterTemplate, err := template.ParseFS(kindCiliumCluster, "kind-cilium-cluster.yaml")
 	if err != nil {
 		return "", err
 	}
@@ -51,12 +67,12 @@ func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion st
 		return nil, fmt.Errorf("could not create cilium params from opts: %w", err)
 	}
 
-	clusterConfig, err := kindKubeClusterConfigFromCiliumParams(params)
+	clusterConfig, err := kindKubeClusterConfigFromCiliumParams(params, kubeVersion)
 	if err != nil {
 		return nil, err
 	}
 
-	cluster, err := kubernetes.NewKindClusterWithConfig(env, vm, name, kubeVersion, clusterConfig, opts...)
+	cluster, err := kubernetes.NewKindClusterWithConfig(env, vm, name, kubeVersion, clusterConfig, containerdDockerioHostConfig, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e-framework/components/kubernetes/hosts.toml
+++ b/test/e2e-framework/components/kubernetes/hosts.toml
@@ -1,0 +1,8 @@
+server = "https://docker.io"
+
+[host."https://mirror.gcr.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://registry-1.docker.io"]
+  capabilities = ["pull", "resolve"]
+[host."https://docker.io"]
+  capabilities = ["pull", "resolve"]

--- a/test/e2e-framework/components/kubernetes/kind-cluster-v1.35+.yaml
+++ b/test/e2e-framework/components/kubernetes/kind-cluster-v1.35+.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /proc
+    containerPath: /host/proc
+  - hostPath: ./certs.d
+    containerPath: "/etc/containerd/certs.d"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+networking:
+  apiServerAddress: "0.0.0.0"
+  apiServerPort: 8443

--- a/test/e2e-framework/components/kubernetes/kind_versions.go
+++ b/test/e2e-framework/components/kubernetes/kind_versions.go
@@ -14,24 +14,30 @@ import (
 
 // KindConfig contains the kind version and the kind node image to use
 type KindConfig struct {
-	KindVersion      string
-	NodeImageVersion string
+	KindVersion            string
+	NodeImageVersion       string
+	UseNewContainerdConfig bool
 }
 
 // Source: https://github.com/kubernetes-sigs/kind/releases
 var kubeToKindVersion = map[string]KindConfig{
 	"1.34": {
-		KindVersion:      "v0.30.0",
-		NodeImageVersion: "v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a",
+		KindVersion:            "v0.30.0",
+		NodeImageVersion:       "v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a",
+		UseNewContainerdConfig: true,
 	},
 	"1.33": {
-		KindVersion:      "v0.28.0",
-		NodeImageVersion: "v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2",
+		KindVersion:            "v0.28.0",
+		NodeImageVersion:       "v1.33.0@sha256:91e9ed777db80279c22d1d1068c091b899b2078506e4a0f797fbf6e397c0b0b2",
+		UseNewContainerdConfig: true,
 	},
 	"1.32": {
-		KindVersion:      "v0.26.0",
-		NodeImageVersion: "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",
+		KindVersion:            "v0.27.0",
+		NodeImageVersion:       "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",
+		UseNewContainerdConfig: true,
 	},
+	// kind versions bellow this line will use containerd <= 2.x and so will need a different containerd docker.io registry mirror config format
+	// we can leave the UseNewContainerdConfig to false as its default value is false
 	"1.31": {
 		KindVersion:      "v0.26.0",
 		NodeImageVersion: "v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30",


### PR DESCRIPTION
### What does this PR do?

update kind cluster configuration to handle new containerd configuration.

new containerd configuration provided with the image `kindest/node:v1..35` requires new configuration to 
override the registry.

depending on the version of kubernetes requested for the test use the appropriate configuration.

### Motivation

run our test suite on kubernetes v1.35

### Describe how you validated your changes

the below link to a CII run that fores the use of kube v1.35 ran successfully 

[here is the link to the CI run](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1345470324)

### Additional Notes

a next task will be to improve this to make it cleaner the way we handle configuration produced for each test.
