### PR TITLE
[SINT-4518] Add missing id_tokens to test_kmt_local_setup_macos job

### DIFF
--- a/.gitlab/source_test/kmt_tasks.yml
+++ b/.gitlab/source_test/kmt_tasks.yml
@@ -54,3 +54,6 @@ test_kmt_local_setup_macos:
     # - PulumiPlugins: no github tokens in the macos runner and the plugins download fails with rate limits sometimes
     # - MacBasePackages: brew fails to update in the CI
     KMT_EXCLUDE_REQUIREMENTS: "Docker,Compiler,UserInDockerGroup,AWSConfig,PulumiPlugins,MacBasePackages"
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities


### PR DESCRIPTION
### What does this PR do?
Fix missing `id_tokens` block in the `test_kmt_local_setup_macos` job

### Motivation
[Failing merge PR job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1349113794)

### Describe how you validated your changes

### Additional Notes
