### PR TITLE
Set disable_failure_notifications for the stable-nightly-build

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -96,6 +96,7 @@ extensions:
           build_only: true
           options:
             disable_bia: true
+            disable_failure_notifications: true
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
### What does this PR do?

Set disable_failure_notifications for the stable-nightly-build

### Motivation

- There's no need to ping us, we already have monitors to do this 
- Discussed with the CI rotation

### Describe how you validated your changes

### Additional Notes
