### PR TITLE
Revert "[SVLS-8160] Add serverless-identifying tag to Azure App Service Windows profiles"

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -627,11 +627,6 @@ func TestFullYamlConfig(t *testing.T) {
 	}, cfg.InstallSignature)
 
 	assert.Equal(t, "edge", cfg.APMMode)
-
-	assert.Equal(t, map[string]string{
-		"_dd.origin": "appservice",
-		"env":        "staging",
-	}, cfg.AdditionalProfileTags)
 }
 
 func TestFileLoggingDisabled(t *testing.T) {

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -681,7 +681,6 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	c.SendAllInternalStats = core.GetBool("apm_config.send_all_internal_stats") // default is false
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	c.ContainerTagsBuffer = core.GetBool("apm_config.enable_container_tags_buffer")
-	c.AdditionalProfileTags = core.GetStringMapString("apm_config.additional_profile_tags")
 	return nil
 }
 

--- a/comp/trace/config/testdata/full.yaml
+++ b/comp/trace/config/testdata/full.yaml
@@ -98,6 +98,3 @@ apm_config:
       max_size: 5555555
 
   mode: edge
-  additional_profile_tags:
-    _dd.origin: appservice
-    env: staging

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1725,23 +1725,6 @@ api_key:
 #   # Increase this value if you experience timeouts with large profile uploads.
 #
 #   profiling_receiver_timeout: 5
-#
-#   # @param additional_profile_tags - map of strings - optional
-#   # @env DD_APM_ADDITIONAL_PROFILE_TAGS - JSON string - optional
-#   # Additional tags to add to all profiles. These tags are added on the agent side
-#   # before forwarding profiles to Datadog. This is useful for environment-identifying
-#   # tags that should be applied to all profiles (e.g., origin).
-#   #
-#   # Note: For Azure App Service in Windows, this configuration is set in the AAS Site Extension.
-#   # Overriding the default tags in AAS Windows should be done with reference to https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/6007685143/Profiling.
-#   #
-#   # additional_profile_tags:
-#   #   _dd.origin: appservice
-#   #   <TAG_KEY>: <TAG_VALUE>
-#
-#   ## DD_APM_ADDITIONAL_PROFILE_TAGS='{"_dd.origin":"appservice","secondtag":"custom"}'
-#
-#   # additional_profile_tags: {}
 {{ if .InternalProfiling }}
 #   # @param profiling - custom object - optional
 #   # Enter specific configurations for internal profiling.

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -141,12 +141,11 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnv("apm_config.profiling_dd_url", "DD_APM_PROFILING_DD_URL")                             //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.profiling_additional_endpoints", "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.BindEnv("apm_config.profiling_receiver_timeout", "DD_APM_PROFILING_RECEIVER_TIMEOUT")         //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnvAndSetDefault("apm_config.additional_profile_tags", map[string]string{}, "DD_APM_ADDITIONAL_PROFILE_TAGS")
-	config.BindEnv("apm_config.additional_endpoints", "DD_APM_ADDITIONAL_ENDPOINTS")               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.replace_tags", "DD_APM_REPLACE_TAGS")                               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.analyzed_spans", "DD_APM_ANALYZED_SPANS")                           //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.ignore_resources", "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
-	config.BindEnv("apm_config.instrumentation.targets", "DD_APM_INSTRUMENTATION_TARGETS")         //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnv("apm_config.additional_endpoints", "DD_APM_ADDITIONAL_ENDPOINTS")                     //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnv("apm_config.replace_tags", "DD_APM_REPLACE_TAGS")                                     //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnv("apm_config.analyzed_spans", "DD_APM_ANALYZED_SPANS")                                 //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnv("apm_config.ignore_resources", "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE")       //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnv("apm_config.instrumentation.targets", "DD_APM_INSTRUMENTATION_TARGETS")               //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	config.ParseEnvAsSlice("apm_config.instrumentation.targets", func(in string) []interface{} {
 		var mappings []interface{}
 		if err := json.Unmarshal([]byte(in), &mappings); err != nil {

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1060,18 +1060,6 @@ func TestPeerTagsEnv(t *testing.T) {
 	require.Equal(t, []string{"aws.s3.bucket", "db.instance", "db.system"}, testConfig.GetStringSlice("apm_config.peer_tags"))
 }
 
-func TestAdditionalProfileTagsEnv(t *testing.T) {
-	testConfig := newTestConf(t)
-	require.Empty(t, testConfig.GetStringMapString("apm_config.additional_profile_tags"))
-
-	t.Setenv("DD_APM_ADDITIONAL_PROFILE_TAGS", `{"_dd.origin":"appservice","env":"staging"}`)
-	testConfig = newTestConf(t)
-	require.Equal(t, map[string]string{
-		"_dd.origin": "appservice",
-		"env":        "staging",
-	}, testConfig.GetStringMapString("apm_config.additional_profile_tags"))
-}
-
 func TestLogDefaults(t *testing.T) {
 	// New config
 	c := newEmptyMockConf(t)

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -97,11 +97,11 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 
 // StartServerlessTraceAgentArgs are the arguments for the StartServerlessTraceAgent method
 type StartServerlessTraceAgentArgs struct {
-	Enabled               bool
-	LoadConfig            Load
-	AdditionalProfileTags map[string]string
-	FunctionTags          string
-	RCService             *remoteconfig.CoreAgentService
+	Enabled             bool
+	LoadConfig          Load
+	AzureServerlessTags string
+	FunctionTags        string
+	RCService           *remoteconfig.CoreAgentService
 }
 
 // Start starts the agent
@@ -124,7 +124,7 @@ func StartServerlessTraceAgent(args StartServerlessTraceAgentArgs) ServerlessTra
 			context, cancel := context.WithCancel(context.Background())
 			tc.Hostname = ""
 			tc.SynchronousFlushing = true
-			tc.AdditionalProfileTags = args.AdditionalProfileTags
+			tc.AzureServerlessTags = args.AzureServerlessTags
 			ta := agent.NewAgent(context, tc, telemetry.NewNoopCollector(), &statsd.NoOpClient{}, zstd.NewComponent())
 
 			// Check if trace stats should be disabled for serverless

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -86,9 +86,8 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 	if orch := r.conf.FargateOrchestrator; orch != config.OrchestratorUnknown {
 		tags.WriteString(",orchestrator:fargate_" + strings.ToLower(string(orch)))
 	}
-	// Add any additional environment-identifying tags
-	for k, v := range r.conf.AdditionalProfileTags {
-		tags.WriteString(fmt.Sprintf(",%s:%s", k, v))
+	if r.conf.AzureServerlessTags != "" {
+		tags.WriteString(r.conf.AzureServerlessTags)
 	}
 
 	return newProfileProxy(r.conf, targets, keys, tags.String(), r.statsd)

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -300,15 +300,7 @@ func TestProfileProxyHandler(t *testing.T) {
 		}))
 		conf := newTestReceiverConfig()
 		conf.ProfilingProxy = config.ProfilingProxyConfig{DDURL: srv.URL}
-		conf.AdditionalProfileTags = map[string]string{
-			"subscription_id":     "123",
-			"resource_group":      "test-rg",
-			"resource_id":         "456",
-			"aca.subscription.id": "123",
-			"aca.resource.group":  "test-rg",
-			"aca.resource.id":     "456",
-			"aca.replica.name":    "test-replica",
-		}
+		conf.AzureServerlessTags = ",subscription_id:123,resource_group:test-rg,resource_id:456,aca.subscription.id:123,aca.resource.group:test-rg,aca.resource.id:456,aca.replica.name:test-replica"
 		req, err := http.NewRequest("POST", "/some/path", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -339,11 +331,7 @@ func TestProfileProxyHandler(t *testing.T) {
 		}))
 		conf := newTestReceiverConfig()
 		conf.ProfilingProxy = config.ProfilingProxyConfig{DDURL: srv.URL}
