### PR TITLE
Add missing checksum to `bazel` dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 # We are temporarily using a development fork which is ahead of the release.
 archive_override(
     module_name = "rules_license",
-    # sha256 = TBD,
+    integrity = "sha256-2EMxXHd6ApakDCLlGJtXbplE9vSzd/5Djr9tHiHnlOs=",
     strip_prefix = "supply-chain-dd_test/rules_license",
     urls = ["https://github.com/aiuto/supply-chain/archive/refs/tags/dd_test.tar.gz"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 # We are temporarily using a development fork which is ahead of the release.
 archive_override(
     module_name = "rules_license",
-    integrity = "sha256-2EMxXHd6ApakDCLlGJtXbplE9vSzd/5Djr9tHiHnlOs=",
+    sha256 = "d843315c777a0296a40c22e5189b576e9944f6f4b377fe438ebf6d1e21e794eb",
     strip_prefix = "supply-chain-dd_test/rules_license",
     urls = ["https://github.com/aiuto/supply-chain/archive/refs/tags/dd_test.tar.gz"],
 )


### PR DESCRIPTION
### What does this PR do?
Fixes annoying:
> DEBUG: Rule 'rules_license+' indicated that a canonical reproducible form can be obtained by modifying arguments integrity = "sha256-2EMxXHd6ApakDCLlGJtXbplE9vSzd/5Djr9tHiHnlOs="