### PR TITLE
system-probe: add system-probe config to factory dependencies

### DIFF
--- a/pkg/system-probe/api/module/common.go
+++ b/pkg/system-probe/api/module/common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -38,14 +39,15 @@ type Module interface {
 type FactoryDependencies struct {
 	fx.In
 
-	CoreConfig  config.Component
-	Log         log.Component
-	WMeta       workloadmeta.Component
-	Tagger      tagger.Component
-	Telemetry   telemetry.Component
-	Compression logscompression.Component
-	Statsd      ddgostatsd.ClientInterface
-	Hostname    hostname.Component
-	Ipc         ipc.Component
-	Traceroute  traceroute.Component
+	SysProbeConfig sysprobeconfig.Component
+	CoreConfig     config.Component
+	Log            log.Component
+	WMeta          workloadmeta.Component
+	Tagger         tagger.Component
+	Telemetry      telemetry.Component
+	Compression    logscompression.Component
+	Statsd         ddgostatsd.ClientInterface
+	Hostname       hostname.Component
+	Ipc            ipc.Component
+	Traceroute     traceroute.Component
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the system-probe config component to the list of components accessible from system-probe modules. This is in preparation for another bigger PR that will require this.

### Motivation

### Describe how you validated your changes

### Additional Notes
