### PR TITLE
[CSPM] add config namespace to sysprobe compliance module

### DIFF
--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -29,6 +29,8 @@ import (
 
 func init() { registerModule(ComplianceModule) }
 
+var complianceConfigNamespaces = []string{"compliance_config", "runtime_security_config"}
+
 // ComplianceModule is a system-probe module that exposes an HTTP api to
 // perform compliance checks that require more privileges than security-agent
 // can offer.
@@ -37,7 +39,7 @@ func init() { registerModule(ComplianceModule) }
 // accessing the /proc/<pid>/root mount point.
 var ComplianceModule = &module.Factory{
 	Name:             config.ComplianceModule,
-	ConfigNamespaces: []string{},
+	ConfigNamespaces: complianceConfigNamespaces,
 	Fn: func(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
 		return &complianceModule{}, nil
 	},


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing definition of configuration namespaces for the compliance module. `compliance_config` is obvious, but `runtime_security_config` is also provided because of the legacy way of enabling the CSPM sysprobe module through `runtime_security_config.compliance_module.enabled`

### Motivation

### Describe how you validated your changes

### Additional Notes
