### PR TITLE
[EBPF] gpu: add integration tests for container assignment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1459,7 +1459,6 @@ workflow:
 
 .on_gpu_integration_tests:
   - !reference [.on_scheduled_main]
-  - !reference [.manual]
   # Run on GPU-related changes
   - changes:
       paths:
@@ -1468,7 +1467,7 @@ workflow:
         - comp/core/workloadmeta/collectors/internal/nvml/**/*
         - .gitlab/build/source_test/linux.yml
       compare_to: $COMPARE_TO_BRANCH
-    when: on_success
+  - !reference [.manual]
 
 .on_installer_systemd_changes:
   - <<: *if_main_branch

--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -210,6 +210,7 @@ tests_gpu:
   allow_failure: true
   before_script:
     - !reference [.retrieve_linux_go_deps]
+    - apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y nvidia-cuda-toolkit
   after_script:
     - !reference [.upload_junit_source]
     - !reference [.upload_coverage]

--- a/pkg/gpu/AGENTS.md
+++ b/pkg/gpu/AGENTS.md
@@ -157,6 +157,11 @@ Releases all held resources without emitting spans:
 - When draining channels during cleanup, limit iterations to prevent blocking
 - Use `cap(channel)` as upper bound for iterations
 
+### Workloadmeta Docker Collector Build Tags
+- The workloadmeta Docker collector is behind the `docker` build tag.
+- GPU integration tests that depend on real docker workloadmeta must include `docker` in their `//go:build` line or be run with `-tags docker`.
+- In tests, feature detection is disabled; call `env.SetFeatures(t, env.Docker)` to allow the docker workloadmeta collector to start.
+
 ## Testing Pools
 
 Use `withTelemetryEnabledPools(t, telemetryMock)` to enable pool telemetry in tests.

