### PR TITLE
Optional tags can remove expected tags in assertTags

### DIFF
--- a/test/new-e2e/tests/containers/utils.go
+++ b/test/new-e2e/tests/containers/utils.go
@@ -15,8 +15,22 @@ import (
 )
 
 func assertTags(actualTags []string, expectedTags []*regexp.Regexp, optionalTags []*regexp.Regexp, acceptUnexpectedTags bool) error {
-	missingTags := make([]*regexp.Regexp, len(expectedTags))
-	copy(missingTags, expectedTags)
+	missingTags := []*regexp.Regexp{}
+
+	// Remove expected tags that are also optional
+	for _, expectedTag := range expectedTags {
+		isOptional := false
+		for _, optionalTag := range optionalTags {
+			if expectedTag.String() == optionalTag.String() {
+				isOptional = true
+				break
+			}
+		}
+		if !isOptional {
+			missingTags = append(missingTags, expectedTag)
+		}
+	}
+
 	unexpectedTags := []string{}
 
 	for _, actualTag := range actualTags {

--- a/test/new-e2e/tests/containers/utils_test.go
+++ b/test/new-e2e/tests/containers/utils_test.go
@@ -118,6 +118,20 @@ func TestAssertTags(t *testing.T) {
 			},
 			expectedOutput: "",
 		},
+		{
+			name: "Expected tag that is also optional",
+			actualTags: []string{
+				"foo:foo",
+			},
+			expectedTags: []*regexp.Regexp{
+				regexp.MustCompile(`^foo:foo$`),
+				regexp.MustCompile(`^bar:bar$`),
+			},
+			optionalTags: []*regexp.Regexp{
+				regexp.MustCompile(`^bar:bar$`), // allow us to be missing bar:bar
+			},
+			expectedOutput: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?
This PR allows users to remove tags from `expectedTags` by adding the tag to the `optionalTags` list. So tags that appear in both list should be treated as optional (i.e., may be missing from `actualTags`). Tags that only appear in `expectedTags` must appear in `actualTags`. And then when `acceptUnexpectedTags=false`, we retain the original behavior that we allow some `optionalTags` to show up. 

### Motivation
We want to mark some tags as optional in the Kubernetes test suite depending on the environment we are running in, but we don't want to add a bunch of conditionals changing the tag list for each test. This solution seems to be the easiest way to later be able to say "in general, we want these tags, but if we're running in OpenShift, don't worry about these specific tags."

### Describe how you validated your changes
This should be a no-op right now. I've added a unit test to test the behavior of `assertTags`, and the CI should also verify.

### Additional Notes
