### PR TITLE
tasks: report ddtool install failure in setup

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -246,7 +246,11 @@ def update_ddtool(ctx) -> SetupResult:
     status = Status.OK
     message = ""
 
-    ctx.run('brew update && brew upgrade ddtool', hide=True)
+    try:
+        ctx.run('brew update && brew upgrade ddtool', hide=True)
+    except Exception as e:
+        message = f'Ddtool update failed: {e}'
+        status = Status.FAIL
 
     return SetupResult("Update ddtool", status, message)
 


### PR DESCRIPTION
### What does this PR do?

When running `dda inv setup`, ensure that a failure in the ddtool install does not crash and stop the entire setup process.

### Motivation

Uniform behavior with the rest of the setup steps.

### Describe how you validated your changes

Ran it manually to check.

### Additional Notes