--- a/pkg/gpu/integrationtests/device_assignment_test.go
+++ b/pkg/gpu/integrationtests/device_assignment_test.go
@@ -1,0 +1,203 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf && nvml && docker
+
+package integrationtests
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	workloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-core"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetadefaults "github.com/DataDog/datadog-agent/comp/core/workloadmeta/defaults"
+	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/gpu"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+const (
+	cudaTestsDockerImage = "ubuntu:24.04" // use Ubuntu images instead of Alpine for CUDA tests, to avoid issues with libc
+)
+
+// requireDocker skips the test if Docker is not available
+func requireDocker(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("Docker not available, skipping test: %v", err)
+	}
+}
+
+// deviceAssignmentTestCase defines a test case for device assignment
+type deviceAssignmentTestCase struct {
+	name                  string
+	cudaVisibleDevices    string // Value for CUDA_VISIBLE_DEVICES env var (empty = not set)
+	selectedDeviceIndex   int32  // Device index to select via SetDeviceSelection
+	expectedPhysicalIndex int    // Expected physical device index in the result
+	requireMultiGPU       bool   // Skip if less than 2 GPUs available
+}
+
+// TestDeviceAssignment tests the GPU device assignment logic in SystemContext
+// for both bare metal processes and Docker containers, with and without
+// CUDA_VISIBLE_DEVICES environment variable.
+//
+// All tests use real processes and real procfs - no fake/mock process data.
+// The workloadmeta store is populated with real container data for Docker tests.
+func TestDeviceAssignment(t *testing.T) {
+	testutil.RequireGPU(t)
+
+	// Initialize real NVML and get device information
+	lib := initNVML(t)
+	deviceCount, err := lib.DeviceGetCount()
+	require.NoError(t, err)
+	require.Greater(t, deviceCount, 0, "Need at least one GPU for this test")
+
+	// Get all device UUIDs for verification
+	deviceUUIDs := make([]string, deviceCount)
+	for i := 0; i < deviceCount; i++ {
+		device, err := lib.DeviceGetHandleByIndex(i)
+		require.NoError(t, err)
+		uuid, err := device.GetUUID()
+		require.NoError(t, err)
+		deviceUUIDs[i] = uuid
+		t.Logf("Device %d: %s", i, uuid)
+	}
+
+	// Common test cases for both bare metal and Docker
+	testCases := []deviceAssignmentTestCase{
+		{
+			name:                  "NoEnvVar_SelectDevice0",
+			cudaVisibleDevices:    "",
+			selectedDeviceIndex:   0,
+			expectedPhysicalIndex: 0,
+			requireMultiGPU:       false,
+		},
+		{
+			name:                  "NoEnvVar_SelectDevice1",
+			cudaVisibleDevices:    "",
+			selectedDeviceIndex:   1,
+			expectedPhysicalIndex: 1,
+			requireMultiGPU:       true,
+		},
+		{
+			name:                  "WithCudaVisibleDevices_1_0_SelectIndex0",
+			cudaVisibleDevices:    "1,0",
+			selectedDeviceIndex:   0,
+			expectedPhysicalIndex: 1, // CUDA_VISIBLE_DEVICES=1,0 means index 0 -> device 1
+			requireMultiGPU:       true,
+		},
+		{
+			name:                  "WithCudaVisibleDevices_1_0_SelectIndex1",
+			cudaVisibleDevices:    "1,0",
+			selectedDeviceIndex:   1,
+			expectedPhysicalIndex: 0, // CUDA_VISIBLE_DEVICES=1,0 means index 1 -> device 0
+			requireMultiGPU:       true,
+		},
+	}
+
+	// BareMetal tests: Run sample binary directly on the host
+	// Uses real process with real procfs
+	t.Run("BareMetal", func(t *testing.T) {
+		for _, tc := range testCases {
+			tc := tc // capture range variable
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.requireMultiGPU && deviceCount < 2 {
+					t.Skip("Need at least 2 GPUs for this test")
+				}
+
+				// Run the sample binary directly on the host with the specified env var
+				args := &testutil.GPUUUIDsSampleArgs{
+					CudaVisibleDevicesEnv: tc.cudaVisibleDevices,
+				}
+				out := testutil.RunSampleWithArgs(t, testutil.GPUUUIDsSample, args)
+				pid := out.PID
+				t.Logf("Sample started: PID=%d, CUDA_VISIBLE_DEVICES=%q", pid, tc.cudaVisibleDevices)
+
+				// Use real procfs and workloadmeta (no container)
+				wmeta := testutil.GetWorkloadMetaMock(t)
+				sysCtx := gpu.GetTestSystemContext(t, wmeta, testutil.GetTelemetryMock(t))
+				sysCtx.SetDeviceSelection(pid, pid, tc.selectedDeviceIndex)
+
+				// Empty container ID for bare metal
+				device, err := sysCtx.GetCurrentActiveGpuDevice(pid, pid, func() string { return "" })
+				require.NoError(t, err)
+				require.Equal(t, deviceUUIDs[tc.expectedPhysicalIndex], device.GetDeviceInfo().UUID)
+			})
+		}
+	})
+
+	// DockerContainer tests: Run sample binary inside a Docker container
+	// Uses real container process with real procfs and real workloadmeta docker collector
+	t.Run("DockerContainer", func(t *testing.T) {
+		requireDocker(t)
+		env.SetFeatures(t, env.Docker)
+
+		type workloadmetaDeps struct {
+			fx.In
+			Wmeta workloadmeta.Component
+		}
+
+		wmeta := fxutil.Test[workloadmetaDeps](t, fx.Options(
+			fx.Supply(core.BundleParams{
+				ConfigParams:         config.NewParams("", config.WithIgnoreErrors(true)),
+				SysprobeConfigParams: sysprobeconfigimpl.NewParams(),
+				LogParams:            log.ForOneShot("gpu-device-assignment-test", "off", true),
+			}),
+			core.Bundle(),
+			secretsnoopfx.Module(),
+			workloadfilterfx.Module(),
+			wmcatalog.GetCatalog(),
+			workloadmetafx.Module(workloadmetadefaults.DefaultParams()),
+		)).Wmeta
+
+		for _, tc := range testCases {
+			tc := tc // capture range variable
+			t.Run(tc.name, func(t *testing.T) {
+				if tc.requireMultiGPU && deviceCount < 2 {
+					t.Skip("Need at least 2 GPUs for this test")
+				}
+
+				// Run sample in Docker with the specified CUDA_VISIBLE_DEVICES
+				args := &testutil.GPUUUIDsSampleArgs{
+					CudaVisibleDevicesEnv: tc.cudaVisibleDevices,
+				}
+				out := testutil.RunSampleInDockerWithArgs(t, testutil.GPUUUIDsSample, cudaTestsDockerImage, args)
+				pid := out.PID
+				containerID := out.ContainerID
+				require.NotZero(t, pid, "Container PID should not be zero")
+				require.NotEmpty(t, containerID, "Container ID should not be empty")
+
+				t.Logf("Container started: PID=%d, ID=%s, CUDA_VISIBLE_DEVICES=%q", pid, containerID, tc.cudaVisibleDevices)
+
+				// Give the container process a moment to fully initialize
+				time.Sleep(100 * time.Millisecond)
+
+				require.Eventually(t, func() bool {
+					container, err := wmeta.GetContainer(containerID)
+					return err == nil && container != nil
+				}, 30*time.Second, 500*time.Millisecond, "container %s not found in workloadmeta", containerID)
+
+				sysCtx := gpu.GetTestSystemContext(t, wmeta, testutil.GetTelemetryMock(t))
+				sysCtx.SetDeviceSelection(pid, pid, tc.selectedDeviceIndex)
+
+				device, err := sysCtx.GetCurrentActiveGpuDevice(pid, pid, func() string { return containerID })
+				require.NoError(t, err)
+				require.Equal(t, deviceUUIDs[tc.expectedPhysicalIndex], device.GetDeviceInfo().UUID)
+			})
+		}
+	})
+}

