### PR TITLE
[CONTP-1151] Respect global CEL process exclusion filters in process listener in autodiscovery

### DIFF
--- a/comp/core/autodiscovery/listeners/process.go
+++ b/comp/core/autodiscovery/listeners/process.go
@@ -29,14 +29,16 @@ import (
 // as services (i.e., processes with a non-nil Service property).
 type ProcessListener struct {
 	workloadmetaListener
-	tagger tagger.Component
+	tagger         tagger.Component
+	processFilters workloadfilter.FilterBundle
 }
 
 // NewProcessListener returns a new ProcessListener.
 func NewProcessListener(options ServiceListernerDeps) (ServiceListener, error) {
 	const name = "ad-processlistener"
 	l := &ProcessListener{
-		tagger: options.Tagger,
+		tagger:         options.Tagger,
+		processFilters: options.Filter.GetProcessFilters([][]workloadfilter.ProcessFilter{{workloadfilter.ProcessCELGlobal}}),
 	}
 	filter := workloadmeta.NewFilterBuilder().
 		SetSource(workloadmeta.SourceAll).
@@ -70,6 +72,14 @@ func (l *ProcessListener) createProcessService(entity workloadmeta.Entity) {
 	if process.ContainerID != "" {
 		log.Debugf("process %d (%s) is container-bound (container: %s), skipping", process.Pid, process.Comm, process.ContainerID)
 		return
+	}
+
+	if l.processFilters != nil {
+		filterableProcess := workloadmetafilter.CreateProcess(process)
+		if l.processFilters.IsExcluded(filterableProcess) {
+			log.Debugf("Process %d excluded from AD process listener by CEL filter", process.Pid)
+			return
+		}
 	}
 
 	// Build ports from Service.TCPPorts

--- a/comp/core/autodiscovery/listeners/process_test.go
+++ b/comp/core/autodiscovery/listeners/process_test.go
@@ -16,6 +16,7 @@ import (
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 )
@@ -304,11 +305,16 @@ func TestProcessServiceEqual(t *testing.T) {
 }
 
 func newProcessListener(t *testing.T, tagger tagger.Component) (*ProcessListener, *testWorkloadmetaListener) {
+	return newProcessListenerWithFilters(t, tagger, nil)
+}
+
+func newProcessListenerWithFilters(t *testing.T, tagger tagger.Component, processFilters workloadfilter.FilterBundle) (*ProcessListener, *testWorkloadmetaListener) {
 	wlm := newTestWorkloadmetaListener(t)
 
 	return &ProcessListener{
 		workloadmetaListener: wlm,
 		tagger:               tagger,
+		processFilters:       processFilters,
 	}, wlm
 }
 
@@ -333,5 +339,112 @@ func assertProcessServices(t *testing.T, wlm *testWorkloadmetaListener, expected
 		for svcID := range wlm.services {
 			t.Errorf("got unexpected service: %s", svcID)
 		}
+	}
+}
+
+// mockFilterBundle is a mock implementation of workloadfilter.FilterBundle for testing
+type mockFilterBundle struct {
+	excludeAll bool
+}
+
+func (m *mockFilterBundle) IsExcluded(_ workloadfilter.Filterable) bool {
+	return m.excludeAll
+}
+
+func (m *mockFilterBundle) GetResult(_ workloadfilter.Filterable) workloadfilter.Result {
+	if m.excludeAll {
+		return workloadfilter.Excluded
+	}
+	return workloadfilter.Unknown
+}
+
+func (m *mockFilterBundle) GetErrors() []error {
+	return nil
+}
+
+func TestCreateProcessServiceWithFilters(t *testing.T) {
+	processEntityID := workloadmeta.EntityID{
+		Kind: workloadmeta.KindProcess,
+		ID:   testPID,
+	}
+
+	basicProcess := &workloadmeta.Process{
+		EntityID: processEntityID,
+		Pid:      testPidInt,
+		Ppid:     testPpidInt,
+		Comm:     testComm,
+		Cmdline:  []string{"/usr/bin/redis-server", "--port", "6379"},
+		Service: &workloadmeta.Service{
+			GeneratedName: "redis",
+			TCPPorts:      []uint16{6379},
+		},
+	}
+
+	taggerComponent := taggerfxmock.SetupFakeTagger(t)
+
+	tests := []struct {
+		name             string
+		process          *workloadmeta.Process
+		processFilters   workloadfilter.FilterBundle
+		expectedServices map[string]wlmListenerSvc
+	}{
+		{
+			name:             "process excluded by filter is skipped",
+			process:          basicProcess,
+			processFilters:   &mockFilterBundle{excludeAll: true},
+			expectedServices: map[string]wlmListenerSvc{
+				// No services should be created
+			},
+		},
+		{
+			name:           "process not excluded by filter creates service",
+			process:        basicProcess,
+			processFilters: &mockFilterBundle{excludeAll: false},
+			expectedServices: map[string]wlmListenerSvc{
+				"process://1234": {
+					service: &ProcessService{
+						process: basicProcess,
+						hosts:   map[string]string{"host": "127.0.0.1"},
+						ports: []ContainerPort{
+							{Port: 6379},
+						},
+						pid:   int(testPidInt),
+						ready: true,
+					},
+				},
+			},
+		},
+		{
+			name:           "nil filter bundle creates service",
+			process:        basicProcess,
+			processFilters: nil,
+			expectedServices: map[string]wlmListenerSvc{
+				"process://1234": {
+					service: &ProcessService{
+						process: basicProcess,
+						hosts:   map[string]string{"host": "127.0.0.1"},
+						ports: []ContainerPort{
+							{Port: 6379},
+						},
+						pid:   int(testPidInt),
+						ready: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listener, wlm := newProcessListenerWithFilters(t, taggerComponent, tt.processFilters)
+
+			if tt.process != nil {
+				listener.Store().(workloadmetamock.Mock).Set(tt.process)
+			}
+
+			listener.createProcessService(tt.process)
+
+			assertProcessServices(t, wlm, tt.expectedServices)
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds support for excluding processes from the process listener in autodiscovery by using the global CEL exclusion filters.

### Motivation

The process Autodiscovery check on logs is using user defined filters from DD_CEL_WORKLOAD_EXCLUDE via the workloadfilter.Component to manage the collection of logs on processes.

### Describe how you validated your changes

- Existing unit tests pass
- Added new unit tests.
