### PR TITLE
Make the windows-products team co-own the OSX systray

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -457,6 +457,7 @@
 /comp/core/autodiscovery/providers/process_log*.go @DataDog/agent-discovery @DataDog/agent-log-pipelines
 /comp/core/autodiscovery/providers/remote_config*.go  @DataDog/fleet
 /comp/core/autodiscovery/providers/datastreams @DataDog/data-streams-monitoring
+/comp/core/gui/guiimpl/systray/ @DataDog/windows-products @DataDog/agent-configuration
 /pkg/cloudfoundry                       @DataDog/agent-integrations
 /pkg/clusteragent/                      @DataDog/container-platform
 /pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling


### PR DESCRIPTION
### What does this PR do?

Make the windows-products team own the windows systray