--- a/pkg/gpu/integrationtests/gpu_test.go
+++ b/pkg/gpu/integrationtests/gpu_test.go
@@ -98,3 +98,46 @@ func TestDeviceBasicProperties(t *testing.T) {
 			i, name, major, minor, memInfo.Total/1024/1024)
 	}
 }
+
+// TestGPUUUIDsMatchNVML validates that the UUIDs reported by the CUDA runtime
+// (via the gpuuuids sample binary) match the UUIDs reported by NVML.
+// This ensures consistency between what CUDA applications see and what we
+// detect via NVML for device identification.
+func TestGPUUUIDsMatchNVML(t *testing.T) {
+	testutil.RequireGPU(t)
+
+	// Get device UUIDs from NVML via the device cache
+	lib := initNVML(t)
+	deviceCache := safenvml.NewDeviceCache(safenvml.WithDeviceCacheLib(lib))
+
+	nvmlDevices, err := deviceCache.All()
+	require.NoError(t, err)
+	require.NotEmpty(t, nvmlDevices, "Should have at least one GPU device")
+
+	nvmlUUIDs := make([]string, len(nvmlDevices))
+	for i, device := range nvmlDevices {
+		nvmlUUIDs[i] = device.GetDeviceInfo().UUID
+		t.Logf("NVML Device %d: %s", i, nvmlUUIDs[i])
+	}
+
+	// Run the gpuuuids sample to get UUIDs from CUDA runtime
+	output := testutil.RunSample(t, testutil.GPUUUIDsSample)
+	require.NoError(t, err, "Failed to run gpuuuids sample")
+
+	cudaUUIDs := testutil.ParseGPUUUIDsOutput(output.Output)
+	require.NotEmpty(t, cudaUUIDs, "gpuuuids sample should report at least one GPU")
+
+	t.Logf("CUDA reported %d device(s), NVML reported %d device(s)", len(cudaUUIDs), len(nvmlUUIDs))
+	for i, uuid := range cudaUUIDs {
+		t.Logf("CUDA Device %d: %s", i, uuid)
+	}
+
+	// Verify the UUIDs match in count and order
+	require.Len(t, cudaUUIDs, len(nvmlUUIDs),
+		"CUDA and NVML should report the same number of devices")
+
+	for i := range nvmlUUIDs {
+		require.Equal(t, nvmlUUIDs[i], cudaUUIDs[i],
+			"Device %d UUID mismatch: NVML=%s, CUDA=%s", i, nvmlUUIDs[i], cudaUUIDs[i])
+	}
+}

