### PR TITLE
[CONTP-1199] Add filter to autoscaling local failover store

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/loadstore/entity.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/entity.go
@@ -9,6 +9,7 @@ package loadstore
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -35,6 +36,21 @@ const (
 	StatefulSet
 	Unsupported
 )
+
+// podOwnerTypeFromString converts a string kind to PodOwnerType.
+// Accepts both capitalized (e.g., "Deployment") and lowercase (e.g., "deployment") formats.
+func podOwnerTypeFromString(kind string) PodOwnerType {
+	switch strings.ToLower(kind) {
+	case "deployment":
+		return Deployment
+	case "replicaset":
+		return ReplicaSet
+	case "statefulset":
+		return StatefulSet
+	default:
+		return Unsupported
+	}
+}
 
 const (
 	// maxDataPoints is the maximum number of data points to store per entity.

--- a/pkg/clusteragent/autoscaling/workload/loadstore/store.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/store.go
@@ -57,10 +57,11 @@ type QueryResult struct {
 	Results []PodResult
 }
 
-// Target represents a workload target for filtering (namespace + podOwnerName)
+// Target represents a workload target for filtering (namespace + kind + name)
 type Target struct {
-	Namespace    string
-	PodOwnerName string
+	Namespace string
+	Kind      string
+	Name      string
 }
 
 // Store is an interface for in-memory storage of entities and their load metric values.
@@ -118,16 +119,7 @@ func createEntitiesFromPayload(payload *gogen.MetricPayload) map[*Entity]*Entity
 			case "kube_ownerref_name":
 				entity.PodOwnerName = v
 			case "kube_ownerref_kind":
-				switch strings.ToLower(v) {
-				case "deployment":
-					entity.PodOwnerkind = Deployment
-				case "replicaset":
-					entity.PodOwnerkind = ReplicaSet
-				case "statefulset":
-					entity.PodOwnerkind = StatefulSet
-				default:
-					entity.PodOwnerkind = Unsupported
-				}
+				entity.PodOwnerkind = podOwnerTypeFromString(v)
 			case "container_name":
 				entity.ContainerName = v
 			case "pod_name":

--- a/pkg/clusteragent/autoscaling/workload/loadstore/store.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/store.go
@@ -57,6 +57,12 @@ type QueryResult struct {
 	Results []PodResult
 }
 
+// Target represents a workload target for filtering (namespace + podOwnerName)
+type Target struct {
+	Namespace    string
+	PodOwnerName string
+}
+
 // Store is an interface for in-memory storage of entities and their load metric values.
 type Store interface {
 	// SetEntitiesValues sets the values for the given map
@@ -70,6 +76,11 @@ type Store interface {
 		namespace string,
 		podOwnerName string,
 		containerName string) QueryResult
+
+	// SetTargets sets the list of targets to filter on.
+	// Only entities matching one of the targets will be stored.
+	// If targets is empty, all entities are accepted (backward compatible - no filtering).
+	SetTargets(targets []Target)
 }
 
 // createEntitiesFromPayload is a helper function used for creating entities from the metric payload.

--- a/pkg/clusteragent/autoscaling/workload/loadstore/store_test.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/store_test.go
@@ -105,7 +105,13 @@ func TestStoreAndPurgeEntities(t *testing.T) {
 		key2ValuesMap: make(map[uint64]*dataItem),
 		keyAttrTable:  make(map[compositeKey]podList),
 		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
 	}
+	// Set targets to test filtering behavior (without targets, all entities would be accepted anyway)
+	store.SetTargets([]Target{
+		{Namespace: "test", PodOwnerName: "redis_test"},
+		{Namespace: "test", PodOwnerName: "nginx_test"},
+	})
 	for _, timeDelta := range []int64{100, 85, 70} {
 		for i := 0; i < numPayloads; i++ {
 			payload := createSeriesPayload(i, timeDelta)
@@ -142,7 +148,13 @@ func TestGetMetrics(t *testing.T) {
 		key2ValuesMap: make(map[uint64]*dataItem),
 		keyAttrTable:  make(map[compositeKey]podList),
 		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
 	}
+	// Set targets to test filtering behavior (without targets, all entities would be accepted anyway)
+	store.SetTargets([]Target{
+		{Namespace: "test", PodOwnerName: "redis_test"},
+		{Namespace: "test", PodOwnerName: "nginx_test"},
+	})
 	for _, timeDelta := range []int64{100, 85, 80} {
 		for i := 0; i < numPayloads; i++ {
 			payload := createSeriesPayload(i, timeDelta)
@@ -207,4 +219,165 @@ func TestGetMetricsWithNonExistingEntityDoesNotPanic(t *testing.T) {
 		queryResult := store.GetMetricsRaw("container.cpu.usage", "test-ns", "test-pod", "")
 		assert.Equal(t, 0, len(queryResult.Results))
 	})
+}
+
+// TestSetTargets verifies that SetTargets correctly registers targets
+func TestSetTargets(t *testing.T) {
+	store := EntityStore{
+		key2ValuesMap: make(map[uint64]*dataItem),
+		keyAttrTable:  make(map[compositeKey]podList),
+		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
+	}
+
+	// Initially no targets
+	assert.Equal(t, 0, len(store.targets))
+
+	// Set multiple targets
+	targets := []Target{
+		{Namespace: "ns1", PodOwnerName: "deploy1"},
+		{Namespace: "ns2", PodOwnerName: "deploy2"},
+		{Namespace: "ns1", PodOwnerName: "deploy3"},
+	}
+	store.SetTargets(targets)
+	assert.Equal(t, 3, len(store.targets))
+
+	// Verify specific targets are registered
+	_, exists := store.targets[targetKey{namespace: "ns1", podOwnerName: "deploy1"}]
+	assert.True(t, exists)
+	_, exists = store.targets[targetKey{namespace: "ns2", podOwnerName: "deploy2"}]
+	assert.True(t, exists)
+	_, exists = store.targets[targetKey{namespace: "ns1", podOwnerName: "deploy3"}]
+	assert.True(t, exists)
+
+	// Update targets (replaces existing)
+	newTargets := []Target{
+		{Namespace: "ns3", PodOwnerName: "deploy4"},
+	}
+	store.SetTargets(newTargets)
+	assert.Equal(t, 1, len(store.targets))
+	_, exists = store.targets[targetKey{namespace: "ns3", podOwnerName: "deploy4"}]
+	assert.True(t, exists)
+	// Old targets should be gone
+	_, exists = store.targets[targetKey{namespace: "ns1", podOwnerName: "deploy1"}]
+	assert.False(t, exists)
+}
+
+// TestInvalidTargetsAreSkipped verifies that malformed targets (empty namespace or podOwnerName) are skipped
+func TestInvalidTargetsAreSkipped(t *testing.T) {
+	store := EntityStore{
+		key2ValuesMap: make(map[uint64]*dataItem),
+		keyAttrTable:  make(map[compositeKey]podList),
+		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
+	}
+
+	// Set targets with some invalid entries
+	store.SetTargets([]Target{
+		{Namespace: "", PodOwnerName: "deploy1"},        // Invalid: empty namespace
+		{Namespace: "ns1", PodOwnerName: ""},            // Invalid: empty podOwnerName
+		{Namespace: "", PodOwnerName: ""},               // Invalid: both empty
+		{Namespace: "test", PodOwnerName: "redis_test"}, // Valid
+	})
+
+	// Only the valid target should be registered
+	assert.Equal(t, 1, len(store.targets), "Only valid targets should be registered")
+	_, exists := store.targets[targetKey{namespace: "test", podOwnerName: "redis_test"}]
+	assert.True(t, exists, "Valid target should be registered")
+}
+
+// TestFilteringMixedEntities verifies filtering with mix of matching and non-matching entities
+func TestFilteringMixedEntities(t *testing.T) {
+	store := EntityStore{
+		key2ValuesMap: make(map[uint64]*dataItem),
+		keyAttrTable:  make(map[compositeKey]podList),
+		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
+	}
+
+	// Set target for only redis_test
+	store.SetTargets([]Target{
+		{Namespace: "test", PodOwnerName: "redis_test"},
+	})
+
+	// Create mixed entities - some matching, some not
+	for i := 0; i < 50; i++ {
+		// These match the target (namespace="test", podOwnerName="redis_test")
+		payload := createSeriesPayload(i, 100)
+		entities := createEntitiesFromPayload(payload)
+		store.SetEntitiesValues(entities)
+
+		// These don't match (namespace="test", podOwnerName="nginx_test")
+		payload2 := createSeriesPayload2(i, 100)
+		entities2 := createEntitiesFromPayload(payload2)
+		store.SetEntitiesValues(entities2)
+	}
+
+	// Verify only matching entities were stored
+	storeInfo := store.GetStoreInfo()
+	assert.Equal(t, 1, len(storeInfo.StatsResults), "Only one group should be stored")
+
+	for _, statsResult := range storeInfo.StatsResults {
+		assert.Equal(t, "test", statsResult.Namespace)
+		assert.Equal(t, "redis_test", statsResult.PodOwner)
+		assert.Equal(t, 50, statsResult.Count, "Only matching entities should be stored")
+	}
+
+	// Verify nginx_test is not accessible
+	result := store.GetMetricsRaw("container.cpu.usage", "test", "nginx_test", "")
+	assert.Equal(t, 0, len(result.Results), "nginx_test should not be stored")
+
+	// Verify redis_test is accessible
+	result = store.GetMetricsRaw("container.memory.usage", "test", "redis_test", "")
+	assert.Equal(t, 50, len(result.Results), "redis_test should be stored")
+}
+
+// TestDynamicTargetUpdates verifies that target updates affect subsequent entity storage
+func TestDynamicTargetUpdates(t *testing.T) {
+	store := EntityStore{
+		key2ValuesMap: make(map[uint64]*dataItem),
+		keyAttrTable:  make(map[compositeKey]podList),
+		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
+	}
+
+	// Initially set target for redis_test
+	store.SetTargets([]Target{
+		{Namespace: "test", PodOwnerName: "redis_test"},
+	})
+
+	// Store redis entities
+	for i := 0; i < 5; i++ {
+		payload := createSeriesPayload(i, 100)
+		entities := createEntitiesFromPayload(payload)
+		store.SetEntitiesValues(entities)
+	}
+
+	// Verify redis entities stored
+	storeInfo := store.GetStoreInfo()
+	assert.Equal(t, 1, len(storeInfo.StatsResults))
+	assert.Equal(t, 5, storeInfo.StatsResults[0].Count)
+
+	// Update targets to include nginx_test as well
+	store.SetTargets([]Target{
+		{Namespace: "test", PodOwnerName: "redis_test"},
+		{Namespace: "test", PodOwnerName: "nginx_test"},
+	})
+
+	// Store nginx entities
+	for i := 0; i < 5; i++ {
+		payload := createSeriesPayload2(i, 100)
+		entities := createEntitiesFromPayload(payload)
+		store.SetEntitiesValues(entities)
+	}
+
+	// Verify both redis and nginx entities are stored
+	storeInfo = store.GetStoreInfo()
+	assert.Equal(t, 2, len(storeInfo.StatsResults))
+
+	totalCount := 0
+	for _, statsResult := range storeInfo.StatsResults {
+		totalCount += statsResult.Count
+	}
+	assert.Equal(t, 10, totalCount, "Both redis and nginx entities should be stored")
 }

--- a/pkg/clusteragent/autoscaling/workload/loadstore/storeimpl.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/storeimpl.go
@@ -55,11 +55,18 @@ type podList struct {
 	metricName   string
 }
 
+// targetKey is used for fast lookup of targets
+type targetKey struct {
+	namespace    string
+	podOwnerName string
+}
+
 // EntityStore manages mappings between entities and their hashed keys.
 type EntityStore struct {
 	key2ValuesMap map[uint64]*dataItem     // Maps hash(entity) to a dataitem (entity and its values)
 	keyAttrTable  map[compositeKey]podList // map Hash<namespace, deployment, metricName> -> pod name ->  dataPerPod
 	lock          sync.RWMutex             // Protects access to store and entityMap
+	targets       map[targetKey]struct{}   // Set of targets to filter on (empty = accept all)
 }
 
 // NewEntityStore creates a new EntityStore.
@@ -68,6 +75,7 @@ func NewEntityStore(ctx context.Context) *EntityStore {
 		key2ValuesMap: make(map[uint64]*dataItem),
 		keyAttrTable:  make(map[compositeKey]podList),
 		lock:          sync.RWMutex{},
+		targets:       make(map[targetKey]struct{}),
 	}
 	store.startCleanupInBackground(ctx)
 	return &store
@@ -80,6 +88,10 @@ func (es *EntityStore) SetEntitiesValues(entities map[*Entity]*EntityValue) {
 	for entity, value := range entities {
 		if entity.EntityName == "" || entity.MetricName == "" || entity.Namespace == "" || entity.PodOwnerName == "" {
 			log.Tracef("Skipping entity with empty entityName, podOwnerName, namespace or metricName: %v", entity)
+			continue
+		}
+		// Filter based on registered targets
+		if !es.matchesTarget(entity) {
 			continue
 		}
 		entityHash := hashEntityToUInt64(entity)
@@ -232,6 +244,43 @@ func (es *EntityStore) startCleanupInBackground(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// SetTargets sets the list of targets to filter on.
+// Only entities matching one of the targets will be stored.
+// If targets is empty, all entities are accepted (backward compatible - no filtering).
+func (es *EntityStore) SetTargets(targets []Target) {
+	es.lock.Lock()
+	defer es.lock.Unlock()
+
+	// Clear existing targets and rebuild
+	es.targets = make(map[targetKey]struct{}, len(targets))
+	for _, t := range targets {
+		if t.Namespace == "" || t.PodOwnerName == "" {
+			continue // Skip malformed targets
+		}
+		key := targetKey{
+			namespace:    t.Namespace,
+			podOwnerName: t.PodOwnerName,
+		}
+		es.targets[key] = struct{}{}
+	}
+	log.Debugf("Updated loadstore targets: %d targets registered", len(es.targets))
+}
+
+// matchesTarget checks if an entity matches any registered target.
+// Returns true if no targets are registered (backward compatible - accept all entities).
+// NOTE: Caller must hold es.lock.
+func (es *EntityStore) matchesTarget(entity *Entity) bool {
+	if len(es.targets) == 0 {
+		return true // No targets = accept all (backward compatible)
+	}
+	key := targetKey{
+		namespace:    entity.Namespace,
+		podOwnerName: entity.PodOwnerName,
+	}
+	_, ok := es.targets[key]
+	return ok
 }
 
 // GetStoreInfo returns the store information, aggregated by namespace, podOwner, and metric name

--- a/pkg/clusteragent/autoscaling/workload/local/recommender.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender.go
@@ -78,6 +78,16 @@ func (r *Recommender) process(ctx context.Context) {
 	}
 	podAutoscalers := r.store.GetFiltered(localFallbackFilter)
 
+	// Sync targets to loadstore - only store metrics for workloads we're autoscaling
+	targets := make([]loadstore.Target, 0, len(podAutoscalers))
+	for _, pa := range podAutoscalers {
+		targets = append(targets, loadstore.Target{
+			Namespace:    pa.Namespace(),
+			PodOwnerName: pa.Spec().TargetRef.Name,
+		})
+	}
+	lStore.SetTargets(targets)
+
 	for _, podAutoscaler := range podAutoscalers {
 		// Generate local recommendations
 		horizontalRecommendation, err := r.replicaCalculator.calculateHorizontalRecommendations(podAutoscaler, lStore)

--- a/pkg/clusteragent/autoscaling/workload/local/recommender.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender.go
@@ -82,8 +82,9 @@ func (r *Recommender) process(ctx context.Context) {
 	targets := make([]loadstore.Target, 0, len(podAutoscalers))
 	for _, pa := range podAutoscalers {
 		targets = append(targets, loadstore.Target{
-			Namespace:    pa.Namespace(),
-			PodOwnerName: pa.Spec().TargetRef.Name,
+			Namespace: pa.Namespace(),
+			Kind:      pa.Spec().TargetRef.Kind,
+			Name:      pa.Spec().TargetRef.Name,
 		})
 	}
 	lStore.SetTargets(targets)


### PR DESCRIPTION
### What does this PR do?
 Adds optional target-based filtering to the autoscaling workload loadstore. When DatadogPodAutoscaler are configured, the loadstore only stores metrics for workloads that are targets of those autoscalers. 
Note:
When no autoscalers are configured, all entities are accepted (same as current behaviour).
  
Key changes:
  - Added SetTargets() method to register namespace/podOwnerName pairs for filtering
  - Added matchesTarget() check in SetEntitiesValues() to filter incoming entities
  - Local recommender syncs targets from PodAutoscaler store every 30 seconds

### Motivation
Reduce cpu/memory usage in the cluster-agent loadstore by only storing metrics for workloads that actually have DatadogPodAutoscaler. Previously, metrics from all workloads were stored regardless of whether they were being autoscaled, leading to unnecessary memory consumption in clusters with many workloads but few autoscaling targets.

### Describe how you validated your changes
Unit test
e2e test

