### PR TITLE
[SQG] Add missing expression attribute

### DIFF
--- a/tasks/libs/common/datadog_api.py
+++ b/tasks/libs/common/datadog_api.py
@@ -208,12 +208,15 @@ def query_metrics(query, from_time, to_time):
 
         # Extract series data from response
         series_list = []
-        if hasattr(response, 'series') and response.series:
-            for series in response.series:
-                series_data = {
-                    "scope": series.scope if hasattr(series, 'scope') else "",
-                    "pointlist": series.pointlist if hasattr(series, 'pointlist') else [],
-                }
-                series_list.append(series_data)
+        if not response.series:
+            return series_list
+
+        for series in response.series:
+            series_data = {
+                "scope": series.scope or "",
+                "pointlist": series.pointlist or [],
+                "expression": series.expression or "",
+            }
+            series_list.append(series_data)
 
         return series_list

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -63,12 +63,15 @@ def _extract_gate_name_from_scope(scope: str) -> str | None:
 
 
 def _get_latest_value_from_pointlist(pointlist: list) -> float | None:
-    """Get the latest non-null value from a pointlist."""
+    """Get the latest non-null value from a pointlist of Point objects.
+
+    Point.value returns [timestamp, metric_value], so we access index 1.
+    """
     if not pointlist:
         return None
     for point in reversed(pointlist):
-        if point and len(point) >= 2 and point[1] is not None:
-            return point[1]
+        if point and point.value and point.value[1] is not None:
+            return point.value[1]
     return None
 
 

--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -62,6 +62,18 @@ from tasks.static_quality_gates.gates import (
 )
 
 
+class MockPoint:
+    """Mock Point object matching datadog_api_client.v1.model.point.Point structure."""
+
+    def __init__(self, timestamp, metric_value):
+        self.value = [timestamp, metric_value]
+
+
+def make_pointlist(points: list) -> list:
+    """Convert [[timestamp, value], ...] to [MockPoint, ...] for tests."""
+    return [MockPoint(p[0], p[1]) for p in points]
+
+
 class TestDataClasses(unittest.TestCase):
     def test_artifact_measurement_validation(self):
         # Valid measurement should work
@@ -1718,19 +1730,19 @@ class TestExceptionThresholdBumpHelpers(unittest.TestCase):
 
     def test_get_latest_value_from_pointlist_valid(self):
         """Should get the latest non-null value from pointlist."""
-        pointlist = [[1704067200, 100.0], [1704153600, 150.0], [1704240000, 200.0]]
+        pointlist = make_pointlist([[1704067200, 100.0], [1704153600, 150.0], [1704240000, 200.0]])
         result = _get_latest_value_from_pointlist(pointlist)
         self.assertEqual(result, 200.0)
 
     def test_get_latest_value_from_pointlist_with_nulls(self):
         """Should skip null values and get the latest non-null value."""
-        pointlist = [[1704067200, 100.0], [1704153600, 150.0], [1704240000, None]]
+        pointlist = make_pointlist([[1704067200, 100.0], [1704153600, 150.0], [1704240000, None]])
         result = _get_latest_value_from_pointlist(pointlist)
         self.assertEqual(result, 150.0)
 
     def test_get_latest_value_from_pointlist_all_nulls(self):
         """Should return None if all values are null."""
-        pointlist = [[1704067200, None], [1704153600, None]]
+        pointlist = make_pointlist([[1704067200, None], [1704153600, None]])
         result = _get_latest_value_from_pointlist(pointlist)
         self.assertIsNone(result)
 
@@ -1850,22 +1862,22 @@ class TestFetchPrMetrics(unittest.TestCase):
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_disk_size{...}",
-                "pointlist": [[1704240000, 100 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 100 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_wire_size{...}",
-                "pointlist": [[1704240000, 50 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 50 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_disk_size{...}",
-                "pointlist": [[1704240000, 150 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 150 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_wire_size{...}",
-                "pointlist": [[1704240000, 75 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 75 * 1024 * 1024]]),
             },
         ]
 
@@ -1898,22 +1910,22 @@ class TestFetchPrMetrics(unittest.TestCase):
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_disk_size{...}",
-                "pointlist": [[1704240000, 100 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 100 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_docker_agent_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_disk_size{...}",
-                "pointlist": [[1704240000, 200 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 200 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_wire_size{...}",
-                "pointlist": [[1704240000, 50 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 50 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_docker_agent_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_wire_size{...}",
-                "pointlist": [[1704240000, 80 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 80 * 1024 * 1024]]),
             },
         ]
 
@@ -1937,22 +1949,22 @@ class TestFetchMainHeadroom(unittest.TestCase):
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_disk_size{...}",
-                "pointlist": [[1704240000, 100 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 100 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_wire_size{...}",
-                "pointlist": [[1704240000, 50 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 50 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_disk_size{...}",
-                "pointlist": [[1704240000, 150 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 150 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_wire_size{...}",
-                "pointlist": [[1704240000, 75 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 75 * 1024 * 1024]]),
             },
         ]
 
@@ -1974,22 +1986,22 @@ class TestFetchMainHeadroom(unittest.TestCase):
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_disk_size{...}",
-                "pointlist": [[1704240000, 200 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 200 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.on_wire_size{...}",
-                "pointlist": [[1704240000, 100 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 100 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_disk_size{...}",
-                "pointlist": [[1704240000, 150 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 150 * 1024 * 1024]]),
             },
             {
                 "scope": "gate_name:static_quality_gate_agent_deb_amd64",
                 "expression": "avg:datadog.agent.static_quality_gate.max_allowed_on_wire_size{...}",
-                "pointlist": [[1704240000, 75 * 1024 * 1024]],
+                "pointlist": make_pointlist([[1704240000, 75 * 1024 * 1024]]),
             },
         ]
 


### PR DESCRIPTION
### What does this PR do?
This fixes a newly introduced SQG bump task that was always reporting no failing gates to bump. The issue was in lack of `expression` attribute that is crucial to determine which metric we want to use. Also, instead of heavily relying on Reflection API we now use attributes directly which makes the code cleaner and easier to read and maintain.

### Describe how you validated your changes
1. I have reduced the maximum for one of the gates.
2. Waited the pipeline to complete (so that SQG job reports the results)
3. Ran `dd-auth -- dda inv quality-gates.exception-threshold-bump 45124`
to see that failing gate was bumped:
```shell
Fetching metrics for PR #45124...
Found metrics for 31 gates
Found 1 failing gates:
  - agent_deb_amd64: disk +4.86 MiB, wire +-1.18 MiB
Fetching main branch metrics for headroom calculation...

[SUCCESS] Updated 1 gate thresholds:
  - agent_deb_amd64: disk: 700.41 MiB → 708.41 MiB
  - agent_deb_amd64: wire: 174.49 MiB → 174.49 MiB
```
4. Verified that `static_quality_gates.yml` contained unstaged changes.

### Additional Notes
This task doesn't work with pipelines anymore. Instead, it relies on Datadog and reported metrics meaning that if a PR doesn't have a run of SQG job and metrics weren't uploaded in the last 24 hours the task will fail. This is to ensure that PR is as close to the current state of the main branch as possible to improve accuracy of the size calculation.