### PR TITLE
[cluster-agent/compliance] Use k8s reflectors to avoid costly list operations

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -28,7 +28,7 @@ import (
 
 func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, apiCl *apiserver.APIClient, compression logscompression.Component, ipc ipc.Component, isLeader func() bool) error {
 	stopper := startstop.NewSerialStopper()
-	if err := startCompliance(senderManager, wmeta, stopper, apiCl, isLeader, compression, ipc); err != nil {
+	if err := startCompliance(ctx, senderManager, wmeta, stopper, apiCl, isLeader, compression, ipc); err != nil {
 		return err
 	}
 
@@ -38,26 +38,29 @@ func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmet
 	return nil
 }
 
-func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Component, stopper startstop.Stopper, apiCl *apiserver.APIClient, isLeader func() bool, compression logscompression.Component, ipc ipc.Component) error {
-	endpoints, ctx, err := seccommon.NewLogContextCompliance()
+func startCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, stopper startstop.Stopper, apiCl *apiserver.APIClient, isLeader func() bool, compression logscompression.Component, ipc ipc.Component) error {
+	endpoints, destinationsCtx, err := seccommon.NewLogContextCompliance()
 	if err != nil {
 		log.Error(err)
 	}
-	stopper.Add(ctx)
+	stopper.Add(destinationsCtx)
 
 	configDir := pkgconfigsetup.Datadog().GetString("compliance_config.dir")
 	checkInterval := pkgconfigsetup.Datadog().GetDuration("compliance_config.check_interval")
 
-	hname, err := hostname.Get(context.TODO())
+	hname, err := hostname.Get(ctx)
 	if err != nil {
 		return err
 	}
 
-	reporter := compliance.NewLogReporter(hname, "compliance-agent", "compliance", endpoints, ctx, compression)
+	reporter := compliance.NewLogReporter(hname, "compliance-agent", "compliance", endpoints, destinationsCtx, compression)
 	statsdClient, err := simpleTelemetrySenderFromSenderManager(senderManager)
 	if err != nil {
 		return err
 	}
+
+	reflectorStore := compliance.NewReflectorStore(apiCl.Cl)
+	reflectorStore.Run(ctx.Done())
 
 	agent := compliance.NewAgent(statsdClient, wmeta, ipc, compliance.AgentOptions{
 		ConfigDir:     configDir,
@@ -72,6 +75,7 @@ func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Comp
 			DockerProvider:     compliance.DefaultDockerProvider,
 			LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
 			KubernetesProvider: wrapKubernetesClient(apiCl, isLeader),
+			ReflectorStore:     reflectorStore,
 		},
 	})
 	err = agent.Start()

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -17,6 +17,8 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
+	"github.com/spf13/pflag"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -29,7 +31,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/spf13/pflag"
 )
 
 // CheckParams needs to be exported because the compliance subcommand is tightly coupled to this subcommand and tests need to be able to access this type.
@@ -90,12 +91,17 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 	if checkArgs.OverrideRegoInput != "" {
 		resolver = newFakeResolver(checkArgs.OverrideRegoInput)
 	} else {
+		var reflectorStore *compliance.ReflectorStore
+		if flavor.GetFlavor() == flavor.ClusterAgent {
+			reflectorStore = startComplianceReflectorStore(context.Background())
+		}
 		resolver = compliance.NewResolver(context.Background(), compliance.ResolverOptions{
 			Hostname:           hname,
 			HostRoot:           os.Getenv("HOST_ROOT"),
 			DockerProvider:     compliance.DefaultDockerProvider,
 			LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
 			KubernetesProvider: complianceKubernetesProvider,
+			ReflectorStore:     reflectorStore,
 			StatsdClient:       statsdClient,
 		})
 	}

--- a/pkg/compliance/cli/resolver_security_agent.go
+++ b/pkg/compliance/cli/resolver_security_agent.go
@@ -8,7 +8,14 @@
 package cli
 
 import (
+	"context"
+
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 )
 
 var complianceKubernetesProvider compliance.KubernetesProvider
+
+// Not used in the security agent. This is only for the Cluster Agent
+func startComplianceReflectorStore(context.Context) *compliance.ReflectorStore {
+	return nil
+}