--- a/pkg/gpu/integrationtests/gpu_test.go
+++ b/pkg/gpu/integrationtests/gpu_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux && nvml
+//go:build linux && nvml && test
 
 package integrationtests
 

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -160,8 +160,9 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	t := s.T()
 
 	probe := s.getProbe()
-	cmd, err := testutil.RunSample(t, testutil.CudaSample)
-	require.NoError(t, err)
+	out := testutil.RunSample(t, testutil.CudaSample)
+	cmd := out.Command
+	require.NotNil(t, cmd)
 
 	handlers := s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
 
@@ -195,8 +196,9 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 
 	probe := s.getProbe()
 
-	cmd, err := testutil.RunSample(t, testutil.CudaSample)
-	require.NoError(t, err)
+	out := testutil.RunSample(t, testutil.CudaSample)
+	cmd := out.Command
+	require.NotNil(t, cmd)
 
 	_ = s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
 
@@ -244,8 +246,9 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 	// Visible devices 1,2 -> selects 1 in that array -> global device index = 2
 	selectedGPU := testutil.GPUUUIDs[2]
 
-	cmd, err := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
-	require.NoError(t, err)
+	out := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
+	cmd := out.Command
+	require.NotNil(t, cmd)
 
 	_ = s.waitForExpectedCudasampleEvents(probe, cmd.Process.Pid)
 
@@ -280,7 +283,9 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	probe := s.getProbe()
 
 	// note: after starting, the program will wait ~5s before making any CUDA call
-	pid, cid := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
+	out := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
+	pid := out.PID
+	cid := out.ContainerID
 
 	handlers := s.waitForExpectedCudasampleEvents(probe, pid)
 
