### PR TITLE
[SBOM] bump ddtrivy to latest and use OfflineJar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -975,7 +975,7 @@ require (
 
 require (
 	github.com/DataDog/datadog-agent/pkg/ssi/testutils v0.0.0-00010101000000-000000000000
-	github.com/DataDog/ddtrivy v0.0.0-20260106134118-984f97198d7f
+	github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/creack/pty v1.1.24

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/DataDog/datadog-traceroute v1.0.3 h1:84fcvLfsOmdm7T6+7Y07KmQfXJR8gjMd
 github.com/DataDog/datadog-traceroute v1.0.3/go.mod h1:aA+OKmKRPghOH/DPIrepgLXos++CHZQ5L/uCCeaaNII=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec h1:Cm7Ksl+mKn9ev56CMpYtUs/rQriT4pmLlgaxzkZ8tXU=
 github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20251120091008-29f645374bec/go.mod h1:zMOs5XpXrqK5KMLnQDkwwWKF2yVzN2TQGSrBHgPP+eY=
-github.com/DataDog/ddtrivy v0.0.0-20260106134118-984f97198d7f h1:7IRtVKVS+J5vlepf3RNsR37oe+qrTfRWJkpAzaiezFM=
-github.com/DataDog/ddtrivy v0.0.0-20260106134118-984f97198d7f/go.mod h1:Yc9pqq42/s9/UiOMUOhPZwJoX/0JdswI1IQMOwhktpo=
+github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=
+github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5/go.mod h1:oz6zVBIVeK9I/AFP9k7TljSGtA9Opslmay0FcXg0fuQ=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=
 github.com/DataDog/ebpf-manager v0.7.15/go.mod h1:aWM8s7mxjzC3iNZNBc4h0qjyQuhKeaU+ET92eB/0pRQ=
 github.com/DataDog/go-cmp v0.0.0-20250605161605-8f326bf2ab9d h1:ErpIQikDqtpE21afk2ExlJn0wg7gGWyUVu/RY4rBlMI=

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -91,6 +91,8 @@ func getDefaultArtifactOption(scanOptions sbom.ScanOptions) artifact.Option {
 	}
 
 	artifactOption.WalkerOption.OnlyDirs = append(artifactOption.WalkerOption.OnlyDirs, scanOptions.AdditionalDirs...)
+	// agent specific config, needed so that we don't download the Java DB at runtime
+	artifactOption.OfflineJar = true
 
 	return artifactOption
 }


### PR DESCRIPTION
### What does this PR do?

This bumps ddtrivy to the latest main (instead of pointing to a branch commit) and makes use of `OfflineJar` to not download the Java DB at runtime. This was a regression from https://github.com/DataDog/datadog-agent/pull/44154.

### Motivation

### Describe how you validated your changes

### Additional Notes
