### PR TITLE
integrate service extraction with CNM/USM direct send

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -77,7 +77,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 		log.Info("event monitoring network consumer initialized")
 
 		if netconfig.DirectSend {
-			dp, err := sender.NewDockerProxyConsumer(evm, deps.Log)
+			dp, err := sender.NewDirectSenderConsumer(evm, deps.Log, deps.SysprobeConfig)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/network/sender/docker_proxy.go
+++ b/pkg/network/sender/docker_proxy.go
@@ -14,14 +14,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	ddmaps "github.com/DataDog/datadog-agent/pkg/util/maps"
-	"github.com/DataDog/datadog-agent/pkg/util/os"
+	ddos "github.com/DataDog/datadog-agent/pkg/util/os"
 )
 
 type containerAddr struct {
@@ -36,13 +34,6 @@ type proxy struct {
 	alive  bool
 }
 
-var _ eventmonitor.EventConsumerHandler = &dockerProxyFilter{}
-var _ eventmonitor.EventConsumer = &dockerProxyFilter{}
-
-// proxyFilterInstance contains the instance of the docker proxy filter (if there is one).
-// this is necessary due to the out-of-order initialization between CNM and Event Monitor.
-var proxyFilterInstance atomic.Pointer[dockerProxyFilter]
-
 type dockerProxyFilter struct {
 	log log.Component
 
@@ -53,78 +44,16 @@ type dockerProxyFilter struct {
 	pidAliveFunc func(pid int) bool
 }
 
-// NewDockerProxyConsumer creates the docker proxy filter and returns it for event monitor registration
-func NewDockerProxyConsumer(em *eventmonitor.EventMonitor, log log.Component) (eventmonitor.EventConsumer, error) {
-	pf := newDockerProxyFilter(log)
-	err := em.AddEventConsumerHandler(pf)
-	if err != nil {
-		return nil, err
-	}
-	proxyFilterInstance.Store(pf)
-	return pf, nil
-}
-
 func newDockerProxyFilter(log log.Component) *dockerProxyFilter {
 	return &dockerProxyFilter{
 		log:           log,
 		proxyByTarget: make(map[containerAddr]*proxy),
 		proxyByPID:    make(map[uint32]*proxy),
-		pidAliveFunc:  os.PidExists,
+		pidAliveFunc:  ddos.PidExists,
 	}
 }
 
-// ID implements eventmonitor.EventConsumer and eventmonitor.EventConsumerHandler
-func (d *dockerProxyFilter) ID() string {
-	return "dockerproxy"
-}
-
-// ChanSize implements eventmonitor.EventConsumerHandler
-func (d *dockerProxyFilter) ChanSize() int {
-	return 100
-}
-
-type dockerProcess struct {
-	Pid       uint32
-	Cmdline   []string
-	EventType model.EventType
-}
-
-// EventTypes implements eventmonitor.EventConsumerHandler
-func (d *dockerProxyFilter) EventTypes() []model.EventType {
-	return []model.EventType{
-		model.ExecEventType,
-		model.ExitEventType,
-	}
-}
-
-// Start implements eventmonitor.EventConsumer
-func (d *dockerProxyFilter) Start() error {
-	return nil
-}
-
-// Stop implements eventmonitor.EventConsumer
-func (d *dockerProxyFilter) Stop() {}
-
-// Copy implements eventmonitor.EventConsumerHandler
-func (d *dockerProxyFilter) Copy(ev *model.Event) any {
-	p := &dockerProcess{
-		Pid:       ev.GetProcessPid(),
-		EventType: ev.GetEventType(),
-		Cmdline:   ev.GetExecCmdargv(),
-	}
-	return p
-}
-
-// HandleEvent implements eventmonitor.EventConsumerHandler
-func (d *dockerProxyFilter) HandleEvent(ev any) {
-	p, ok := ev.(*dockerProcess)
-	if !ok {
-		return
-	}
-	d.process(p)
-}
-
-func (d *dockerProxyFilter) process(event *dockerProcess) {
+func (d *dockerProxyFilter) process(event *process) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -222,7 +151,7 @@ func (d *dockerProxyFilter) discoverProxyIP(p *proxy, c network.ConnectionStats)
 	return netip.Addr{}
 }
 
-func extractProxyTarget(p *dockerProcess) *proxy {
+func extractProxyTarget(p *process) *proxy {
 	if len(p.Cmdline) == 0 {
 		return nil
 	}

--- a/pkg/network/sender/docker_proxy.go
+++ b/pkg/network/sender/docker_proxy.go
@@ -57,7 +57,7 @@ func (d *dockerProxyFilter) process(event *process) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	// TODO if we miss the exec event, we will never consider that process a docker-proxy
+	// TODO if we miss the fork/exec event, we will never consider that process a docker-proxy
 
 	if proxy, seen := d.proxyByPID[event.Pid]; seen {
 		if event.EventType == model.ExitEventType {
@@ -65,7 +65,7 @@ func (d *dockerProxyFilter) process(event *process) {
 			proxy.alive = false
 			return
 		}
-		if event.EventType != model.ExecEventType {
+		if event.EventType != model.ExecEventType && event.EventType != model.ForkEventType {
 			return
 		}
 		// we've received a new exec event with the same PID as an existing entry.

--- a/pkg/network/sender/event_consumer.go
+++ b/pkg/network/sender/event_consumer.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package sender
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	ddos "github.com/DataDog/datadog-agent/pkg/util/os"
+)
+
+var _ eventmonitor.EventConsumerHandler = &directSenderConsumer{}
+var _ eventmonitor.EventConsumer = &directSenderConsumer{}
+
+// directSenderConsumerInstance contains the instance of the direct sender consumer (if there is one).
+// this is necessary due to the out-of-order initialization between CNM and Event Monitor.
+var directSenderConsumerInstance atomic.Pointer[directSenderConsumer]
+
+type directSenderConsumer struct {
+	log       log.Component
+	processes map[uint32]bool
+	mtx       sync.Mutex
+
+	proxyFilter  *dockerProxyFilter
+	extractor    *serviceExtractor
+	pidAliveFunc func(pid int) bool
+}
+
+// NewDirectSenderConsumer creates the direct sender consumer and returns it for event monitor registration
+func NewDirectSenderConsumer(em *eventmonitor.EventMonitor, log log.Component, sysprobeconfig sysprobeconfig.Component) (eventmonitor.EventConsumer, error) {
+	dsc := &directSenderConsumer{
+		log:          log,
+		processes:    make(map[uint32]bool),
+		proxyFilter:  newDockerProxyFilter(log),
+		extractor:    newServiceExtractor(sysprobeconfig),
+		pidAliveFunc: ddos.PidExists,
+	}
+	err := em.AddEventConsumerHandler(dsc)
+	if err != nil {
+		return nil, err
+	}
+	directSenderConsumerInstance.Store(dsc)
+	return dsc, nil
+}
+
+// ID implements eventmonitor.EventConsumer and eventmonitor.EventConsumerHandler
+func (d *directSenderConsumer) ID() string {
+	return "networkdirectsender"
+}
+
+// ChanSize implements eventmonitor.EventConsumerHandler
+func (d *directSenderConsumer) ChanSize() int {
+	return 100
+}
+
+type process struct {
+	Pid       uint32
+	Cmdline   []string
+	Cwd       string
+	EventType model.EventType
+
+	alive bool
+}
+
+// EventTypes implements eventmonitor.EventConsumerHandler
+func (d *directSenderConsumer) EventTypes() []model.EventType {
+	return []model.EventType{
+		model.ExecEventType,
+		model.ExitEventType,
+	}
+}
+
+// Start implements eventmonitor.EventConsumer
+func (d *directSenderConsumer) Start() error {
+	return nil
+}
+
+// Stop implements eventmonitor.EventConsumer
+func (d *directSenderConsumer) Stop() {}
+
+// Copy implements eventmonitor.EventConsumerHandler
+func (d *directSenderConsumer) Copy(ev *model.Event) any {
+	p := &process{
+		Pid:       ev.GetProcessPid(),
+		EventType: ev.GetEventType(),
+		Cmdline:   ev.GetExecCmdargv(),
+	}
+	return p
+}
+
+// HandleEvent implements eventmonitor.EventConsumerHandler
+func (d *directSenderConsumer) HandleEvent(ev any) {
+	p, ok := ev.(*process)
+	if !ok {
+		return
+	}
+	if p.EventType == model.ExecEventType {
+		cwd, err := os.Readlink(kernel.HostProc(strconv.Itoa(int(p.Pid)), "cwd"))
+		if err != nil {
+			d.log.Warnf("error reading working directory for pid %d: %s", p.Pid, err)
+		}
+		p.Cwd = cwd
+	}
+	d.process(p)
+}
+
+func (d *directSenderConsumer) process(p *process) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	if _, seen := d.processes[p.Pid]; seen {
+		if p.EventType == model.ExitEventType {
+			// mark process as dead so it will be removed after next set of connections are collected
+			d.processes[p.Pid] = false
+		}
+	}
+
+	if p.EventType == model.ExecEventType {
+		d.processes[p.Pid] = true
+	}
+	d.proxyFilter.process(p)
+	d.extractor.process(p)
+}
+
+// cleanupProcesses is called after connections have been collected, so stale process entries can be cleaned up.
+func (d *directSenderConsumer) cleanupProcesses() {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	for pid, alive := range d.processes {
+		if alive {
+			alive = d.pidAliveFunc(int(pid))
+		}
+
+		if !alive {
+			d.extractor.handleDeadProcess(pid)
+			delete(d.processes, pid)
+		}
+	}
+}

--- a/pkg/network/sender/event_consumer.go
+++ b/pkg/network/sender/event_consumer.go
@@ -70,8 +70,6 @@ type process struct {
 	Cmdline   []string
 	Cwd       string
 	EventType model.EventType
-
-	alive bool
 }
 
 // EventTypes implements eventmonitor.EventConsumerHandler
@@ -135,6 +133,8 @@ func (d *directSenderConsumer) process(p *process) {
 }
 
 // cleanupProcesses is called after connections have been collected, so stale process entries can be cleaned up.
+//
+//nolint:unused // will be used once direct send loop is added in future PR
 func (d *directSenderConsumer) cleanupProcesses() {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()

--- a/pkg/network/sender/event_consumer_unsupported.go
+++ b/pkg/network/sender/event_consumer_unsupported.go
@@ -9,10 +9,11 @@ package sender
 
 import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 )
 
-// NewDockerProxyConsumer is not supported on non-linux systems
-func NewDockerProxyConsumer(_ *eventmonitor.EventMonitor, _ log.Component) (eventmonitor.EventConsumer, error) {
+// NewDirectSenderConsumer is not supported on non-linux systems
+func NewDirectSenderConsumer(_ *eventmonitor.EventMonitor, _ log.Component, _ sysprobeconfig.Component) (eventmonitor.EventConsumer, error) {
 	return nil, nil
 }

--- a/pkg/network/sender/service_extract.go
+++ b/pkg/network/sender/service_extract.go
@@ -40,6 +40,7 @@ func (s *serviceExtractor) process(event *process) {
 	})
 }
 
+//nolint:unused // will be used once direct send loop is added in future PR
 func (s *serviceExtractor) handleDeadProcess(pid uint32) {
 	s.Remove(int32(pid))
 }

--- a/pkg/network/sender/service_extract.go
+++ b/pkg/network/sender/service_extract.go
@@ -29,7 +29,7 @@ func newServiceExtractor(sysprobeconfig sysprobeconfig.Component) *serviceExtrac
 }
 
 func (s *serviceExtractor) process(event *process) {
-	if event.EventType != model.ExecEventType {
+	if event.EventType != model.ExecEventType && event.EventType != model.ForkEventType {
 		return
 	}
 

--- a/pkg/network/sender/service_extract.go
+++ b/pkg/network/sender/service_extract.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package sender
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/pkg/process/metadata/parser"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+)
+
+type serviceExtractor struct {
+	*parser.ServiceExtractor
+}
+
+func newServiceExtractor(sysprobeconfig sysprobeconfig.Component) *serviceExtractor {
+	serviceExtractorEnabled := sysprobeconfig.GetBool("system_probe_config.process_service_inference.enabled")
+	useWindowsServiceName := sysprobeconfig.GetBool("system_probe_config.process_service_inference.use_windows_service_name")
+	useImprovedAlgorithm := sysprobeconfig.GetBool("system_probe_config.process_service_inference.use_improved_algorithm")
+
+	return &serviceExtractor{
+		ServiceExtractor: parser.NewServiceExtractor(serviceExtractorEnabled, useWindowsServiceName, useImprovedAlgorithm),
+	}
+}
+
+func (s *serviceExtractor) process(event *process) {
+	if event.EventType != model.ExecEventType {
+		return
+	}
+
+	s.ExtractSingle(&procutil.Process{
+		Pid:     int32(event.Pid),
+		Cmdline: event.Cmdline,
+		Cwd:     event.Cwd,
+	})
+}
+
+func (s *serviceExtractor) handleDeadProcess(pid uint32) {
+	s.Remove(int32(pid))
+}

--- a/pkg/system-probe/api/module/common.go
+++ b/pkg/system-probe/api/module/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -38,14 +39,15 @@ type Module interface {
 type FactoryDependencies struct {
 	fx.In
 
-	CoreConfig  config.Component
-	Log         log.Component
-	WMeta       workloadmeta.Component
-	Tagger      tagger.Component
-	Telemetry   telemetry.Component
-	Compression logscompression.Component
-	Statsd      ddgostatsd.ClientInterface
-	Hostname    hostname.Component
-	Ipc         ipc.Component
-	Traceroute  traceroute.Component
+	SysprobeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	Log            log.Component
+	WMeta          workloadmeta.Component
+	Tagger         tagger.Component
+	Telemetry      telemetry.Component
+	Compression    logscompression.Component
+	Statsd         ddgostatsd.ClientInterface
+	Hostname       hostname.Component
+	Ipc            ipc.Component
+	Traceroute     traceroute.Component
 }


### PR DESCRIPTION
### What does this PR do?

- Creates a single process event consumer that pushes data to both docker proxy filtering (existing) and service extraction (new)
- Adapts service extraction to deal with single process events at a time.

### Motivation

Integration of service extraction with CNM/USM direct send

### Describe how you validated your changes

Existing tests.

### Additional Notes

We must hold onto dead process data until after connections have been collected, in case we have connection data that corresponds to a dead process.
