### PR TITLE
Add Check Metrics + Container Lifecycle Events 

### DIFF
--- a/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer.go
+++ b/comp/aggregator/demultiplexer/demultiplexerimpl/demultiplexer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	orchestratorforwarder "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator"
 	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -46,6 +47,7 @@ type dependencies struct {
 	Compressor             compression.Component
 	Tagger                 tagger.Component
 	Hostname               hostnameinterface.Component
+	Observer               observer.Component `optional:"true"`
 
 	Params Params
 }
@@ -85,6 +87,8 @@ func newDemultiplexer(deps dependencies) (provides, error) {
 		deps.Tagger,
 		hostnameDetected,
 	)
+	// Wire observer via setter to avoid changing the constructor signature (for POC)
+	agentDemultiplexer.SetObserver(deps.Observer)
 	demultiplexer := demultiplexer{
 		AgentDemultiplexer: agentDemultiplexer,
 	}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -148,12 +148,12 @@ type AnomalyProcessor interface {
 	Flush() []ReportOutput
 }
 
-// MarkerReceiver is an optional interface for processors that accept discrete event markers.
+// EventSignalReceiver is an optional interface for processors that accept discrete event signals.
 // Events like container OOMs, restarts, and lifecycle transitions are routed here
 // instead of being processed as logs (no metric derivation).
