### PR TITLE
Restore openssl-related files dropped by transition to bazel

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -98,10 +98,5 @@ pkg_files(
 
 pkg_install(
     name = "install",
-    srcs = [":install_files"] + select({
-        "@platforms//os:windows": [
-            "@openssl//:openssl_exe_file",
-        ],
-        "//conditions:default": [],
-    }),
+    srcs = [":install_files"],
 )

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -300,7 +300,6 @@ pkg_install(
         ":libcrypto_with_symlink",
     ] + select({
         "@platforms//os:windows": [
-            ":dll_a",
             ":openssl_exe_file",
         ],
         "//conditions:default": [

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -135,7 +135,11 @@ configure_make(
         ],
         "//conditions:default": [],
     }),
-    out_data_dirs = ["lib/pkgconfig"],
+    out_data_dirs = [
+        "lib/pkgconfig",
+        "lib/engines-3",
+        "lib/ossl-modules",
+    ],
     # For whatever reason rules_foreign_cc does not respect
     # out_dll_dir parameter and tries to find Windows DLLs in
     # lib instead of bin. Technically, those are binaries,
@@ -257,6 +261,27 @@ filegroup(
     target_compatible_with = ["@platforms//os:windows"],
 )
 
+filegroup(
+    name = "engines-3",
+    srcs = [":openssl"],
+    output_group = "engines-3",
+)
+
+filegroup(
+    name = "ossl-modules",
+    srcs = [":openssl"],
+    output_group = "ossl-modules",
+)
+
+pkg_files(
+    name = "lib_dir_files",
+    srcs = [":engines-3", ":ossl-modules"],
+    prefix = "lib",
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
+)
+
 pkg_files(
     name = "dll_a",
     srcs = [
@@ -298,6 +323,7 @@ pkg_install(
         ":openssl_hdr_files",
         ":libssl_with_symlink",
         ":libcrypto_with_symlink",
+        ":lib_dir_files",
     ] + select({
         "@platforms//os:windows": [
             ":openssl_exe_file",

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -139,6 +139,7 @@ configure_make(
         "lib/pkgconfig",
         "lib/engines-3",
         "lib/ossl-modules",
+        "ssl",
     ],
     # For whatever reason rules_foreign_cc does not respect
     # out_dll_dir parameter and tries to find Windows DLLs in
@@ -282,6 +283,17 @@ pkg_files(
     ),
 )
 
+filegroup(
+    name = "ssl_dir",
+    srcs = [":openssl"],
+    output_group = "ssl",
+)
+
+pkg_files(
+    name = "ssl_dir_files",
+    srcs = [":ssl_dir"],
+)
+
 pkg_files(
     name = "dll_a",
     srcs = [
@@ -324,6 +336,7 @@ pkg_install(
         ":libssl_with_symlink",
         ":libcrypto_with_symlink",
         ":lib_dir_files",
+        ":ssl_dir_files",
     ] + select({
         "@platforms//os:windows": [
             ":openssl_exe_file",

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -43,11 +43,17 @@ build do
       # openssl binaries on macos
       real_install_dir = if mac_os_x? then "/opt/datadog-agent" else install_dir end
       lib_extension = if linux_target? then ".so" else ".dylib" end
-      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{real_install_dir}/embedded" \
-        " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
-        " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \
-        " #{install_dir}/embedded/lib/pkgconfig/*.pc" \
-        " #{install_dir}/embedded/bin/openssl"
+
+      files_to_patch = [
+        "lib/libssl#{lib_extension}",
+        "lib/libcrypto#{lib_extension}",
+        "lib/engines-3/*#{lib_extension}",
+        "lib/ossl-modules/*#{lib_extension}",
+        "lib/pkgconfig/*.pc",
+        "bin/openssl",
+      ].map { |path| "#{install_dir}/embedded/#{path}" }
+
+      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded #{files_to_patch.join(' ')}"
       command_on_repo_root "bazelisk run -- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
         " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
         " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -33,8 +33,9 @@ relative_path "openssl-#{version}"
 
 build do
   if !fips_mode?
-    # OpenSSL on Windows now gets installed as part of the Python install, so we don't need to do anything here
-    if !windows?
+    if windows?
+      command_on_repo_root "bazelisk run -- @openssl//:install --destdir=#{install_dir}/embedded3"
+    else
       command_on_repo_root "bazelisk run -- @openssl//:install --destdir=#{install_dir}/embedded"
       # build_agent_dmg.sh sets INSTALL_DIR to some temporary folder.
       # This messes up openssl's internal paths. So we have to use another variable


### PR DESCRIPTION
### What does this PR do?

It restores some files from the OpenSSL installation that were dropped during the recent conversion of OpenSSL and Python (just on Windows) to Bazel. These omissions were found during work on doing the equivalent conversion for FIPS (https://github.com/DataDog/datadog-agent/pull/43852).

- OpenSSL DLL files under the embedded3/bin folder which were accidentally dropped by https://github.com/DataDog/datadog-agent/pull/43636. Without this file, the `openssl.exe` executable fails to execute. This affects Agent 7.75.
- `lib/engines-3` and `lib/ossl-modules`. These contain a few OpenSSL modules and were dropped by https://github.com/DataDog/datadog-agent/pull/42930. Agent 7.74 was released without these.
- Files under `embedded3/ssl` including a config file and a few others. These were dropped by https://github.com/DataDog/datadog-agent/pull/42930. Agent 7.74 was released without these.

### Motivation

Restoring lost files, since we can't tell for sure whether this could break anyone.

### Describe how you validated your changes

I mainly downloaded packages from the pipelines, compared them with the fips package from the same pipeline, and checked whether the diff made sense, and being able to tell that the directories / files described above where indeed added back.

### Additional Notes

This adds some size back to the Agent, particularly to the msi (where it triggers the gates). But this is restoring what shouldn't have been gone in the first place.

Details on the files that were dropped and now recovered:

From debian package:

```
  -opt/datadog-agent/embedded/lib/engines-3/
  -opt/datadog-agent/embedded/lib/engines-3/afalg.so
  -opt/datadog-agent/embedded/lib/engines-3/capi.so
  -opt/datadog-agent/embedded/lib/engines-3/loader_attic.so
  -opt/datadog-agent/embedded/lib/engines-3/padlock.so
  -opt/datadog-agent/embedded/lib/ossl-modules/
  -opt/datadog-agent/embedded/lib/ossl-modules/legacy.so
  -opt/datadog-agent/embedded/ssl/ct_log_list.cnf
  -opt/datadog-agent/embedded/ssl/ct_log_list.cnf.dist
  -opt/datadog-agent/embedded/ssl/misc/
  -opt/datadog-agent/embedded/ssl/misc/CA.pl
  -opt/datadog-agent/embedded/ssl/misc/tsget
  -opt/datadog-agent/embedded/ssl/misc/tsget.pl
  -opt/datadog-agent/embedded/ssl/openssl.cnf
  -opt/datadog-agent/embedded/ssl/openssl.cnf.dist
```

From the Windows package:

```
  -embedded3/bin/libcrypto-3-x64.dll
  -embedded3/bin/libssl-3-x64.dll
  -embedded3/DLLs/libcrypto-3-x64.lib  # These .lib files are not really needed, though, so this PR doesn't restore them
  -embedded3/DLLs/libssl-3-x64.lib
  -embedded3/include/openssl/
  -embedded3/include/openssl/aes.h
  # ... lots of other openssl headers
  -embedded3/lib/engines-3/
  -embedded3/lib/engines-3/capi.dll
  -embedded3/lib/engines-3/loader_attic.dll
  -embedded3/lib/engines-3/padlock.dll
  -embedded3/lib/ossl-modules/legacy.dll
  -embedded3/ssl/openssl.cnf.tmp
```