--- a/pkg/compliance/k8s_reflectors.go
+++ b/pkg/compliance/k8s_reflectors.go
@@ -1,0 +1,337 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package compliance
+
+import (
+	"context"
+	"sync"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ReflectorStore maintains a filtered cache of RoleBindings and
+// ClusterRoleBindings that reference "default" ServiceAccounts.
+//
+// This store is used to optimize compliance rule cis-kubernetes-1.5.1-5.1.5
+// which needs to check if the default ServiceAccounts are used. Instead of
+// fetching all objects every check interval, which can cause memory spikes in
+// large clusters, we use reflectors to watch for changes and only store
+// bindings that reference default ServiceAccounts.
+type ReflectorStore struct {
+	roleBindingStore        *roleBindingStore
+	clusterRoleBindingStore *clusterRoleBindingStore
+
+	roleBindingReflector        *cache.Reflector
+	clusterRoleBindingReflector *cache.Reflector
+}
+
+// NewReflectorStore creates a new store with reflectors watching RoleBindings
+// and ClusterRoleBindings. Call Run() to start the reflectors.
+func NewReflectorStore(client kubernetes.Interface) *ReflectorStore {
+	store := &ReflectorStore{
+		roleBindingStore:        newRoleBindingStore(),
+		clusterRoleBindingStore: newClusterRoleBindingStore(),
+	}
+
+	roleBindingListWatch := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			return client.RbacV1().RoleBindings(metav1.NamespaceAll).List(ctx, options)
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return client.RbacV1().RoleBindings(metav1.NamespaceAll).Watch(ctx, options)
+		},
+	}
+	store.roleBindingReflector = cache.NewReflector(roleBindingListWatch, &rbacv1.RoleBinding{}, store.roleBindingStore, 0)
+
+	clusterRoleBindingListWatch := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			return client.RbacV1().ClusterRoleBindings().List(ctx, options)
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return client.RbacV1().ClusterRoleBindings().Watch(ctx, options)
+		},
+	}
+	store.clusterRoleBindingReflector = cache.NewReflector(clusterRoleBindingListWatch, &rbacv1.ClusterRoleBinding{}, store.clusterRoleBindingStore, 0)
+
+	return store
+}
+
+// Run starts the reflectors.
+func (s *ReflectorStore) Run(stopCh <-chan struct{}) {
+	go s.roleBindingReflector.Run(stopCh)
+	go s.clusterRoleBindingReflector.Run(stopCh)
+}
+
+// HasSynced returns true if all reflectors have synced.
+func (s *ReflectorStore) HasSynced() bool {
+	return s.roleBindingStore.HasSynced() && s.clusterRoleBindingStore.HasSynced()
+}
+
+// GetRoleBindings returns stored RoleBindings that reference default ServiceAccounts.
+func (s *ReflectorStore) GetRoleBindings() []*rbacv1.RoleBinding {
+	return s.roleBindingStore.GetFiltered()
+}
+
+// GetClusterRoleBindings returns stored ClusterRoleBindings that reference default ServiceAccounts.
+func (s *ReflectorStore) GetClusterRoleBindings() []*rbacv1.ClusterRoleBinding {
+	return s.clusterRoleBindingStore.GetFiltered()
+}
+
+// referencesDefaultServiceAccount returns true if any subject in the list is a
+// ServiceAccount named "default".
+func referencesDefaultServiceAccount(subjects []rbacv1.Subject) bool {
+	for _, subject := range subjects {
+		if subject.Kind == rbacv1.ServiceAccountKind && subject.Name == "default" {
+			return true
+		}
+	}
+	return false
+}
+
+type roleBindingStore struct {
+	mu        sync.RWMutex
+	items     map[string]*rbacv1.RoleBinding
+	hasSynced bool
+}
+
+func newRoleBindingStore() *roleBindingStore {
+	return &roleBindingStore{
+		items: make(map[string]*rbacv1.RoleBinding),
+	}
+}
+
+func (s *roleBindingStore) HasSynced() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.hasSynced
+}
+
+func (s *roleBindingStore) GetFiltered() []*rbacv1.RoleBinding {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*rbacv1.RoleBinding, 0, len(s.items))
+	for _, rb := range s.items {
+		result = append(result, rb)
+	}
+	return result
+}
+
+func (s *roleBindingStore) Add(obj interface{}) error {
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		return nil
+	}
+	if !referencesDefaultServiceAccount(rb.Subjects) {
+		return nil
+	}
+	key := rb.GetNamespace() + "/" + rb.GetName()
+	s.mu.Lock()
+	s.items[key] = rb
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *roleBindingStore) Update(obj interface{}) error {
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		return nil
+	}
+	key := rb.GetNamespace() + "/" + rb.GetName()
+	s.mu.Lock()
+	if referencesDefaultServiceAccount(rb.Subjects) {
+		s.items[key] = rb
+	} else {
+		delete(s.items, key)
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *roleBindingStore) Delete(obj interface{}) error {
+	rb, ok := obj.(*rbacv1.RoleBinding)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil
+		}
+		rb, ok = tombstone.Obj.(*rbacv1.RoleBinding)
+		if !ok {
+			return nil
+		}
+	}
+	key := rb.GetNamespace() + "/" + rb.GetName()
+	s.mu.Lock()
+	delete(s.items, key)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *roleBindingStore) Replace(list []interface{}, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = make(map[string]*rbacv1.RoleBinding)
+	for _, obj := range list {
+		rb, ok := obj.(*rbacv1.RoleBinding)
+		if !ok {
+			continue
+		}
+		if referencesDefaultServiceAccount(rb.Subjects) {
+			key := rb.GetNamespace() + "/" + rb.GetName()
+			s.items[key] = rb
+		}
+	}
+	s.hasSynced = true
+	return nil
+}
+
+// List is not implemented
+func (s *roleBindingStore) List() []interface{} {
+	panic("not implemented")
+}
+
+// ListKeys is not implemented
+func (s *roleBindingStore) ListKeys() []string {
+	panic("not implemented")
+}
+
+// Get is not implemented
+func (s *roleBindingStore) Get(_ interface{}) (interface{}, bool, error) {
+	panic("not implemented")
+}
+
+// GetByKey is not implemented
+func (s *roleBindingStore) GetByKey(_ string) (interface{}, bool, error) {
+	panic("not implemented")
+}
+
+// Resync is not implemented
+func (s *roleBindingStore) Resync() error {
+	panic("not implemented")
+}
+
+type clusterRoleBindingStore struct {
+	mu        sync.RWMutex
+	items     map[string]*rbacv1.ClusterRoleBinding
+	hasSynced bool
+}
+
+func newClusterRoleBindingStore() *clusterRoleBindingStore {
+	return &clusterRoleBindingStore{
+		items: make(map[string]*rbacv1.ClusterRoleBinding),
+	}
+}
+
+func (s *clusterRoleBindingStore) HasSynced() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.hasSynced
+}
+
+func (s *clusterRoleBindingStore) GetFiltered() []*rbacv1.ClusterRoleBinding {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*rbacv1.ClusterRoleBinding, 0, len(s.items))
+	for _, crb := range s.items {
+		result = append(result, crb)
+	}
+	return result
+}
+
+func (s *clusterRoleBindingStore) Add(obj interface{}) error {
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return nil
+	}
+	if !referencesDefaultServiceAccount(crb.Subjects) {
+		return nil
+	}
+	s.mu.Lock()
+	s.items[crb.GetName()] = crb
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *clusterRoleBindingStore) Update(obj interface{}) error {
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		return nil
+	}
+	s.mu.Lock()
+	if referencesDefaultServiceAccount(crb.Subjects) {
+		s.items[crb.GetName()] = crb
+	} else {
+		delete(s.items, crb.GetName())
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *clusterRoleBindingStore) Delete(obj interface{}) error {
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return nil
+		}
+		crb, ok = tombstone.Obj.(*rbacv1.ClusterRoleBinding)
+		if !ok {
+			return nil
+		}
+	}
+	s.mu.Lock()
+	delete(s.items, crb.GetName())
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *clusterRoleBindingStore) Replace(list []interface{}, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = make(map[string]*rbacv1.ClusterRoleBinding)
+	for _, obj := range list {
+		crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+		if !ok {
+			continue
+		}
+		if referencesDefaultServiceAccount(crb.Subjects) {
+			s.items[crb.GetName()] = crb
+		}
+	}
+	s.hasSynced = true
+	return nil
+}
+
+// List is not implemented
+func (s *clusterRoleBindingStore) List() []interface{} {
+	panic("not implemented")
+}
+
+// ListKeys is not implemented
+func (s *clusterRoleBindingStore) ListKeys() []string {
+	panic("not implemented")
+}
+
+// Get is not implemented
+func (s *clusterRoleBindingStore) Get(_ interface{}) (interface{}, bool, error) {
+	panic("not implemented")
+}
+
+// GetByKey is not implemented
+func (s *clusterRoleBindingStore) GetByKey(_ string) (interface{}, bool, error) {
+	panic("not implemented")
+}
+
+// Resync is not implemented
+func (s *clusterRoleBindingStore) Resync() error {
+	panic("not implemented")
+}

