### PR TITLE
[FA] Fix windows deployment id

### DIFF
--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -62,7 +62,8 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if err != nil {
 		return fmt.Errorf("error creating target directory: %w", err)
 	}
-	err = backupOrRestoreDirectory(ctx, d.StablePath, d.ExperimentPath)
+	// Copy deployment ID during backup - we want to preserve stable's deployment ID in the backup
+	err = backupOrRestoreDirectory(ctx, d.StablePath, d.ExperimentPath, true)
 	if err != nil {
 		return fmt.Errorf("error writing deployment ID file: %w", err)
 	}
@@ -108,7 +109,8 @@ func (d *Directories) RemoveExperiment(ctx context.Context) error {
 	if os.IsNotExist(err) {
 		return nil
 	}
-	err = backupOrRestoreDirectory(ctx, d.ExperimentPath, d.StablePath)
+	// Skip copying deployment ID during rollback - we want to preserve stable's deployment ID
+	err = backupOrRestoreDirectory(ctx, d.ExperimentPath, d.StablePath, false)
 	if err != nil {
 		return fmt.Errorf("error backing up stable directory: %w", err)
 	}
@@ -121,7 +123,8 @@ func (d *Directories) RemoveExperiment(ctx context.Context) error {
 
 // backupOrRestoreDirectory copies YAML files from source to target.
 // It preserves the directory structure and file permissions.
-func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string) error {
+// If copyDeploymentID is true, also copies the .deployment-id file.
+func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string, copyDeploymentID bool) error {
 	_, err := os.Stat(sourcePath)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("error checking if source directory exists: %w", err)
@@ -137,16 +140,21 @@ func backupOrRestoreDirectory(ctx context.Context, sourcePath, targetPath string
 	if _, err := os.Stat(targetPath); err != nil {
 		return fmt.Errorf("failed to open target directory: %w", err)
 	}
-	deploymentID, err := os.ReadFile(filepath.Join(sourcePath, deploymentIDFile))
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("error reading deployment ID file: %w", err)
-	}
-	if !os.IsNotExist(err) {
-		err = os.WriteFile(filepath.Join(targetPath, deploymentIDFile), deploymentID, 0640)
-		if err != nil {
-			return fmt.Errorf("error writing deployment ID file: %w", err)
+
+	// Only copy deployment ID if explicitly requested (during backup, not during restore)
+	if copyDeploymentID {
+		deploymentID, err := os.ReadFile(filepath.Join(sourcePath, deploymentIDFile))
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("error reading deployment ID file: %w", err)
+		}
+		if !os.IsNotExist(err) {
+			err = os.WriteFile(filepath.Join(targetPath, deploymentIDFile), deploymentID, 0640)
+			if err != nil {
+				return fmt.Errorf("error writing deployment ID file: %w", err)
+			}
 		}
 	}
+
 	cmd := telemetry.CommandContext(
 		ctx,
 		"robocopy",

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -297,9 +297,8 @@ func (s *configSuite) TestSystemProbeConfig() {
 }
 
 // TestConfigRollbackDeploymentID tests that rolling back a config experiment
-// does not incorrectly set the stable_config_version.
-// This test reproduces a Windows-specific bug where RemoveExperiment copies
-// the experiment deployment ID to stable during rollback.
+// correctly preserves the stable_config_version and does not overwrite it
+// with the experiment deployment ID.
 func (s *configSuite) TestConfigRollbackDeploymentID() {
 	s.Agent.MustInstall()
 	defer s.Agent.MustUninstall()
@@ -326,7 +325,7 @@ func (s *configSuite) TestConfigRollbackDeploymentID() {
 		FileOperations: []backend.FileOperation{
 			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "debug"}`)},
 		},
-	})
+	}, nil)
 	require.NoError(s.T(), err)
 
 	// Verify config changed during experiment
@@ -373,11 +372,9 @@ func (s *configSuite) TestConfigRollbackDeploymentID() {
 	}
 	require.NotNil(s.T(), agentStateAfterRollback, "datadog-agent package should be in remote config state")
 
-	// BUG: On Windows, stable_config_version gets incorrectly set to experimentDeploymentID
-	// Expected: stable_config_version should remain unchanged (initialStableConfigVersion)
-	// Actual: stable_config_version = experimentDeploymentID due to backupOrRestoreDirectory copying .deployment-id
+	// Verify stable_config_version is preserved after rollback
 	require.Equal(s.T(), initialStableConfigVersion, agentStateAfterRollback.StableConfigVersion,
-		"BUG: stable_config_version should not change after rollback, but got: %s (expected: %s)",
+		"stable_config_version should not change after rollback, but got: %s (expected: %s)",
 		agentStateAfterRollback.StableConfigVersion, initialStableConfigVersion)
 	require.Empty(s.T(), agentStateAfterRollback.ExperimentConfigVersion,
 		"experiment_config_version should be empty after rollback")


### PR DESCRIPTION
This pull request updates the Windows config experiment logic to ensure that rolling back an experiment does not overwrite the stable deployment ID with the experiment's deployment ID. The changes introduce a new parameter to control whether the deployment ID file is copied during backup or restore operations, and add tests to verify correct behavior and prevent regression.

**Config experiment and rollback logic improvements:**

* Modified the `backupOrRestoreDirectory` function in `config_windows.go` to accept a `copyDeploymentID` boolean parameter, allowing explicit control over whether the `.deployment-id` file is copied during backup or restore operations. This prevents the experiment deployment ID from overwriting the stable deployment ID during rollback. [[1]](diffhunk://#diff-e1153357305bbc55ffdde81d014efdddfa0688fcd8c19c6fde61993b39db2ee5L124-R127) [[2]](diffhunk://#diff-e1153357305bbc55ffdde81d014efdddfa0688fcd8c19c6fde61993b39db2ee5R143-R145) [[3]](diffhunk://#diff-e1153357305bbc55ffdde81d014efdddfa0688fcd8c19c6fde61993b39db2ee5R156-R157)
* Updated calls to `backupOrRestoreDirectory` in `WriteExperiment` and `RemoveExperiment` to set `copyDeploymentID` to `true` during backup and `false` during rollback, preserving the correct deployment ID in each scenario. [[1]](diffhunk://#diff-e1153357305bbc55ffdde81d014efdddfa0688fcd8c19c6fde61993b39db2ee5L65-R66) [[2]](diffhunk://#diff-e1153357305bbc55ffdde81d014efdddfa0688fcd8c19c6fde61993b39db2ee5L111-R113)

**Testing and regression prevention:**

* Added a unit test `TestDeploymentIDAfterRollback` in `config_windows_test.go` to reproduce and verify the bug where `RemoveExperiment` incorrectly copied the experiment deployment ID to stable during rollback. This test ensures the stable deployment ID remains unchanged after rollback.
* Added an end-to-end test `TestConfigRollbackDeploymentID` in `config_test.go` to verify that rolling back a config experiment correctly preserves the stable config version and does not overwrite it with the experiment deployment ID.