-type MarkerReceiver interface {
-	// AddMarker adds a discrete event marker for correlation context.
-	AddMarker(marker Marker)
+type EventSignalReceiver interface {
+	// AddEventSignal adds a discrete event signal for correlation context.
+	AddEventSignal(signal EventSignal)
 }
 
 // Reporter receives reports and displays or delivers them.
@@ -173,21 +173,21 @@ type CorrelationState interface {
 
 // ActiveCorrelation represents a detected correlation pattern.
 type ActiveCorrelation struct {
-	Pattern     string          // pattern name, e.g. "kernel_bottleneck"
-	Title       string          // display title, e.g. "Correlated: Kernel network bottleneck"
-	Signals     []string        // contributing signal sources
-	Anomalies   []AnomalyOutput // the actual anomalies that triggered this correlation
-	Markers     []Marker        // discrete event markers relevant to this correlation
-	FirstSeen   int64           // when pattern first matched (unix seconds, from data)
-	LastUpdated int64           // most recent contributing signal (unix seconds, from data)
+	Pattern      string          // pattern name, e.g. "kernel_bottleneck"
+	Title        string          // display title, e.g. "Correlated: Kernel network bottleneck"
+	Signals      []string        // contributing signal sources
+	Anomalies    []AnomalyOutput // the actual anomalies that triggered this correlation
+	EventSignals []EventSignal   // discrete event signals relevant to this correlation
+	FirstSeen    int64           // when pattern first matched (unix seconds, from data)
+	LastUpdated  int64           // most recent contributing signal (unix seconds, from data)
 }
 
-// Marker represents a discrete event used as correlation evidence or annotation.
-// Unlike anomalies (which are detected from time series analysis), markers are
+// EventSignal represents a discrete event used as correlation evidence or annotation.
+// Unlike anomalies (which are detected from time series analysis), event signals are
 // explicit events such as container OOMs, restarts, or lifecycle transitions.
 // They are not analyzed with CUSUM but serve as context for understanding correlations.
-type Marker struct {
-	Source    string   // event source, e.g., "container.oom", "container.restart"
+type EventSignal struct {
+	Source    string   // event source, e.g., "container_oom", "container_restart", "agent_startup"
 	Timestamp int64    // when the event occurred (unix seconds)
 	Tags      []string // event tags for filtering/grouping
 	Message   string   // optional human-readable description

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -10,7 +10,6 @@
 // passed to data pipelines without adding significant overhead.
 package observer
 
-
 // team: agent-metric-pipelines
 
 // Component is the central observer that receives data via handles.
@@ -170,8 +169,20 @@ type ActiveCorrelation struct {
 	Title       string          // display title, e.g. "Correlated: Kernel network bottleneck"
 	Signals     []string        // contributing signal sources
 	Anomalies   []AnomalyOutput // the actual anomalies that triggered this correlation
+	Markers     []Marker        // discrete event markers relevant to this correlation
 	FirstSeen   int64           // when pattern first matched (unix seconds, from data)
 	LastUpdated int64           // most recent contributing signal (unix seconds, from data)
+}
+
+// Marker represents a discrete event used as correlation evidence or annotation.
+// Unlike anomalies (which are detected from time series analysis), markers are
+// explicit events such as container OOMs, restarts, or lifecycle transitions.
+// They are not analyzed with CUSUM but serve as context for understanding correlations.
+type Marker struct {
+	Source    string   // event source, e.g., "container.oom", "container.restart"
+	Timestamp int64    // when the event occurred (unix seconds)
+	Tags      []string // event tags for filtering/grouping
+	Message   string   // optional human-readable description
 }
 
 // RawAnomalyState provides read access to raw anomalies before correlation processing.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -148,6 +148,14 @@ type AnomalyProcessor interface {
 	Flush() []ReportOutput
 }
 
+// MarkerReceiver is an optional interface for processors that accept discrete event markers.
+// Events like container OOMs, restarts, and lifecycle transitions are routed here
+// instead of being processed as logs (no metric derivation).
+type MarkerReceiver interface {
+	// AddMarker adds a discrete event marker for correlation context.
+	AddMarker(marker Marker)
+}
+
 // Reporter receives reports and displays or delivers them.
 type Reporter interface {
 	// Name returns the reporter name for debugging.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -74,8 +74,18 @@ func NewComponent(deps Requires) Provides {
 	obs := &observerImpl{
 		logProcessors: []observerdef.LogProcessor{
 			&LogTimeSeriesAnalysis{
-				// Keep defaults minimal; future steps add filtering + caps.
 				MaxEvalBytes: 4096,
+				// Exclude metadata fields that shouldn't be metrics.
+				// These are common timestamp/ID fields that appear in event JSON.
+				ExcludeFields: map[string]struct{}{
+					"timestamp": {}, // event.Event.Ts serializes as "timestamp"
+					"ts":        {}, // alternate timestamp field name
+					"time":      {},
+					"pid":       {},
+					"ppid":      {},
+					"uid":       {},
+					"gid":       {},
+				},
 			},
 			&BadDetector{},
 			&ConnectionErrorExtractor{},
@@ -89,8 +99,9 @@ func NewComponent(deps Requires) Provides {
 		reporters: []observerdef.Reporter{
 			reporter,
 		},
-		storage: newTimeSeriesStorage(),
-		obsCh:   make(chan observation, 1000),
+		storage:   newTimeSeriesStorage(),
+		obsCh:     make(chan observation, 1000),
+		maxEvents: 1000, // Keep last 1000 events for debugging
 	}
 	go obs.run()
 
@@ -98,6 +109,7 @@ func NewComponent(deps Requires) Provides {
 
 	// Start periodic metric dump if configured
 	dumpPath := cfg.GetString("observer.debug_dump_path")
+	eventsDumpPath := cfg.GetString("observer.debug_events_dump_path")
 	dumpInterval := cfg.GetDuration("observer.debug_dump_interval")
 	if dumpPath != "" && dumpInterval > 0 {
 		go func() {
@@ -108,6 +120,14 @@ func NewComponent(deps Requires) Provides {
 					fmt.Fprintf(os.Stderr, "[observer] dump error: %v\n", err)
 				} else {
 					fmt.Printf("[observer] dumped metrics to %s\n", dumpPath)
+				}
+				// Also dump events if configured
+				if eventsDumpPath != "" {
+					if err := obs.DumpEvents(eventsDumpPath); err != nil {
+						fmt.Fprintf(os.Stderr, "[observer] events dump error: %v\n", err)
+					} else {
+						fmt.Printf("[observer] dumped events to %s\n", eventsDumpPath)
+					}
 				}
 			}
 		}()
@@ -212,6 +232,10 @@ type observerImpl struct {
 	reporters         []observerdef.Reporter
 	storage           *timeSeriesStorage
 	obsCh             chan observation
+	// eventBuffer stores recent events (markers) for debugging/dumping.
+	// Ring buffer with maxEvents capacity.
+	eventBuffer []observerdef.Marker
+	maxEvents   int
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.AnomalyOutput
@@ -253,6 +277,13 @@ func (o *observerImpl) processMetric(source string, m *metricObs) {
 
 // processLog handles a log observation.
 func (o *observerImpl) processLog(source string, l *logObs) {
+	// Events (from check-events source) are routed as markers for correlation,
+	// not processed through log processors for metric derivation.
+	if source == "check-events" {
+		o.routeEventAsMarker(l)
+		return
+	}
+
 	// Create a view for processors
 	view := &logView{obs: l}
 
@@ -277,6 +308,43 @@ func (o *observerImpl) processLog(source string, l *logObs) {
 	}
 
 	o.flushAndReport()
+}
+
+// routeEventAsMarker converts an event log observation to a Marker and sends it
+// to all MarkerReceivers (typically the correlator). Events are used as correlation
+// context, not as inputs for metric derivation or anomaly detection.
+func (o *observerImpl) routeEventAsMarker(l *logObs) {
+	// Extract event type from tags if available (e.g., "event_type:container.oom")
+	eventSource := "event"
+	for _, tag := range l.tags {
+		if strings.HasPrefix(tag, "event_type:") {
+			eventSource = strings.TrimPrefix(tag, "event_type:")
+			break
+		}
+	}
+
+	marker := observerdef.Marker{
+		Source:    eventSource,
+		Timestamp: l.timestamp,
+		Tags:      l.tags,
+		Message:   string(l.content),
+	}
+
+	// Store in event buffer (ring buffer)
+	if o.maxEvents > 0 {
+		if len(o.eventBuffer) >= o.maxEvents {
+			// Shift out oldest event
+			o.eventBuffer = o.eventBuffer[1:]
+		}
+		o.eventBuffer = append(o.eventBuffer, marker)
+	}
+
+	// Send to all anomaly processors that implement MarkerReceiver
+	for _, proc := range o.anomalyProcessors {
+		if receiver, ok := proc.(observerdef.MarkerReceiver); ok {
+			receiver.AddMarker(marker)
+		}
+	}
 }
 
 // runTSAnalyses runs all time series analyses on a series with the given aggregation.
@@ -402,6 +470,36 @@ func (o *observerImpl) DumpMetrics(path string) error {
 	// For simplicity, just dump directly (storage access is single-threaded from run loop,
 	// but this is a debug tool so approximate snapshot is fine)
 	return o.storage.DumpToFile(path)
+}
+
+// DumpEvents writes all buffered events (markers) to the specified file as JSON.
+// Events are container lifecycle events (OOM, restart, etc.) used for correlation.
+func (o *observerImpl) DumpEvents(path string) error {
+	type dumpEvent struct {
+		Source    string   `json:"source"`
+		Timestamp int64    `json:"timestamp"`
+		Tags      []string `json:"tags,omitempty"`
+		Message   string   `json:"message"`
+	}
+
+	events := make([]dumpEvent, len(o.eventBuffer))
+	for i, m := range o.eventBuffer {
+		events[i] = dumpEvent{
+			Source:    m.Source,
+			Timestamp: m.Timestamp,
+			Tags:      m.Tags,
+			Message:   m.Message,
+		}
+	}
+
+	data, err := json.MarshalIndent(events, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal events: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write events file: %w", err)
+	}
+	return nil
 }
 
 // handle is the lightweight observation interface passed to other components.

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
@@ -218,6 +218,7 @@ func (a *Agent) SetupPipeline(
 		a.compression,
 		a.config.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
+		nil,   // observer handle (not integrated with otel-agent yet)
 	)
 
 	a.destinationsCtx = destinationsCtx

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -272,6 +273,14 @@ type BufferedAggregator struct {
 	globalTags                  func(types.TagCardinality) ([]string, error) // This function gets global tags from the tagger when host tags are not available
 	tagger                      tagger.Component
 	flushAndSerializeInParallel FlushAndSerializeInParallel
+
+	// observerHandle is an optional handle used to mirror check metric samples into the observer.
+	// It is set by the demultiplexer at startup and then copied into newly created CheckSamplers.
+	observerHandle observer.Handle
+	// observerEventSink is an optional callback invoked for every event received by the aggregator.
+	// It is intended for best-effort local observability (e.g., forwarding container lifecycle
+	// events into the observer for correlation) without changing the canonical event pipeline.
+	observerEventSink func(event.Event)
 
 	// use this chan to trigger a filterList reconfiguration
 	filterListChan  chan utilstrings.Matcher
@@ -541,6 +550,23 @@ func (agg *BufferedAggregator) addEvent(e event.Event) {
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)
+
+	// Best-effort: also forward events to an optional local sink (e.g., observer).
+	if agg.observerEventSink != nil {
+		agg.observerEventSink(e)
+	}
+}
+
+// SetObserverEventSink registers a best-effort callback invoked for each event received by the aggregator.
+// Passing nil disables forwarding.
+func (agg *BufferedAggregator) SetObserverEventSink(sink func(event.Event)) {
+	agg.observerEventSink = sink
+}
+
+// SetObserverHandle sets the observer handle for mirroring check metrics.
+// The handle will be passed to newly created CheckSamplers.
+func (agg *BufferedAggregator) SetObserverHandle(h observer.Handle) {
+	agg.observerHandle = h
 }
 
 // GetSeriesAndSketches grabs all the series & sketches from the queue and clears the queue
@@ -1014,7 +1040,7 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		log.Debugf("Sampler with ID '%s' has already been registered, will use existing sampler", id)
 		return
 	}
-	agg.checkSamplers[id] = newCheckSampler(
+	cs := newCheckSampler(
 		pkgconfigsetup.Datadog().GetInt("check_sampler_bucket_commits_count_expiry"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_expire_metrics"),
 		pkgconfigsetup.Datadog().GetBool("check_sampler_context_metrics"),
@@ -1024,4 +1050,9 @@ func (agg *BufferedAggregator) handleRegisterSampler(id checkid.ID) {
 		id,
 		agg.tagger,
 	)
+	// Wire observer handle if configured (set via SetObserverHandle on the aggregator)
+	if agg.observerHandle != nil {
+		cs.SetObserverHandle(agg.observerHandle)
+	}
+	agg.checkSamplers[id] = cs
 }

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/tags"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/internal/util"
@@ -35,6 +36,7 @@ type CheckSampler struct {
 	contextResolverMetrics bool
 	logThrottling          util.SimpleThrottler
 	allowSketchBucketReset bool
+	observerHandle         observer.Handle
 }
 
 // newCheckSampler returns a newly initialized CheckSampler
@@ -62,8 +64,22 @@ func newCheckSampler(
 	}
 }
 
+// SetObserverHandle sets the observer handle for mirroring check samples.
+// This should be called after construction if observer integration is enabled.
+func (cs *CheckSampler) SetObserverHandle(h observer.Handle) {
+	cs.observerHandle = h
+}
+
 func (cs *CheckSampler) addSample(metricSample *metrics.MetricSample, tagFilterList *TagMatcher) {
 	contextKey := cs.contextResolver.trackContext(metricSample, tagFilterList)
+
+	// Best-effort: if an observer handle is configured, mirror the raw check sample
+	// into the observer. This allows local correlation/anomaly detection using the
+	// exact same samples that the aggregator will process and forward upstream.
+	if cs.observerHandle != nil {
+		cs.observerHandle.ObserveMetric(metricSample)
+	}
+
 	if metricSample.Mtype == metrics.DistributionType {
 		cs.sketchMap.insert(int64(metricSample.Timestamp), contextKey, metricSample.Value, metricSample.SampleRate)
 		return

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -52,6 +52,7 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
+		nil,   // observer handle
 	)
 	pipelineProvider.Start()
 

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -233,6 +233,7 @@ func TestProviderConfigurations(t *testing.T) {
 				compression,
 				tc.legacyMode,
 				tc.serverless,
+				nil, // observer handle
 			)
 			require.NotNil(t, providerImpl)
 
@@ -301,6 +302,7 @@ func TestPipelineChannelDistribution(t *testing.T) {
 				compression,
 				false, // legacy mode
 				false, // serverless
+				nil,   // observer handle
 			)
 
 			require.NotNil(t, providerImpl)

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -61,6 +61,7 @@ func newReporter(hostname string, stopper startstop.Stopper, sourceName, sourceT
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),
 		false, // serverless
+		nil,   // observer handle (not integrated with security-agent yet)
 	)
 	pipelineProvider.Start()
 	stopper.Add(pipelineProvider)


### PR DESCRIPTION
### What does this PR do?
Integrates the observer component with the agent's aggregator to enable anomaly detection on check metrics and correlation with lifecycle events

- Check Metrics Mirroring: Mirrors raw check samples via `CheckSampler.ObserveMetric()` to `check-metrics` handle for local CUSUM analysis
- Event-as-Signal Routing: Routes events from `check-events` handle as correlation signals (not metrics) via new `EventSignalReceiver` interface
- Observer-Aggregator Wiring: Adds `SetObserver()` in demultiplexer to wire both handles
- Event Buffer & Debug Dump: Adds ring buffer (1000 events) and `DumpEvents()` with config `observer.debug_events_dump_path` for debugging purposes
- Signal Integration: Extends `CrossSignalCorrelator` to include EventSignals in correlation output
- Log Processing Fix: Excludes metadata fields (timestamp, pid, etc.) from becoming metrics

### Motivation
Enable correlation between time-series anomalies detected on check metrics (via CUSUM) and discrete lifecycle events (container OOM, restarts) for better root cause analysis. Metrics feed anomaly detection; events serve as context/evidence.

### Describe how you validated your changes
built + ran locally, inspected for metrics and event signals: 
```
// EventSignals
[
  {
    "source": "agent_startup",
    "timestamp": 1768250745,
    "tags": [
      "observer_signal:event",
      "observer_ts:1768250745",
      "event_type:agent_startup"
    ],
    "message": "{\"msg_title\":\"\",\"msg_text\":\"Version 7.76.0-devel+git.245.83d88eb\",\"timestamp\":1768250745,\"host\":\"dev-agent\",\"source_type_name\":\"System
\",\"event_type\":\"Agent Startup\"}"
  }
]


// metrics 
{
    "namespace": "check-metrics",
    "name": "system.fs.inodes.total",
    "tags": [
      "device:/System/Volumes/VM",
      "device_name:disk3s6"
    ],
    "points": [
      {
        "ts": 1768250757,
        "sum": 469267640,
        "count": 1,
        "min": 469267640,
        "max": 469267640
      },
      {
        "ts": 1768250772,
        "sum": 446530920,
        "count": 1,
        "min": 446530920,
        "max": 446530920
      },
      {
        "ts": 1768250787,
        "sum": 425918960,
        "count": 1,
        "min": 425918960,
        "max": 425918960
      },
....
{
    "namespace": "check-metrics",
    "name": "system.mem.used",
    "tags": null,
    "points": [
      {
        "ts": 1768250769,
        "sum": 61183.4375,
        "count": 1,
        "min": 61183.4375,
        "max": 61183.4375
      },
      {
        "ts": 1768250784,
        "sum": 60934.625,
        "count": 1,
        "min": 60934.625,
        "max": 60934.625
      },
      {
        "ts": 1768250799,
        "sum": 60987.515625,
        "count": 1,
        "min": 60987.515625,
        "max": 60987.515625
      },
      {
        "ts": 1768250814,
        "sum": 60189.421875,
        "count": 1,
        "min": 60189.421875,
        "max": 60189.421875
      },

``` 
### Additional Notes
