### PR TITLE
[APMLP-846] Update `image_resolution_attempts` fields to better visualize K8s SSI rollouts

### DIFF
--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -115,6 +115,6 @@ var (
 
 	// Image resolution tracking for gradual rollout monitoring
 	ImageResolutionAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "image_resolution_attempts",
-		[]string{"registry", "repository", "digest_resolution", "outcome"}, "Number of image resolution attempts by registry, repository, digest resolution capability, and outcome (digest/mutable)",
-		telemetry.Options{NoDoubleUnderscoreSep: true})
+		[]string{"repository", "tag", "outcome"}, "Number of image resolution attempts by repository, tag, and resolution outcome",
+		telemetry.Options{})
 )

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/image_resolver.go
@@ -43,7 +43,7 @@ func newNoOpImageResolver() ImageResolver {
 // ResolveImage returns the original image reference.
 func (r *noOpImageResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
 	log.Debugf("Cannot resolve %s/%s:%s without remote config", registry, repository, tag)
-	metrics.ImageResolutionAttempts.Inc(registry, repository, metrics.DigestResolutionDisabled, tag)
+	metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
 	return nil, false
 }
 
@@ -123,14 +123,14 @@ func (r *remoteConfigImageResolver) Resolve(registry string, repository string, 
 
 	if len(r.imageMappings) == 0 {
 		log.Debugf("Cache empty, no resolution available")
-		metrics.ImageResolutionAttempts.Inc(registry, repository, metrics.DigestResolutionEnabled, tag)
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
 		return nil, false
 	}
 
 	repoCache, exists := r.imageMappings[repository]
 	if !exists {
 		log.Debugf("No mapping found for repository %s", repository)
-		metrics.ImageResolutionAttempts.Inc(registry, repository, metrics.DigestResolutionEnabled, tag)
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
 		return nil, false
 	}
 
@@ -139,12 +139,12 @@ func (r *remoteConfigImageResolver) Resolve(registry string, repository string, 
 	resolved, exists := repoCache[normalizedTag]
 	if !exists {
 		log.Debugf("No mapping found for %s:%s", repository, normalizedTag)
-		metrics.ImageResolutionAttempts.Inc(registry, repository, metrics.DigestResolutionEnabled, tag)
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
 		return nil, false
 	}
 	resolvedImage := newResolvedImage(registry, repository, resolved)
 	log.Debugf("Resolved %s/%s:%s -> %s", registry, repository, tag, resolvedImage.FullImageRef)
-	metrics.ImageResolutionAttempts.Inc(registry, repository, metrics.DigestResolutionEnabled, resolved.Digest)
+	metrics.ImageResolutionAttempts.Inc(repository, tag, resolved.Digest)
 	return resolvedImage, true
 }
 

--- a/releasenotes/notes/update-image-resolution-attempt-telemetry-54cd9ebf6081c736.yaml
+++ b/releasenotes/notes/update-image-resolution-attempt-telemetry-54cd9ebf6081c736.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Update image resolution attempt telemetry to include the `tag` specified
+    in the configuration, and remove the `registry` and `digest_resolution` tags.


### PR DESCRIPTION
### What does this PR do?
Updates the existing `admission_webhooks.image_resolution_attempts` metric fields to improve K8s SSI gradual rollout visibility. Now the fields are:
- `repository` - ex) `dd-lib-python-init`
- `tag` - Whatever version tag is specified by the customer ex) `latest`, `v[major]`, `v[major].[minor]`, `v[major].[minor].[patch]`
- `outcome` - The outcome of the resolution. This should be a SHA256 digest if the resolution was successful, and the tag value from above if resolution failed for any reason. 

`registry` and `digest_resolution` are being removed since they are a "nice to have", but add unnecessary cardinality for onboarding COAT. The latter can be inferred from the `outcome` field as well, so it's slightly redundant.

### Motivation
The goal is to onboard this metric onto COAT (see PR [here](https://github.com/DataDog/datadog-agent/pull/42338)), and have ways to answer questions like:
- For each `repository`, what is the breakdown of `tag`s that customers are configuring?
- For each `tag` for a given `repository`, what is the breakdown of `outcome`s?
- Which `org_id`s (provided by onboarding COAT) have failed resolutions? How many? And for which `tag`s?
- How many `org_id`s are requesting `latest` for their `tag`?
- For each `repository`, which `tag` is the most popular?

### Describe how you validated your changes
Running a local test app with a cluster agent built from this branch, and validating the metrics are showing up properly in my dogfood org.

### Additional Notes
