### PR TITLE
e2e(install_script): Restore the docker test

### DIFF
--- a/.gitlab/e2e_install_packages/include.yml
+++ b/.gitlab/e2e_install_packages/include.yml
@@ -4,6 +4,7 @@
 include:
   - .gitlab/e2e_install_packages/common.yml
   - .gitlab/e2e_install_packages/debian.yml
+  - .gitlab/e2e_install_packages/docker.yml
   - .gitlab/e2e_install_packages/ubuntu.yml
   - .gitlab/e2e_install_packages/amazonlinux.yml
   - .gitlab/e2e_install_packages/centos.yml


### PR DESCRIPTION
### What does this PR do?
- Restore the docker test on install script stage (detected during tests on #44764)
- Fix them to use the correct signature

### Motivation
Restore missing tests

### Describe how you validated your changes
Test [passed](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1345450228) on the CI execution

### Additional Notes
