### PR TITLE
[CWS] prctl fix

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -254,7 +254,7 @@ static __attribute__((always_inline)) u64 is_network_flow_monitor_enabled() {
 #define SYSCTL_OLD_VALUE_TRUNCATED (1 << 1)
 #define SYSCTL_NEW_VALUE_TRUNCATED (1 << 2)
 #define MAX_BPF_FILTER_SIZE (511 * sizeof(struct sock_filter))
-#define MAX_PRCTL_NAME_LEN 255
+#define MAX_PRCTL_NAME_LEN 16
 #define TRACER_MEMFD_SUFFIX_LEN 8
 
 static __attribute__((always_inline)) u64 has_tracing_helpers_in_cgroup_sysctl() {

--- a/pkg/security/ebpf/c/include/hooks/prctl.h
+++ b/pkg/security/ebpf/c/include/hooks/prctl.h
@@ -21,10 +21,12 @@ long __attribute__((always_inline)) trace__sys_prctl(u8 async, int option, void 
     };
     switch (option) {
     case PR_SET_NAME: {
-        int n = bpf_probe_read_str(&syscall.prctl.name, MAX_PRCTL_NAME_LEN, arg2);
+        int n = bpf_probe_read_str(&syscall.prctl.name, MAX_PRCTL_NAME_LEN + 1, arg2);
         syscall.prctl.name_size_to_send = n;
-        if (n >= MAX_PRCTL_NAME_LEN) {
+        if (n > MAX_PRCTL_NAME_LEN) {
             syscall.prctl.name_truncated = 1;
+        } else if (n < 0) {
+            syscall.prctl.name_size_to_send = 0;
         }
         break;
         }

--- a/pkg/security/ebpf/c/include/hooks/prctl.h
+++ b/pkg/security/ebpf/c/include/hooks/prctl.h
@@ -21,12 +21,10 @@ long __attribute__((always_inline)) trace__sys_prctl(u8 async, int option, void 
     };
     switch (option) {
     case PR_SET_NAME: {
-        int n = bpf_probe_read_str(&syscall.prctl.name, MAX_PRCTL_NAME_LEN + 1, arg2);
-        if (n > 0) {
-            syscall.prctl.name_truncated = (n == (MAX_PRCTL_NAME_LEN + 1)) ? 1 : 0;
-            syscall.prctl.name_size_to_send = n - 1;
-        } else {
-            syscall.prctl.name_size_to_send = 0;
+        int n = bpf_probe_read_str(&syscall.prctl.name, MAX_PRCTL_NAME_LEN, arg2);
+        syscall.prctl.name_size_to_send = n;
+        if (n >= MAX_PRCTL_NAME_LEN) {
+            syscall.prctl.name_truncated = 1;
         }
         break;
         }

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -280,7 +280,7 @@ struct syscall_cache_t {
             int option;
             u32 name_size_to_send;
             u32 name_truncated;
-            char name[MAX_PRCTL_NAME_LEN];
+            char name[MAX_PRCTL_NAME_LEN + 1];
         } prctl;
 
         struct {


### PR DESCRIPTION
### What does this PR do?

* Reduce `prctl()` name len to 16 bytes


### Motivation

* The max length of prctl is only 16 bytes long and gets truncated by the kernel even if the user passes a longer string
* see: https://man7.org/linux/man-pages/man2/pr_set_name.2const.html
* This is to reduce the amount of traffic to userland

### Describe how you validated your changes

### Additional Notes
