### PR TITLE
dyninst/symdb: make SymDB upload more deterministic

### DIFF
--- a/pkg/dyninst/symdb/symdb.go
+++ b/pkg/dyninst/symdb/symdb.go
@@ -914,7 +914,10 @@ func (b *packagesIterator) addAbstractFunctions(targetPackage *Package) {
 		}
 		// Sort variables so that output is stable.
 		sort.Slice(variables, func(i, j int) bool {
-			return variables[i].Name < variables[j].Name
+			if variables[i].Name != variables[j].Name {
+				return variables[i].Name < variables[j].Name
+			}
+			return variables[i].DeclLine < variables[j].DeclLine
 		})
 		f := Function{
 			Name:            af.name,

--- a/pkg/dyninst/symdb/uploader/symdb.go
+++ b/pkg/dyninst/symdb/uploader/symdb.go
@@ -18,6 +18,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -277,10 +278,13 @@ func ConvertPackageToScope(pkg symdb.Package, agentVersion string) Scope {
 	}
 
 	// Add types as struct scopes.
-	for _, typ := range pkg.Types {
-		typeScope := convertTypeToScope(*typ)
-		scope.Scopes = append(scope.Scopes, typeScope)
+	for _, s := range pkg.Types {
+		scope.Scopes = append(scope.Scopes, convertTypeToScope(*s))
 	}
+	// Sort the types for stable output.
+	slices.SortFunc(scope.Scopes, func(a, b Scope) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return scope
 }


### PR DESCRIPTION
Before this patch, producing the output JSON depended on a
non-deterministic map iteration. Having more deterministic output helps,
for example, with debugging, when you want to diff two uploads and see
if they're the same.
