### PR TITLE
[CWS] add missing lock in `(*EBPFResolver).ApplyExitEntry`

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -334,6 +334,9 @@ func (p *EBPFResolver) AddExecEntry(event *model.Event) error {
 
 // ApplyExitEntry delete entry from the local cache if present
 func (p *EBPFResolver) ApplyExitEntry(event *model.Event, newEntryCb func(*model.ProcessCacheEntry, error)) bool {
+	p.Lock()
+	defer p.Unlock()
+
 	event.ProcessCacheEntry = p.resolve(event.PIDContext.Pid, event.PIDContext.Tid, event.PIDContext.ExecInode, false, newEntryCb)
 	if event.ProcessCacheEntry == nil {
 		// no need to dispatch an exit event that don't have the corresponding cache entry


### PR DESCRIPTION
### What does this PR do?

This PR adds missing locking in `ApplyExitEntry` that could cause concurrent access to the entryCache map of the process resolver. Since `ApplyExitEntry` calls `resolve` which is the "internal, to be called with the lock taken", it needs to be called with the lock taken.

[Fixes this kind of logs](https://ddstaging.datadoghq.com/logs?query=%22Java%20DB%20client%20not%20initialized%22%20service%3Adatadog-agent&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1765899661442&to_ts=1768491661442&live=true)

### Motivation

### Describe how you validated your changes

### Additional Notes