@@ -403,8 +408,9 @@ func BenchmarkProbeEventProcessing(b *testing.B) {
 		startTime := time.Now()
 
 		// Run the rate sample
-		cmd, err := testutil.RunSampleWithArgs(b, testutil.RateSample, rateArgs)
-		require.NoError(b, err)
+		out := testutil.RunSampleWithArgs(b, testutil.RateSample, rateArgs)
+		cmd := out.Command
+		require.NotNil(b, cmd)
 
 		// Ensure that we have streams for the process
 		require.Eventually(b, func() bool {
@@ -561,8 +567,9 @@ func (s *probeTestSuite) TestDebugCollectorEvents() {
 	probe.consumer.debugCollector.enable(totalExpectedEvents * 2) // some margin in case we get extra events
 
 	// Run the CUDA sample
-	cmd, err := testutil.RunSample(t, testutil.CudaSample)
-	require.NoError(t, err)
+	out := testutil.RunSample(t, testutil.CudaSample)
+	cmd := out.Command
+	require.NotNil(t, cmd)
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()

--- a/pkg/gpu/testdata/.gitignore
+++ b/pkg/gpu/testdata/.gitignore
@@ -1,2 +1,3 @@
 cudasample
 cudarate
+gpuuuids

--- a/pkg/gpu/testdata/gpuuuids.cu
+++ b/pkg/gpu/testdata/gpuuuids.cu
@@ -1,0 +1,62 @@
+// This program prints the UUIDs of all CUDA-visible GPUs.
+// It uses the real CUDA runtime library to query device properties.
+// This binary should be run using the pkg/gpu/testutil/samplebins.go:RunSample* methods.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <cuda_runtime.h>
+
+// Format a CUDA UUID as a string in the standard GPU-xxxx format
+void format_uuid(cudaUUID_t *uuid, char *output) {
+    unsigned char *bytes = (unsigned char *)uuid->bytes;
+    sprintf(output, "GPU-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5],
+            bytes[6], bytes[7],
+            bytes[8], bytes[9],
+            bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
+}
+
+int main(int argc, char **argv) {
+    int deviceCount;
+    cudaError_t err;
+
+    // This string is used by PatternScanner to validate a proper start of this sample program
+    fprintf(stderr, "Starting GPU UUID printer\n");
+
+    err = cudaGetDeviceCount(&deviceCount);
+    if (err != cudaSuccess) {
+        fprintf(stderr, "cudaGetDeviceCount failed: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+
+    fprintf(stderr, "Found %d CUDA device(s)\n", deviceCount);
+
+    for (int i = 0; i < deviceCount; i++) {
+        cudaDeviceProp props;
+        err = cudaGetDeviceProperties(&props, i);
+        if (err != cudaSuccess) {
+            fprintf(stderr, "cudaGetDeviceProperties failed for device %d: %s\n", i, cudaGetErrorString(err));
+            continue;
+        }
+
+        char uuid_str[64];
+        format_uuid(&props.uuid, uuid_str);
+
+        // Print to stdout for parsing, stderr for logging
+        printf("%s\n", uuid_str);
+        fprintf(stderr, "Device %d: %s (%s)\n", i, props.name, uuid_str);
+    }
+
+    // Flush stdout to ensure UUIDs are available for reading
+    fflush(stdout);
+
+    // This line is used as a marker by patternScanner to indicate the end of the program
+    fprintf(stderr, "GPU UUIDs printed.\n");
+
+    // Keep running so the container stays alive for tests that need to inspect it
+    pause();
+
+    return 0;
+}

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -33,6 +33,16 @@ type Sample struct {
 	StartPattern    *regexp.Regexp
 	FinishedPattern *regexp.Regexp
 	DefaultArgs     SampleArgs
+	// RequiresCUDA indicates whether the sample needs to be built with nvcc (real CUDA)
+	RequiresCUDA bool
+}
+
+// SampleOutput represents the output of a sample binary
+type SampleOutput struct {
+	PID         int
+	ContainerID string
+	Output      []string
+	Command     *exec.Cmd
 }
 
 // CudaSample is a binary that calls all the CUDA functions we probe for
@@ -49,6 +59,16 @@ var RateSample = Sample{
 	StartPattern:    regexp.MustCompile("Starting CudaRateSample program"),
 	FinishedPattern: regexp.MustCompile("CUDA calls made."),
 	DefaultArgs:     defaultRateSampleArgs(),
+}
+
+// GPUUUIDsSample is a binary that prints the UUIDs of all CUDA-visible GPUs.
+// It requires real CUDA runtime libraries to be installed on the system.
+var GPUUUIDsSample = Sample{
+	Name:            "gpuuuids",
+	StartPattern:    regexp.MustCompile("Starting GPU UUID printer"),
+	FinishedPattern: regexp.MustCompile("GPU UUIDs printed."),
+	DefaultArgs:     defaultGPUUUIDsSampleArgs(),
+	RequiresCUDA:    true,
 }
 
 // dockerImage represents the Docker image to use for running the sample binary.
@@ -134,21 +154,56 @@ func defaultRateSampleArgs() *RateSampleArgs {
 	}
 }
 
-// RunSampleWithArgs executes the sample binary and returns the command. Cleanup is configured automatically
+// GPUUUIDsSampleArgs holds arguments for the GPU UUIDs sample binary
+type GPUUUIDsSampleArgs struct {
+	// CudaVisibleDevicesEnv represents the value of the CUDA_VISIBLE_DEVICES environment variable
+	CudaVisibleDevicesEnv string
+}
+
+// Env returns the environment variables for the GPU UUIDs sample binary
+func (a *GPUUUIDsSampleArgs) Env() []string {
+	if a.CudaVisibleDevicesEnv != "" {
+		return []string{"CUDA_VISIBLE_DEVICES=" + a.CudaVisibleDevicesEnv}
+	}
+	return nil
+}
+
+// CLIArgs returns the command line arguments for the GPU UUIDs sample binary
+func (a *GPUUUIDsSampleArgs) CLIArgs() []string {
+	return nil // No CLI args needed
+}
+
+// defaultGPUUUIDsSampleArgs returns the default arguments for the GPU UUIDs sample binary
+func defaultGPUUUIDsSampleArgs() *GPUUUIDsSampleArgs {
+	return &GPUUUIDsSampleArgs{
+		CudaVisibleDevicesEnv: "",
+	}
+}
+
+// getBuiltSamplePath builds the sample binary and returns the path to it
 func getBuiltSamplePath(t testing.TB, sample Sample) string {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 
-	sourceFile := filepath.Join(curDir, "..", "testdata", sample.Name+".c")
+	// CUDA samples use .cu extension, regular C samples use .c
+	ext := ".c"
+	if sample.RequiresCUDA {
+		ext = ".cu"
+	}
+
+	sourceFile := filepath.Join(curDir, "..", "testdata", sample.Name+ext)
 	binaryFile := filepath.Join(curDir, "..", "testdata", sample.Name)
 
-	builtBin, err := buildCBinary(sourceFile, binaryFile)
+	opts := BuildOptions{
+		UseCUDA: sample.RequiresCUDA,
+	}
+	builtBin, err := buildCBinary(sourceFile, binaryFile, opts)
 	require.NoError(t, err)
 
 	return builtBin
 }
 
-func runCommandAndPipeOutput(t testing.TB, command []string, sample Sample, args SampleArgs) (cmd *exec.Cmd, err error) {
+func runCommandAndPipeOutput(t testing.TB, command []string, sample Sample, args SampleArgs) (cmd *exec.Cmd, output []string, err error) {
 	command = append(command, args.CLIArgs()...)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -176,44 +231,53 @@ func runCommandAndPipeOutput(t testing.TB, command []string, sample Sample, args
 
 	err = cmd.Start()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			if err = ctx.Err(); err != nil {
-				return nil, fmt.Errorf("failed to start the process %s due to: %w", command[0], err)
+				return nil, nil, fmt.Errorf("failed to start the process %s due to: %w", command[0], err)
 			}
 		case <-scanner.DoneChan:
 			t.Logf("%s command succeeded", command)
-			return cmd, nil
+			return cmd, scanner.Lines(), nil
 		case <-time.After(dockerutils.DefaultTimeout):
 			//setting the error explicitly to trigger the defer function
 			err = fmt.Errorf("%s execution attempt reached timeout %v ", sample.Name, dockerutils.DefaultTimeout)
-			return nil, err
+			return nil, scanner.Lines(), err
 		}
 	}
 }
 
 // RunSample executes the sample binary and returns the command. Cleanup is configured automatically
-func RunSample(t testing.TB, sample Sample) (*exec.Cmd, error) {
+func RunSample(t testing.TB, sample Sample) SampleOutput {
 	return RunSampleWithArgs(t, sample, sample.DefaultArgs)
 }
 
 // RunSampleWithArgs executes the sample binary with args and returns the command. Cleanup is configured automatically
-func RunSampleWithArgs(t testing.TB, sample Sample, args SampleArgs) (*exec.Cmd, error) {
+func RunSampleWithArgs(t testing.TB, sample Sample, args SampleArgs) SampleOutput {
+	var output SampleOutput
 	builtBin := getBuiltSamplePath(t, sample)
-	return runCommandAndPipeOutput(t, []string{builtBin}, sample, args)
+	cmd, lines, err := runCommandAndPipeOutput(t, []string{builtBin}, sample, args)
+	require.NoError(t, err, "failed to run command")
+
+	if cmd.Process != nil {
+		output.PID = cmd.Process.Pid
+		output.Output = lines
+	}
+
+	return output
 }
 
 // RunSampleInDocker executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDocker(t testing.TB, sample Sample, image dockerImage) (int, string) {
+func RunSampleInDocker(t testing.TB, sample Sample, image dockerImage) SampleOutput {
 	return RunSampleInDockerWithArgs(t, sample, image, sample.DefaultArgs)
 }
 
 // RunSampleInDockerWithArgs executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDockerWithArgs(t testing.TB, sample Sample, image dockerImage, args SampleArgs) (int, string) {
+func RunSampleInDockerWithArgs(t testing.TB, sample Sample, image dockerImage, args SampleArgs) SampleOutput {
 	builtBin := getBuiltSamplePath(t, sample)
 	containerName := "gpu-testutil-" + utils.RandString(10)
 	scanner, err := procutil.NewScanner(sample.StartPattern, sample.FinishedPattern)
@@ -242,5 +306,27 @@ func RunSampleInDockerWithArgs(t testing.TB, sample Sample, image dockerImage, a
 
 	log.Debugf("Sample binary %s running in Docker container %s (CID=%s) with PID %d", sample.Name, containerName, dockerContainerID, dockerPID)
 
-	return int(dockerPID), dockerContainerID
+	return SampleOutput{
+		PID:         int(dockerPID),
+		ContainerID: dockerContainerID,
+		Output:      scanner.Lines(),
+		Command:     nil,
+	}
+}
+
+// ParseGPUUUIDsOutput parses the output from the gpuuuids binary and returns
+// the list of GPU UUIDs, taking only into account the lines that only have the
+// GPU The binary prints one UUID per line to stdout in the format
+// GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+func ParseGPUUUIDsOutput(output []string) []string {
+	gpuUUIDPattern := regexp.MustCompile(`^(GPU|MIG)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+	var uuids []string
+	for _, line := range output {
+		match := gpuUUIDPattern.FindString(line)
+		if match != "" {
+			uuids = append(uuids, match)
+		}
+	}
+	return uuids
 }

--- a/pkg/util/testutil/docker/config.go
+++ b/pkg/util/testutil/docker/config.go
@@ -104,6 +104,7 @@ type runConfig struct {
 	NetworkMode string            // Network mode to use for the container. If empty, the docker default will apply
 	PIDMode     string            // PID mode to use for the container. If empty, the docker default will apply
 	Privileged  bool              // Whether to run the container in privileged mode.
+	GPUs        string            // GPUs to use for the container
 }
 
 func (r runConfig) command() string {
@@ -137,6 +138,10 @@ func (r runConfig) commandArgs(t subCommandType) []string {
 
 		if r.PIDMode != "" {
 			args = append(args, "--pid", r.PIDMode)
+		}
+
+		if r.GPUs != "" {
+			args = append(args, "--gpus", r.GPUs)
 		}
 
 		//append container name and container image name
@@ -264,6 +269,12 @@ func WithRetries(retries int) BaseConfigOption {
 func WithEnv(env []string) BaseConfigOption {
 	return func(c *BaseConfig) {
 		c.env = env
+	}
+}
+
+func WithGPUs(gpus string) RunConfigOption {
+	return func(c *runConfig) {
+		c.GPUs = gpus
 	}
 }
 

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -111,7 +111,11 @@ func (ps *PatternScanner) notifyAndStop() {
 	})
 }
 
+func (ps *PatternScanner) Lines() []string {
+	return ps.buffers
+}
+
 // PrintLogs writes the captured logs into the test logger.
 func (ps *PatternScanner) PrintLogs(t testing.TB) {
-	t.Log(strings.Join(ps.buffers, "\n"))
+	t.Log(strings.Join(ps.Lines(), "\n"))
 }

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -374,7 +374,7 @@ def get_sysprobe_test_buildtags(is_windows, bundle_ebpf):
     return build_tags
 
 
-@task
+@task(iterable=['extra_tags'])
 def test(
     ctx,
     packages=TEST_PACKAGES,
@@ -386,6 +386,7 @@ def test(
     kernel_release=None,
     timeout=None,
     extra_arguments="",
+    extra_tags: list[str] | None = None,
 ):
     """
     Run tests on eBPF parts
@@ -407,6 +408,9 @@ def test(
         )
 
     build_tags = get_sysprobe_test_buildtags(is_windows, bundle_ebpf)
+
+    if extra_tags:
+        build_tags.extend(extra_tags)
 
     args = get_common_test_args(build_tags, failfast)
     args["output_params"] = f"-c -o {output_path}" if output_path else ""


### PR DESCRIPTION
### What does this PR do?

This PR adds unit tests to ensure that the container assignment logic works correctly in bare metal and Docker setups. This is done by adding a new sample binary that prints the GPUs that it sees using CUDA, so that we can test the exact behavior of CUDA without depending on our interpretation of the docs. The Docker test execution code is updated to be able to run containers with GPUs.

It also changes CI to support building this binary, and fixes a minor issue where the `tests_gpu` job would not get automatically triggered.

### Motivation

Increase test coverage.

### Describe how you validated your changes

Changes are unit tests and CI jobs, checked that they're being executed.

### Additional Notes
