### PR TITLE
feat(ssi): add config option to set the injection mode

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -176,6 +176,10 @@ type InstrumentationConfig struct {
 	// used. If no target matches, the auto instrumentation will not be applied. Full config key:
 	// apm_config.instrumentation.targets
 	Targets []Target `mapstructure:"targets" json:"targets"`
+	// InjectionMode determines the default method for injecting libraries into pods.
+	// Possible values: "auto" (default), "init_container" and "csi".
+	// Full config key: apm_config.instrumentation.injection_mode
+	InjectionMode string `mapstructure:"injection_mode" json:"injection_mode"`
 }
 
 // NewInstrumentationConfig creates a new InstrumentationConfig from the datadog config. It returns an error if the

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -36,6 +36,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 					"python": "v3",
 				},
 				InjectorImageTag: "foo",
+				InjectionMode:    "auto",
 			},
 		},
 		{
@@ -56,6 +57,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 					"python": "default",
 				},
 				InjectorImageTag: "foo",
+				InjectionMode:    "auto",
 			},
 		},
 		{
@@ -103,6 +105,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 						},
 					},
 				},
+				InjectionMode: "auto",
 			},
 		},
 		{
@@ -159,6 +162,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 						},
 					},
 				},
+				InjectionMode: "auto",
 			},
 		},
 		{
@@ -185,6 +189,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 						},
 					},
 				},
