### PR TITLE
logs(file): add optional recursive glob

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -548,7 +548,7 @@ require (
 	github.com/bhmj/xpression v0.9.1 // indirect
 	github.com/bitnami/go-version v0.0.0-20231130084017-bb00604d650c // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 // indirect
 	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -384,7 +384,8 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	if resp.StatusCode == http.StatusBadRequest ||
 		resp.StatusCode == http.StatusUnauthorized ||
 		resp.StatusCode == http.StatusForbidden ||
-		resp.StatusCode == http.StatusRequestEntityTooLarge {
+		resp.StatusCode == http.StatusRequestEntityTooLarge ||
+		resp.StatusCode == http.StatusUnprocessableEntity {
 		// the logs-agent is likely to be misconfigured,
 		// the URL or the API key may be wrong.
 		tlmDropped.Inc()

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -384,8 +384,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	if resp.StatusCode == http.StatusBadRequest ||
 		resp.StatusCode == http.StatusUnauthorized ||
 		resp.StatusCode == http.StatusForbidden ||
-		resp.StatusCode == http.StatusRequestEntityTooLarge ||
-		resp.StatusCode == http.StatusUnprocessableEntity {
+		resp.StatusCode == http.StatusRequestEntityTooLarge {
 		// the logs-agent is likely to be misconfigured,
 		// the URL or the API key may be wrong.
 		tlmDropped.Inc()

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
@@ -24,6 +24,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // OpenFilesLimitWarningType is the key of the message generated when too many
@@ -290,7 +292,15 @@ func (p *FileProvider) CollectFiles(source *sources.LogSource) ([]*tailer.File, 
 // filesMatchingSource returns all the files matching the source path pattern.
 func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer.File, error) {
 	pattern := source.Config.Path
-	paths, err := filepath.Glob(pattern)
+	recursiveGlobEnabled := pkgconfigsetup.Datadog().GetBool("logs_config.enable_recursive_glob")
+
+	var paths []string
+	var err error
+	if recursiveGlobEnabled && strings.Contains(pattern, "**") {
+		paths, err = doublestar.FilepathGlob(pattern)
+	} else {
+		paths, err = filepath.Glob(pattern)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("malformed pattern, could not find any file: %s", pattern)
 	}
@@ -301,7 +311,13 @@ func (p *FileProvider) filesMatchingSource(source *sources.LogSource) ([]*tailer
 
 	excludedPaths := make(map[string]int)
 	for _, excludePattern := range source.Config.ExcludePaths {
-		excludedGlob, err := filepath.Glob(excludePattern)
+		var excludedGlob []string
+		var err error
+		if recursiveGlobEnabled && strings.Contains(excludePattern, "**") {
+			excludedGlob, err = doublestar.FilepathGlob(excludePattern)
+		} else {
+			excludedGlob, err = filepath.Glob(excludePattern)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("malformed exclusion pattern: %s, %s", excludePattern, err)
 		}

--- a/pkg/logs/launchers/file/provider/file_provider.go
+++ b/pkg/logs/launchers/file/provider/file_provider.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
+	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
@@ -660,6 +661,55 @@ func TestApplyOrdering(t *testing.T) {
 	})
 }
 
+func TestCollectFiles_RecursiveGlobEnabled(t *testing.T) {
+	fs := newTempFs(t)
+	fs.mkDir("alpha")
+	fs.mkDir("alpha/beta")
+	fs.mkDir("gamma")
+	fs.createFile("root.log")
+	fs.createFile("alpha/beta/ab.log")
+	fs.createFile("gamma/g.log")
+
+	fileProvider := NewFileProvider(10, WildcardUseFileName)
+	source := sources.NewLogSource("recursive", &config.LogsConfig{
+		Type: config.FileType,
+		Path: fs.path("**/*.log"),
+	})
+	cfg := configmock.New(t)
+	cfg.Set("logs_config.enable_recursive_glob", true, configmodel.SourceCLI)
+	status.InitStatus(cfg, testutils.CreateSources([]*sources.LogSource{source}))
+	files, err := fileProvider.CollectFiles(source)
+	assert.NoError(t, err)
+	paths := make(map[string]bool)
+	for _, f := range files {
+		paths[f.Path] = true
+	}
+	assert.True(t, paths[fs.path("root.log")], "should match top-level file")
+	assert.True(t, paths[fs.path("alpha/beta/ab.log")], "should match nested file")
+	assert.True(t, paths[fs.path("gamma/g.log")], "should match nested file")
+}
+
+func TestCollectFiles_RecursiveGlobDisabled(t *testing.T) {
+	fs := newTempFs(t)
+	fs.mkDir("alpha")
+	fs.mkDir("alpha/beta")
+	fs.createFile("root.log")
+	fs.createFile("alpha/beta/ab.log")
+
+	fileProvider := NewFileProvider(10, WildcardUseFileName)
+	source := sources.NewLogSource("recursive-off", &config.LogsConfig{
+		Type: config.FileType,
+		Path: fs.path("**/*.log"),
+	})
+	cfg := configmock.New(t)
+	cfg.Set("logs_config.enable_recursive_glob", false, configmodel.SourceCLI)
+	status.InitStatus(cfg, testutils.CreateSources([]*sources.LogSource{source}))
+	files, err := fileProvider.CollectFiles(source)
+	// When recursive glob is disabled, a '**' pattern should not expand; expect an error and no matches.
+	assert.Error(t, err)
+	assert.Len(t, files, 0)
+}
+
 func TestContainerIDInContainerLogFile(t *testing.T) {
 	assert := assert.New(t)
 
@@ -748,4 +798,36 @@ func TestContainerPathsAreCorrectlyIgnored(t *testing.T) {
 	}
 	files := fileProvider.FilesToTail(context.Background(), true, sources, auditor.NewMockAuditor())
 	assert.Len(t, files, 2) // 1 file from k8s source, 1 file from regular file source.
+}
+
+func TestCollectFiles_RecursiveGlobWithExcludePaths(t *testing.T) {
+	fs := newTempFs(t)
+	fs.mkDir("alpha")
+	fs.mkDir("alpha/beta")
+	fs.mkDir("gamma")
+	fs.createFile("root.log")
+	fs.createFile("alpha/beta/ab.log")
+	fs.createFile("gamma/g.log")
+
+	fileProvider := NewFileProvider(10, WildcardUseFileName)
+	source := sources.NewLogSource("recursive-exclude", &config.LogsConfig{
+		Type:         config.FileType,
+		Path:         fs.path("**/*.log"),
+		ExcludePaths: []string{fs.path("alpha/**/*.log")},
+	})
+	cfg := configmock.New(t)
+	cfg.Set("logs_config.enable_recursive_glob", true, configmodel.SourceCLI)
+	status.InitStatus(cfg, testutils.CreateSources([]*sources.LogSource{source}))
+
+	files, err := fileProvider.CollectFiles(source)
+	assert.NoError(t, err)
+	paths := make(map[string]bool)
+	for _, f := range files {
+		paths[f.Path] = true
+	}
+	// Included
+	assert.True(t, paths[fs.path("root.log")], "root should be included")
+	assert.True(t, paths[fs.path("gamma/g.log")], "gamma should be included")
+	// Excluded by pattern
+	assert.False(t, paths[fs.path("alpha/beta/ab.log")], "alpha subtree should be excluded by ExcludePaths")
 }

--- a/pkg/logs/launchers/file/provider/file_provider_test.go
+++ b/pkg/logs/launchers/file/provider/file_provider_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
-	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	tailer "github.com/DataDog/datadog-agent/pkg/logs/tailers/file"


### PR DESCRIPTION
### What does this PR do?

- Adds opt‑in support for recursive globs (**) in file log paths, using doublestar. Off by default; turn on with logs_config.enable_recursive_glob: true. Works in ExcludePaths too. [AGNTLOG-66](https://datadoghq.atlassian.net/browse/AGNTLOG-66)
- EDIT TAKEN OFF: Treats HTTP 422 as non‑retryable in the logs HTTP sender (same bucket as 400/401/403/413), so we drop instead of retry-looping. [AGNTLOG-119](https://datadoghq.atlassian.net/browse/AGNTLOG-119)

### Motivation
- Make it easier to match deep directory trees without a dozen patterns.
- Avoid pointless retries on 422s and surface them as proper drops.

### Describe how you validated your changes
- Built locally

dev/dist/datadog.yaml:
```
api_key: ********************
cmd_port: 5090
logs_enabled: true

logs_config:
  enable_recursive_glob: true
```

dev/dist/conf.d/logs.d/conf.yaml:
```
logs:
  - type: file
    path: /tmp/testlogs/**/*.log
    service: test
    source: test
```

agent status:
```
- Type: file
      Path: /tmp/testlogs/**/*.log
      Service: test
      Source: test
      Status: OK
        5 files tailed out of 5 files matching
      Inputs:
        /tmp/testlogs/gamma/g.log
        /tmp/testlogs/alpha/beta/ab.log
        /tmp/testlogs/alpha/a.log
        /tmp/testlogs/delta/epsilon/zeta/z.log
        /tmp/testlogs/root.log  
      Bytes Read: 31   
```

[Partlow
](https://app.datadoghq.com/logs?query=service%3Atest&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1768422982558&to_ts=1768426582558&live=true)

<img width="1512" height="738" alt="image" src="https://github.com/user-attachments/assets/c96b1314-ec4f-4edb-b4c0-798ade491acc" />

Other tests:
- Tested when flag enable_recursive_glob: true is missing (default is false), only tails root.log
- Exclude path /tmp/testlogs/**/*.log works, they are not returned
- Workaround still works as expected

```
logs:
  - type: file
    path: <PATH>/logs/*/*.log     # match 2 level depth   
    source: airflow
  - type: file
    path: <PATH>/logs/*/*/*.log    # match 3 level depth
    source: airflow

```
- Pattern but no matches -> nothing happens 

I’ve added tests in `pkg/logs/launchers/file/provider/file_provider_test.go`:

- `TestCollectFiles_RecursiveGlobEnabled`: '/.log' with logs_config.enable_recursive_glob=true → matches nested files.
- `TestCollectFiles_RecursiveGlobDisabled`: '/.log' with recursive glob disabled → returns error and zero matches.
- `TestCollectFiles_RecursiveGlobWithExcludePaths`: '/.log' with ExcludePaths ('alpha//.log') → excludes nested alpha paths.

Tested on mac using configmock + SourceCLI and status.InitStatus; ran with -tags test:
`go test -tags test ./pkg/logs/launchers/file/provider -run 'RecursiveGlob|RecursiveGlobWithExcludePaths' -v`
All new tests pass.
- Lints are clean

### Additional Notes
- Default behavior unchanged unless you set logs_config.enable_recursive_glob: true.
- New dep: github.com/bmatcuk/doublestar/v4.

[AGNTLOG-66]: https://datadoghq.atlassian.net/browse/AGNTLOG-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AGNTLOG-119]: https://datadoghq.atlassian.net/browse/AGNTLOG-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