### PR TITLE
Simplify the OTel metrics client

### DIFF
--- a/comp/otelcol/otlp/components/metricsclient/metrics_client.go
+++ b/comp/otelcol/otlp/components/metricsclient/metrics_client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -24,8 +23,6 @@ const (
 
 type metricsClient struct {
 	meter  metric.Meter
-	gauges map[string]float64
-	mutex  sync.Mutex
 	source string
 }
 
@@ -39,35 +36,21 @@ func InitializeMetricClient(mp metric.MeterProvider, source string) (statsd.Clie
 	}
 	return &metricsClient{
 		meter:  meter,
-		gauges: make(map[string]float64),
 		source: source,
 	}, nil
 }
 
 // Gauge implements the Statsd Gauge interface
 func (m *metricsClient) Gauge(name string, value float64, tags []string, _ float64) error {
-	// The last parameter is rate, but we're omitting it because rate does not have effect for gauge points: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/dedd44436ae064f5a0b43769d24adf897533957b/receiver/statsdreceiver/internal/protocol/metric_translator.go#L153-L156
-	m.mutex.Lock()
-	if _, ok := m.gauges[name]; ok {
-		m.gauges[name] = value
-		m.mutex.Unlock()
-		return nil
-	}
-	m.gauges[name] = value
-	// unlocking the mutex before calling into the meter provider, which may want to acquire another mutex
-	m.mutex.Unlock()
-	_, err := m.meter.Float64ObservableGauge(name, metric.WithFloat64Callback(func(_ context.Context, f metric.Float64Observer) error {
-		attr := m.attributeFromTags(tags)
-		m.mutex.Lock()
-		defer m.mutex.Unlock()
-		if v, ok := m.gauges[name]; ok {
-			f.Observe(v, metric.WithAttributeSet(attr))
-		}
-		return nil
-	}))
+	// The last parameter is rate, but we're omitting it because rate does not have effect for gauge points:
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/dedd44436ae064f5a0b43769d24adf897533957b/receiver/statsdreceiver/internal/protocol/metric_translator.go#L153-L156
+
+	gauge, err := m.meter.Float64Gauge(name)
 	if err != nil {
 		return err
 	}
+	attr := m.attributeFromTags(tags)
+	gauge.Record(context.Background(), value, metric.WithAttributeSet(attr))
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Use a plain gauge instead of an asynchronous callback-based gauge.

### Motivation

Because end-users do not provide the callback, and the "observed" value is just the last value stored in the wrapper's hashmap, it will never be more up-to-date than a plain gauge, the whole purpose of the observable gauges is defeated.

Furthermore, callbacks cannot safely lock mutexes (or would need to trylock in a loop with a timeout).

See:
- https://opentelemetry.io/docs/specs/otel/metrics/api/#asynchronous-instrument-api
- https://pkg.go.dev/go.opentelemetry.io/otel/metric#Callback
- https://github.com/open-telemetry/opentelemetry-go/pull/7755
- https://github.com/open-telemetry/opentelemetry-go/pull/7792

### Describe how you validated your changes

CI