### PR TITLE
Example network IO bounds checks for `quality_gate_metrics_logs`

### DIFF
--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -51,6 +51,24 @@ checks:
       series: lost_bytes
       upper_bound: 0KiB
 
+  - name: bytes_received_metrics_intake
+    description: "Allowable bytes received by datatog intake metrics endpoint"
+    bounds:
+      series: bytes_received['metrics_intake']
+      upper_bound: 100 MiB
+
+  - name: bytes_received_logs_intake
+    description: "Allowable bytes received by datatog intake logs endpoint"
+    bounds:
+      series: bytes_received['logs_intake']
+      upper_bound: 100 MiB
+
+  - name: bytes_received_process_intake
+    description: "Allowable bytes received by datatog intake processes endpoint"
+    bounds:
+      series: bytes_received['process_intake']
+      upper_bound: 100 MiB
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/lading/lading.yaml
@@ -62,12 +62,15 @@ generator:
         mount_point: /smp-shared
 
 blackhole:
-  - http:
+  - id: "metrics_intake"
+    http:
       binding_addr: "127.0.0.1:9091"
-  - http:
+  - id: "logs_intake"
+    http:
       binding_addr: "127.0.0.1:9092"
       response_delay_millis: 75
-  - http:
+  - id: "process_intake" 
+    http:
       binding_addr: "127.0.0.1:9093"
 
 target_metrics:


### PR DESCRIPTION
### What does this PR do?

Adds network IO bounds checks to `quality_gate_metrics_logs`

### Motivation

Example for how to setup network IO bounds checks

### Additional Notes

This is NOT ready yet. There are a few small changes that need to land (and be released) in lading and single-machine-performance before we can do this. 

This PR will be brought back once the pre-reqs in lading and smp are released