### PR TITLE
discovery: Restrict sd-agent to Linux

### DIFF
--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -18,6 +18,9 @@ rust_library(
     ),
     crate_name = "dd_discovery",
     edition = "2024",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:anyhow",
@@ -61,6 +64,9 @@ rust_shared_library(
     crate_name = "dd_discovery",
     crate_root = "src/lib.rs",
     edition = "2024",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:anyhow",


### PR DESCRIPTION
### What does this PR do?

It is only supported on Linux at the moment, so do not attempt to build or test
it on other platforms.

Incompatibly is transitive so we only need to add the annotation on the main
library's targets.

### Motivation

So that `bzl build //...` and `bzl test //...` don't break on non-Linux
platforms.
