### PR TITLE
[DJM - databricks] avoid obfuscation on job correlation ids

### DIFF
--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -89,6 +89,7 @@ type DatadogConfig struct {
 	GPUCheck             GPUCheckConfig             `yaml:"gpu,omitempty"`
 	SBOM                 SBOMConfig                 `yaml:"sbom,omitempty"`
 	InfrastructureMode   string                     `yaml:"infrastructure_mode,omitempty"`
+	Obfuscation          ObfuscationConfig          `yaml:"obfuscation,omitempty"`
 }
 
 // GPUCheckConfig represents the configuration for the GPU check

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -89,7 +89,7 @@ type DatadogConfig struct {
 	GPUCheck             GPUCheckConfig             `yaml:"gpu,omitempty"`
 	SBOM                 SBOMConfig                 `yaml:"sbom,omitempty"`
 	InfrastructureMode   string                     `yaml:"infrastructure_mode,omitempty"`
-	Obfuscation          ObfuscationConfig          `yaml:"obfuscation,omitempty"`
+	APMConfig            DatadogAPMConfig           `yaml:"apm_config,omitempty"`
 }
 
 // GPUCheckConfig represents the configuration for the GPU check
@@ -232,6 +232,9 @@ type LogProcessingRule struct {
 	Type    string `yaml:"type" json:"type"`
 	Name    string `yaml:"name" json:"name"`
 	Pattern string `yaml:"pattern" json:"pattern"`
+}
+type DatadogAPMConfig struct {
+	ObfuscationConfig *ObfuscationConfig `yaml:"obfuscation_config,omitempty"`
 }
 
 // ObfuscationConfig represents the configuration for obfuscation

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -233,6 +233,16 @@ type LogProcessingRule struct {
 	Pattern string `yaml:"pattern" json:"pattern"`
 }
 
