### PR TITLE
bin size script

### DIFF
--- a/README_analyze_external_imports.md
+++ b/README_analyze_external_imports.md
@@ -1,0 +1,95 @@
+# External Import Analyzer
+
+Analyzes external GitHub dependencies in the Datadog Agent codebase, mapping them to teams (via CODEOWNERS) and measuring their binary size impact.
+
+## Quick Start
+
+```bash
+# Analyze entire codebase (pkg, comp, cmd)
+python3 analyze_external_imports.py
+
+# Analyze specific directories
+python3 analyze_external_imports.py pkg/logs comp/logs
+python3 analyze_external_imports.py pkg/network
+
+# Skip binary size analysis for faster results
+python3 analyze_external_imports.py --no-binary
+```
+
+## What It Does
+
+1. **Finds Go Files**: Scans specified directories for `.go` files (excluding `*_test.go`)
+2. **Extracts Imports**: Identifies external GitHub imports (non-DataDog dependencies)
+3. **Maps to Teams**: Uses `.github/CODEOWNERS` to determine which team owns each import
+4. **Analyzes Binary Size**: Uses `go tool nm` to measure the binary size impact of each dependency
+5. **Reports Results**: Shows which teams are responsible for the most external dependency binary bloat
+
+## Output
+
+The script produces three sections:
+
+### 1. External Imports by Team
+Lists all external imports grouped by owning team, showing which files use them.
+
+### 2. Binary Size Impact Analysis
+Shows the binary size contribution of each external dependency, aggregated by team.
+
+### 3. Summary
+Quick overview with top imports by size and usage statistics.
+
+## Requirements
+
+- Python 3.7+
+- `.github/CODEOWNERS` file in repo root
+- Binary built at `bin/agent/agent` (or specify with `--binary`)
+- `go tool nm` available in PATH
+
+## Options
+
+```
+usage: analyze_external_imports.py [-h] [--no-binary] [--binary BINARY]
+                                   [directories ...]
+
+positional arguments:
+  directories      Directories to analyze (default: pkg, comp, cmd)
+
+options:
+  -h, --help       show this help message and exit
+  --no-binary      Skip binary size analysis
+  --binary BINARY  Path to binary for size analysis (default: bin/agent/agent)
+```
+
+## Examples
+
+```bash
+# Analyze entire codebase
+python3 analyze_external_imports.py
+
+# Analyze specific subsystems
+python3 analyze_external_imports.py pkg/logs comp/logs
+python3 analyze_external_imports.py pkg/network comp/networkpath
+
+# Quick import check without binary analysis
+python3 analyze_external_imports.py --no-binary
+
+# Analyze only pkg directory
+python3 analyze_external_imports.py pkg
+
+# Use different binary
+python3 analyze_external_imports.py --binary bin/system-probe/system-probe pkg/ebpf
+```
+
+## Use Cases
+
+- **Dependency Audit**: Find which teams are adding external dependencies
+- **Binary Size Analysis**: Identify which external deps contribute most to binary size
+- **Code Review**: Understand dependency ownership before adding new imports
+- **Refactoring**: Track dependency reduction efforts across teams
+
+## Notes
+
+- The script only finds external GitHub dependencies (excludes `github.com/DataDog/*`)
+- Binary size analysis requires the binary to be built first (`dda inv agent.build`)
+- Some dependencies may show 0 bytes if they're build-tag specific or optimized out
+- Platform-specific imports (e.g., Linux-only) may not appear in macOS-built binaries
+

