### PR TITLE
Reduce libcurl size

### DIFF
--- a/omnibus/config/software/curl.rb
+++ b/omnibus/config/software/curl.rb
@@ -53,6 +53,9 @@ build do
            "--disable-docs",
            "--disable-libcurl-option",
            "--disable-versioned-symbols",
+           "--disable-libuv",
+           "--disable-verbose",
+           "--disable-progress-meter",
   ]
   configure(*configure_options, env: env)
 

--- a/omnibus/config/software/curl.rb
+++ b/omnibus/config/software/curl.rb
@@ -16,13 +16,13 @@
 #
 
 name "curl"
-default_version "8.16.0"
+default_version "8.18.0"
 
 dependency "zlib"
 dependency "openssl3"
 dependency "nghttp2"
 source url:    "https://curl.haxx.se/download/curl-#{version}.tar.gz",
-       sha256: "a21e20476e39eca5a4fc5cfb00acf84bbc1f5d8443ec3853ad14c26b3c85b970"
+       sha256: "e9274a5f8ab5271c0e0e6762d2fce194d5f98acc568e4ce816845b2dcc0cf88f"
 
 relative_path "curl-#{version}"
 


### PR DESCRIPTION
### What does this PR do?

Disable a few features we don't need in curl
* `libuv` is only used for debugging purposes (as per `curl`'s configure
* On `--disable-verbose`: https://curl.se/mail/lib-2017-02/0027.html I assume that we don't rely on the verbose outupt, but please correct me if I'm wrong
* The progress-meter is definitely something we shouldn't need

### Motivation

Reducing the package size, bit by bit

### Describe how you validated your changes

### Additional Notes

This is meant to offset https://github.com/DataDog/datadog-agent/pull/45032
