### PR TITLE
fix(ask-review): Prevent error when single quotes in the requested_teams object

### DIFF
--- a/.github/workflows/ask_review.yml
+++ b/.github/workflows/ask_review.yml
@@ -3,7 +3,7 @@ name: "Ask for code reviews"
 
 on:
   pull_request:
-    types: [labeled, ready_for_review, review_requested]
+    types: [labeled, review_requested]
 
 permissions: {}
 

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -754,18 +754,20 @@ def create_release_pr(title, base_branch, target_branch, version, changelog_pr=F
     return create_datadog_agent_pr(title, base_branch, target_branch, milestone_name, labels)
 
 
-def get_events_info(pr):
-    actor, team = None, None
-    for event in reversed(list(pr.get_issue_events())):
-        if (event.event == "labeled" and event.label.name == "ask-review") or event.event in [
-            "review_requested",
-            "ready_for_review",
-        ]:
-            actor = event.actor.name or event.actor.login
-            if "requested_team" in event.raw_data:
-                team = event.raw_data["requested_team"]["slug"]
-            break
-    return actor, team
+def get_event_info(event):
+    actor, event_type, target = None, None, None
+    event_type = event.event
+    if (event.event == "labeled" and event.label.name == "ask-review") or event.event in [
+        "review_requested",
+        "ready_for_review",
+    ]:
+        actor = event.actor.name or event.actor.login
+        if "requested_reviewer" in event.raw_data:
+            event_type = "unique_reviewer_request"
+            target = event.raw_data["requested_reviewer"]["login"]
+        elif "requested_team" in event.raw_data:
+            target = event.raw_data["requested_team"]["slug"]
+    return actor, event_type, target
 
 
 def generate_local_github_token(ctx):


### PR DESCRIPTION
### What does this PR do?
Update the quotes on the `toJSON` method to prevent conflict when a quote is in the `requested_teams` object

### Motivation
Prevent failure like [here](https://github.com/DataDog/datadog-agent/actions/runs/21180226611/job/60920205019?pr=45278). The issue come from the description field
```
"description": "Team responsible for Agent's configuration and CLI",
```
resulting in `syntax error near unexpected token '('`


### Describe how you validated your changes
Addition of `agent-configuration` as requested owner

### Additional Notes
