### PR TITLE
Bump agent-deb-amd64 size gate

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,5 +1,5 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 708.4 MiB
+  max_on_disk_size: 708.6 MiB
   max_on_wire_size: 174.5 MiB
 static_quality_gate_agent_deb_amd64_fips:
   max_on_disk_size: 703.97 MiB


### PR DESCRIPTION
### What does this PR do?

Bumps the size limit for `agent_deb_amd64` for the 7.75.x branch such that we can remove a distraction from the release process.

### Motivation

At one point, the impacted gate got slightly over the limit on the 7.75.x branch, despite not having had static quality gates failures on the PR branches that were merged. This causes PRs to be blocked even if they don't change the size of the impacted artifact.

There are upcoming changes that will help address these situations more effectively, in the meantime, it's reasonable to just bump the limit slightly for this release branch, which will reduce disruption to the release process for no significant drawbacks (since the bump is not ported back to main, we're simply allowing a few extra KB increase at most only for this release).

### Describe how you validated your changes

Passing quality gates.

### Additional Notes