--- a/pkg/compliance/k8s_reflectors_no_k8s.go
+++ b/pkg/compliance/k8s_reflectors_no_k8s.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package compliance
+
+// ReflectorStore is a stub for non-kubeapiserver builds
+type ReflectorStore struct{}

--- a/pkg/compliance/k8s_reflectors_test.go
+++ b/pkg/compliance/k8s_reflectors_test.go
@@ -1,0 +1,308 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package compliance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var defaultSASubject = rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "default", Namespace: "ns1"}
+var otherSASubject = rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "other", Namespace: "ns1"}
+
+func TestRoleBindingStoreAdd(t *testing.T) {
+	tests := []struct {
+		name         string
+		roleBinding  *rbacv1.RoleBinding
+		expectStored bool
+	}{
+		{
+			name: "references default SA",
+			roleBinding: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			expectStored: true,
+		},
+		{
+			name: "does not reference default SA",
+			roleBinding: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb2", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			expectStored: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newRoleBindingStore()
+
+			err := store.Add(test.roleBinding)
+			require.NoError(t, err)
+
+			if test.expectStored {
+				assert.ElementsMatch(t, store.GetFiltered(), []*rbacv1.RoleBinding{test.roleBinding})
+			} else {
+				assert.Empty(t, store.GetFiltered())
+			}
+		})
+	}
+}
+
+func TestRoleBindingStoreUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      *rbacv1.RoleBinding
+		updated      *rbacv1.RoleBinding
+		expectStored bool
+	}{
+		{
+			name: "add default SA reference",
+			initial: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			updated: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			expectStored: true,
+		},
+		{
+			name: "remove default SA reference",
+			initial: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			updated: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			expectStored: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newRoleBindingStore()
+			err := store.Add(test.initial)
+			require.NoError(t, err)
+
+			err = store.Update(test.updated)
+			require.NoError(t, err)
+
+			if test.expectStored {
+				assert.Len(t, store.GetFiltered(), 1)
+			} else {
+				assert.Empty(t, store.GetFiltered())
+			}
+		})
+	}
+}
+
+func TestRoleBindingStoreDelete(t *testing.T) {
+	store := newRoleBindingStore()
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+		Subjects:   []rbacv1.Subject{defaultSASubject},
+	}
+	err := store.Add(roleBinding)
+	require.NoError(t, err)
+	require.Len(t, store.GetFiltered(), 1)
+
+	err = store.Delete(roleBinding)
+	require.NoError(t, err)
+	assert.Empty(t, store.GetFiltered())
+}
+
+func TestRoleBindingStoreReplace(t *testing.T) {
+	store := newRoleBindingStore()
+
+	initialRoleBindings := []interface{}{
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "rb2", Namespace: "ns2"},
+			Subjects:   []rbacv1.Subject{otherSASubject},
+		},
+	}
+
+	for _, roleBinding := range initialRoleBindings {
+		err := store.Add(roleBinding)
+		require.NoError(t, err)
+	}
+
+	// Only the first element refers to default SA
+	require.ElementsMatch(t, store.GetFiltered(), []*rbacv1.RoleBinding{initialRoleBindings[0].(*rbacv1.RoleBinding)})
+
+	newRoleBindings := []interface{}{
+		&rbacv1.RoleBinding{ // No changes
+			ObjectMeta: metav1.ObjectMeta{Name: "rb1", Namespace: "ns1"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+		&rbacv1.RoleBinding{ // Now refers to default SA
+			ObjectMeta: metav1.ObjectMeta{Name: "rb2", Namespace: "ns2"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+	}
+
+	err := store.Replace(newRoleBindings, "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, store.GetFiltered(), newRoleBindings)
+}
+
+func TestClusterRoleBindingStoreAdd(t *testing.T) {
+	tests := []struct {
+		name               string
+		clusterRoleBinding *rbacv1.ClusterRoleBinding
+		expectStored       bool
+	}{
+		{
+			name: "references default SA",
+			clusterRoleBinding: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			expectStored: true,
+		},
+		{
+			name: "does not reference default SA",
+			clusterRoleBinding: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb2"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			expectStored: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newClusterRoleBindingStore()
+
+			err := store.Add(test.clusterRoleBinding)
+			require.NoError(t, err)
+
+			if test.expectStored {
+				assert.ElementsMatch(t, store.GetFiltered(), []*rbacv1.ClusterRoleBinding{test.clusterRoleBinding})
+			} else {
+				assert.Empty(t, store.GetFiltered())
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingStoreUpdate(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      *rbacv1.ClusterRoleBinding
+		updated      *rbacv1.ClusterRoleBinding
+		expectStored bool
+	}{
+		{
+			name: "add default SA reference",
+			initial: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			updated: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			expectStored: true,
+		},
+		{
+			name: "remove default SA reference",
+			initial: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+				Subjects:   []rbacv1.Subject{defaultSASubject},
+			},
+			updated: &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+				Subjects:   []rbacv1.Subject{otherSASubject},
+			},
+			expectStored: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newClusterRoleBindingStore()
+			err := store.Add(test.initial)
+			require.NoError(t, err)
+
+			err = store.Update(test.updated)
+			require.NoError(t, err)
+
+			if test.expectStored {
+				assert.Len(t, store.GetFiltered(), 1)
+			} else {
+				assert.Empty(t, store.GetFiltered())
+			}
+		})
+	}
+}
+
+func TestClusterRoleBindingStoreDelete(t *testing.T) {
+	store := newClusterRoleBindingStore()
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb1"},
+		Subjects:   []rbacv1.Subject{defaultSASubject},
+	}
+	err := store.Add(clusterRoleBinding)
+	require.NoError(t, err)
+	require.Len(t, store.GetFiltered(), 1)
+
+	err = store.Delete(clusterRoleBinding)
+	assert.NoError(t, err)
+	assert.Empty(t, store.GetFiltered())
+}
+
+func TestClusterRoleBindingStoreReplace(t *testing.T) {
+	store := newClusterRoleBindingStore()
+
+	initialClusterRoleBindings := []interface{}{
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb1", Namespace: "ns1"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "crb2", Namespace: "ns2"},
+			Subjects:   []rbacv1.Subject{otherSASubject},
+		},
+	}
+
+	for _, clusterRoleBinding := range initialClusterRoleBindings {
+		err := store.Add(clusterRoleBinding)
+		require.NoError(t, err)
+	}
+
+	// Only the first element refers to default SA
+	require.ElementsMatch(t, store.GetFiltered(), []*rbacv1.ClusterRoleBinding{initialClusterRoleBindings[0].(*rbacv1.ClusterRoleBinding)})
+
+	newClusterRoleBindings := []interface{}{
+		&rbacv1.ClusterRoleBinding{ // No changes
+			ObjectMeta: metav1.ObjectMeta{Name: "crb1", Namespace: "ns1"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+		&rbacv1.ClusterRoleBinding{ // Now refers to default SA
+			ObjectMeta: metav1.ObjectMeta{Name: "crb2", Namespace: "ns2"},
+			Subjects:   []rbacv1.Subject{defaultSASubject},
+		},
+	}
+
+	err := store.Replace(newClusterRoleBindings, "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, store.GetFiltered(), newClusterRoleBindings)
+}

--- a/pkg/compliance/resolver.go
+++ b/pkg/compliance/resolver.go
@@ -85,6 +85,11 @@ type ResolverOptions struct {
 	// resolver (optional)
 	StatsdClient statsd.ClientInterface
 
+	// ReflectorStore contains kubernetes objects fetched using reflectors. This is
+	// used to avoid calling the kube API server with "list" operations that can
+	// return many objects and cause memory spikes.
+	ReflectorStore *ReflectorStore
+
 	DockerProvider
 	KubernetesProvider
 	LinuxAuditProvider
@@ -218,7 +223,7 @@ func (r *defaultResolver) ResolveInputs(ctx context.Context, rule *Rule) (Resolv
 			result, err = r.resolveDocker(ctx, *spec.Docker)
 		case spec.KubeApiserver != nil:
 			resultType = "kubernetes"
-			result, err = r.k8sapiserverResolver.resolveKubeApiserver(ctx, *spec.KubeApiserver)
+			result, err = r.k8sapiserverResolver.resolveKubeApiserver(ctx, rule.ID, *spec.KubeApiserver)
 			kubernetesCluster = r.k8sapiserverResolver.resolveKubeClusterID(ctx)
 		case spec.Package != nil:
 			resultType = "package"

--- a/pkg/compliance/resolver_k8s.go
+++ b/pkg/compliance/resolver_k8s.go
@@ -12,8 +12,10 @@ import (
 	"errors"
 	"fmt"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	kubemetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeunstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	kubeschema "k8s.io/apimachinery/pkg/runtime/schema"
 	kubedynamic "k8s.io/client-go/dynamic"
 )
@@ -34,10 +36,14 @@ type k8sapiserverResolver struct {
 
 	kubernetesCl                    kubedynamic.Interface
 	kubernetesGroupAndResourcesFunc KubernetesGroupsAndResourcesProvider
+
+	reflectorStore *ReflectorStore
 }
 
 func newK8sapiserverResolver(ctx context.Context, opts ResolverOptions) *k8sapiserverResolver {
-	r := &k8sapiserverResolver{}
+	r := &k8sapiserverResolver{
+		reflectorStore: opts.ReflectorStore,
+	}
 
 	if opts.KubernetesProvider != nil {
 		r.kubernetesCl, r.kubernetesGroupAndResourcesFunc, _ = opts.KubernetesProvider(ctx)
@@ -77,7 +83,7 @@ func (r *k8sapiserverResolver) resolveKubeClusterID(ctx context.Context) string 
 	return r.kubeClusterIDCache
 }
 
-func (r *k8sapiserverResolver) resolveKubeApiserver(ctx context.Context, spec InputSpecKubeapiserver) (interface{}, error) {
+func (r *k8sapiserverResolver) resolveKubeApiserver(ctx context.Context, ruleID string, spec InputSpecKubeapiserver) (interface{}, error) {
 	cl := r.kubernetesCl
 	if cl == nil {
 		return nil, ErrIncompatibleEnvironment
@@ -134,6 +140,11 @@ func (r *k8sapiserverResolver) resolveKubeApiserver(ctx context.Context, spec In
 		}
 		items = []kubeunstructured.Unstructured{*resource}
 	case "list":
+		// Try using data from reflectors instead of calling "list" when it could return many objects and cause memory spikes
+		if objects, ok := r.getFromReflectorStore(ruleID, spec); ok {
+			return objects, nil
+		}
+
 		list, err := resourceAPI.List(ctx, kubemetav1.ListOptions{
 			LabelSelector: spec.LabelSelector,
 			FieldSelector: spec.FieldSelector,
@@ -183,4 +194,65 @@ func (r *k8sapiserverResolver) checkKubeServerResourceSupport(resourceSchema kub
 		}
 	}
 	return false, nil
+}
+
+// getFromReflectorStore tries to get Kubernetes objects from the ReflectorStore
+// instead of calling the Kubernetes API. This optimization only applies to
+// rule cis-kubernetes-1.5.1-5.1.5.
+func (r *k8sapiserverResolver) getFromReflectorStore(ruleID string, spec InputSpecKubeapiserver) (interface{}, bool) {
+	if ruleID != "cis-kubernetes-1.5.1-5.1.5" {
+		return nil, false
+	}
+
+	store := r.reflectorStore
+	if store == nil || !store.HasSynced() {
+		return nil, false
+	}
+
+	if spec.Group != rbacv1.SchemeGroupVersion.Group {
+		return nil, false
+	}
+
+	var resolved []interface{}
+
+	switch spec.Kind {
+	case "rolebindings":
+		for _, rb := range store.GetRoleBindings() {
+			if spec.Namespace != "" && rb.GetNamespace() != spec.Namespace {
+				continue
+			}
+			unstructuredContent, err := kuberuntime.DefaultUnstructuredConverter.ToUnstructured(rb)
+			if err != nil {
+				continue
+			}
+			resolved = append(resolved, map[string]interface{}{
+				"kind":      "RoleBinding",
+				"group":     rbacv1.SchemeGroupVersion.Group,
+				"version":   rbacv1.SchemeGroupVersion.Version,
+				"namespace": rb.GetNamespace(),
+				"name":      rb.GetName(),
+				"resource":  kubeunstructured.Unstructured{Object: unstructuredContent},
+			})
+		}
+		return resolved, true
+
+	case "clusterrolebindings":
+		for _, crb := range store.GetClusterRoleBindings() {
+			unstructuredContent, err := kuberuntime.DefaultUnstructuredConverter.ToUnstructured(crb)
+			if err != nil {
+				continue
+			}
+			resolved = append(resolved, map[string]interface{}{
+				"kind":      "ClusterRoleBinding",
+				"group":     rbacv1.SchemeGroupVersion.Group,
+				"version":   rbacv1.SchemeGroupVersion.Version,
+				"namespace": crb.GetNamespace(),
+				"name":      crb.GetName(),
+				"resource":  kubeunstructured.Unstructured{Object: unstructuredContent},
+			})
+		}
+		return resolved, true
+	}
+
+	return nil, false
 }

--- a/pkg/compliance/resolver_no_k8s.go
+++ b/pkg/compliance/resolver_no_k8s.go
@@ -33,6 +33,6 @@ func (r *k8sapiserverResolver) resolveKubeClusterID(context.Context) string {
 	return ""
 }
 
-func (r *k8sapiserverResolver) resolveKubeApiserver(context.Context, InputSpecKubeapiserver) (interface{}, error) {
+func (r *k8sapiserverResolver) resolveKubeApiserver(context.Context, string, InputSpecKubeapiserver) (interface{}, error) {
 	return nil, ErrIncompatibleEnvironment
 }

--- a/releasenotes-dca/notes/kube-compliance-use-informers-c724a3cd1d3d48bc.yaml
+++ b/releasenotes-dca/notes/kube-compliance-use-informers-c724a3cd1d3d48bc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Reduced memory usage of compliance checks on large clusters


### PR DESCRIPTION
### What does this PR do?

This PR reduces memory spikes caused by one of the compliance rules run by the Cluster Agent.

While investigating memory issues in the Cluster Agent, I noticed spikes every 20 minutes, which is the default interval for compliance checks. I was able to determine that the responsible rule is `cis-kubernetes-1.5.1-5.1.5`. This rule lists all cluster role bindings and role bindings, which can return a lot of objects in large clusters.

To fix this, the PR uses a reflector instead of calling the Kubernetes API server with a list operation. The rule checks if any cluster role bindings or role bindings reference the default service account, so in the reflector we only keep those instead of all of them. In compliant clusters, this means we don't need to store anything.

The PR fixes the issue both for the long-running check and also the `agent compliance check` command.

This needs a new permission for the cluster Agent, until now it only required "list" for cluster role bindings and role bindings, but now it requires "watch" as well. The operator and helm chart will need to be updated.

I've attached some screenshots from the large cluster where I tested this. They show the `container.memory.usage` metric for 1 leader and 2 replicas of the cluster agent container. Before this PR, spikes were visible every 20 minutes on the leader instance and were around 1 GB. After the PR, the spikes disappear.

<img width="1828" height="469" alt="before" src="https://github.com/user-attachments/assets/e63f6556-fb5d-4771-814e-fd0f592903b5" />

<img width="1828" height="469" alt="after" src="https://github.com/user-attachments/assets/21a0183a-6f99-41f8-bb15-c36644ae001c" />


### Describe how you validated your changes

I deployed in a large cluster to verify that the memory spikes are gone. I also ran `agent compliance check` to verify that it doesn't cause any memory spike. Also, in a kind cluster I verified that the rule still fails or passes as expected.
