### PR TITLE
APM: Add DJM tags to CC Obfuscator skip list

### DIFF
--- a/pkg/obfuscate/credit_cards.go
+++ b/pkg/obfuscate/credit_cards.go
@@ -28,6 +28,7 @@ func newCCObfuscator(config *CreditCardsConfig) *creditCard {
 
 // ObfuscateCreditCardNumber obfuscates any "credit card like" numbers in value for keys not in the allow-list
 func (o *Obfuscator) ObfuscateCreditCardNumber(key, val string) string {
+	// These tags are known to not be credit card numbers
 	switch key {
 	case "_sample_rate",
 		"_sampling_priority_v1",
@@ -56,8 +57,12 @@ func (o *Obfuscator) ObfuscateCreditCardNumber(key, val string) string {
 		"service.name",
 		"service",
 		"sql.query",
-		"version":
-		// these tags are known to not be credit card numbers
+		"version",
+		// Data Job Monitoring tags - these values are frequently similar to credit card numbers
+		"databricks_job_id",
+		"databricks_job_run_id",
+		"databricks_task_run_id",
+		"config.spark_app_startTime":
 		return val
 	}
 	if strings.HasPrefix(key, "_") {

--- a/pkg/obfuscate/credit_cards.go
+++ b/pkg/obfuscate/credit_cards.go
@@ -62,7 +62,8 @@ func (o *Obfuscator) ObfuscateCreditCardNumber(key, val string) string {
 		"databricks_job_id",
 		"databricks_job_run_id",
 		"databricks_task_run_id",
-		"config.spark_app_startTime":
+		"config.spark_app_startTime",
+		"config.spark_databricks_job_parentRunId":
 		return val
 	}
 	if strings.HasPrefix(key, "_") {

--- a/releasenotes/notes/more-cc-skip-keys-71bc99cbee2cf173.yaml
+++ b/releasenotes/notes/more-cc-skip-keys-71bc99cbee2cf173.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Add tags `databricks_job_id`, `databricks_job_run_id`, `databricks_task_run_id`, `config.spark_app_startTime`
+    to the default list of tags that are known to not be credit card numbers so they are skipped by the credit card obfuscator.

--- a/releasenotes/notes/more-cc-skip-keys-71bc99cbee2cf173.yaml
+++ b/releasenotes/notes/more-cc-skip-keys-71bc99cbee2cf173.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    APM: Add tags `databricks_job_id`, `databricks_job_run_id`, `databricks_task_run_id`, `config.spark_app_startTime`
+    APM: Add tags `databricks_job_id`, `databricks_job_run_id`, `databricks_task_run_id`, `config.spark_app_startTime`, `config.spark_databricks_job_parentRunId`
     to the default list of tags that are known to not be credit card numbers so they are skipped by the credit card obfuscator.


### PR DESCRIPTION
### What does this PR do?
Adds `databricks_job_id`, `databricks_job_run_id`, `databricks_task_run_id`, `config.spark_app_startTime` to the static list of tags that should be skipped by the credit card obfuscator.

### Motivation
These tags are attached by DJM automatically and very frequently have IDs that might trigger a false positive from the CC Obfuscator, thereby replacing these useful fields with `?`.

### Describe how you validated your changes
Existing unit tests are sufficient here

### Additional Notes
