### PR TITLE
bazel: deps: fix some erroneous static linking

### DIFF
--- a/deps/acl/overlay/overlay.BUILD.bazel
+++ b/deps/acl/overlay/overlay.BUILD.bazel
@@ -165,6 +165,9 @@ cc_library(
 cc_shared_library(
     name = "acl",
     deps = [":libacl"],
+    dynamic_deps = [
+        "@attr//:attr",
+    ],
     additional_linker_inputs = [
         "exports",
     ],

--- a/deps/libselinux.BUILD.bazel
+++ b/deps/libselinux.BUILD.bazel
@@ -68,7 +68,7 @@ cc_shared_library(
     ],
     dynamic_deps = [
         "@libsepol//:sepol",
-        "@pcre2//:pcre2",
+        "@pcre2//:pcre2-8",
     ],
     additional_linker_inputs = [
         "src/libselinux.map",

--- a/deps/libselinux.BUILD.bazel
+++ b/deps/libselinux.BUILD.bazel
@@ -66,6 +66,10 @@ cc_shared_library(
     deps = [
         ":libselinux",
     ],
+    dynamic_deps = [
+        "@libsepol//:sepol",
+        "@pcre2//:pcre2_so",
+    ],
     additional_linker_inputs = [
         "src/libselinux.map",
     ],

--- a/deps/libselinux.BUILD.bazel
+++ b/deps/libselinux.BUILD.bazel
@@ -41,7 +41,7 @@ cc_library(
     ]),
     deps = [
         "@libsepol//:libsepol",
-        "@pcre2//:pcre2",
+        "@pcre2//:libpcre2",
     ],
     local_defines = [
         "_LARGEFILE_SOURCE",
@@ -68,7 +68,7 @@ cc_shared_library(
     ],
     dynamic_deps = [
         "@libsepol//:sepol",
-        "@pcre2//:pcre2_so",
+        "@pcre2//:pcre2",
     ],
     additional_linker_inputs = [
         "src/libselinux.map",

--- a/deps/openscap/overlay/overlay.BUILD.bazel
+++ b/deps/openscap/overlay/overlay.BUILD.bazel
@@ -50,7 +50,7 @@ filegroup(
         "@libxml2",
         "@libxslt",
         "@nghttp2",
-        "@pcre2",
+        "@pcre2//:pcre2-8",
         "@popt",
         "@zstd",
     ],

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -60,7 +60,7 @@ copy_file(
 # src/pcre2_tables.c. Also fixed typo: ckdint should be chkdint.
 # PH, 22-March-2023.
 cc_library(
-    name = "pcre2",
+    name = "libpcre2",
     srcs = [
         "src/pcre2_auto_possess.c",
         "src/pcre2_chkdint.c",
@@ -119,7 +119,7 @@ cc_library(
 )
 
 cc_library(
-    name = "pcre2-posix",
+    name = "libpcre2-posix",
     srcs = [
         "src/pcre2posix.c",
         ":config_h_generic",
@@ -137,7 +137,7 @@ cc_library(
     includes = ["src"],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
-    deps = [":pcre2"],
+    deps = [":libpcre2"],
 )
 
 # Totally weird issue in Bazel. It won't let you #include any files unless they
@@ -185,7 +185,8 @@ cc_binary(
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
-    deps = [":pcre2test_dotc_headers", ":pcre2", ":pcre2-posix"],
+    deps = [":pcre2test_dotc_headers", ":libpcre2", ":libpcre2-posix"],
+    dynamic_deps = [":pcre2", ":pcre2posix"]
 )
 
 filegroup(
@@ -251,27 +252,27 @@ pkg_files(
 )
 
 cc_shared_library(
-    name = "pcre2_so",
-    deps = [":pcre2"],
+    name = "pcre2",
+    deps = [":libpcre2"],
     visibility = ["//visibility:public"],
 )
 
 cc_shared_library(
-    name = "pcre2posix_so",
-    deps = [":pcre2-posix"],
+    name = "pcre2posix",
+    deps = [":libpcre2-posix"],
     visibility = ["//visibility:public"],
 )
 
 so_symlink(
     name = "pcre2_libfiles",
-    src = ":pcre2_so",
+    src = ":pcre2",
     libname = "libpcre2-8",
     version = "0.11.2",
 )
 
 so_symlink(
     name = "pcre2posix_libfiles",
-    src = ":pcre2posix_so",
+    src = ":pcre2posix",
     libname = "libpcre2-posix",
     version = "3.0.4",
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -252,13 +252,13 @@ pkg_files(
 )
 
 cc_shared_library(
-    name = "pcre2",
+    name = "pcre2-8",
     deps = [":libpcre2"],
     visibility = ["//visibility:public"],
 )
 
 cc_shared_library(
-    name = "pcre2posix",
+    name = "pcre2-posix",
     deps = [":libpcre2-posix"],
     dynamic_deps = [":pcre2"],
     visibility = ["//visibility:public"],

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -186,7 +186,7 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [":pcre2test_dotc_headers", ":libpcre2", ":libpcre2-posix"],
-    dynamic_deps = [":pcre2", ":pcre2posix"]
+    dynamic_deps = [":pcre2-8", ":pcre2-posix"]
 )
 
 filegroup(
@@ -260,20 +260,20 @@ cc_shared_library(
 cc_shared_library(
     name = "pcre2-posix",
     deps = [":libpcre2-posix"],
-    dynamic_deps = [":pcre2"],
+    dynamic_deps = [":pcre2-8"],
     visibility = ["//visibility:public"],
 )
 
 so_symlink(
     name = "pcre2_libfiles",
-    src = ":pcre2",
+    src = ":pcre2-8",
     libname = "libpcre2-8",
     version = "0.11.2",
 )
 
 so_symlink(
     name = "pcre2posix_libfiles",
-    src = ":pcre2posix",
+    src = ":pcre2-posix",
     libname = "libpcre2-posix",
     version = "3.0.4",
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -260,6 +260,7 @@ cc_shared_library(
 cc_shared_library(
     name = "pcre2posix",
     deps = [":libpcre2-posix"],
+    dynamic_deps = [":pcre2"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
### What does this PR do?

Dynamically link `libacl` with `libattr` and `libselinux` with `libsepol` and `pcre2`

### Motivation

The current setup effictively duplicates the content of each lib in its dependent libraries.
This also causes bazel to refuse to link if the same static library is present in 2 shared libraries:
```
Error in fail: Two shared libraries in dependencies link the same  library statically. Both @@+_repo_rules+attr//:attr and @@+_repo_rules+acl//:acl link statically @@+_repo_rules+attr/
/:libattr
```

### Describe how you validated your changes

Local build for linux x86_64, and the CI

### Additional Notes
