### PR TITLE
[EBPF-888] gpu: add gpu_type tag

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -761,6 +761,9 @@ func (c *WorkloadMetaCollector) extractGPUTags(gpu *workloadmeta.GPU, tagList *t
 	tagList.AddLow(tags.GPUDriverVersion, gpu.DriverVersion)
 	tagList.AddLow(tags.GPUVirtualizationMode, gpu.VirtualizationMode)
 	tagList.AddLow(tags.GPUArchitecture, strings.ToLower(gpu.Architecture))
+	if gpu.GPUType != "" {
+		tagList.AddLow(tags.GPUType, strings.ToLower(gpu.GPUType))
+	}
 
 	if gpu.DeviceType == workloadmeta.GPUDeviceTypeMIG {
 		tagList.AddLow(tags.GPUSlicingMode, "mig")

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2520,8 +2520,9 @@ func TestHandleGPU(t *testing.T) {
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: entityID.ID,
 				},
-				Vendor: "nvidia",
-				Device: "tesla-v100",
+				Vendor:  "nvidia",
+				Device:  "tesla-v100",
+				GPUType: "v100",
 			},
 			expected: []*types.TagInfo{
 				{
@@ -2532,6 +2533,7 @@ func TestHandleGPU(t *testing.T) {
 					LowCardTags: []string{
 						"gpu_vendor:nvidia",
 						"gpu_device:tesla-v100",
+						"gpu_type:v100",
 						"gpu_uuid:gpu-1234",
 						"gpu_slicing_mode:none",
 						"gpu_parent_uuid:gpu-1234",
@@ -2550,8 +2552,9 @@ func TestHandleGPU(t *testing.T) {
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: "GPU-1234",
 				},
-				Vendor: "Nvidia",
-				Device: "Tesla v100",
+				Vendor:  "Nvidia",
+				Device:  "Tesla v100",
+				GPUType: "V100",
 			},
 			expected: []*types.TagInfo{
 				{
@@ -2562,6 +2565,7 @@ func TestHandleGPU(t *testing.T) {
 					LowCardTags: []string{
 						"gpu_vendor:nvidia",
 						"gpu_device:tesla_v100",
+						"gpu_type:v100",
 						"gpu_uuid:gpu-1234",
 						"gpu_slicing_mode:none",
 						"gpu_parent_uuid:gpu-1234",
@@ -2582,6 +2586,7 @@ func TestHandleGPU(t *testing.T) {
 				},
 				Vendor:             "nvidia",
 				Device:             "A100-SXM4-40GB MIG 3g.20gb",
+				GPUType:            "a100",
 				DriverVersion:      "525.60.13",
 				DeviceType:         workloadmeta.GPUDeviceTypeMIG,
 				ParentGPUUUID:      "GPU-1234",
@@ -2600,6 +2605,7 @@ func TestHandleGPU(t *testing.T) {
 						"gpu_driver_version:525.60.13",
 						"gpu_parent_uuid:gpu-1234",
 						"gpu_slicing_mode:mig",
+						"gpu_type:a100",
 						"gpu_uuid:mig-432",
 						"gpu_vendor:nvidia",
 						"gpu_virtualization_mode:none",
@@ -2620,6 +2626,7 @@ func TestHandleGPU(t *testing.T) {
 				},
 				Vendor:             "nvidia",
 				Device:             "A100-SXM4-40GB",
+				GPUType:            "a100",
 				DriverVersion:      "525.60.13",
 				DeviceType:         workloadmeta.GPUDeviceTypePhysical,
 				ParentGPUUUID:      "GPU-1234",
@@ -2639,6 +2646,7 @@ func TestHandleGPU(t *testing.T) {
 						"gpu_driver_version:525.60.13",
 						"gpu_parent_uuid:gpu-1234",
 						"gpu_slicing_mode:mig-parent",
+						"gpu_type:a100",
 						"gpu_uuid:gpu-1234",
 						"gpu_vendor:nvidia",
 						"gpu_virtualization_mode:none",

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -137,6 +137,8 @@ const (
 	GPUVirtualizationMode = "gpu_virtualization_mode"
 	// GPUArchitecture is the tag for the GPU model architecture (e.g. Blackwell, Hopper, ...)
 	GPUArchitecture = "gpu_architecture"
+	// GPUType is the tag for the normalized GPU model type (e.g., a100, t4)
+	GPUType = "gpu_type"
 	// GPUSlicingMode is the tag for the GPU slicing mode (mig, none)
 	GPUSlicingMode = "gpu_slicing_mode"
 	// GPUParentGPUUUID is the tag for the parent GPU UUID

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -34,6 +34,7 @@ const (
 )
 
 var logLimiter = log.NewLogLimit(20, 10*time.Minute)
+
 // this regex matches device names from NVML and extracts the GPU type. For example, from "nvidia_a100-80gb" it will extract "a100". The groups are as follows:
 // 1. The optional prefix "nvidia" or "tesla" (T4 GPUs are named "tesla_t4" despite being NVIDIA GPUs)
 // 2. The optional prefix "geforce_" which we ignore

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -34,6 +34,11 @@ const (
 )
 
 var logLimiter = log.NewLogLimit(20, 10*time.Minute)
+// this regex matches device names from NVML and extracts the GPU type. For example, from "nvidia_a100-80gb" it will extract "a100". The groups are as follows:
+// 1. The optional prefix "nvidia" or "tesla" (T4 GPUs are named "tesla_t4" despite being NVIDIA GPUs)
+// 2. The optional prefix "geforce_" which we ignore
+// 3. The optional prefix "rtx_pro_" or "rtx_", which we use it as it's part of the GPU type
+// 4. The GPU type, which is the next alphanumeric part of the device name. Anything behind it (such as the memory size or whether it's PCI or SXM) is ignored.
 var gpuTypeRegex = regexp.MustCompile(`^(?:nvidia|tesla)_(?:geforce_)?(rtx_pro_|rtx_)?([a-z\d]+)`)
 var gpuNameSeparatorRegex = regexp.MustCompile(`[^a-z\d]+`)
 

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -90,6 +90,98 @@ func TestGpuArchToString(t *testing.T) {
 	}
 }
 
+func TestExtractGPUType(t *testing.T) {
+	tests := []struct {
+		deviceName string
+		expected   string
+	}{
+		// instances: g4dn.12xlarge, g4dn.16xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.metal, g4dn.xlarge, standard_nc16as_t4_v3, standard_nc4as_t4_v3, standard_nc64as_t4_v3, standard_nc8as_t4_v3
+		{deviceName: "Tesla T4", expected: "t4"},
+		// instances: g4dn.12xlarge, g4dn.16xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.metal, g4dn.xlarge, standard_nc16as_t4_v3, standard_nc4as_t4_v3, standard_nc64as_t4_v3, standard_nc8as_t4_v3
+		{deviceName: "Tesla_T4", expected: "t4"},
+		// instances: g5g.16xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.metal, g5g.xlarge
+		{deviceName: "NVIDIA T4G", expected: "t4g"},
+		// instances: g5g.16xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.metal, g5g.xlarge
+		{deviceName: "NVIDIA_T4G", expected: "t4g"},
+		// instances: standard_nc16ads_a10_v4, standard_nc32ads_a10_v4, standard_nc8ads_a10_v4, standard_nv12ads_a10_v5, standard_nv18ads_a10_v5, standard_nv36adms_a10_v5, standard_nv36ads_a10_v5, standard_nv6ads_a10_v5, standard_nv72ads_a10_v5
+		{deviceName: "NVIDIA A10", expected: "a10"},
+		// instances: standard_nc16ads_a10_v4, standard_nc32ads_a10_v4, standard_nc8ads_a10_v4, standard_nv12ads_a10_v5, standard_nv18ads_a10_v5, standard_nv36adms_a10_v5, standard_nv36ads_a10_v5, standard_nv6ads_a10_v5, standard_nv72ads_a10_v5
+		{deviceName: "NVIDIA_A10", expected: "a10"},
+		// instances: NVadsA10_v5 family
+		{deviceName: "NVIDIA A10-4Q", expected: "a10"},
+		// instances: g5.12xlarge, g5.16xlarge, g5.24xlarge, g5.2xlarge, g5.48xlarge, g5.4xlarge, g5.8xlarge, g5.xlarge
+		{deviceName: "NVIDIA A10G", expected: "a10g"},
+		// instances: g5.12xlarge, g5.16xlarge, g5.24xlarge, g5.2xlarge, g5.48xlarge, g5.4xlarge, g5.8xlarge, g5.xlarge
+		{deviceName: "NVIDIA_A10G", expected: "a10g"},
+		// instances: a2-highgpu-1g, a2-highgpu-2g, a2-highgpu-4g, a2-highgpu-8g, a2-megagpu-16g, a2-ultragpu-1g, a2-ultragpu-2g, a2-ultragpu-4g, a2-ultragpu-8g, p4d.24xlarge, p4de.24xlarge, standard_nc24ads_a100_v4, standard_nc48ads_a100_v4, standard_nc96ads_a100_v4, standard_nd96amsr_a100_v4, standard_nd96asr_v4
+		{deviceName: "NVIDIA A100-SXM4-40GB", expected: "a100"},
+		// instances: a2-highgpu-1g, a2-highgpu-2g, a2-highgpu-4g, a2-highgpu-8g, a2-megagpu-16g, a2-ultragpu-1g, a2-ultragpu-2g, a2-ultragpu-4g, a2-ultragpu-8g, p4d.24xlarge, p4de.24xlarge, standard_nc24ads_a100_v4, standard_nc48ads_a100_v4, standard_nc96ads_a100_v4, standard_nd96amsr_a100_v4, standard_nd96asr_v4
+		{deviceName: "NVIDIA_A100-SXM4-40GB", expected: "a100"},
+		// instances: a3-edgegpu-8g, a3-edgegpu-8g-nolssd, a3-highgpu-1g, a3-highgpu-2g, a3-highgpu-4g, a3-highgpu-8g, a3-megagpu-8g, p5.48xlarge, p5.4xlarge, standard_nc40ads_h100_v5, standard_nc80adis_h100_v5, standard_ncc40ads_h100_v5, standard_nd96isr_h100_v5
+		{deviceName: "NVIDIA H100-PCIE", expected: "h100"},
+		// instances: a3-edgegpu-8g, a3-edgegpu-8g-nolssd, a3-highgpu-1g, a3-highgpu-2g, a3-highgpu-4g, a3-highgpu-8g, a3-megagpu-8g, p5.48xlarge, p5.4xlarge, standard_nc40ads_h100_v5, standard_nc80adis_h100_v5, standard_ncc40ads_h100_v5, standard_nd96isr_h100_v5
+		{deviceName: "NVIDIA_H100-PCIE", expected: "h100"},
+		// instances: a3-ultragpu-8g, a3-ultragpu-8g-nolssd, p5en.48xlarge, standard_nd96isr_h200_v5
+		{deviceName: "NVIDIA H200", expected: "h200"},
+		// instances: a3-ultragpu-8g, a3-ultragpu-8g-nolssd, p5en.48xlarge, standard_nd96isr_h200_v5
+		{deviceName: "NVIDIA_H200", expected: "h200"},
+		// instances: p3.16xlarge, p3.2xlarge, p3.8xlarge, p3dn.24xlarge, standard_nc12s_v3, standard_nc24rs_v3, standard_nc24s_v3, standard_nc6s_v3, standard_nd40rs_v2
+		{deviceName: "NVIDIA V100-32GB", expected: "v100"},
+		// instances: p3.16xlarge, p3.2xlarge, p3.8xlarge, p3dn.24xlarge, standard_nc12s_v3, standard_nc24rs_v3, standard_nc24s_v3, standard_nc6s_v3, standard_nd40rs_v2
+		{deviceName: "NVIDIA_V100-32GB", expected: "v100"},
+		// instances: g2-standard-12, g2-standard-16, g2-standard-24, g2-standard-32, g2-standard-4, g2-standard-48, g2-standard-8, g2-standard-96, g6.12xlarge, g6.16xlarge, g6.24xlarge, g6.2xlarge, g6.48xlarge, g6.4xlarge, g6.8xlarge, g6.xlarge, g6f.2xlarge, g6f.4xlarge, g6f.large, g6f.xlarge, gr6.4xlarge, gr6.8xlarge, gr6f.4xlarge
+		{deviceName: "NVIDIA L4", expected: "l4"},
+		// instances: g2-standard-12, g2-standard-16, g2-standard-24, g2-standard-32, g2-standard-4, g2-standard-48, g2-standard-8, g2-standard-96, g6.12xlarge, g6.16xlarge, g6.24xlarge, g6.2xlarge, g6.48xlarge, g6.4xlarge, g6.8xlarge, g6.xlarge, g6f.2xlarge, g6f.4xlarge, g6f.large, g6f.xlarge, gr6.4xlarge, gr6.8xlarge, gr6f.4xlarge
+		{deviceName: "NVIDIA_L4", expected: "l4"},
+		{deviceName: " NVIDIA L4 ", expected: "l4"},
+		{deviceName: "NVIDIA-L4", expected: "l4"},
+		{deviceName: "L4", expected: ""},
+		{deviceName: "l4", expected: ""},
+		{deviceName: "NVIDIA: L4", expected: "l4"},
+		{deviceName: "NVIDIA   L4", expected: "l4"},
+		{deviceName: "NVIDIA__L4", expected: "l4"},
+		{deviceName: "NVIDIA--L4", expected: "l4"},
+		{deviceName: "NVIDIA L4 24GB", expected: "l4"},
+		{deviceName: "NVIDIA L4-24GB", expected: "l4"},
+		{deviceName: "NVIDIA L4 (rev.2)", expected: "l4"},
+		{deviceName: "\"NVIDIA L4\"", expected: "l4"},
+		{deviceName: "'NVIDIA L4'", expected: "l4"},
+		{deviceName: "NVIDIA GeForce-RTX-3090", expected: "rtx_3090"},
+		{deviceName: "NVIDIA GeForce RTX_3090", expected: "rtx_3090"},
+		{deviceName: "NVIDIA GeForce   RTX 3090", expected: "rtx_3090"},
+		// instances: g6e.12xlarge, g6e.16xlarge, g6e.24xlarge, g6e.2xlarge, g6e.48xlarge, g6e.4xlarge, g6e.8xlarge, g6e.xlarge
+		{deviceName: "NVIDIA L40S", expected: "l40s"},
+		// instances: g6e.12xlarge, g6e.16xlarge, g6e.24xlarge, g6e.2xlarge, g6e.48xlarge, g6e.4xlarge, g6e.8xlarge, g6e.xlarge
+		{deviceName: "NVIDIA_L40S", expected: "l40s"},
+		// instances: standard_nv12s_v2, standard_nv12s_v3, standard_nv24s_v2, standard_nv24s_v3, standard_nv48s_v3, standard_nv6s_v2
+		{deviceName: "Tesla M60", expected: "m60"},
+		// instances: standard_nv12s_v2, standard_nv12s_v3, standard_nv24s_v2, standard_nv24s_v3, standard_nv48s_v3, standard_nv6s_v2
+		{deviceName: "Tesla_M60", expected: "m60"},
+		// instances: p6-b200.48xlarge
+		{deviceName: "NVIDIA B200-96GB", expected: "b200"},
+		// instances: p6-b200.48xlarge
+		{deviceName: "NVIDIA_B200-96GB", expected: "b200"},
+		{deviceName: "NVIDIA RTX A6000", expected: "rtx_a6000"},
+		{deviceName: "NVIDIA_RTX_A6000", expected: "rtx_a6000"},
+		{deviceName: "NVIDIA RTX 6000 Ada Generation", expected: "rtx_6000"},
+		{deviceName: "NVIDIA_RTX_6000_Ada_Generation", expected: "rtx_6000"},
+		{deviceName: "NVIDIA GeForce RTX 3090", expected: "rtx_3090"},
+		{deviceName: "NVIDIA_GeForce_RTX_3090", expected: "rtx_3090"},
+		{deviceName: "NVIDIA GeForce RTX 4090", expected: "rtx_4090"},
+		{deviceName: "NVIDIA_GeForce_RTX_4090", expected: "rtx_4090"},
+		{deviceName: "", expected: ""},
+		{deviceName: "Unknown GPU", expected: ""},
+		{deviceName: "Unknown_GPU", expected: ""},
+		{deviceName: "nViDiA a100", expected: "a100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.deviceName, func(t *testing.T) {
+			require.Equal(t, tt.expected, extractGPUType(tt.deviceName))
+		})
+	}
+}
+
 func TestGpuProcessInfoUpdate(t *testing.T) {
 	wmetaMock := testutil.GetWorkloadMetaMock(t)
 	nvmlMock := testutil.GetBasicNvmlMock()

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -117,10 +117,12 @@ func TestExtractGPUType(t *testing.T) {
 		{deviceName: "NVIDIA A100-SXM4-40GB", expected: "a100"},
 		// instances: a2-highgpu-1g, a2-highgpu-2g, a2-highgpu-4g, a2-highgpu-8g, a2-megagpu-16g, a2-ultragpu-1g, a2-ultragpu-2g, a2-ultragpu-4g, a2-ultragpu-8g, p4d.24xlarge, p4de.24xlarge, standard_nc24ads_a100_v4, standard_nc48ads_a100_v4, standard_nc96ads_a100_v4, standard_nd96amsr_a100_v4, standard_nd96asr_v4
 		{deviceName: "NVIDIA_A100-SXM4-40GB", expected: "a100"},
+		{deviceName: "NVIDIA A100 80GB PCIe MIG 3g.40gb", expected: "a100"},
 		// instances: a3-edgegpu-8g, a3-edgegpu-8g-nolssd, a3-highgpu-1g, a3-highgpu-2g, a3-highgpu-4g, a3-highgpu-8g, a3-megagpu-8g, p5.48xlarge, p5.4xlarge, standard_nc40ads_h100_v5, standard_nc80adis_h100_v5, standard_ncc40ads_h100_v5, standard_nd96isr_h100_v5
 		{deviceName: "NVIDIA H100-PCIE", expected: "h100"},
 		// instances: a3-edgegpu-8g, a3-edgegpu-8g-nolssd, a3-highgpu-1g, a3-highgpu-2g, a3-highgpu-4g, a3-highgpu-8g, a3-megagpu-8g, p5.48xlarge, p5.4xlarge, standard_nc40ads_h100_v5, standard_nc80adis_h100_v5, standard_ncc40ads_h100_v5, standard_nd96isr_h100_v5
 		{deviceName: "NVIDIA_H100-PCIE", expected: "h100"},
+		{deviceName: "NVIDIA H100 NVL MIG 3g.47gb", expected: "h100"},
 		// instances: a3-ultragpu-8g, a3-ultragpu-8g-nolssd, p5en.48xlarge, standard_nd96isr_h200_v5
 		{deviceName: "NVIDIA H200", expected: "h200"},
 		// instances: a3-ultragpu-8g, a3-ultragpu-8g-nolssd, p5en.48xlarge, standard_nd96isr_h200_v5

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1994,6 +1994,12 @@ type GPU struct {
 	// specific.
 	Device string
 
+	// GPUType is the normalized model type of the GPU (e.g., "a100", "t4", "h100").
+	// This is extracted from the Device name and normalized to lowercase.
+	// For RTX cards, includes the rtx prefix (e.g., "rtx_a6000").
+	// Empty string if the type cannot be determined.
+	GPUType string
+
 	// DriverVersion is the version of the driver used for the gpu device
 	DriverVersion string
 
@@ -2087,6 +2093,7 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Vendor:", g.Vendor)
 	_, _ = fmt.Fprintln(&sb, "Driver Version:", g.DriverVersion)
 	_, _ = fmt.Fprintln(&sb, "Device:", g.Device)
+	_, _ = fmt.Fprintln(&sb, "GPU Type:", g.GPUType)
 	_, _ = fmt.Fprintln(&sb, "Active PIDs:", g.ActivePIDs)
 	_, _ = fmt.Fprintln(&sb, "Index:", g.Index)
 	_, _ = fmt.Fprintln(&sb, "Architecture:", g.Architecture)

--- a/releasenotes/notes/gpu-type-eb19eca3cde87e4a.yaml
+++ b/releasenotes/notes/gpu-type-eb19eca3cde87e4a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    GPU: add new tag `gpu_type` to the GPU metrics to identify the type of GPU (e.g., `a100`, `h100`).


### PR DESCRIPTION
### What does this PR do?

Adds a `gpu_type` tag that contains the model name of the GPU, without vendor or suffixes.

### Motivation

Allow correlation with cloud capacity planning metrics, as they only provide the general type of the GPU and not the specific device name.

### Describe how you validated your changes

Added unit tests.

### Additional Notes

We are implementing this in the agent as a fallback, as the device name cannot be retrieved from the cloud reservations (there is more than one device that matches each GPU type, e.g., there's A100-40GB and A100-80GB both of the a100 family) and we cannot modify the tags of the GPU metrics in the backend.