### PR TITLE
[CONTP-730] fix(log): Remove unset source from SourceAll subscriber wlm event entities

### DIFF
--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -64,7 +64,11 @@ func NewKubeletListener(options ServiceListernerDeps) (ServiceListener, error) {
 }
 
 func (l *KubeletListener) processPod(entity workloadmeta.Entity) {
-	pod := entity.(*workloadmeta.KubernetesPod)
+	pod, err := l.Store().GetKubernetesPod(entity.GetID().ID)
+	if err != nil || pod == nil {
+		log.Warn("DEBUG: Pod not found in workloadmeta store, using pod from event")
+		pod = entity.(*workloadmeta.KubernetesPod)
+	}
 
 	wlmContainers := pod.GetAllContainers()
 	containers := make([]*workloadmeta.Container, 0, len(wlmContainers))

--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -105,7 +105,7 @@ func (f *Filter) MatchEntity(entity *Entity) bool {
 		return true
 	}
 
-	if entity == nil {
+	if entity == nil || *entity == nil {
 		return false
 	}
 

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -824,16 +824,21 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 				continue
 			}
 
+			entityForThisSub := cachedEntity
 			var isEventTypeSet bool
 			if ev.Type == wmdef.EventTypeSet {
 				isEventTypeSet = true
 			} else if filter.Source() == wmdef.SourceAll {
-				isEventTypeSet = len(cachedEntity.sources) > 1
+				isEventTypeSet = len(entityForThisSub.sources) > 1
+				if len(entityForThisSub.sources) > 1 {
+					entityForThisSub = cachedEntity.copy()
+					entityForThisSub.unset(ev.Source)
+				}
 			} else {
 				isEventTypeSet = false
 			}
 
-			entity := cachedEntity.get(filter.Source())
+			entity := entityForThisSub.get(filter.Source())
 			if !filter.MatchEntity(&entity) {
 				continue
 			}

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -824,21 +824,16 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 				continue
 			}
 
-			entityForThisSub := cachedEntity
 			var isEventTypeSet bool
 			if ev.Type == wmdef.EventTypeSet {
 				isEventTypeSet = true
 			} else if filter.Source() == wmdef.SourceAll {
-				isEventTypeSet = len(entityForThisSub.sources) > 1
-				if len(entityForThisSub.sources) > 1 {
-					entityForThisSub = cachedEntity.copy()
-					entityForThisSub.unset(ev.Source)
-				}
+				isEventTypeSet = len(cachedEntity.sources) > 1
 			} else {
 				isEventTypeSet = false
 			}
 
-			entity := entityForThisSub.get(filter.Source())
+			entity := cachedEntity.get(filter.Source())
 			if !filter.MatchEntity(&entity) {
 				continue
 			}


### PR DESCRIPTION
### What does this PR do?

In a small subset of cases (~3% of the time), the Agent would log a `WARN` saying it could not create a file tailer for a container because its parent pod is missing.

```
2024-10-25 10:25:35 UTC | CORE | WARN | (pkg/logs/launchers/container/tailerfactory/factory.go:95 in makeTailer) | Could not make file tailer for source container_collect_all (falling back to socket): cannot find pod for container "6f585560fac9d45127f20509c7c84d017126776573772f42e1bd45af59090e54": "6f585560fac9d45127f20509c7c84d017126776573772f42e1bd45af59090e54" not found
```

The cause stems from the Kubelet AD subscribing to `SourceAll` entity events in WLM and short lived pods that have been terminated are then being sent as 'Set' events leading the Kubelet AD adding the pod and its containers as services, triggering a file tailer attempt.

### Motivation

### Describe how you validated your changes

### Additional Notes
