### PR TITLE
[CONTP-1198] Extract GPU device id from k8s container runtime

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -154,6 +154,7 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 
 		workloadContainer.EnvVars = envs
 		workloadContainer.Hostname = spec.Hostname
+		workloadContainer.GPUDeviceIDs = util.ExtractGPUDeviceIDsFromEnvMap(envs)
 		if spec.Linux != nil {
 			workloadContainer.CgroupPath = extractCgroupPath(spec.Linux.CgroupsPath)
 		}

--- a/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker_test.go
@@ -18,62 +18,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
-func Test_extractGPUDeviceIDs(t *testing.T) {
-	tests := []struct {
-		name     string
-		envVars  []string
-		expected []string
-	}{
-		{
-			name:     "single GPU UUID",
-			envVars:  []string{"PATH=/usr/bin", "NVIDIA_VISIBLE_DEVICES=GPU-aec058b1-c18e-236e-c14d-49d2990fda0f"},
-			expected: []string{"GPU-aec058b1-c18e-236e-c14d-49d2990fda0f"},
-		},
-		{
-			name:     "multiple GPU UUIDs",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=GPU-aec058b1-c18e-236e-c14d-49d2990fda0f,GPU-bec058b1-d18e-336e-d14d-59d2990fda1f"},
-			expected: []string{"GPU-aec058b1-c18e-236e-c14d-49d2990fda0f", "GPU-bec058b1-d18e-336e-d14d-59d2990fda1f"},
-		},
-		{
-			name:     "all GPUs",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=all"},
-			expected: []string{"all"},
-		},
-		{
-			name:     "none",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=none"},
-			expected: []string{"none"},
-		},
-		{
-			name:     "void",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES=void"},
-			expected: []string{"void"},
-		},
-		{
-			name:     "empty value",
-			envVars:  []string{"NVIDIA_VISIBLE_DEVICES="},
-			expected: nil,
-		},
-		{
-			name:     "no NVIDIA_VISIBLE_DEVICES",
-			envVars:  []string{"PATH=/usr/bin", "HOME=/root"},
-			expected: nil,
-		},
-		{
-			name:     "empty env vars",
-			envVars:  []string{},
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractGPUDeviceIDs(tt.envVars)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func Test_LayersFromDockerHistoryAndInspect(t *testing.T) {
 	var emptySize int64
 	var noDiffCmd = "ENV var=dummy"

--- a/comp/core/workloadmeta/collectors/util/gpu_util.go
+++ b/comp/core/workloadmeta/collectors/util/gpu_util.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+)
+
+// gpuUUIDRegex matches valid NVIDIA GPU and MIG device UUID formats.
+//
+// Supported formats:
+//   - GPU UUID: GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (physical GPU)
+//   - MIG UUID (modern): MIG-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//   - MIG UUID (legacy): MIG-GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/gi/ci
+//
+// The UUID portion follows the standard 8-4-4-4-12 hexadecimal format.
+//
+// References:
+//   - NVML API (nvmlDeviceGetUUID): https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceQueries.html
+//   - NVIDIA Container Toolkit: https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/cmd/nvidia-container-runtime/README.md
+//   - MIG User Guide: https://docs.nvidia.com/datacenter/tesla/mig-user-guide/
+//
+// This regex is used to validate that NVIDIA_VISIBLE_DEVICES contains actual GPU UUIDs
+// set by the NVIDIA device plugin, rather than user overrides like "all", "none", or indices.
+var gpuUUIDRegex = regexp.MustCompile(
+	`^(?:` +
+		`GPU-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}|` + // Physical GPU
+		`MIG-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}|` + // Modern MIG format
+		`MIG-GPU-[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/\d+/\d+` + // Legacy MIG format
+		`)$`,
+)
+
+// IsGPUUUID returns true if the value is a valid NVIDIA GPU or MIG device UUID.
+// This distinguishes device plugin-assigned UUIDs from user overrides like "all", "none", or indices.
+func IsGPUUUID(value string) bool {
+	return gpuUUIDRegex.MatchString(value)
+}
+
+// areAllValidGPUUUIDs returns true if all values in the slice are valid GPU UUIDs.
+// Returns false if the slice is empty or contains any non-UUID value (e.g., "all", "none", "0").
+//
+// This is used to detect user overrides of NVIDIA_VISIBLE_DEVICES. The NVIDIA device plugin
+// always returns a list of UUIDs, never mixed with special values. If we see any non-UUID value,
+// it indicates user override and we should fall back to PodResources API.
+func areAllValidGPUUUIDs(values []string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	for _, v := range values {
+		if !IsGPUUUID(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// NVIDIAVisibleDevicesEnvVar is the environment variable set by NVIDIA container runtime
+// or Kubernetes device plugin to specify which GPUs are visible to the container.
+// Values can be GPU UUIDs (e.g., "GPU-uuid1,GPU-uuid2"), special values like "all", "none", "void",
+// or MIG instance identifiers.
+const NVIDIAVisibleDevicesEnvVar = "NVIDIA_VISIBLE_DEVICES"
+
+// ExtractGPUDeviceIDs parses GPU device identifiers from NVIDIA_VISIBLE_DEVICES environment variable.
+// This is the core parsing function that extracts GPU IDs from a list of environment variables.
+//
+// Returns:
+//   - GPU UUIDs as a slice (e.g., ["GPU-uuid1", "GPU-uuid2"])
+//   - Special values like ["all"], ["none"], ["void"] are preserved
+//   - nil if the env var is not set or has an empty value
+func ExtractGPUDeviceIDs(envVars []string) []string {
+	prefix := NVIDIAVisibleDevicesEnvVar + "="
+	for _, e := range envVars {
+		if value, found := strings.CutPrefix(e, prefix); found {
+			if value == "" {
+				return nil
+			}
+			return strings.Split(value, ",")
+		}
+	}
+	return nil
+}
+
+// ShouldExtractGPUDeviceIDsFromConfig returns true if GPU device IDs should be extracted
+// from container config/spec based on the current environment.
+//
+// Supported environments:
+//   - ECS: env var set by ECS agent in task definition
+//   - Kubernetes (non-GKE): env var set by NVIDIA device plugin via Allocate() API
+//
+// Not supported (returns false):
+//   - Docker standalone: env var injected at runtime by nvidia-container-toolkit, not in config
+//   - Standalone containerd: env var may be injected at runtime, not in spec
+//   - GKE: uses custom device plugin + gVisor runtime that ignores NVIDIA_VISIBLE_DEVICES
+//
+// Note: GKE is not explicitly detected here. On GKE, the env var is either not set in a useful way
+// or ignored by the runtime, so extraction returns nil and falls back to PodResources API.
+func ShouldExtractGPUDeviceIDsFromConfig() bool {
+	return env.IsECS() || env.IsKubernetes()
+}
+
+// ExtractGPUDeviceIDsFromEnvVars extracts GPU device IDs from environment variables
+// if the current environment supports it. This combines the environment check
+// with the extraction logic for convenience.
+//
+// In Kubernetes environments, this function validates that all extracted values are valid GPU UUIDs.
+// If any non-UUID value is detected (e.g., "all", "none", "0"), it returns nil to indicate
+// a potential user override, allowing the caller to fall back to PodResources API.
+//
+// Use this function when you have a list of environment variable strings (e.g., from container config).
+func ExtractGPUDeviceIDsFromEnvVars(envVars []string) []string {
+	if !ShouldExtractGPUDeviceIDsFromConfig() {
+		return nil
+	}
+	ids := ExtractGPUDeviceIDs(envVars)
+	// In Kubernetes, validate UUIDs to detect user overrides
+	// ECS is excluded because users cannot override env vars set by ECS agent
+	if env.IsKubernetes() && !areAllValidGPUUUIDs(ids) {
+		return nil
+	}
+	return ids
+}
+
+// ExtractGPUDeviceIDsFromEnvMap extracts GPU device IDs from an environment variable map
+// if the current environment supports it.
+//
+// In Kubernetes environments, this function validates that all extracted values are valid GPU UUIDs.
+// If any non-UUID value is detected (e.g., "all", "none", "0"), it returns nil to indicate
+// a potential user override, allowing the caller to fall back to PodResources API.
+//
+// Use this function when you have a map of environment variables (e.g., from containerd spec parsing).
+func ExtractGPUDeviceIDsFromEnvMap(envs map[string]string) []string {
+	if !ShouldExtractGPUDeviceIDsFromConfig() {
+		return nil
+	}
+	if val, ok := envs[NVIDIAVisibleDevicesEnvVar]; ok && val != "" {
+		ids := strings.Split(val, ",")
+		// In Kubernetes, validate UUIDs to detect user overrides
+		// ECS is excluded because users cannot override env vars set by ECS agent
+		if env.IsKubernetes() && !areAllValidGPUUUIDs(ids) {
+			return nil
+		}
+		return ids
+	}
+	return nil
+}

--- a/comp/core/workloadmeta/collectors/util/gpu_util_test.go
+++ b/comp/core/workloadmeta/collectors/util/gpu_util_test.go
@@ -1,0 +1,214 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// envMapToSlice converts a map of env vars to slice format (KEY=VALUE)
+func envMapToSlice(envs map[string]string) []string {
+	if envs == nil {
+		return nil
+	}
+	result := make([]string, 0, len(envs))
+	for k, v := range envs {
+		result = append(result, k+"="+v)
+	}
+	return result
+}
+
+// TestIsGPUUUID tests the GPU UUID validation regex
+func TestIsGPUUUID(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		// Valid GPU UUIDs
+		{name: "valid GPU UUID", value: "GPU-aec058b1-c18e-236e-c14d-49d2990fda0f", expected: true},
+		{name: "valid GPU UUID uppercase", value: "GPU-AEC058B1-C18E-236E-C14D-49D2990FDA0F", expected: true},
+		{name: "valid GPU UUID mixed case", value: "GPU-Aec058b1-C18e-236E-c14d-49D2990fda0F", expected: true},
+		// Valid MIG UUIDs (modern format)
+		{name: "valid MIG UUID", value: "MIG-aec058b1-c18e-236e-c14d-49d2990fda0f", expected: true},
+		// Valid MIG UUIDs (legacy format)
+		{name: "valid MIG legacy format", value: "MIG-GPU-aec058b1-c18e-236e-c14d-49d2990fda0f/0/0", expected: true},
+		{name: "valid MIG legacy format multi-digit", value: "MIG-GPU-aec058b1-c18e-236e-c14d-49d2990fda0f/1/3", expected: true},
+		// Invalid values (user overrides)
+		{name: "special value all", value: "all", expected: false},
+		{name: "special value none", value: "none", expected: false},
+		{name: "special value void", value: "void", expected: false},
+		{name: "device index 0", value: "0", expected: false},
+		{name: "device index 1", value: "1", expected: false},
+		{name: "device indices comma-separated", value: "0,1,2", expected: false},
+		{name: "short invalid UUID", value: "GPU-xxx", expected: false},
+		{name: "invalid format no prefix", value: "aec058b1-c18e-236e-c14d-49d2990fda0f", expected: false},
+		{name: "invalid format wrong prefix", value: "CUDA-aec058b1-c18e-236e-c14d-49d2990fda0f", expected: false},
+		{name: "empty string", value: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGPUUUID(tt.value)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestExtractGPUDeviceIDs tests ExtractGPUDeviceIDsFromEnvVars and ExtractGPUDeviceIDsFromEnvMap
+// with the same test cases, ensuring consistent behavior across different environments.
+func TestExtractGPUDeviceIDs(t *testing.T) {
+	// Valid GPU UUIDs for testing (using proper 8-4-4-4-12 format)
+	validGPU1 := "GPU-aec058b1-c18e-236e-c14d-49d2990fda0f"
+	validGPU2 := "GPU-b8ea3855-276c-c9cb-b366-c6fa655957c5"
+	validGPU3 := "GPU-00cc6634-6a30-b312-2dc9-731a61cb17a9"
+	validMIG := "MIG-aec058b1-c18e-236e-c14d-49d2990fda0f"
+
+	tests := []struct {
+		name     string
+		envMap   map[string]string
+		isECS    bool
+		isK8s    bool
+		expected []string
+	}{
+		// Environment detection tests
+		{
+			name:     "ECS extracts GPU",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": validGPU1},
+			isECS:    true,
+			expected: []string{validGPU1},
+		},
+		{
+			name:     "Kubernetes extracts GPU",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": validGPU1},
+			isK8s:    true,
+			expected: []string{validGPU1},
+		},
+		{
+			name:     "Standalone returns nil",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": validGPU1},
+			expected: nil,
+		},
+		// Parsing tests (in K8s environment)
+		{
+			name:     "single GPU UUID",
+			envMap:   map[string]string{"PATH": "/usr/bin", "NVIDIA_VISIBLE_DEVICES": validGPU1},
+			isK8s:    true,
+			expected: []string{validGPU1},
+		},
+		{
+			name:     "multiple GPU UUIDs",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": validGPU1 + "," + validGPU2 + "," + validGPU3},
+			isK8s:    true,
+			expected: []string{validGPU1, validGPU2, validGPU3},
+		},
+		{
+			name:     "MIG UUID (modern format)",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": validMIG},
+			isK8s:    true,
+			expected: []string{validMIG},
+		},
+		// User override detection in Kubernetes (should return nil to trigger fallback)
+		{
+			name:     "K8s user override - all",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "all"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		{
+			name:     "K8s user override - none",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "none"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		{
+			name:     "K8s user override - void",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "void"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		{
+			name:     "K8s user override - device index",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "0"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		{
+			name:     "K8s user override - device indices",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "0,1"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		{
+			name:     "K8s user override - short invalid UUID",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "GPU-xxx"},
+			isK8s:    true,
+			expected: nil, // Invalid UUID, fall back to PodResources API
+		},
+		// ECS does NOT validate UUIDs (users can't override env vars set by ECS agent)
+		{
+			name:     "ECS allows all (ECS agent sets this)",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "all"},
+			isECS:    true,
+			expected: []string{"all"}, // ECS doesn't validate
+		},
+		{
+			name:     "ECS allows index (edge case)",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": "0"},
+			isECS:    true,
+			expected: []string{"0"}, // ECS doesn't validate
+		},
+		// Edge cases
+		{
+			name:     "empty value",
+			envMap:   map[string]string{"NVIDIA_VISIBLE_DEVICES": ""},
+			isK8s:    true,
+			expected: nil,
+		},
+		{
+			name:     "no NVIDIA_VISIBLE_DEVICES",
+			envMap:   map[string]string{"PATH": "/usr/bin"},
+			isK8s:    true,
+			expected: nil,
+		},
+		{
+			name:     "nil map",
+			envMap:   nil,
+			isK8s:    true,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear environment detection vars first (CI may have them set)
+			// t.Setenv with empty string effectively clears the var for this test
+			t.Setenv("KUBERNETES_SERVICE_PORT", "")
+			t.Setenv("KUBERNETES_SERVICE_HOST", "")
+			t.Setenv("ECS_CONTAINER_METADATA_URI_V4", "")
+			t.Setenv("ECS_CONTAINER_METADATA_URI", "")
+
+			// Now set the specific environment for this test case
+			if tt.isECS {
+				t.Setenv("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4")
+			}
+			if tt.isK8s {
+				t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+			}
+
+			// Test map-based function (used by containerd)
+			resultMap := ExtractGPUDeviceIDsFromEnvMap(tt.envMap)
+			assert.Equal(t, tt.expected, resultMap, "ExtractGPUDeviceIDsFromEnvMap")
+
+			// Test slice-based function (used by docker)
+			envSlice := envMapToSlice(tt.envMap)
+			resultSlice := ExtractGPUDeviceIDsFromEnvVars(envSlice)
+			assert.Equal(t, tt.expected, resultSlice, "ExtractGPUDeviceIDsFromEnvVars")
+		})
+	}
+}

--- a/pkg/util/containers/env_vars_filter.go
+++ b/pkg/util/containers/env_vars_filter.go
@@ -30,6 +30,7 @@ var (
 		"NOMAD_JOB_NAME",
 		"NOMAD_NAMESPACE",
 		"NOMAD_TASK_NAME",
+		"NVIDIA_VISIBLE_DEVICES", // included for GPU device extraction
 		"OTEL_RESOURCE_ATTRIBUTES",
 		"OTEL_SERVICE_NAME",
 		"TEST_ENV", // Included to ease unit tests without requiring a mock


### PR DESCRIPTION
## What does this PR do?

Enables GPU device extraction from container runtime configuration (`NVIDIA_VISIBLE_DEVICES` environment variable) for Kubernetes workloads, with UUID validation to detect and handle user overrides.

### Changes
1. Add GPU utility functions** (`comp/core/workloadmeta/collectors/util/gpu_util.go`)
   - `ExtractGPUDeviceIDsFromEnvMap()` - Extract GPU IDs from env var map (containerd)
   - `ExtractGPUDeviceIDsFromEnvVars()` - Extract GPU IDs from env var slice (docker)
   - `IsGPUUUID()` - Validate NVIDIA GPU/MIG UUID format
   - `ShouldExtractGPUDeviceIDsFromConfig()` - Environment detection (ECS/K8s only)
   - UUID validation in Kubernetes to detect user overrides with non-UUID format and trigger fallback

2. Update containerd collector** (`comp/core/workloadmeta/collectors/internal/containerd/container_builder.go`)
   - Extract `GPUDeviceIDs` from container spec env vars

3.  Refactor docker collector** (`comp/core/workloadmeta/collectors/internal/docker/docker.go`) to use shard util extract function

## Motivation
### Background: How GPU device mapping works

In Kubernetes, the NVIDIA device plugin handles GPU allocation:
1. Pod requests `nvidia.com/gpu` resource
2. Device plugin's `Allocate()` API selects GPU(s) and returns UUID(s)
3. NVIDIA container toolkit injects `NVIDIA_VISIBLE_DEVICES=GPU-uuid` at **container runtime** (not in pod spec)
4. Agent currently uses **PodResources API** as the primary source for GPU-to-container mapping

### Why this change
1. `NVIDIA_VISIBLE_DEVICES` is what the NVIDIA container runtime actually uses to determine GPU visibility.
2. The env var is already available at container discovery time. PodResources API requires an additional gRPC call to kubelet. 
3. Users can manually set `NVIDIA_VISIBLE_DEVICES` in their pod spec with values like `all`, `0`, or `none`. In those non-canonical cases, the agent validates the value and falls back to PodResources API.     

## GPU UUID Validation

In Kubernetes, the NVIDIA device plugin sets `NVIDIA_VISIBLE_DEVICES` to GPU UUIDs. However, users can override this in their pod specs. The UUID validation detects these overrides:

| Value | Is Valid UUID | Behavior |
|-------|--------------|----------|
| `GPU-aec058b1-c18e-236e-c14d-49d2990fda0f` | Yes | Use env var |
| `MIG-aec058b1-c18e-236e-c14d-49d2990fda0f` | Yes | Use env var |
| `MIG-GPU-aec058b1-.../0/0` | Yes | Use env var (legacy MIG) |
| `all` | No | Fall back to PodResources API |
| `none`, `void` | No | Fall back to PodResources API |
| `0`, `1`, `0,1` | No | Fall back to PodResources API |

**Note:** ECS does not validate UUIDs because users cannot override env vars set by the ECS agent.

## GPU Discovery Priority

| Priority | Source | When Used |
|----------|--------|-----------|
| 1 | `GPUDeviceIDs` (runtime) | ECS, K8s with valid UUID from NVIDIA device plugin |
| 2 | PodResources API | K8s fallback (GKE, user override, or env var not available) |
| 3 | procfs (`/proc/PID/environ`) | Docker standalone |

## Testing

### Test Environment: EKS (Kubernetes + containerd)

**Setup:**
- EKS cluster with GPU node group with NVIDIA device plugin installed
```
inv aws.create-eks --stack-name my-gpu-test --gpu-node-group
```
---
**Test Case 1: Normal GPU pod**
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: gpu-test-normal
spec:
  containers:
  - name: cuda-test
    image: nvidia/cuda:12.0.0-base-ubuntu22.04
    command: ["sleep", "infinity"]
    resources:
      limits:
        nvidia.com/gpu: "1"
```

**Verification - Agent workload-list:**
```
=== Entity container sources(merged):[node_orchestrator runtime] id: c9b8db4a575876a20b6091c7cbe37fb1b88d7458cbec7e6928b5ee68cf2a3bf2 ===
----------- Entity Meta -----------
Name: cuda-test
----------- Resources -----------
GPUVendor: [nvidia]
----------- Allocated Resources -----------
Name: nvidia.com/gpu, ID: GPU-00cc6634-6a30-b312-2dc9-731a61cb17a9
----------- GPU Info -----------
GPU Device IDs: [GPU-00cc6634-6a30-b312-2dc9-731a61cb17a9]
```

**Verification - Agent logs:**
```
 2026-01-16 06:26:24 UTC | CORE | DEBUG | (pkg/gpu/containers/containers.go:76 in MatchContainerDevices) | GPU device source for container c9b8db4a575876a20b6091c7cbe37fb1b88d7458cbec7e6928b5ee68cf2a3bf2: runtime (NVIDIA_VISIBLE_DEVICES from config)
```

**Result:** GPU device extracted from container runtime config (`NVIDIA_VISIBLE_DEVICES` in containerd spec). The NVIDIA device plugin sets this env var via `Allocate()` API.

---

---

**Test Case 2: User override with `NVIDIA_VISIBLE_DEVICES=all`**
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: gpu-test-override
spec:
  containers:
  - name: cuda-test
    image: nvidia/cuda:12.0.0-base-ubuntu22.04
    command: ["sleep", "infinity"]
    env:
      - name: NVIDIA_VISIBLE_DEVICES
        value: "all"  # User override
    resources:
      limits:
        nvidia.com/gpu: "1"
```

**Verification - Agent workload-list:**
```
=== Entity container sources(merged):[node_orchestrator runtime] id: 2fb4e10564c1742ddd2501ac800b6a2f01061d7d11208edbefeec0f6d085d35e ===
----------- Entity Meta -----------
Name: cuda-test
----------- Resources -----------
GPUVendor: [nvidia]
----------- Allocated Resources -----------
Name: nvidia.com/gpu, ID: GPU-00cc6634-6a30-b312-2dc9-731a61cb17a9
```

**Verification - Agent logs:**
```
GPU device source for container 2fb4e10564c1742ddd2501ac800b6a2f01061d7d11208edbefeec0f6d085d35e: pod_resources_api
```

**Result:** Agent detected `all` is not a valid UUID → returned `nil` for `GPUDeviceIDs` → fell back to PodResources API for correct GPU assignment. Note: No `GPU Device IDs` section in workload-list (field is nil).

