### PR TITLE
[PROF-13465] Uniformize logs

### DIFF
--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -10,7 +10,6 @@ package collectorimpl
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -27,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
-	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -97,6 +95,7 @@ func (c *collectorImpl) Run() error {
 
 func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.CollectorSettings, error) {
 	zapCore := extraFactories.GetZapCore()
+	extraFactories.SetupSlogDefault(zapCore)
 
 	// Replace default core to use Agent logger
 	options := []zap.Option{
@@ -104,8 +103,6 @@ func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.Co
 			return zapCore
 		}),
 	}
-
-	slog.SetDefault(slog.New(zapslog.NewHandler(zapCore)))
 
 	return otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{

--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -10,6 +10,7 @@ package collectorimpl
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -26,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -103,7 +105,7 @@ func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.Co
 		}),
 	}
 
-	SetSlogLogger(zapCore)
+	slog.SetDefault(slog.New(zapslog.NewHandler(zapCore)))
 
 	return otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -31,7 +31,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
-	"go.uber.org/zap/exp/zapslog"
 	"go.uber.org/zap/zapcore"
 
 	"go.opentelemetry.io/collector/confmap"
@@ -43,10 +42,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 )
-
-func SetSlogLogger(core zapcore.Core) {
-	slog.SetDefault(slog.New(zapslog.NewHandler(core)))
-}
 
 // ExtraFactories is an interface that provides extra factories for the collector.
 // It is used to provide extra factories for the collector when the Agent Core is available or not.

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -64,6 +64,12 @@ type extraFactoriesWithAgentCore struct {
 
 var _ ExtraFactories = (*extraFactoriesWithAgentCore)(nil)
 
+const (
+	// zapCoreStackDepth skips the slog handler and wrapper frames in the logging
+	// pipeline to show the actual caller location in log output.
+	zapCoreStackDepth = 7
+)
+
 // NewExtraFactoriesWithAgentCore creates a new ExtraFactories instance when the Agent Core is available.
 func NewExtraFactoriesWithAgentCore(
 	tagger tagger.Component,
@@ -83,8 +89,7 @@ func NewExtraFactoriesWithAgentCore(
 }
 
 func (e extraFactoriesWithAgentCore) GetZapCore() zapcore.Core {
-	// depth of 7 to account for additional frames from slog/otel
-	return zapAgent.NewZapCoreWithDepth(7)
+	return zapAgent.NewZapCoreWithDepth(zapCoreStackDepth)
 }
 
 func (e extraFactoriesWithAgentCore) GetExtensions() []extension.Factory {
@@ -128,8 +133,7 @@ func (e extraFactoriesWithoutAgentCore) GetZapCore() zapcore.Core {
 	// manually init agent's log module since it's not done for us in Standalone mode
 	logAgent.SetupLogger(slogWrapper.NewWrapper(handler), logLevel)
 
-	// depth of 7 to account for additional frames from slog/otel
-	return zapAgent.NewZapCoreWithDepth(7)
+	return zapAgent.NewZapCoreWithDepth(zapCoreStackDepth)
 }
 
 // GetExtensions returns the extensions for the collector.

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -10,8 +10,6 @@ package collectorimpl
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"context"
-	"fmt"
 	"log/slog"
 	"os"
 
@@ -27,8 +25,6 @@ import (
 	traceagent "github.com/DataDog/datadog-agent/comp/trace/agent/def"
 	logAgent "github.com/DataDog/datadog-agent/pkg/util/log"
 	slogWrapper "github.com/DataDog/datadog-agent/pkg/util/log/slog"
-	"github.com/DataDog/datadog-agent/pkg/util/log/slog/formatters"
-	"github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
 	zapAgent "github.com/DataDog/datadog-agent/pkg/util/log/zap"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
@@ -127,22 +123,7 @@ func NewExtraFactoriesWithoutAgentCore() ExtraFactories {
 }
 
 func (e extraFactoriesWithoutAgentCore) GetZapCore() zapcore.Core {
-	// Create a formatter that matches the agent's text format
-	// Uses the same building blocks as the agent's commonFormatter
-	formatter := func(_ context.Context, r slog.Record) string {
-		date := formatters.Date(false)(r.Time)
-		level := formatters.UppercaseLevel(r.Level)
-
-		frame := formatters.Frame(r)
-		shortFilePath := formatters.ShortFilePath(frame)
-		funcShort := formatters.ShortFunction(frame)
-		extraContext := formatters.ExtraTextContext(r)
-
-		return fmt.Sprintf("%s | %s | (%s:%d in %s) | %s%s\n",
-			date, level, shortFilePath, frame.Line, funcShort, extraContext, r.Message)
-	}
-
-	handler := handlers.NewFormat(formatter, os.Stdout)
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logLevel := "info"
 
 	if envLevel := os.Getenv("DD_LOG_LEVEL"); envLevel != "" {

--- a/go.mod
+++ b/go.mod
@@ -915,7 +915,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/goleak v1.3.0
-	go.uber.org/zap/exp v0.3.0 // indirect
+	go.uber.org/zap/exp v0.3.0
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect


### PR DESCRIPTION
### What does this PR do?
Unifies logging across the host profiler to use the Agent's logging system:
- Init agent's log wrapper for standalone mode
- Wrap agent's logger in a `zapcore.Core` for OTEL collectors
- Set global `slog` logger using `zapslog` for symbol uploader

### Motivation

The host profiler uses multiple logging systems (zap, slog, custom loggers), resulting in inconsistent log formatting and configuration. This PR routes all logs through the Agent's logging infrastructure.

### Describe how you validated your changes

Ran the profiler in both modes (with agent core and standalone). Verified logs appear correctly with proper formatting and respect log level configuration.

### Additional Notes

An alternative implementation https://github.com/DataDog/datadog-agent/pull/42838 uses a relative depth API and custom wrapper for the symbol uploader. This PR uses absolute depth specification and relies on upstream `slog` support. This approach avoids having to take care of a custom wrapper while enabling every logging function to work, but I'm happy to discuss the way forward!