### PR TITLE
kmt: allocate a bit more to the trace_pipe

### DIFF
--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -15,6 +15,16 @@ if command -v docker ; then
 else
     echo "Docker not available, skipping docker provisioning"
 fi
+
+## Increase tracing buffer size a tad, the default is 64KiB.
+if [[ -f /sys/kernel/debug/tracing/buffer_size_kb ]]; then
+    echo "Setting tracing buffer size to 1024 KB"
+    echo 1024 > /sys/kernel/debug/tracing/buffer_size_kb || \
+        echo "Failed to set tracing buffer size, continuing anyway"
+else
+    echo "Tracing buffer size file not found, skipping"
+fi
+
 # VM provisioning end !
 
 # Start tests


### PR DESCRIPTION
### What does this PR do?

In KMT, increase the trace_pipe (`/sys/kernel/debug/tracing/trace_pipe`) allocation to 1MiB.

### Motivation

The default trace_pipe size is 64KiB. I've added debugging logic to collect the trace_pipe as part of our integration tests. We were dropping some events (not surprising). It's nice to allocate a bit more to catch issues.

### Describe how you validated your changes

It's just testing.
