### PR TITLE
[FA] Fix instance id reported

### DIFF
--- a/pkg/jmxfetch/scheduler.go
+++ b/pkg/jmxfetch/scheduler.go
@@ -37,7 +37,7 @@ func (s *JmxScheduler) Schedule(configs []integration.Config) {
 
 		digest := config.Digest()
 
-		for _, instance := range config.Instances {
+		for instanceIndex, instance := range config.Instances {
 			if !check.IsJMXInstance(config.Name, instance, config.InitConfig) {
 				continue
 			}
@@ -51,7 +51,7 @@ func (s *JmxScheduler) Schedule(configs []integration.Config) {
 				MetricConfig:  config.MetricConfig,
 				Name:          config.Name,
 				Provider:      config.Provider,
-				Source:        config.Source,
+				Source:        fmt.Sprintf("%s[%d]", config.Source, instanceIndex),
 			}
 
 			id := fmt.Sprintf("%v_%x", c.Name, c.IntDigest())


### PR DESCRIPTION
This pull request makes a targeted improvement to the way JMX instance sources are labeled in the `JmxScheduler`. The main change is to ensure that each JMX instance's `Source` field is uniquely identified by appending its index, which helps distinguish between multiple instances from the same config.

Key change:

- The `Source` field for each JMX instance in the scheduler is now set to include the instance index (e.g., `source[0]`, `source[1]`), making it easier to differentiate between instances from the same integration config.

Follow the same pattern as other integrations