### PR TITLE
Fix and check direct `bazel_dep`s are honored

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,7 @@ startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of ina
 
 # Common options -------------------------------------------------------------------------------------------------------
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
+common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -224,6 +224,6 @@ include("//deps/windows:drivers.MODULE.bazel")
 # This enables cross-compilation for macOS x86_64 on Apple Silicon.
 # Simply add --platforms=@apple_support//platforms:macos_x86_64
 # to the build command to enable it.
-bazel_dep(name = "apple_support", version = "1.23.1")
+bazel_dep(name = "apple_support", version = "1.24.1")
 
 use_repo_rule("//bazel/tools:check_bazel_version.bzl", "check_bazel_version")(name = "check_bazel_version")

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -58,7 +58,7 @@ set "bazel_exit=!errorlevel!"
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
 set "should_diagnose=1"
-for %%c in (0 1 3 34 36) do if !bazel_exit!==%%c set "should_diagnose=0"
+for %%c in (0 1 3 34 36 48) do if !bazel_exit!==%%c set "should_diagnose=0"
 if !should_diagnose!==1 (
   >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (


### PR DESCRIPTION
### What does this PR do?
This bumps an out-of-sync project dependency to its actually resolved version (hence no change in lock file) and prevents such a discrepancy from happening again by verifying no configured `bazel_dep` can be bumped again out of `MODULE.bazel` control.

### Motivation
Recent changes led to bump a dependency voiding its explicit declaration.

### Describe how you validated your changes
Before/after adding `--check_direct_dependencies=error`:
```diff
-WARNING: For repository 'apple_support', the root module requires module version apple_support@1.23.1, but got apple_support@1.24.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off
+ERROR: For repository 'apple_support', the root module requires module version apple_support@1.23.1, but got apple_support@1.24.1 in the resolved dependency graph. Please update the version in your MODULE.bazel or set --check_direct_dependencies=off
echo $?
-0
+48
```

### Additional Notes
Corresponding exit code `48` doesn't need to trigger verbose Bazel diagnostics on Windows.