+// ObfuscationConfig represents the configuration for obfuscation
+type ObfuscationConfig struct {
+	CreditCard CreditCardObfuscationConfig `yaml:"credit_card,omitempty"`
+}
+
+// CreditCardObfuscationConfig represents the configuration for credit card obfuscation
+type CreditCardObfuscationConfig struct {
+	KeepValues []string `yaml:"keep_values,omitempty"`
+}
+
 // ApplicationMonitoringConfig represents the configuration for the application monitoring
 type ApplicationMonitoringConfig struct {
 	Default APMConfigurationDefault `yaml:"apm_configuration_default,omitempty"`

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -236,7 +236,7 @@ type LogProcessingRule struct {
 
 // ObfuscationConfig represents the configuration for obfuscation
 type ObfuscationConfig struct {
-	CreditCard CreditCardObfuscationConfig `yaml:"credit_card,omitempty"`
+	CreditCards CreditCardObfuscationConfig `yaml:"credit_cards,omitempty"`
 }
 
 // CreditCardObfuscationConfig represents the configuration for credit card obfuscation

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -234,7 +234,7 @@ type LogProcessingRule struct {
 	Pattern string `yaml:"pattern" json:"pattern"`
 }
 type DatadogAPMConfig struct {
-	ObfuscationConfig *ObfuscationConfig `yaml:"obfuscation_config,omitempty"`
+	ObfuscationConfig *ObfuscationConfig `yaml:"obfuscation,omitempty"`
 }
 
 // ObfuscationConfig represents the configuration for obfuscation

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -233,6 +233,8 @@ type LogProcessingRule struct {
 	Name    string `yaml:"name" json:"name"`
 	Pattern string `yaml:"pattern" json:"pattern"`
 }
+
+// DatadogAPMConfig represents the config for the APM agent
 type DatadogAPMConfig struct {
 	ObfuscationConfig *ObfuscationConfig `yaml:"obfuscation,omitempty"`
 }

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -241,6 +241,7 @@ type ObfuscationConfig struct {
 
 // CreditCardObfuscationConfig represents the configuration for credit card obfuscation
 type CreditCardObfuscationConfig struct {
+	Enabled    *bool    `yaml:"enabled,omitempty"`
 	KeepValues []string `yaml:"keep_values,omitempty"`
 }
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -157,7 +157,7 @@ func SetupDatabricks(s *common.Setup) error {
 	// Disable credit card obfuscation for Databricks to avoid issues with job and run ids
 	s.Config.DatadogYAML.APMConfig.ObfuscationConfig = &config.ObfuscationConfig{
 		CreditCards: config.CreditCardObfuscationConfig{
-			KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime"},
+			KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime", "config.spark_databricks_job_parentRunId"},
 		},
 	}
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -155,7 +155,7 @@ func SetupDatabricks(s *common.Setup) error {
 	}
 
 	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCards: config.CreditCardObfuscationConfig{
-		KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime"},
+		KeepValues: []string{"meta.databricks_job_id", "meta.databricks_job_run_id", "meta.databricks_task_run_id", "meta.config.spark_app_startTime"},
 	}}
 
 	setupCommonHostTags(s)

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -154,7 +154,7 @@ func SetupDatabricks(s *common.Setup) error {
 		Default: tracerConfigDatabricks,
 	}
 
-	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCard: config.CreditCardObfuscationConfig{
+	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCards: config.CreditCardObfuscationConfig{
 		KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime"},
 	}}
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -157,7 +157,7 @@ func SetupDatabricks(s *common.Setup) error {
 	// Disable credit card obfuscation for Databricks to avoid issues with job and run ids
 	s.Config.DatadogYAML.APMConfig.ObfuscationConfig = &config.ObfuscationConfig{
 		CreditCards: config.CreditCardObfuscationConfig{
-			Enabled: config.BoolToPtr(false),
+			KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime"},
 		},
 	}
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -155,7 +155,8 @@ func SetupDatabricks(s *common.Setup) error {
 	}
 
 	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCards: config.CreditCardObfuscationConfig{
-		KeepValues: []string{"meta.databricks_job_id", "meta.databricks_job_run_id", "meta.databricks_task_run_id", "meta.config.spark_app_startTime"},
+		Enabled: config.BoolToPtr(false),
+		//KeepValues: []string{"meta.databricks_job_id", "meta.databricks_job_run_id", "meta.databricks_task_run_id", "config.spark_app_startTime"},
 	}}
 
 	setupCommonHostTags(s)

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -154,6 +154,10 @@ func SetupDatabricks(s *common.Setup) error {
 		Default: tracerConfigDatabricks,
 	}
 
+	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCard: config.CreditCardObfuscationConfig{
+		KeepValues: []string{"databricks_job_id", "databricks_job_run_id", "databricks_task_run_id", "config.spark_app_startTime"},
+	}}
+
 	setupCommonHostTags(s)
 	installMethod := "manual"
 	if os.Getenv("DD_DJM_INIT_IS_MANAGED_INSTALL") == "true" {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -154,10 +154,12 @@ func SetupDatabricks(s *common.Setup) error {
 		Default: tracerConfigDatabricks,
 	}
 
-	s.Config.DatadogYAML.Obfuscation = config.ObfuscationConfig{CreditCards: config.CreditCardObfuscationConfig{
-		Enabled: config.BoolToPtr(false),
-		//KeepValues: []string{"meta.databricks_job_id", "meta.databricks_job_run_id", "meta.databricks_task_run_id", "config.spark_app_startTime"},
-	}}
+	// Disable credit card obfuscation for Databricks to avoid issues with job and run ids
+	s.Config.DatadogYAML.APMConfig.ObfuscationConfig = &config.ObfuscationConfig{
+		CreditCards: config.CreditCardObfuscationConfig{
+			Enabled: config.BoolToPtr(false),
+		},
+	}
 
 	setupCommonHostTags(s)
 	installMethod := "manual"


### PR DESCRIPTION
### What does this PR do?

Disable obfuscation for these Databricks attributes in the Databricks flavor of the DJM Installer:
-"databricks_job_id", 
- "databricks_job_run_id", 
- "databricks_task_run_id", 
- "config.spark_app_startTime",
- "config.spark_databricks_job_parentRunId"

### Motivation

These ids are interpreted as credit card number and obfuscated with `?` on the UI, breaking metrics to Databricks job traces correlation.

### Describe how you validated your changes


### Additional Notes
