### PR TITLE
dyninst: collect trace pipe in integration test

### DIFF
--- a/pkg/dyninst/ebpf/debug.h
+++ b/pkg/dyninst/ebpf/debug.h
@@ -11,9 +11,9 @@
 // LOG is a macro that prints a message if the level is less than or equal to
 // the DEBUG level.
 volatile const uint32_t debug_level = 0;
-#define LOG(level, fmt, ...)        \
-  if (level <= debug_level) {       \
-    bpf_printk(fmt, ##__VA_ARGS__); \
+#define LOG(level, fmt, ...)                                                     \
+  if (level <= debug_level) {                                                    \
+    bpf_printk("%lld: " fmt, (bpf_get_current_pid_tgid() >> 32), ##__VA_ARGS__); \
   }
 
 static const char* padding(unsigned long depth) {

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -8,6 +8,7 @@
 package dyninst_test
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"embed"
@@ -34,8 +35,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-
-	"github.com/DataDog/ebpf-manager/tracefs"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
@@ -69,27 +68,14 @@ func TestDyninst(t *testing.T) {
 
 	sem := dyninsttest.MakeSemaphore()
 
-	// The debug variants of the tests spew logs to the trace_pipe, so we need
-	// to clear it after the tests to avoid interfering with other tests.
-	// Leave the option to disable this behavior for debugging purposes.
-	dontClear, _ := strconv.ParseBool(os.Getenv("DONT_CLEAR_TRACE_PIPE"))
-	if !dontClear {
-		t.Logf("clearing trace_pipe!")
-		tp, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			for {
-				deadline := time.Now().Add(100 * time.Millisecond)
-				require.NoError(t, tp.SetReadDeadline(deadline))
-				n, err := io.Copy(io.Discard, tp)
-				require.ErrorIs(t, err, os.ErrDeadlineExceeded)
-				if n == 0 {
-					break
-				}
-			}
-			t.Logf("closing trace_pipe!")
-			require.NoError(t, tp.Close())
-		})
+	// The debug variants of the tests spew logs to the trace_pipe. We collect
+	// these logs organized by PID so they can be output on test failure.
+	// Set DONT_COLLECT_TRACE_PIPE=1 to disable collection (e.g., for manual debugging).
+	var collector *tracePipeCollector
+	dontCollect, _ := strconv.ParseBool(os.Getenv("DONT_COLLECT_TRACE_PIPE"))
+	if !dontCollect {
+		collector = newTracePipeCollector(t)
+		t.Cleanup(func() { collector.Close() })
 	}
 	rewrite, _ := strconv.ParseBool(os.Getenv("REWRITE"))
 
@@ -100,7 +86,7 @@ func TestDyninst(t *testing.T) {
 		}
 		t.Run(svc, func(t *testing.T) {
 			runIntegrationTestSuite(
-				t, svc, rewrite, sem, cfgs...,
+				t, svc, rewrite, sem, collector, cfgs...,
 			)
 		})
 	}
@@ -117,6 +103,7 @@ func testDyninst(
 	expOut map[string][]json.RawMessage,
 	debug bool,
 	sem dyninsttest.Semaphore,
+	collector *tracePipeCollector,
 ) map[string][]json.RawMessage {
 	defer sem.Acquire()()
 	start := time.Now()
@@ -168,15 +155,39 @@ func testDyninst(
 	t.Cleanup(m.Close)
 
 	// Launch the sample service.
-	t.Logf("launching %s", service)
 	ctx := context.Background()
 	sampleProc, sampleStdin := dyninsttest.StartProcess(
 		ctx, t, tempDir, servicePath,
 	)
+	pid := sampleProc.Process.Pid
+	t.Logf("launched %s with pid %d", service, pid)
 	defer func() {
 		_ = sampleProc.Process.Kill()
 		_ = sampleProc.Wait()
 	}()
+
+	// On failure in debug mode, output trace_pipe logs for this process.
+	t.Cleanup(func() {
+		if collector == nil || !t.Failed() || !debug {
+			return
+		}
+		if err := collector.Flush(); err != nil {
+			t.Logf("trace pipe flush error: %v", err)
+		}
+		f, err := collector.GetLogs(pid)
+		if err != nil {
+			t.Logf("trace pipe GetLogs error: %v", err)
+			return
+		}
+		if f == nil {
+			return
+		}
+		defer f.Close()
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			t.Log(scanner.Text())
+		}
+	})
 
 	exe, err := process.ResolveExecutable(kernel.ProcFSRoot(), int32(sampleProc.Process.Pid))
 	require.NoError(t, err)
@@ -295,6 +306,7 @@ func runIntegrationTestSuite(
 	service string,
 	rewrite bool,
 	sem dyninsttest.Semaphore,
+	collector *tracePipeCollector,
 	cfgs ...testprogs.Config,
 ) {
 	var outputs = struct {
@@ -378,7 +390,7 @@ func runIntegrationTestSuite(
 					t.Parallel()
 					actual := testDyninst(
 						t, service, cfg, bin, probeSlice, resultNames, rewrite, expectedOutput,
-						debug, sem,
+						debug, sem, collector,
 					)
 					if t.Failed() {
 						return nil

--- a/pkg/dyninst/trace_pipe_collector_test.go
+++ b/pkg/dyninst/trace_pipe_collector_test.go
@@ -1,0 +1,261 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/DataDog/ebpf-manager/tracefs"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// tracePipeCollector reads from the kernel trace_pipe and organizes output
+// by PID into separate log files. This is useful for debugging test failures
+// where BPF programs emit debug output via bpf_trace_printk.
+type tracePipeCollector struct {
+	dir  string   // temp directory for log files
+	tp   *os.File // trace_pipe file handle
+	done chan struct{}
+	wg   sync.WaitGroup
+
+	mu struct {
+		sync.Mutex
+		closed       bool
+		err          error            // stored error from reader goroutine
+		files        map[int]*os.File // pid -> open file handle for writing
+		pendingPID   int              // PID of current incomplete entry (-1 if none)
+		pendingData  bytes.Buffer     // accumulated lines for current entry
+		flushWaiters []chan struct{}  // channels to notify on flush
+	}
+}
+
+// traceLineRegex parses trace_pipe lines to extract timestamp, PID, and message.
+// Example: "           <...>-117990  [000] ...11 103871.126847: bpf_trace_printk: 117990: message"
+// Groups: 1=timestamp, 2=pid, 3=message
+var traceLineRegex = regexp.MustCompile(`^\s*\S+\s+\[\d+\]\s+\S+\s+(\d+\.\d+): bpf_trace_printk: (\d+): (.*)$`)
+
+// newTracePipeCollector creates a new collector that reads from trace_pipe
+// and writes per-PID log files to t.TempDir().
+func newTracePipeCollector(t *testing.T) *tracePipeCollector {
+	dir := t.TempDir()
+	tp, err := tracefs.OpenFile("trace_pipe", os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("failed to open trace_pipe: %v", err)
+	}
+
+	c := &tracePipeCollector{
+		dir:  dir,
+		tp:   tp,
+		done: make(chan struct{}),
+	}
+	c.mu.files = make(map[int]*os.File)
+	c.mu.pendingPID = -1
+
+	c.wg.Add(1)
+	go c.readLoop()
+
+	t.Logf("trace pipe collector started, logging to %s", dir)
+	return c
+}
+
+// Close stops the collector and closes all file handles.
+// It is safe to call Close multiple times.
+func (c *tracePipeCollector) Close() {
+	c.mu.Lock()
+	if c.mu.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.mu.closed = true
+	// Notify any pending flush waiters that we're closing
+	waiters := c.mu.flushWaiters
+	c.mu.flushWaiters = nil
+	c.mu.Unlock()
+
+	for _, ch := range waiters {
+		close(ch)
+	}
+
+	close(c.done)
+	c.wg.Wait()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Flush any remaining pending entry
+	c.flushPendingLocked()
+
+	// Close all file handles
+	for _, f := range c.mu.files {
+		f.Close()
+	}
+}
+
+// Flush blocks until the collector has processed all pending trace_pipe data.
+// This is signaled when a read times out with no data, indicating the pipe is empty.
+// If the collector is already closed, Flush returns immediately.
+func (c *tracePipeCollector) Flush() error {
+	ch := make(chan struct{})
+
+	c.mu.Lock()
+	if c.mu.closed {
+		err := c.mu.err
+		c.mu.Unlock()
+		return err
+	}
+	c.mu.flushWaiters = append(c.mu.flushWaiters, ch)
+	c.mu.Unlock()
+
+	<-ch
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.err
+}
+
+// GetLogs returns a read-only file handle for the logs of the given PID.
+// Returns nil, nil if no logs exist for this PID.
+// The caller is responsible for closing the returned file.
+func (c *tracePipeCollector) GetLogs(pid int) (*os.File, error) {
+	path := filepath.Join(c.dir, fmt.Sprintf("%d.log", pid))
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// readLoop is the main goroutine that reads from trace_pipe.
+func (c *tracePipeCollector) readLoop() {
+	defer c.wg.Done()
+
+	reader := bufio.NewReader(c.tp)
+	for {
+		select {
+		case <-c.done:
+			return
+		default:
+		}
+
+		if err := c.tp.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+			c.mu.Lock()
+			c.mu.err = fmt.Errorf("failed to set read deadline: %w", err)
+			c.mu.Unlock()
+			log.Warnf("trace_pipe set deadline error: %v", err)
+			return
+		}
+
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if os.IsTimeout(err) {
+				c.mu.Lock()
+				c.flushPendingLocked()
+				c.mu.Unlock()
+				c.notifyFlushWaiters()
+				continue
+			}
+			c.mu.Lock()
+			c.mu.err = err
+			c.mu.Unlock()
+			log.Warnf("trace_pipe read error: %v", err)
+			return
+		}
+
+		line = strings.TrimSuffix(line, "\n")
+		c.processLine(line)
+	}
+}
+
+// processLine handles a single line from trace_pipe.
+func (c *tracePipeCollector) processLine(line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if match := traceLineRegex.FindStringSubmatch(line); match != nil {
+		// New entry - flush any pending entry first
+		c.flushPendingLocked()
+
+		timestamp := match[1]
+		pid, _ := strconv.Atoi(match[2])
+		message := match[3]
+
+		c.mu.pendingPID = pid
+		c.mu.pendingData.WriteString(timestamp)
+		c.mu.pendingData.WriteString(": ")
+		c.mu.pendingData.WriteString(message)
+	} else if c.mu.pendingPID >= 0 {
+		// Continuation line - append to pending entry
+		c.mu.pendingData.WriteString(" ")
+		c.mu.pendingData.WriteString(strings.TrimSpace(line))
+	}
+}
+
+// flushPendingLocked writes the pending entry to its PID's log file.
+// Must be called with c.mu held.
+func (c *tracePipeCollector) flushPendingLocked() {
+	if c.mu.pendingPID < 0 {
+		c.mu.pendingData.Reset()
+		return
+	}
+
+	f, err := c.getOrCreateFileLocked(c.mu.pendingPID)
+	if err != nil {
+		log.Warnf("trace_pipe failed to get file for pid %d: %v", c.mu.pendingPID, err)
+	} else {
+		c.mu.pendingData.WriteString("\n")
+		if _, err := f.Write(c.mu.pendingData.Bytes()); err != nil {
+			log.Warnf("trace_pipe failed to write to file for pid %d: %v", c.mu.pendingPID, err)
+		}
+	}
+
+	c.mu.pendingPID = -1
+	c.mu.pendingData.Reset()
+}
+
+// getOrCreateFileLocked returns the file handle for the given PID, creating it if needed.
+// Must be called with c.mu held.
+func (c *tracePipeCollector) getOrCreateFileLocked(pid int) (*os.File, error) {
+	if f, ok := c.mu.files[pid]; ok {
+		return f, nil
+	}
+
+	path := filepath.Join(c.dir, fmt.Sprintf("%d.log", pid))
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.files[pid] = f
+	return f, nil
+}
+
+// notifyFlushWaiters closes all waiting flush channels and clears the list.
+func (c *tracePipeCollector) notifyFlushWaiters() {
+	c.mu.Lock()
+	waiters := c.mu.flushWaiters
+	c.mu.flushWaiters = nil
+	c.mu.Unlock()
+
+	for _, ch := range waiters {
+		close(ch)
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This change updates the logging macro to print the PID of the probed process.  TestDyninst uses this to attribute log messages to processes. When tests fail, the ebpf debug logs get printed now to the test output. 

### Motivation

This should hopefully help us to diagnose our rare and hard-to-reproduce flakes we see sometimes in CI.

### Describe how you validated your changes

It's a testing-only change.
