### PR TITLE
[CSPM] enable sysprobe module with correct config flag

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -338,7 +338,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.enabled", true)
 	cfg.BindEnvAndSetDefault("event_monitoring_config.network_process.container_store.max_containers_tracked", 1024)
 
-	cfg.BindEnvAndSetDefault("compliance_config.enabled", false)
+	cfg.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)
 
 	// enable/disable use of root net namespace
 	cfg.BindEnvAndSetDefault("network_config.enable_root_netns", true)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -142,7 +142,7 @@ func load() (*types.Config, error) {
 		diEnabled {
 		c.EnabledModules[EventMonitorModule] = struct{}{}
 	}
-	complianceEnabled := cfg.GetBool(compNS("enabled")) ||
+	complianceEnabled := cfg.GetBool(compNS("database_benchmarks.enabled")) ||
 		(cfg.GetBool(secNS("enabled")) && cfg.GetBool(secNS("compliance_module.enabled")))
 	if complianceEnabled {
 		c.EnabledModules[ComplianceModule] = struct{}{}


### PR DESCRIPTION
### What does this PR do?

This PR renames the config flag to enable the current system-probe module to `compliance_config.database_benchmarks.enabled` instead of just `compliance_config.enabled`. While this is a breaking change, the system-probe module has never been enabled by default nor communicated to customers, it's only used internally (where it's enabled using the CWS based configuration anyway).

This renaming is going to allow the usage of `compliance_config.enabled` to enable the full CSPM module, that is also going to run the checks themselves when running CSPM fully in the system-probe process.

### Motivation

### Describe how you validated your changes

### Additional Notes