-		conf.AdditionalProfileTags = map[string]string{
-			"aas.subscription.id": "123",
-			"aas.resource.group":  "test-rg",
-			"aas.resource.id":     "456",
-		}
+		conf.AzureServerlessTags = ",aas.subscription.id:123,aas.resource.group:test-rg,aas.resource.id:456"
 		req, err := http.NewRequest("POST", "/some/path", nil)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -533,8 +533,9 @@ type AgentConfig struct {
 	// Install Signature
 	InstallSignature InstallSignatureConfig
 
-	// Additional profile tags are statically defined tags to attach to proxied profiles, this is primarily used by serverless
-	AdditionalProfileTags map[string]string
+	// Azure serverless apps tags, in the form of a comma-separated list of
+	// key-value pairs, starting with a comma
+	AzureServerlessTags string
 
 	// AuthToken is the auth token for the agent
 	AuthToken string `json:"-"`

--- a/test/new-e2e/tests/fleet/agent/agent.go
+++ b/test/new-e2e/tests/fleet/agent/agent.go
@@ -370,7 +370,7 @@ type Status struct {
 			} `json:"AnalyzedRateByServiceLegacy"`
 			AnalyzedSpansByService struct {
 			} `json:"AnalyzedSpansByService"`
-			AdditionalProfileTags    string `json:"AdditionalProfileTags"`
+			AzureServerlessTags      string `json:"AzureServerlessTags"`
 			BucketInterval           int64  `json:"BucketInterval"`
 			ClientStatsFlushInterval int    `json:"ClientStatsFlushInterval"`
 			ComputeStatsBySpanKind   bool   `json:"ComputeStatsBySpanKind"`


### PR DESCRIPTION
Reverts DataDog/datadog-agent#44488, as it's breaking the CI on the `main` branch of the repo