### PR TITLE
[ABLD-317] Remove `//go:build go1.18` tags from fuzzing tests

### DIFF
--- a/pkg/trace/agent/fuzz_test.go
+++ b/pkg/trace/agent/fuzz_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.18 && !windows
+//go:build !windows
 
 package agent
 

--- a/pkg/trace/api/fuzz_test.go
+++ b/pkg/trace/api/fuzz_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.18
-
 package api
 
 import (

--- a/pkg/trace/traceutil/normalize/fuzz_test.go
+++ b/pkg/trace/traceutil/normalize/fuzz_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.18
-
 package normalize
 
 import (


### PR DESCRIPTION
### What does this PR do?
Go 1.18 support was dropped in 2023 through #14930 when the project upgraded from Go 1.18.9 to Go 1.19.4, making `//go:build go1.18` tags redundant.

Fuzzing (`testing.F`) is now standard in all supported Go versions.

### Motivation
Decrease the number of Go build tags to help transition the agent's build from `omnibus` (`invoke`, etc.) to `bazel`.