### PR TITLE
[CWS] prefer the process cache to resolver the cgroup id

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -100,13 +100,7 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
     }
     resolve_pid(skb, pkt);
 
-    u64 sched_cls_has_current_cgroup_id_helper = 0;
-    LOAD_CONSTANT("sched_cls_has_current_cgroup_id_helper", sched_cls_has_current_cgroup_id_helper);
-    if (sched_cls_has_current_cgroup_id_helper) {
-        pkt->cgroup_id = bpf_get_current_cgroup_id();
-    } else {
-        pkt->cgroup_id = get_cgroup_id(pkt->pid);
-    }
+    pkt->cgroup_id = get_cgroup_id(pkt->pid);
 
     if (!prepare_raw_packet_event(skb, pkt)) {
         return TC_ACT_UNSPEC;

--- a/pkg/security/ebpf/c/include/hooks/network/tc.h
+++ b/pkg/security/ebpf/c/include/hooks/network/tc.h
@@ -101,6 +101,13 @@ int classifier_raw_packet_egress(struct __sk_buff *skb) {
     resolve_pid(skb, pkt);
 
     pkt->cgroup_id = get_cgroup_id(pkt->pid);
+    if (!pkt->cgroup_id) {
+        u64 sched_cls_has_current_cgroup_id_helper = 0;
+        LOAD_CONSTANT("sched_cls_has_current_cgroup_id_helper", sched_cls_has_current_cgroup_id_helper);
+        if (sched_cls_has_current_cgroup_id_helper) {
+            pkt->cgroup_id = bpf_get_current_cgroup_id();
+        }
+    }
 
     if (!prepare_raw_packet_event(skb, pkt)) {
         return TC_ACT_UNSPEC;


### PR DESCRIPTION
### What does this PR do?

The `bpf_get_current_cgroup_id` doesn't always returns the correct cgroup id. Use the process cache instead.

### Motivation

### Describe how you validated your changes

### Additional Notes
