### PR TITLE
APM: Expand logs for failing prob sampler e2e test (APMSP-2337)

### DIFF
--- a/test/new-e2e/tests/apm/tests.go
+++ b/test/new-e2e/tests/apm/tests.go
@@ -172,7 +172,7 @@ func tracesSampledByProbabilitySampler(t *testing.T, c *assert.CollectT, intake 
 					t.Errorf("Expected trace chunk tags to contain _dd.p.dm, but it does not.")
 				}
 				if dm != "-9" {
-					t.Errorf("Expected dm == -9, but got %v", dm)
+					t.Errorf("Expected dm == -9, but got %v for service %s", dm, chunk.Spans[0].Service)
 				}
 			}
 		}


### PR DESCRIPTION
### What does this PR do?
Expand the logs for the probability sampler e2e tests
### Motivation
We recently had a flaking failure on this test and I'm unable to determine the cause. The flake seems extremely rare (1/670 times in the last month). My best hypothesis is that there's some sort of race condition related to the clearing of the fake intake such that we're asserting on data from another test, the service names are different so by adding this log we can confirm/deny that hypothesis the next time this flakes.

### Describe how you validated your changes
Existing CI is sufficient here
### Additional Notes
