### PR TITLE
[ABLD-317] Remove `//go:build go1.19` tags from runtime package

### DIFF
--- a/pkg/runtime/gomemlimit.go
+++ b/pkg/runtime/gomemlimit.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux || !go1.19
+//go:build !linux
 
 package runtime
 

--- a/pkg/runtime/gomemlimit_linux.go
+++ b/pkg/runtime/gomemlimit_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && go1.19
+//go:build linux
 
 package runtime
 


### PR DESCRIPTION
### What does this PR do?
Go 1.19 support was dropped in 2023 through #17744 when the project upgraded from Go 1.19.10 to Go 1.20.5, making `//go:build go1.19` tags redundant.

The `runtime.debug.SetMemoryLimit` API introduced in Go 1.19 is now standard in all supported Go versions.

### Motivation
Decrease the number of Go build tags to help transition the agent's build from `omnibus` (`invoke`, etc.) to `bazel`.