### PR TITLE
APM: reduce flakes of container tags test (APMSP-2374)

### DIFF
--- a/pkg/trace/containertags/buffer_test.go
+++ b/pkg/trace/containertags/buffer_test.go
@@ -233,7 +233,11 @@ func TestAsyncEnrichment_Buffered_Expiration(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for expiration flush")
 	}
-	assert.Equal(t, ctb.memoryUsage.Load(), int64(0))
+	// Memory is released via defer after the callback returns, so use Eventually
+	// to avoid a race between receiving the callback result and the defer executing
+	require.Eventually(t, func() bool {
+		return ctb.memoryUsage.Load() == 0
+	}, 1*time.Second, 10*time.Millisecond, "memory should be released after callback")
 
 	// container is now denied
 	assert.True(t, ctb.deniedContainers.shouldDeny(time.Now(), "container-expire"))
@@ -267,7 +271,11 @@ func TestAsyncEnrichment_Buffered_HardLimit(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for expiration flush")
 	}
-	assert.Equal(t, ctb.memoryUsage.Load(), int64(0))
+	// Memory is released via defer after the callback returns, so use Eventually
+	// to avoid a race between receiving the callback result and the defer executing
+	require.Eventually(t, func() bool {
+		return ctb.memoryUsage.Load() == 0
+	}, 1*time.Second, 10*time.Millisecond, "memory should be released after callback")
 
 	// container is now denied
 	assert.True(t, ctb.deniedContainers.shouldDeny(time.Now(), "container-expire"))


### PR DESCRIPTION
### What does this PR do?
Use an "eventually" assertion to reduce the likelihood of flakes here. The goroutine in the buffer code means that we only remove the memory usage _after_ the callback code has been called. This means that from the test it is possible (albeit very rare) to see the memory still in use even after the callback returns.

### Motivation
Flakes are bad (don't tell Tony the Tiger)

### Describe how you validated your changes
Modified the test to make it easier to reproduce the failure, then was unable to generate a flake after making this change

### Additional Notes
