### PR TITLE
chore: Update Security Filter Initialization

### DIFF
--- a/comp/core/workloadfilter/baseimpl/filter_utils.go
+++ b/comp/core/workloadfilter/baseimpl/filter_utils.go
@@ -236,7 +236,7 @@ func (pf *filterSelection) computeKubeEndpointAutodiscoveryFilters(_ config.Comp
 // computeContainerComplianceFilters computes container compliance filters
 func (pf *filterSelection) computeContainerComplianceFilters(cfg config.Component) [][]workloadfilter.ContainerFilter {
 	flist := []workloadfilter.ContainerFilter{workloadfilter.ContainerLegacyCompliance}
-	if cfg.GetBool("compliance_config.exclude_pause_containers") {
+	if cfg.GetBool("compliance_config.exclude_pause_container") {
 		flist = append(flist, workloadfilter.ContainerPaused)
 	}
 	return [][]workloadfilter.ContainerFilter{flist}
@@ -245,7 +245,7 @@ func (pf *filterSelection) computeContainerComplianceFilters(cfg config.Componen
 // computeContainerRuntimeSecurityFilters computes container runtime security filters
 func (pf *filterSelection) computeContainerRuntimeSecurityFilters(cfg config.Component) [][]workloadfilter.ContainerFilter {
 	flist := []workloadfilter.ContainerFilter{workloadfilter.ContainerLegacyRuntimeSecurity}
-	if cfg.GetBool("runtime_security_config.exclude_pause_containers") {
+	if cfg.GetBool("runtime_security_config.exclude_pause_container") {
 		flist = append(flist, workloadfilter.ContainerPaused)
 	}
 	return [][]workloadfilter.ContainerFilter{flist}

--- a/comp/core/workloadfilter/impl/filter_test.go
+++ b/comp/core/workloadfilter/impl/filter_test.go
@@ -1345,6 +1345,7 @@ func TestContainerRuntimeSecurityAndComplianceFilters(t *testing.T) {
 	// Setup Compliance Config
 	mockConfig.SetWithoutSource("compliance_config.container_include", []string{"image:compliance-agent"})
 	mockConfig.SetWithoutSource("compliance_config.container_exclude", []string{"image:malicious"})
+	mockConfig.SetWithoutSource("compliance_config.exclude_pause_container", false)
 
 	// Setup Runtime Security Config
 	mockSystemProbe.SetWithoutSource("runtime_security_config.container_include", []string{"image:security-agent"})
@@ -1357,12 +1358,14 @@ func TestContainerRuntimeSecurityAndComplianceFilters(t *testing.T) {
 		includedContainer := workloadfilter.CreateContainerImage("compliance-agent")
 		excludedContainer := workloadfilter.CreateContainerImage("malicious")
 		unknownContainer := workloadfilter.CreateContainerImage("security-agent")
+		pauseContainer := workloadfilter.CreateContainerImage("kubernetes/pause")
 
 		filterBundle := filterStore.GetContainerComplianceFilters()
 
 		assert.Equal(t, workloadfilter.Included, filterBundle.GetResult(includedContainer))
 		assert.Equal(t, workloadfilter.Excluded, filterBundle.GetResult(excludedContainer))
 		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(unknownContainer))
+		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(pauseContainer))
 	})
 
 	// Test Runtime Security Filter
@@ -1370,12 +1373,14 @@ func TestContainerRuntimeSecurityAndComplianceFilters(t *testing.T) {
 		includedContainer := workloadfilter.CreateContainerImage("security-agent")
 		excludedContainer := workloadfilter.CreateContainerImage("suspicious")
 		unknownContainer := workloadfilter.CreateContainerImage("malicious")
+		pauseContainer := workloadfilter.CreateContainerImage("kubernetes/pause")
 
 		filterBundle := filterStore.GetContainerRuntimeSecurityFilters()
 
 		assert.Equal(t, workloadfilter.Included, filterBundle.GetResult(includedContainer))
 		assert.Equal(t, workloadfilter.Excluded, filterBundle.GetResult(excludedContainer))
 		assert.Equal(t, workloadfilter.Unknown, filterBundle.GetResult(unknownContainer))
+		assert.Equal(t, workloadfilter.Excluded, filterBundle.GetResult(pauseContainer))
 	})
 
 }


### PR DESCRIPTION
### What does this PR do?

Updates the new filter config introduced in https://github.com/DataDog/datadog-agent/pull/44258 to properly reference the pause container configuration option.

`exclude_pause_containers => exclude_pause_container`

### Describe how you validated your changes

Unit tests

### Additional Notes

No user impact. These filters have been defined to be lazily loaded but they are currently used no where.