### PR TITLE
Rename all->all_srcs in openssl build

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -7,7 +7,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "all",
+    name = "all_srcs",
     srcs = glob(["**"], exclude = ["BUILD.bazel"]),
 )
 
@@ -115,7 +115,7 @@ configure_make(
         },
         "//conditions:default": {},
     }),
-    lib_source = ":all",
+    lib_source = ":all_srcs",
     out_include_dir = "include",
     out_static_libs = select({
         "@platforms//os:windows": [


### PR DESCRIPTION
### What does this PR do?

Renames a target named "all" to "all_srcs".   "all" is reserved in Bazel semantics.
