### PR TITLE
[AGTMETRICS-442] Add `agent-data-plane` to `agentNames` for the `agent diagnose` command

### DIFF
--- a/pkg/diagnose/ports/ports.go
+++ b/pkg/diagnose/ports/ports.go
@@ -17,7 +17,7 @@ import (
 
 var agentNames = map[string]struct{}{
 	"agent": {}, "trace-agent": {}, "trace-loader": {}, "process-agent": {},
-	"system-probe": {}, "security-agent": {},
+	"system-probe": {}, "security-agent": {}, "agent-data-plane": {},
 }
 
 // DiagnosePortSuite displays information about the ports used in the agent configuration


### PR DESCRIPTION
### What does this PR do?
Adds `agent-data-plane` to `agentNames` so that its process name is recognized for the `diagnose` command.

### Motivation
`agent diagnose` was showing
```
  FAIL dogstatsd_port
  Diagnosis: Required port 8125 is already used by 'agent-data-plane' process (PID=1067793) for udp.
```

### Describe how you validated your changes
Run the agent + adp. 
`agent diagnose --verbose` does not fail
```
  PASS dogstatsd_port
  Diagnosis: Required port 8125 is used by 'agent-data-plane' process (PID=40250) for udp
  ```


### Additional Notes
