### PR TITLE
deps: util-linux: fix public headers

### DIFF
--- a/deps/util-linux.BUILD.bazel
+++ b/deps/util-linux.BUILD.bazel
@@ -57,7 +57,10 @@ cc_library(
         "lib/ttyutils.c",
         "lib/xxhash.c",
     ] + ["generated/config.h"],
-    hdrs = glob(["include/*.h"]),
+    hdrs = glob(["include/*.h"]) + [
+        ":blkid_h",
+    ],
+    include_prefix = "blkid",
     includes = [
         "include",
     ],


### PR DESCRIPTION
### What does this PR do?

Add a missing libblkid public header

### Motivation

This is needed by code depending on libblkid

### Describe how you validated your changes

Local bazel build of openscap

### Additional Notes