+				InjectionMode: "auto",
 			},
 		},
 		{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
@@ -18,8 +18,11 @@ import (
 type InjectionMode string
 
 const (
+	// InjectionModeAuto determines the best injection mode
+	InjectionModeAuto InjectionMode = "auto"
+
 	// InjectionModeInitContainer uses init containers to copy library files into an EmptyDir volume.
-	// This is the traditional/default injection method.
+	// This is the traditional injection method.
 	InjectionModeInitContainer InjectionMode = "init_container"
 
 	// InjectionModeCSI uses a CSI driver to mount library files directly into the pod.
@@ -49,12 +52,12 @@ func (f *ProviderFactory) GetProviderForPod(pod *corev1.Pod, cfg LibraryInjectio
 	}
 
 	switch mode {
+	default:
+		log.Warnf("Unknown injection mode %q for pod %s/%s, using 'auto'", mode, pod.Namespace, pod.Name)
+		fallthrough
+	case InjectionModeAuto, InjectionModeInitContainer:
+		return NewInitContainerProvider(cfg)
 	case InjectionModeCSI:
 		return NewCSIProvider(cfg)
-	case InjectionModeInitContainer:
-		return NewInitContainerProvider(cfg)
-	default:
-		log.Warnf("Unknown injection mode %q for pod %s/%s, using init_container", mode, pod.Namespace, pod.Name)
-		return NewInitContainerProvider(cfg)
 	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
@@ -25,7 +25,7 @@ const (
 	// This is the traditional injection method.
 	InjectionModeInitContainer InjectionMode = "init_container"
 
-	// InjectionModeCSI uses a CSI driver to mount library files directly into the pod.
+	// InjectionModeCSI uses the Datadog CSI driver to mount library files directly into the pod.
 	InjectionModeCSI InjectionMode = "csi"
 )
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package libraryinjection_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection"
+)
+
+func TestGetProviderForPod_DefaultMode(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+	}
+
+	// Default mode is init_container
+	factory := libraryinjection.NewProviderFactory(libraryinjection.InjectionModeInitContainer)
+	provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
+
+	// Should return InitContainerProvider
+	_, isInitContainer := provider.(*libraryinjection.InitContainerProvider)
+	assert.True(t, isInitContainer, "expected InitContainerProvider")
+}
+
+func TestGetProviderForPod_AnnotationOverridesDefault(t *testing.T) {
+	tests := []struct {
+		name             string
+		defaultMode      libraryinjection.InjectionMode
+		annotationValue  string
+		expectedProvider string
+	}{
+		{
+			name:             "default init_container, annotation csi",
+			defaultMode:      libraryinjection.InjectionModeInitContainer,
+			annotationValue:  "csi",
+			expectedProvider: "CSIProvider",
+		},
+		{
+			name:             "default csi, annotation init_container",
+			defaultMode:      libraryinjection.InjectionModeCSI,
+			annotationValue:  "init_container",
+			expectedProvider: "InitContainerProvider",
+		},
+		{
+			name:             "default init_container, annotation auto",
+			defaultMode:      libraryinjection.InjectionModeInitContainer,
+			annotationValue:  "auto",
+			expectedProvider: "InitContainerProvider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotation.InjectionMode: tt.annotationValue,
+					},
+				},
+			}
+
+			factory := libraryinjection.NewProviderFactory(tt.defaultMode)
+			provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
+
+			switch tt.expectedProvider {
+			case "CSIProvider":
+				_, ok := provider.(*libraryinjection.CSIProvider)
+				assert.True(t, ok, "expected CSIProvider")
+			case "InitContainerProvider":
+				_, ok := provider.(*libraryinjection.InitContainerProvider)
+				assert.True(t, ok, "expected InitContainerProvider")
+			}
+		})
+	}
+}
+
+func TestGetProviderForPod_UnknownModeFallsBackToAuto(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotation.InjectionMode: "unknown_mode",
+			},
+		},
+	}
+
+	factory := libraryinjection.NewProviderFactory(libraryinjection.InjectionModeCSI)
+	provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
+
+	// Unknown mode should fallback to InitContainerProvider (auto behavior)
+	_, isInitContainer := provider.(*libraryinjection.InitContainerProvider)
+	assert.True(t, isInitContainer, "unknown mode should fallback to InitContainerProvider")
+}
+
+func TestGetProviderForPod_EmptyAnnotationUsesDefault(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotation.InjectionMode: "",
+			},
+		},
+	}
+
+	// Default is CSI
+	factory := libraryinjection.NewProviderFactory(libraryinjection.InjectionModeCSI)
+	provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
+
+	// Empty annotation should use default (CSI)
+	_, isCSI := provider.(*libraryinjection.CSIProvider)
+	assert.True(t, isCSI, "empty annotation should use default mode")
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
@@ -29,7 +29,7 @@ import (
 // Returns an error if the injection fails.
 func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 	// Select the provider based on the injection mode (annotation or default)
-	factory := NewProviderFactory(InjectionModeInitContainer)
+	factory := NewProviderFactory(InjectionMode(cfg.InjectionMode))
 	provider := factory.GetProviderForPod(pod, cfg)
 
 	// Inject the APM injector

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
@@ -70,6 +70,10 @@ type LibraryConfig struct {
 
 // LibraryInjectionConfig contains all configuration needed to perform APM library injection.
 type LibraryInjectionConfig struct {
+	// InjectionMode determines the method for injecting libraries into pods.
+	// Possible values: "auto" (default), "init_container" and "csi".
+	InjectionMode string
+
 	// DefaultResourceRequirements are the default resource requirements for init containers.
 	// If empty, the provider will compute requirements based on the pod's existing resources.
 	DefaultResourceRequirements map[corev1.ResourceName]resource.Quantity

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -102,6 +102,7 @@ func (m *mutatorCore) apmInjectionMutator(config extractedPodLibInfo, autoDetect
 		}
 
 		return libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
+			InjectionMode:               m.config.Instrumentation.InjectionMode,
 			DefaultResourceRequirements: m.config.defaultResourceRequirements,
 			InitSecurityContext:         m.config.initSecurityContext,
 			ContainerFilter:             m.config.containerFilter,

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -81,6 +81,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", true, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                           //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled", false, "DD_APM_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.workload_selection", true, "DD_APM_WORKLOAD_SELECTION")
+	config.BindEnvAndSetDefault("apm_config.instrumentation.injection_mode", "auto", "DD_APM_INSTRUMENTATION_INJECTION_MODE")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES")
 	config.ParseEnvAsStringSlice("apm_config.instrumentation.enabled_namespaces", func(in string) []string {
 		var mappings []string

--- a/releasenotes-dca/notes/apm-injection-mode-config-837e27d1a82337b0.yaml
+++ b/releasenotes-dca/notes/apm-injection-mode-config-837e27d1a82337b0.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    APM: Add ``apm_config.instrumentation.injection_mode`` configuration option to control APM library injection method.
+    Possible values are ``auto`` (default), ``init_container``, and ``csi``.
+    The ``auto`` mode automatically selects the best injection mode (currently uses init containers).
+    The ``init_container`` mode is the legacy method that copies APM libraries into pods using init containers.
+    The ``csi`` mode mounts APM libraries directly into pods using the Datadog CSI driver. It is experimental and requires Cluster Agent 7.76+ and the Datadog CSI driver.


### PR DESCRIPTION
### What does this PR do?

Add a configuration option `apm_config.instrumentation.injection_mode` (`DD_APM_INSTRUMENTATION_INJECTION_MODE`) to set the default injection mode for APM library injection. Supported values are `auto`, `init_container`, and `csi`.

### Motivation

Allow cluster administrators to configure the default injection mode globally, instead of requiring annotations on each workload. This is useful for clusters that want to use CSI injection by default.

### Describe how you validated your changes

- Added unit tests for the `ProviderFactory.GetProviderForPod` method
- All existing tests pass
- Tested with minikube 
```yaml
  config:
    clusterAgent:
      env:
        - name: DD_APM_INSTRUMENTATION_INJECTION_MODE
          value: "auto" # <--
```

### Additional Notes

- Default value is `auto` (which currently uses init containers)
- Users can still override the mode per-workload using the `admission.datadoghq.com/apm-inject.injection-mode` annotation