### PR TITLE
Fix `bazel:mod-tidy` job to ignore lockfile changes

### DIFF
--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -19,7 +19,7 @@ bazel:mod-tidy:
   extends: .bazel:runner:linux-amd64
   stage: lint
   script:
-    - bazel mod tidy
+    - bazel mod tidy --lockfile_mode=off
     - git diff --exit-code
   after_script:
     - |-


### PR DESCRIPTION
### Motivation
The `bazel:mod-tidy` job is meant to ensure `MODULE.bazel` remains in an optimal state (not only in `bazel`'s opinionated format, but first and foremost to help maintain the `use_repo` directives that Gazelle will update).

The problem is that I added it without thinking it could fail due to `MODULE.bazel.lock` being updated by side effect, which is already (and better) guarded by the sibling `bazel:mod-deps` job, misleadingly causing [both to fail](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/90857566) on inadvertent changes in the lockfile:
<img width="337" height="159" alt="image" src="https://github.com/user-attachments/assets/c6a3f998-29ef-4286-a561-2a48f3555a61" />

### What does this PR do?
Adding `--lockfile_mode=off` to `bazel mod tidy` is therefore meant to prevent `bazel:mod-tidy` from failing on lockfile changes for a proper separation of concerns, distinct hints being provided:
```diff
-💡 bazel mod tidy
+💡 bazel mod deps
```