### PR TITLE
Fix and check `bazel mod tidy` in CI

### DIFF
--- a/.gitlab/bazel/lint.yaml
+++ b/.gitlab/bazel/lint.yaml
@@ -15,6 +15,18 @@ bazel:mod-deps:
         echo >&2 "💡 bazel mod deps"
       fi
 
+bazel:mod-tidy:
+  extends: .bazel:runner:linux-amd64
+  stage: lint
+  script:
+    - bazel mod tidy
+    - git diff --exit-code
+  after_script:
+    - |-
+      if [ $CI_JOB_STATUS = failed ]; then
+        echo >&2 "💡 bazel mod tidy"
+      fi
+
 bazel:run-buildifier-test:
   extends: .bazel:runner:linux-amd64
   stage: lint

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -321,41 +321,41 @@ http_archive(
         "BUILD.bazel": "//deps:dbus/dbus.BUILD.bazel",
     },
     sha256 = "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2",
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
     strip_prefix = "dbus-1.16.2",
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
 )
 
 http_archive(
     name = "lua",
-    sha256 = "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88",
-    url = "https://www.lua.org/ftp/lua-5.4.6.tar.gz",
-    strip_prefix = "lua-5.4.6",
     files = {
         "BUILD.bazel": "//deps:lua/lua.BUILD.bazel",
         "license_file": "//deps:lua/license",
     },
+    sha256 = "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88",
+    strip_prefix = "lua-5.4.6",
+    url = "https://www.lua.org/ftp/lua-5.4.6.tar.gz",
 )
 
 http_archive(
     name = "xmlsec",
-    url = "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
-    sha256 = "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
-    strip_prefix = "xmlsec1-1.3.7",
     files = {
         "BUILD.bazel": "//deps:xmlsec/xmlsec.BUILD.bazel",
         "config-linux-x86_64.h": "//deps:xmlsec/config-linux-x86_64.h",
         "config-linux-arm64.h": "//deps:xmlsec/config-linux-arm64.h",
     },
+    sha256 = "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
+    strip_prefix = "xmlsec1-1.3.7",
+    url = "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
 )
 
 http_archive(
     name = "rpm",
-    sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
-    url = "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
-    strip_prefix = "rpm-rpm-4.18.1-release",
     files = {
         "BUILD.bazel": "//deps:rpm/rpm.BUILD.bazel",
         "config-linux-x86_64.h": "//deps:rpm/config-linux-x86_64.h",
         "config-linux-arm64.h": "//deps:rpm/config-linux-arm64.h",
     },
+    sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
+    strip_prefix = "rpm-rpm-4.18.1-release",
+    url = "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
 )


### PR DESCRIPTION
### What does this PR do?
Add a GitLab CI job to verify that `MODULE.bazel` is in sync with `bazel mod tidy`.

### Motivation
Short term: re-sync `MODULE.bazel` (only format-related discrepancies as it seems) and prevent it from diverging again.

Mid term: this will also prevent module extension drifts in `MODULE.bazel`, particularly ensuring that when Gazelle is used, contributors haven't forgotten to regenerate build files and update `use_repo(...)` calls.

While Bazel 7.1.1+ allows to auto-update `use_repo(...)` during builds, this check will indeed catch cases where changes are committed without running a build first or simply when changes in `MODULE.bazel` were inadvertently omitted from the commit.

### Describe how you validated your changes
See [failing job output](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1349314161) before reformatting:
```bash
# [...]
$ bazel mod tidy
# [...]
$ git diff --exit-code
diff --git a/deps/repos.MODULE.bazel b/deps/repos.MODULE.bazel
index d4c7568a0f..264a0b8169 100644
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -321,41 +321,41 @@ http_archive(
         "BUILD.bazel": "//deps:dbus/dbus.BUILD.bazel",
     },
     sha256 = "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2",
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
     strip_prefix = "dbus-1.16.2",
+    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
 )

# [...]

 http_archive(
     name = "rpm",
-    sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
-    url = "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
-    strip_prefix = "rpm-rpm-4.18.1-release",
     files = {
         "BUILD.bazel": "//deps:rpm/rpm.BUILD.bazel",
         "config-linux-x86_64.h": "//deps:rpm/config-linux-x86_64.h",
         "config-linux-arm64.h": "//deps:rpm/config-linux-arm64.h",
     },
+    sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
+    strip_prefix = "rpm-rpm-4.18.1-release",
+    url = "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
 )
Running after script...
$ if [ $CI_JOB_STATUS = failed ]; then
💡 bazel mod tidy
# [...]
```

### Additional Notes
The job also validates Rust and other module extensions beyond Go, so there's no need to wait for Gazelle to be configured.