### PR TITLE
Simplify `synctest` usage with Go 1.25

### DIFF
--- a/pkg/trace/containertags/buffer_test.go
+++ b/pkg/trace/containertags/buffer_test.go
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Following directive won't be needed with Go 1.25+
-//go:build goexperiment.synctest
+//go:build go1.25
 
 // Package containertagsbuffer contains the logic to buffer payloads for container tags
 // enrichment
@@ -12,7 +11,6 @@ package containertagsbuffer
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"strings"
 	"sync"
@@ -276,9 +274,7 @@ func TestAsyncEnrichment_Buffered_HardLimit(t *testing.T) {
 }
 
 func TestAsyncEnrichment_Concurrent_MixedScenarios(t *testing.T) {
-	synctest.Run(func() {
-		syncTestAsyncEnrichmentConcurrentMixedScenarios(t)
-	})
+	synctest.Test(t, syncTestAsyncEnrichmentConcurrentMixedScenarios)
 }
 
 func syncTestAsyncEnrichmentConcurrentMixedScenarios(t *testing.T) {
@@ -295,7 +291,7 @@ func syncTestAsyncEnrichmentConcurrentMixedScenarios(t *testing.T) {
 			}
 
 			if shouldResolveContainers.Load() {
-				return []string{fmt.Sprintf("kube_image:%s", cid)}, nil
+				return []string{"kube_image:" + cid}, nil
 			}
 			return []string{"tag:incomplete_tags"}, nil
 		},


### PR DESCRIPTION
### Motivation
Now that the project uses Go 1.25 (#43774), we can simplify `synctest` usage.

### What does this PR do?
- replace `//go:build goexperiment.synctest` with `//go:build go1.25` since `synctest` is now in the standard library,
- simplify `synctest.Run(func() {...})` to `synctest.Test(t, funcRef)`.

### Additional Notes
This is a follow-up to #43452 which originally started using `synctest` when the project was still on Go 1.24.