--- a/analyze_external_imports.py
+++ b/analyze_external_imports.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""
+Analyze external GitHub imports, mapping them to teams and their binary size impact.
+
+This script:
+1. Finds all Go files (excluding tests) in specified directories
+2. Extracts external GitHub imports (non-DataDog dependencies)
+3. Maps imports to teams using .github/CODEOWNERS
+4. Analyzes binary size impact using 'go tool nm'
+5. Reports which teams are responsible for the most binary size from external deps
+
+Usage:
+    python3 analyze_external_imports.py [directories...]
+    
+    If no directories specified, analyzes entire codebase (pkg, comp, cmd)
+    
+Examples:
+    python3 analyze_external_imports.py              # Analyze entire codebase
+    python3 analyze_external_imports.py pkg/logs     # Analyze specific directory
+    python3 analyze_external_imports.py pkg comp     # Analyze multiple directories
+    python3 analyze_external_imports.py --no-binary  # Skip binary analysis (faster)
+
+Requirements:
+    - .github/CODEOWNERS file in repo root
+    - Binary built at bin/agent/agent (or specify with --binary)
+    - 'go tool nm' available
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+
+class CodeOwnersParser:
+    """Parse CODEOWNERS file and map paths to teams."""
+    
+    def __init__(self, codeowners_path: Path):
+        self.rules = []  # List of (pattern, teams) tuples, in order
+        self._parse(codeowners_path)
+    
+    def _parse(self, path: Path):
+        """Parse CODEOWNERS file."""
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                # Skip comments and empty lines
+                if not line or line.startswith('#'):
+                    continue
+                
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                
+                pattern = parts[0]
+                teams = [t for t in parts[1:] if t.startswith('@')]
+                
+                if teams:
+                    self.rules.append((pattern, teams))
+    
+    def get_teams(self, file_path: str) -> List[str]:
+        """Get teams owning a file path. Returns last matching rule (bottom-to-top)."""
+        # Normalize path
+        path = file_path.lstrip('/')
+        
+        matched_teams = []
+        # Rules are matched bottom-to-top in CODEOWNERS
+        for pattern, teams in self.rules:
+            if self._matches(pattern, path):
+                matched_teams = teams
+        
+        return matched_teams if matched_teams else ['@DataDog/unowned']
+    
+    def _matches(self, pattern: str, path: str) -> bool:
+        """Check if a CODEOWNERS pattern matches a path."""
+        pattern = pattern.lstrip('/')
+        
+        # Exact match
+        if pattern == path:
+            return True
+        
+        # Directory match (pattern ends with /)
+        if pattern.endswith('/') and path.startswith(pattern):
+            return True
+        
+        # Wildcard patterns
+        if '*' in pattern:
+            regex = pattern.replace('*', '.*').replace('/', '\\/')
+            if re.match(f'^{regex}', path):
+                return True
+        
+        # Parent directory match
+        if path.startswith(pattern + '/'):
+            return True
+        
+        return False
+
+
+def find_go_files(directories: List[str]) -> List[Path]:
+    """Find all .go files (excluding _test.go) in given directories."""
+    files = []
+    for directory in directories:
+        dir_path = Path(directory)
+        if dir_path.exists():
+            files.extend(
+                f for f in dir_path.rglob('*.go')
+                if not f.name.endswith('_test.go')
+            )
+    return files
+
+
+def extract_imports(file_path: Path) -> Set[str]:
+    """Extract import statements from a Go file."""
+    imports = set()
+    in_import_block = False
+    
+    with open(file_path) as f:
+        for line in f:
+            line = line.strip()
+            
+            # Single-line import
+            if line.startswith('import "'):
+                match = re.search(r'import "([^"]+)"', line)
+                if match:
+                    imports.add(match.group(1))
+            
+            # Multi-line import block
+            elif line.startswith('import ('):
+                in_import_block = True
+            elif in_import_block:
+                if line == ')':
+                    in_import_block = False
+                else:
+                    match = re.search(r'"([^"]+)"', line)
+                    if match:
+                        imports.add(match.group(1))
+    
+    return imports
+
+
+def is_external_github_import(pkg: str) -> bool:
+    """Check if import is external GitHub package (not DataDog)."""
+    return pkg.startswith('github.com/') and not pkg.startswith('github.com/DataDog/')
+
+
+def parse_nm_output(binary_path: str) -> Dict[str, int]:
+    """Parse `go tool nm` output and aggregate sizes by package."""
+    try:
+        result = subprocess.run(
+            ['go', 'tool', 'nm', '-size', binary_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"Error running go tool nm: {e}", file=sys.stderr)
+        print(f"stderr: {e.stderr}", file=sys.stderr)
+        return {}
+    except FileNotFoundError:
+        print(f"Binary not found: {binary_path}", file=sys.stderr)
+        return {}
+    
+    package_sizes = defaultdict(int)
+    
+    # Parse nm output: address size type symbol
+    for line in result.stdout.splitlines():
+        parts = line.split(maxsplit=3)
+        if len(parts) >= 4:
+            try:
+                size = int(parts[1])  # Size is in decimal
+                symbol_type = parts[2]
+                symbol = parts[3]
+                
+                # Skip undefined symbols (type 'U') and very large sizes (likely undefined)
+                if symbol_type == 'U' or size > 1000000000:
+                    continue
+                
+                # Extract package from symbol (e.g., github.com/pkg/name.Function)
+                # Go symbols typically have format: package/path.Symbol
+                if '.' in symbol:
+                    pkg_path = symbol.rsplit('.', 1)[0]
+                    # Clean up vendor prefixes
+                    pkg_path = pkg_path.replace('vendor/', '')
+                    package_sizes[pkg_path] += size
+            except (ValueError, IndexError):
+                continue
+    
+    return dict(package_sizes)
+
+
+def get_package_prefixes(import_path: str) -> List[str]:
+    """Get all possible package prefixes for matching symbols.
+    
+    Returns multiple prefixes to match the main package and subpackages.
+    E.g., for "github.com/spf13/afero" returns:
+    - github.com/spf13/afero
+    - github.com/spf13/afero/
+    """
+    prefixes = [import_path]
+    # Also match subpackages
+    if not import_path.endswith('/'):
+        prefixes.append(import_path + '/')
+    return prefixes
+
+
+def print_summary(directories, go_files, import_to_files, team_to_imports, 
+                  import_sizes, import_to_teams):
+    """Print summary section."""
+    print("=" * 80)
+    print("SUMMARY")
+    print("=" * 80)
+    print(f"\nDirectories analyzed: {', '.join(directories)}")
+    print(f"Go files (non-test): {len(go_files)}")
+    print(f"Unique external GitHub imports: {len(import_to_files)}")
+    print(f"Teams involved: {len(team_to_imports)}")
+    
+    if import_sizes:
+        total_external_size = sum(import_sizes.values())
+        print(f"Total binary size from external deps: {total_external_size:,} bytes ({total_external_size / 1024 / 1024:.2f} MB)")
+        
+        # Top imports by size
+        print(f"\nTop 10 external imports by binary size:")
+        top_5 = sorted(import_sizes.items(), key=lambda x: x[1], reverse=True)[:10]
+        for i, (imp, size) in enumerate(top_5, 1):
+            pct = (size / total_external_size * 100) if total_external_size > 0 else 0
+            teams = ', '.join(sorted(import_to_teams.get(imp, [])))
+            print(f"  {i}. {imp}")
+            print(f"     Size: {size:,} bytes ({size / 1024:.1f} KB, {pct:.1f}%)")
+            print(f"     Teams: {teams}")
+            print(f"     Used in {len(import_to_files[imp])} files")
+    else:
+        print("Binary size analysis: not performed")
+    
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze external GitHub imports by team and binary size impact',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                          # Analyze entire codebase (pkg, comp, cmd)
+  %(prog)s pkg/logs                 # Analyze only pkg/logs
+  %(prog)s pkg comp                 # Analyze pkg and comp directories
+  %(prog)s --no-binary              # Skip binary analysis (faster)
+        """
+    )
+    parser.add_argument(
+        'directories',
+        nargs='*',
+        default=None,
+        help='Directories to analyze (default: pkg, comp, cmd)'
+    )
+    parser.add_argument(
+        '--no-binary',
+        action='store_true',
+        help='Skip binary size analysis'
+    )
+    parser.add_argument(
+        '--binary',
+        default='bin/agent/agent',
+        help='Path to binary for size analysis (default: bin/agent/agent)'
+    )
+    
+    args = parser.parse_args()
+    
+    repo_root = Path(__file__).parent.resolve()
+    codeowners_path = repo_root / '.github' / 'CODEOWNERS'
+    
+    if not codeowners_path.exists():
+        print(f"CODEOWNERS file not found: {codeowners_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    print("Parsing CODEOWNERS...")
+    codeowners = CodeOwnersParser(codeowners_path)
+    
+    # Default to analyzing entire codebase if no directories specified
+    directories = args.directories
+    if not directories:  # Empty list or None
+        directories = ['pkg', 'comp', 'cmd']
+        print(f"Finding Go files in {', '.join(directories)} (entire codebase)...")
+    else:
+        print(f"Finding Go files in {', '.join(directories)}...")
+    
+    go_files = find_go_files(directories)
+    print(f"Found {len(go_files)} Go files (excluding tests)")
+    
+    print("\nExtracting external imports...")
+    # Map: import -> set of files using it -> teams
+    import_to_files = defaultdict(set)
+    file_to_teams = {}
+    
+    for go_file in go_files:
+        imports = extract_imports(go_file)
+        external_imports = {imp for imp in imports if is_external_github_import(imp)}
+        
+        # Get teams for this file
+        rel_path = str(go_file.resolve().relative_to(repo_root))
+        teams = codeowners.get_teams(rel_path)
+        file_to_teams[rel_path] = teams
+        
+        # Map imports to files
+        for imp in external_imports:
+            import_to_files[imp].add(rel_path)
+    
+    # Map imports to teams
+    import_to_teams = defaultdict(set)
+    for imp, files in import_to_files.items():
+        for file in files:
+            teams = file_to_teams.get(file, [])
+            import_to_teams[imp].update(teams)
+    
+    print(f"Found {len(import_to_files)} unique external GitHub imports")
+    
+    # Print import breakdown by team
+    print("\n" + "=" * 80)
+    print("EXTERNAL IMPORTS BY TEAM")
+    print("=" * 80)
+    
+    team_to_imports = defaultdict(set)
+    for imp, teams in import_to_teams.items():
+        for team in teams:
+            team_to_imports[team].add(imp)
+    
+    for team in sorted(team_to_imports.keys()):
+        imports = sorted(team_to_imports[team])
+        print(f"\n{team} ({len(imports)} imports):")
+        for imp in imports:
+            files = sorted(import_to_files[imp])
+            print(f"  - {imp}")
+            for f in files[:3]:  # Show first 3 files
+                print(f"      {f}")
+            if len(files) > 3:
+                print(f"      ... and {len(files) - 3} more files")
+    
+    # Binary size analysis
+    if args.no_binary:
+        print("\nSkipping binary size analysis (--no-binary flag set)")
+        print_summary(directories, go_files, import_to_files, team_to_imports, None, None)
+        return
+    
+    binary_path = repo_root / args.binary
+    if not binary_path.exists():
+        print(f"\n⚠️  Binary not found: {binary_path}", file=sys.stderr)
+        print(f"Run 'dda inv agent.build' to build the agent first.", file=sys.stderr)
+        print("\nSkipping binary size analysis.")
+        print_summary(directories, go_files, import_to_files, team_to_imports, None, None)
+        return
+    
+    print("\n" + "=" * 80)
+    print("BINARY SIZE IMPACT ANALYSIS")
+    print("=" * 80)
+    print(f"\nAnalyzing binary: {binary_path}")
+    print("Running 'go tool nm' (this may take a moment)...")
+    
+    package_sizes = parse_nm_output(str(binary_path))
+    
+    if not package_sizes:
+        print("⚠️  Could not parse binary symbol data", file=sys.stderr)
+        return
+    
+    # Map external imports to their symbol sizes
+    import_sizes = {}
+    for imp in import_to_files.keys():
+        prefixes = get_package_prefixes(imp)
+        total_size = 0
+        
+        # Sum sizes for all symbols matching this package or subpackages
+        for pkg, size in package_sizes.items():
+            for prefix in prefixes:
+                if pkg == prefix.rstrip('/') or pkg.startswith(prefix):
+                    total_size += size
+                    break  # Don't double-count
+        
+        if total_size > 0:
+            import_sizes[imp] = total_size
+    
+    # Aggregate by team
+    team_sizes = defaultdict(int)
+    team_imports_with_sizes = defaultdict(list)
+    
+    for imp, size in import_sizes.items():
+        teams = import_to_teams.get(imp, [])
+        for team in teams:
+            team_sizes[team] += size
+            team_imports_with_sizes[team].append((imp, size))
+    
+    # Sort teams by total size impact
+    sorted_teams = sorted(team_sizes.items(), key=lambda x: x[1], reverse=True)
+    
+    total_external_size = sum(import_sizes.values())
+    
+    print(f"\nTotal external dependency size: {total_external_size:,} bytes ({total_external_size / 1024 / 1024:.2f} MB)")
+    print(f"\nTop teams by external dependency binary size impact:\n")
+    
+    for team, size in sorted_teams:
+        percentage = (size / total_external_size * 100) if total_external_size > 0 else 0
+        print(f"{team}")
+        print(f"  Total: {size:,} bytes ({size / 1024 / 1024:.2f} MB, {percentage:.1f}%)")
+        
+        # Show top imports for this team
+        top_imports = sorted(team_imports_with_sizes[team], key=lambda x: x[1], reverse=True)[:5]
+        if top_imports:
+            print(f"  Top imports:")
+            for imp, imp_size in top_imports:
+                imp_pct = (imp_size / size * 100) if size > 0 else 0
+                print(f"    - {imp}: {imp_size:,} bytes ({imp_pct:.1f}%)")
+        print()
+    
+    # Summary
+    print_summary(directories, go_files, import_to_files, team_to_imports, 
+                  import_sizes, import_to_teams)
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
### What does this PR do?


```
================================================================================
BINARY SIZE IMPACT ANALYSIS
================================================================================

Analyzing binary: /Users/brian.floersch/go/src/github.com/DataDog/datadog-agent/bin/agent/agent
Running 'go tool nm' (this may take a moment)...

Total external dependency size: 16,889,259 bytes (16.11 MB)

Top teams by external dependency binary size impact:

@DataDog/database-monitoring
  Total: 13,919,515 bytes (13.27 MB, 82.4%)
  Top imports:
    - github.com/sijms/go-ora/v2: 13,079,604 bytes (94.0%)
    - github.com/godror/godror: 350,901 bytes (2.5%)
    - github.com/aws/aws-sdk-go-v2/service/rds: 241,448 bytes (1.7%)
    - github.com/aws/aws-sdk-go-v2/config: 105,952 bytes (0.8%)
    - github.com/aws/aws-sdk-go-v2/aws: 89,610 bytes (0.6%)

@DataDog/agent-runtimes
  Total: 1,633,720 bytes (1.56 MB, 9.7%)
  Top imports:
    - github.com/itchyny/gojq: 429,106 bytes (26.3%)
    - github.com/json-iterator/go: 166,904 bytes (10.2%)
    - github.com/klauspost/compress/zstd: 154,936 bytes (9.5%)
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (8.7%)
    - github.com/cihub/seelog: 104,684 bytes (6.4%)

@DataDog/agent-configuration
  Total: 739,974 bytes (0.71 MB, 4.4%)
  Top imports:
    - github.com/gogo/protobuf/proto: 318,555 bytes (43.0%)
    - github.com/json-iterator/go: 166,904 bytes (22.6%)
    - github.com/spf13/cobra: 63,140 bytes (8.5%)
    - github.com/go-viper/mapstructure/v2: 46,992 bytes (6.4%)
    - github.com/go-ini/ini: 25,957 bytes (3.5%)

@DataDog/container-integrations
  Total: 685,494 bytes (0.65 MB, 4.1%)
  Top imports:
    - github.com/json-iterator/go: 166,904 bytes (24.3%)
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (20.6%)
    - github.com/gobwas/glob: 97,564 bytes (14.2%)
    - github.com/spf13/cobra: 63,140 bytes (9.2%)
    - github.com/openshift/api/quota/v1: 47,464 bytes (6.9%)

@DataDog/container-platform
  Total: 683,507 bytes (0.65 MB, 4.0%)
  Top imports:
    - github.com/json-iterator/go: 166,904 bytes (24.4%)
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (20.7%)
    - github.com/gobwas/glob: 97,564 bytes (14.3%)
    - github.com/spf13/cobra: 63,140 bytes (9.2%)
    - github.com/google/cel-go/cel: 46,912 bytes (6.9%)

@DataDog/cloud-network-monitoring
  Total: 632,290 bytes (0.60 MB, 3.7%)
  Top imports:
    - github.com/gogo/protobuf/proto: 318,555 bytes (50.4%)
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (22.4%)
    - github.com/gogo/protobuf/jsonpb: 40,320 bytes (6.4%)
    - github.com/davecgh/go-spew/spew: 26,881 bytes (4.3%)
    - github.com/gorilla/mux: 16,736 bytes (2.6%)

@DataDog/container-experiences
  Total: 515,180 bytes (0.49 MB, 3.1%)
  Top imports:
    - github.com/gogo/protobuf/proto: 318,555 bytes (61.8%)
    - github.com/spf13/cobra: 63,140 bytes (12.3%)
    - github.com/gogo/protobuf/jsonpb: 40,320 bytes (7.8%)
    - github.com/gorilla/mux: 16,736 bytes (3.2%)
    - github.com/benbjohnson/clock: 11,968 bytes (2.3%)

@DataDog/agent-metric-pipelines
  Total: 405,095 bytes (0.39 MB, 2.4%)
  Top imports:
    - github.com/json-iterator/go: 166,904 bytes (41.2%)
    - github.com/spf13/cobra: 63,140 bytes (15.6%)
    - github.com/h2non/filetype: 39,700 bytes (9.8%)
    - github.com/h2non/filetype/matchers: 37,564 bytes (9.3%)
    - github.com/golang/protobuf/proto: 21,673 bytes (5.4%)

@DataDog/ebpf-platform
  Total: 358,562 bytes (0.34 MB, 2.1%)
  Top imports:
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (39.4%)
    - github.com/cihub/seelog: 104,684 bytes (29.2%)
    - github.com/spf13/cobra: 63,140 bytes (17.6%)
    - github.com/pierrec/lz4/v4: 19,744 bytes (5.5%)
    - github.com/gorilla/mux: 16,736 bytes (4.7%)

@DataDog/ndm-integrations
  Total: 280,745 bytes (0.27 MB, 1.7%)
  Top imports:
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (50.4%)
    - github.com/netsampler/goflow2/decoders/netflow: 38,776 bytes (13.8%)
    - github.com/prometheus/client_golang/prometheus/promhttp: 27,448 bytes (9.8%)
    - github.com/netsampler/goflow2/producer: 26,544 bytes (9.5%)
    - github.com/netsampler/goflow2/utils: 21,320 bytes (7.6%)

@DataDog/opentelemetry-agent
  Total: 270,523 bytes (0.26 MB, 1.6%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (23.3%)
    - github.com/tinylib/msgp/msgp: 47,508 bytes (17.6%)
    - github.com/go-viper/mapstructure/v2: 46,992 bytes (17.4%)
    - github.com/golang/protobuf/proto: 21,673 bytes (8.0%)
    - github.com/gorilla/mux: 16,736 bytes (6.2%)

@DataDog/agent-cspm
  Total: 267,445 bytes (0.26 MB, 1.6%)
  Top imports:
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (52.9%)
    - github.com/spf13/cobra: 63,140 bytes (23.6%)
    - github.com/spf13/cast: 25,488 bytes (9.5%)
    - github.com/spf13/pflag: 24,864 bytes (9.3%)
    - github.com/shirou/gopsutil/v4/process: 6,344 bytes (2.4%)

@DataDog/container-autoscaling
  Total: 223,096 bytes (0.21 MB, 1.3%)
  Top imports:
    - github.com/prometheus/client_golang/prometheus: 141,417 bytes (63.4%)
    - github.com/spf13/cobra: 63,140 bytes (28.3%)
    - github.com/twmb/murmur3: 6,240 bytes (2.8%)
    - github.com/fatih/color: 5,361 bytes (2.4%)
    - github.com/hashicorp/go-multierror: 4,112 bytes (1.8%)

@DataDog/agent-security
  Total: 221,496 bytes (0.21 MB, 1.3%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (28.5%)
    - github.com/davecgh/go-spew/spew: 26,881 bytes (12.1%)
    - github.com/spf13/cast: 25,488 bytes (11.5%)
    - github.com/gorilla/mux: 16,736 bytes (7.6%)
    - github.com/mailru/easyjson: 11,552 bytes (5.2%)

@DataDog/agent-apm
  Total: 208,947 bytes (0.20 MB, 1.2%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (30.2%)
    - github.com/tinylib/msgp/msgp: 47,508 bytes (22.7%)
    - github.com/outcaste-io/ristretto: 31,144 bytes (14.9%)
    - github.com/davecgh/go-spew/spew: 26,881 bytes (12.9%)
    - github.com/golang/protobuf/proto: 21,673 bytes (10.4%)

@DataDog/kubernetes-experiences
  Total: 204,904 bytes (0.20 MB, 1.2%)
  Top imports:
    - github.com/json-iterator/go: 166,904 bytes (81.5%)
    - github.com/benbjohnson/clock: 11,968 bytes (5.8%)
    - github.com/pkg/errors: 6,480 bytes (3.2%)
    - github.com/twmb/murmur3: 6,240 bytes (3.0%)
    - github.com/patrickmn/go-cache: 4,944 bytes (2.4%)

@DataDog/ndm-core
  Total: 203,332 bytes (0.19 MB, 1.2%)
  Top imports:
    - github.com/gosnmp/gosnmp: 99,744 bytes (49.1%)
    - github.com/spf13/cobra: 63,140 bytes (31.1%)
    - github.com/prometheus-community/pro-bing: 17,464 bytes (8.6%)
    - github.com/gorilla/mux: 16,736 bytes (8.2%)
    - github.com/invopop/jsonschema: 4,944 bytes (2.4%)

@DataDog/remote-config
  Total: 180,072 bytes (0.17 MB, 1.1%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (35.1%)
    - github.com/tinylib/msgp/msgp: 47,508 bytes (26.4%)
    - github.com/gorilla/websocket: 37,136 bytes (20.6%)
    - github.com/benbjohnson/clock: 11,968 bytes (6.6%)
    - github.com/Masterminds/semver: 9,728 bytes (5.4%)

@DataDog/action-platform
  Total: 176,178 bytes (0.17 MB, 1.0%)
  Top imports:
    - github.com/gobwas/glob: 97,564 bytes (55.4%)
    - github.com/spf13/cobra: 63,140 bytes (35.8%)
    - github.com/fatih/color: 5,361 bytes (3.0%)
    - github.com/google/uuid: 5,033 bytes (2.9%)
    - github.com/hashicorp/go-multierror: 4,112 bytes (2.3%)

@DataDog/universal-service-monitoring
  Total: 160,746 bytes (0.15 MB, 1.0%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (39.3%)
    - github.com/davecgh/go-spew/spew: 26,881 bytes (16.7%)
    - github.com/golang/protobuf/proto: 21,673 bytes (13.5%)
    - github.com/benbjohnson/clock: 11,968 bytes (7.4%)
    - github.com/Masterminds/semver: 9,728 bytes (6.1%)

@DataDog/windows-products
  Total: 145,288 bytes (0.14 MB, 0.9%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (43.5%)
    - github.com/fsnotify/fsnotify: 19,449 bytes (13.4%)
    - github.com/gorilla/mux: 16,736 bytes (11.5%)
    - github.com/shirou/gopsutil/v4/disk: 10,592 bytes (7.3%)
    - github.com/pkg/errors: 6,480 bytes (4.5%)

@DataDog/debugger-go
  Total: 114,741 bytes (0.11 MB, 0.7%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (55.0%)
    - github.com/benbjohnson/clock: 11,968 bytes (10.4%)
    - github.com/goccy/go-yaml: 11,928 bytes (10.4%)
    - github.com/hashicorp/golang-lru/v2: 9,424 bytes (8.2%)
    - github.com/dustin/go-humanize: 6,768 bytes (5.9%)

@DataDog/fleet
  Total: 114,311 bytes (0.11 MB, 0.7%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (55.2%)
    - github.com/gorilla/mux: 16,736 bytes (14.6%)
    - github.com/shirou/gopsutil/v4/disk: 10,592 bytes (9.3%)
    - github.com/shirou/gopsutil/v4/process: 6,344 bytes (5.5%)
    - github.com/fatih/color: 5,361 bytes (4.7%)

@DataDog/agent-log-pipelines
  Total: 111,796 bytes (0.11 MB, 0.7%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (56.5%)
    - github.com/gorilla/mux: 16,736 bytes (15.0%)
    - github.com/benbjohnson/clock: 11,968 bytes (10.7%)
    - github.com/patrickmn/go-cache: 4,944 bytes (4.4%)
    - github.com/cenkalti/backoff: 4,912 bytes (4.4%)

@DataDog/agent-integrations
  Total: 95,709 bytes (0.09 MB, 0.6%)
  Top imports:
    - github.com/spf13/cobra: 63,140 bytes (66.0%)
    - github.com/gorilla/mux: 16,736 bytes (17.5%)
    - github.com/pkg/errors: 6,480 bytes (6.8%)
    - github.com/fatih/color: 5,361 bytes (5.6%)
    - github.com/coreos/go-semver/semver: 3,992 bytes (4.2%)

@DataDog/agent-discovery
  Total: 92,736 bytes (0.09 MB, 0.5%)
  Top imports:
    - github.com/tinylib/msgp/msgp: 47,508 bytes (51.2%)
    - github.com/gorilla/mux: 16,736 bytes (18.0%)
    - github.com/vibrantbyte/go-antpath/antpath: 9,148 bytes (9.9%)
    - github.com/rickar/props: 7,048 bytes (7.6%)
    - github.com/shirou/gopsutil/v4/process: 6,344 bytes (6.8%)

@DataDog/agent-delivery
  Total: 80,193 bytes (0.08 MB, 0.5%)
  Top imports:
    - github.com/ProtonMail/go-crypto/openpgp: 80,193 bytes (100.0%)

@iglendd
  Total: 35,260 bytes (0.03 MB, 0.2%)
  Top imports:
    - github.com/robfig/cron/v3: 22,296 bytes (63.2%)
    - github.com/prometheus/client_model/go: 12,964 bytes (36.8%)

@DataDog/profiling-full-host
  Total: 28,664 bytes (0.03 MB, 0.2%)
  Top imports:
    - github.com/gorilla/mux: 16,736 bytes (58.4%)
    - github.com/goccy/go-yaml: 11,928 bytes (41.6%)

@DataDog/network-path
  Total: 21,769 bytes (0.02 MB, 0.1%)
  Top imports:
    - github.com/gorilla/mux: 16,736 bytes (76.9%)
    - github.com/google/uuid: 5,033 bytes (23.1%)

@DataDog/opentelemetry
  Total: 21,673 bytes (0.02 MB, 0.1%)
  Top imports:
    - github.com/golang/protobuf/proto: 21,673 bytes (100.0%)

@DataDog/network-device-monitoring
  Total: 11,968 bytes (0.01 MB, 0.1%)
  Top imports:
    - github.com/benbjohnson/clock: 11,968 bytes (100.0%)

@DataDog/serverless-azure-gcp
  Total: 4,144 bytes (0.00 MB, 0.0%)
  Top imports:
    - github.com/spf13/afero: 4,144 bytes (100.0%)

@DataDog/injection-platform
  Total: 976 bytes (0.00 MB, 0.0%)
  Top imports:
    - github.com/opencontainers/go-digest: 976 bytes (100.0%)

================================================================================
SUMMARY
================================================================================

Directories analyzed: pkg, comp, cmd
Go files (non-test): 6156
Unique external GitHub imports: 341
Teams involved: 35
Total binary size from external deps: 16,889,259 bytes (16.11 MB)

Top 10 external imports by binary size:
  1. github.com/sijms/go-ora/v2
     Size: 13,079,604 bytes (12773.1 KB, 77.4%)
     Teams: @DataDog/database-monitoring
     Used in 4 files
  2. github.com/itchyny/gojq
     Size: 429,106 bytes (419.0 KB, 2.5%)
     Teams: @DataDog/agent-runtimes
     Used in 1 files
  3. github.com/godror/godror
     Size: 350,901 bytes (342.7 KB, 2.1%)
     Teams: @DataDog/database-monitoring
     Used in 2 files
  4. github.com/gogo/protobuf/proto
     Size: 318,555 bytes (311.1 KB, 1.9%)
     Teams: @DataDog/agent-configuration, @DataDog/cloud-network-monitoring, @DataDog/container-experiences
     Used in 4 files
  5. github.com/aws/aws-sdk-go-v2/service/rds
     Size: 241,448 bytes (235.8 KB, 1.4%)
     Teams: @DataDog/database-monitoring
     Used in 4 files
  6. github.com/json-iterator/go
     Size: 166,904 bytes (163.0 KB, 1.0%)
     Teams: @DataDog/agent-configuration, @DataDog/agent-metric-pipelines, @DataDog/agent-runtimes, @DataDog/container-integrations, @DataDog/container-platform, @DataDog/kubernetes-experiences
     Used in 16 files
  7. github.com/klauspost/compress/zstd
     Size: 154,936 bytes (151.3 KB, 0.9%)
     Teams: @DataDog/agent-runtimes
     Used in 1 files
  8. github.com/prometheus/client_golang/prometheus
     Size: 141,417 bytes (138.1 KB, 0.8%)
     Teams: @DataDog/agent-cspm, @DataDog/agent-runtimes, @DataDog/cloud-network-monitoring, @DataDog/container-autoscaling, @DataDog/container-integrations, @DataDog/container-platform, @DataDog/ebpf-platform, @DataDog/ndm-integrations
     Used in 40 files
  9. github.com/aws/aws-sdk-go-v2/config
     Size: 105,952 bytes (103.5 KB, 0.6%)
     Teams: @DataDog/database-monitoring
     Used in 1 files
  10. github.com/cihub/seelog
     Size: 104,684 bytes (102.2 KB, 0.6%)
     Teams: @DataDog/agent-runtimes, @DataDog/ebpf-platform
     Used in 11 files
```

### Motivation

### Describe how you validated your changes

### Additional Notes
