### PR TITLE
feat(internal-image): [O11YINFRA-72] bump internal agent image template to v18

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -36,7 +36,7 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
-  IMAGE_VERSION: tmpl-v17
+  IMAGE_VERSION: tmpl-v18
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 


### PR DESCRIPTION
### What does this PR do?

Bumps the internal agent image template from tmpl-v17 to tmpl-v18.

### Motivation

The new template includes an updated internal integration version with improved error handling and logging.

### Describe how you validated your changes

- Template changes validated and merged in the images repo
- Integration changes tested via CI

### Additional Notes

Related internal PRs:
- https://github.com/DataDog/integrations-internal/pull/270
- https://github.com/DataDog/images/pull/8516"