### PR TITLE
dyninst: deflake test

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -201,7 +201,7 @@ func testDyninst(
 					Service:    service,
 				},
 				RuntimeID:         runtimeID,
-				Probes:            probes,
+				Probes:            slices.Clone(probes),
 				ShouldUploadSymDB: false,
 			},
 		},
@@ -388,6 +388,7 @@ func runIntegrationTestSuite(
 			for _, debug := range []bool{false, true} {
 				runTest := func(t *testing.T, probeSlice []ir.ProbeDefinition) map[string][]json.RawMessage {
 					t.Parallel()
+					probeSlice = slices.Clone(probeSlice)
 					actual := testDyninst(
 						t, service, cfg, bin, probeSlice, resultNames, rewrite, expectedOutput,
 						debug, sem, collector,


### PR DESCRIPTION
### What does this PR do?

The flake was that we sort the probes, and very rarely two concurrent calls to sort can interfere with each other. The tests should be isolated and not share state, and also we should clone the slice for the process update too. Both changes are in this commit even though either one would work fine.

### Motivation

Fixes the following flaky tests: 
DD_6PXP2A DD_YBV13L DD_A603A0 DD_P0IL9Q DD_0N2VXN DD_EDJSS2 DD_I9NJA5 DD_OR3LLX DD_0543WY DD_Y8HHZ7 DD_7N6BVU DD_HF1ZEB DD_JT4B9Y DD_W9DB6U DD_LDKR4H DD_SCTYNP DD_1XP03F DD_YU8U9A DD_ZTRA18 DD_4QQRN4 DD_EY7MKB DD_BPJM8I DD_58I4IL DD_VMX0V8 DD_2TXI24 DD_RRJM8R DD_JIPCDE DD_1H8B7B DD_YIZLT8 DD_1ZSSHG DD_2QQ55V DD_4Y7GZ0 DD_PXNI1E DD_0444LJ DD_AD0ZGG DD_K1T6O5 DD_91DGXC DD_TIQWPN DD_BQCVCC DD_S07TPC DD_2LU9XD DD_OSHJHH DD_7SEYH7 DD_OG1ZDT DD_FVWZKJ DD_1AYHWU DD_8SGZTB DD_PZV3SD DD_4ZIZA2 DD_9F6A3X DD_4VJBH0 DD_7K029E DD_UU9WM2 DD_OH4F1F DD_83QX5L DD_MY3JLS DD_WRWWLQ DD_GEWBOI DD_AVDJ8W DD_MW65CY DD_KIDBQR DD_EF2POK DD_NB0CEM DD_LEN38D DD_YEC8CH DD_LFMCSQ DD_KCVDGV DD_D17PP0 DD_EP6COG DD_HX0TRQ DD_OWHW9C DD_AZ8EIZ DD_BBPANG DD_N8XJ60 DD_MC0ODO DD_0QTGZV DD_156AOP DD_LQICYI DD_ZAGDDN DD_GKHCAR DD_6ZZDOD DD_12M77Q DD_QJQ20G DD_RNDPR6

