### PR TITLE
Make sure init tests are also skipped if the test should be skipped

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -294,7 +294,10 @@ def run(
                 changed_files = get_modified_files(ctx)
                 changed_packages = list({os.path.dirname(change) for change in changed_files})
                 print(color_message(f"The following changes were detected: {changed_files}", "yellow"))
-                to_skip = executor.tests_to_skip(os.getenv("CI_JOB_NAME"), changed_packages + changed_files)
+                test_job_name = os.getenv("CI_JOB_NAME")
+                if test_job_name.endswith("-init"):
+                    test_job_name = test_job_name.removesuffix("-init")
+                to_skip = executor.tests_to_skip(test_job_name, changed_packages + changed_files)
                 ctx.run(f"datadog-ci measure --level job --measures 'e2e.skipped_tests:{len(to_skip)}'", warn=True)
                 print(color_message(f"The following tests will be skipped: {to_skip}", "yellow"))
                 skip.extend(to_skip)


### PR DESCRIPTION
### What does this PR do?

Update the dynamic tests for init job, to make sure that they are skipped if the main test would be skipped.

Without that change we can have the EKS cluster being initialized, and then being leaked because the test is never executed to call the tear down of the cluster.


### Motivation

Avoid unnecessary steps in the CI, and prevent leaking EKS cluster

### Describe how you validated your changes

### Additional Notes
