### PR TITLE
[AGNTLOG-437] Added `logs.dropped` metric to http

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -297,10 +297,11 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 			// Permanent error, increment the logs dropped metric
 			metrics.DestinationLogsDropped.Add(d.host, payload.Count())
 			metrics.TlmLogsDropped.Add(float64(payload.Count()), d.host)
+		} else {
+			metrics.LogsSent.Add(payload.Count())
+			metrics.TlmLogsSent.Add(float64(payload.Count()))
 		}
 
-		metrics.LogsSent.Add(payload.Count())
-		metrics.TlmLogsSent.Add(float64(payload.Count()))
 		output <- payload
 		return result
 	}

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -128,7 +128,7 @@ func TestLogsDroppedMetric(t *testing.T) {
 	testLogsDropped(t, 413)
 }
 
-func testLogsDropped(t *testing.T, statusCode int){
+func testLogsDropped(t *testing.T, statusCode int) {
 	cfg := configmock.New(t)
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	metrics.TlmLogsDropped = telemetryMock.NewCounter("logs", "dropped", []string{"destination"}, "")
@@ -149,10 +149,10 @@ func testLogsDropped(t *testing.T, statusCode int){
 
 	// Send Payload that should fail & be non-retryable
 	input <- payload
-	<- output
+	<-output
 
 	// Verify the logs.dropped metric was incremented & has correct destination tag
-	metric, err := telemetryMock.(telemetry.Mock).GetCountMetric("logs","dropped")
+	metric, err := telemetryMock.(telemetry.Mock).GetCountMetric("logs", "dropped")
 	assert.NoError(t, err)
 	assert.Len(t, metric, 1, "Should have one metric entry")
 

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -121,6 +121,47 @@ func testNoRetry(t *testing.T, statusCode int) {
 	server.Stop()
 }
 
+func TestLogsDroppedMetric(t *testing.T) {
+	testLogsDropped(t, 400)
+	testLogsDropped(t, 401)
+	testLogsDropped(t, 403)
+	testLogsDropped(t, 413)
+}
+
+func testLogsDropped(t *testing.T, statusCode int){
+	cfg := configmock.New(t)
+	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+	metrics.TlmLogsDropped = telemetryMock.NewCounter("logs", "dropped", []string{"destination"}, "")
+
+	server := NewTestServer(statusCode, cfg)
+	input := make(chan *message.Payload)
+	output := make(chan *message.Payload)
+	server.Destination.Start(input, output, nil)
+
+	payload := &message.Payload{
+		MessageMetas: []*message.MessageMetadata{
+			{},
+			{},
+			{},
+		},
+		Encoded: []byte("test payload"),
+	}
+
+	// Send Payload that should fail & be non-retryable
+	input <- payload
+	<- output
+
+	// Verify the logs.dropped metric was incremented & has correct destination tag
+	metric, err := telemetryMock.(telemetry.Mock).GetCountMetric("logs","dropped")
+	assert.NoError(t, err)
+	assert.Len(t, metric, 1, "Should have one metric entry")
+
+	assert.Equal(t, float64(3), metric[0].Value())
+	assert.Equal(t, server.Destination.host, metric[0].Tags()["destination"])
+
+	server.Stop()
+}
+
 func retryTest(t *testing.T, statusCode int) {
 	cfg := configmock.New(t)
 	respondChan := make(chan int)

--- a/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
+++ b/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    The ``logs.dropped`` metric now tracks dropped logs for both TCP and HTTP 
+    The `logs.dropped` metric now tracks dropped logs for both TCP and HTTP 
     log transports. Previously, this metric was only available when using TCP 
     transport. Customers can now monitor dropped logs with a single unified 
     metric regardless of which transport protocol is configured, making it 

--- a/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
+++ b/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    The ``logs.dropped`` metric now tracks dropped logs for both TCP and HTTP 
+    log transports. Previously, this metric was only available when using TCP 
+    transport. Customers can now monitor dropped logs with a single unified 
+    metric regardless of which transport protocol is configured, making it 
+    easier to detect and troubleshoot log delivery issues.

--- a/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
+++ b/releasenotes/notes/logs-dropped-http-metric-f1a08e187bf0ffc2.yaml
@@ -6,3 +6,8 @@ enhancements:
     transport. Customers can now monitor dropped logs with a single unified 
     metric regardless of which transport protocol is configured, making it 
     easier to detect and troubleshoot log delivery issues.
+fixes:
+  - |
+    Fixed the ``logs.sent`` metric for the HTTP log transport to no longer 
+    increment when logs are dropped due to non-retryable errors. This ensures 
+    more accurate reporting of successfully delivered logs.


### PR DESCRIPTION
### What does this PR do?

Adds the `logs.dropped` metric to the HTTP log sender, bringing it to parity with the TCP sender which already tracks this metric. The metric is incremented when logs are permanently dropped due to non-retryable errors (400, 401, 403, 413).

### Motivation

[Ticket](https://datadoghq.atlassian.net/jira/software/c/projects/AGNTLOG/boards/8654?quickFilter=10125&selectedIssue=AGNTLOG-437)

### Describe how you validated your changes

Manual QA. To remake the conditions possible, set up [mitmproxy](https://www.mitmproxy.org/) with a custom python script:
```python
from mitmproxy import http

def request(flow: http.HTTPFlow):
    if "agent-http-intake.logs.datadoghq.com" in flow.request.pretty_host:
        flow.response = http.Response.make(400, b"Bad Request")
```
that intercepts requests to the Datadog logs intake endpoint and returns 400 Bad Request errors, allowing me to test the agent's error handling behavior. Configured the agent to use the proxy (http_proxy: http://localhost:8080) and verified the expected behavior by having the agent ingest a log file, wait 10-15 seconds, and check the telemetry output:

`curl -s http://localhost:5000/telemetry 2>&1 | grep "logs"` ->
```bash
  logs__destination_http_resp{status_code="400",url="https://agent-http-intake.logs.datadoghq.com./api/v2/logs"} 3
  # HELP logs__dropped Total number of logs dropped per Destination
  # TYPE logs__dropped counter
  logs__dropped{destination="agent-http-intake.logs.datadoghq.com."} 3
```

#### Testing the Agent

Update your `datadog.yaml` with 
```
proxy:
  https: "http://localhost:8080"
  http: "http://localhost:8080"

skip_ssl_validation: true
```

In a terminal download mitmproxy via brew and run `mitmdump -p 8080 -s <python-file> --ssl-insecure`

Setup the agent to ingest from a log source:
```
logs:
  - type: file
    path: /tmp/test_app.log
    service: test-service
    source: custom
    sourcecategory: test
```

Build the agent: `dda inv agent.build`
Run the agent: `./bin/agent/agent run -c dev/dist/datadog.yaml`
Add logs to your log file & wait a few seconds

In a new terminal run: `curl -s http://localhost:5000/telemetry 2>&1 | grep "logs"`
You should see:
```bash
logs__destination_http_resp{status_code="400",url="https://agent-http-intake.logs.datadoghq.com./api/v2/logs"} 3
# HELP logs__dropped Total number of logs dropped per Destination
# TYPE logs__dropped counter
logs__dropped{destination="agent-http-intake.logs.datadoghq.com."} 3
```

### Unit Tests

Added `TestLogsDroppedMetric` which verifies:
- Non-retryable errors (400, 401, 403, 413) increment the metric
- The metric counts by `payload.Count()` (number of logs), not payloads
- The destination tag is set correctly