### PR TITLE
tasks: force enable duashipping when using the fakeintake

### DIFF
--- a/tasks/e2e_framework/deploy.py
+++ b/tasks/e2e_framework/deploy.py
@@ -66,6 +66,13 @@ def deploy(
     if install_agent:
         flags["ddagent:apiKey"] = config.get_api_key(cfg)
 
+    # When using fakeintake, enable dual shipping to send data to both fakeintake and Datadog
+    # Otherwise pulumi will configure the agent to send data directly to fakeintake
+    # this is breakind UI/console related features that require communication with Datadog backend
+    # see go package agent.HelmValues.configureFakeintake for more details
+    if use_fakeintake is True:
+        flags["ddagent:dualshipping"] = True
+
     # add stack params values
     stackParams = cfg.get_stack_params()
     for namespace in stackParams:


### PR DESCRIPTION
### What does this PR do?

When deploying a lab/test stack, if the fakeintake is enabled we must enable _dual shipping_. otherwise the stack will be deployed with the fakeintake IP as URL target for all services. That works but only for basic payloads (metrics, logs, events ?) not for any live view on the datadog UI/console.

Enable _dual shipping_ will allows the agent to send data to both the datadog backend and the fakeintake to consult the metrics produced.

this allows all feature on the UI/console to work as expected.

### Motivation

deploy a stack using fakeintake and it works

### Describe how you validated your changes

### Additional Notes
