### PR TITLE
[CWS] Send custom event for non-remediation actions

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3468,7 +3468,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 
 			p.probe.onRuleActionPerformed(rule, action.Def)
 
-			p.HandleNetworkRemediation(rule, ev, policy, string(reportStatus))
+			p.HandleNetworkRemediation(rule, ev, report)
 		}
 	}
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -189,7 +189,7 @@ type EBPFProbe struct {
 	rawPacketActionFilters []rawpacket.Filter
 
 	// remediation tracking
-	activeRemediations     map[string]*remediationAction
+	activeRemediations     map[string]*Remediation
 	activeRemediationsLock sync.RWMutex
 
 	// PrCtl and name truncation
@@ -861,7 +861,7 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 		p.putBackPoolEvent(event)
 	}
 	// send not triggered remediations
-	p.handleRemediationNotTriggered()
+	p.HandleRemediationNotTriggered()
 }
 
 func (p *EBPFProbe) sendAnomalyDetection(event *model.Event) {
@@ -2540,7 +2540,7 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.FilterReport, boo
 func (p *EBPFProbe) OnNewRuleSetLoaded(rs *rules.RuleSet) {
 	p.processKiller.Reset(rs)
 
-	p.handleRemediationStatus(rs)
+	p.HandleRemediationStatus(rs)
 }
 
 // NewEvent returns a new event
@@ -2922,7 +2922,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, ipc ipc.Component, opts O
 		ipc:                  ipc,
 		BPFFilterTruncated:   atomic.NewUint64(0),
 		MetricNameTruncated:  atomic.NewUint64(0),
-		activeRemediations:   make(map[string]*remediationAction),
+		activeRemediations:   make(map[string]*Remediation),
 	}
 
 	if err := p.detectKernelVersion(); err != nil {
@@ -3413,8 +3413,8 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 
 			if p.processKiller.KillAndReport(action.Def.Kill, rule, ev) {
 				p.probe.onRuleActionPerformed(rule, action.Def)
+				p.HandleKillRemediation(rule, ev)
 			}
-			p.handleKillRemediaitonAction(rule, ev)
 
 		case action.Def.CoreDump != nil:
 			if p.config.RuntimeSecurity.InternalMonitoringEnabled {
@@ -3468,7 +3468,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 
 			p.probe.onRuleActionPerformed(rule, action.Def)
 
-			p.handleNetworkRemediaitonAction(rule, ev, policy, string(reportStatus))
+			p.HandleNetworkRemediation(rule, ev, policy, string(reportStatus))
 		}
 	}
 }

--- a/pkg/security/probe/remediations_linux.go
+++ b/pkg/security/probe/remediations_linux.go
@@ -9,6 +9,8 @@
 package probe
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -17,12 +19,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-// remediationAction tracks the state of an applied remediation
-type remediationAction struct {
+// Remediation tracks the state of an applied remediation
+type Remediation struct {
 	actionType         uint8
 	scope              string
 	triggered          bool
@@ -31,16 +34,15 @@ type remediationAction struct {
 	policy             string
 	isolationReApplied bool
 	isolationNew       bool
-
-	ruleTags RuleTags
+	ruleTags           RuleTags
 }
 
 const (
-	// remediationActionTypeKill
-	remediationActionTypeKill uint8 = iota
+	// RemediationTypeKill
+	RemediationTypeKill uint8 = iota
 
-	// remediationActionTypeNetworkIsolation
-	remediationActionTypeNetworkIsolation
+	// RemediationTypeNetworkIsolation
+	RemediationTypeNetworkIsolation
 )
 
 type RuleTags map[string]string
@@ -73,21 +75,21 @@ type RemediationAgentContext struct {
 // RemediationEvent defines a custom remediation event
 // easyjson:json
 type RemediationEvent struct {
-	Date              string                      `json:"date"`
-	Process           RemediationProcessContext   `json:"process,omitempty"`
-	Container         RemediationContainerContext `json:"container,omitempty"`
-	Agent             RemediationAgentContext     `json:"agent"`
-	EventType         string                      `json:"event_type"`
-	Service           string                      `json:"service"`
-	Scope             string                      `json:"scope"`
-	RemediationAction string                      `json:"remediation_action"`
-	Status            string                      `json:"status"`
-	Timestamp         int64                       `json:"timestamp"`
-	RuleTags          RuleTags                    `json:"rule_tags,omitempty"`
+	Date        string                      `json:"date"`
+	Process     RemediationProcessContext   `json:"process,omitempty"`
+	Container   RemediationContainerContext `json:"container,omitempty"`
+	Agent       RemediationAgentContext     `json:"agent"`
+	EventType   string                      `json:"event_type"`
+	Service     string                      `json:"service"`
+	Scope       string                      `json:"scope"`
+	Remediation string                      `json:"remediation"`
+	Status      string                      `json:"status"`
+	Timestamp   int64                       `json:"timestamp"`
+	RuleTags    RuleTags                    `json:"rule_tags,omitempty"`
 }
 
 // ToJSON marshals the remediation event to JSON
-func (k *RemediationEvent) ToJSON() ([]byte, error) {
+func (k RemediationEvent) ToJSON() ([]byte, error) {
 	return utils.MarshalEasyJSON(k)
 }
 
@@ -111,10 +113,30 @@ func getRemediationTagBool(rule *rules.Rule) bool {
 	return false
 }
 
-// NewRemediationEvent creates a new network remediation event from the latest action report
+func getRemediationKey(rule *rules.Rule) string {
+	if getRemediationTagBool(rule) {
+		return "rem_" + getAgentEventID(rule)
+	}
+	for _, action := range rule.Actions {
+		if action.Def.Kill != nil {
+			return "kill_" + utils.RandString(10)
+		}
+		if action.Def.NetworkFilter != nil {
+			filter := action.Def.NetworkFilter.BPFFilter
+			hash := sha256.Sum256([]byte(filter))
+			return "n_f_" + rule.ID + hex.EncodeToString(hash[:10])
+		}
+	}
+	return ""
+}
+
+// NewRemediationEvent creates a new Remediation event from the latest action report
 // activeRemediationsLock must be held
-func NewRemediationEvent(p *EBPFProbe, agentID string, status string, remediationAction string) *RemediationEvent {
-	remediation := p.activeRemediations[agentID]
+func NewRemediationEvent(p *EBPFProbe, remediationKey string, status string, remediationType string) *RemediationEvent {
+	remediation, ok := p.activeRemediations[remediationKey]
+	if !ok || remediation == nil {
+		return nil
+	}
 
 	now := time.Now()
 
@@ -133,17 +155,17 @@ func NewRemediationEvent(p *EBPFProbe, agentID string, status string, remediatio
 	}
 
 	return &RemediationEvent{
-		Date:              now.Format(time.RFC3339Nano),
-		Container:         remediation.containerContext,
-		Process:           remediation.processContext,
-		Agent:             agentContext,
-		EventType:         "remediation_status",
-		Service:           "runtime-security-agent",
-		Scope:             remediation.scope,
-		Status:            status,
-		Timestamp:         now.UnixMilli(),
-		RemediationAction: remediationAction,
-		RuleTags:          remediation.ruleTags,
+		Date:        now.Format(time.RFC3339Nano),
+		Container:   remediation.containerContext,
+		Process:     remediation.processContext,
+		Agent:       agentContext,
+		EventType:   "remediation_status",
+		Service:     "runtime-security-agent",
+		Scope:       remediation.scope,
+		Status:      status,
+		Timestamp:   now.UnixMilli(),
+		Remediation: remediationType,
+		RuleTags:    remediation.ruleTags,
 	}
 }
 
@@ -161,17 +183,19 @@ func getTagsFromRule(rule *rules.Rule) RuleTags {
 	return ruleTags
 }
 
-func (p *EBPFProbe) handleRemediationStatus(rs *rules.RuleSet) {
+// HandleRemediationStatus is called when a new ruleset is loaded
+// It cleans up the activeRemediations map from the kill actions and network isolation actions that are not persistent
+func (p *EBPFProbe) HandleRemediationStatus(rs *rules.RuleSet) {
 	p.activeRemediationsLock.Lock()
 	defer p.activeRemediationsLock.Unlock()
-	// First, remove all the previous kill actions because only network isolation actions can be persistent
+	// First, remove all the previous actions because only network isolation actions can be persistent
 	for key, state := range p.activeRemediations {
-		if state.actionType == remediationActionTypeKill {
+		if state.actionType != RemediationTypeNetworkIsolation {
 			delete(p.activeRemediations, key)
 		}
 	}
 
-	// When a new ruleset is loaded, reset all remediation flags
+	// When a new ruleset is loaded, reset all flags
 	for _, state := range p.activeRemediations {
 		state.triggered = false
 		state.isolationReApplied = false
@@ -180,22 +204,19 @@ func (p *EBPFProbe) handleRemediationStatus(rs *rules.RuleSet) {
 
 	for _, rule := range rs.GetRules() {
 		for _, action := range rule.Actions {
-			var actionType uint8
 			if action.Def.NetworkFilter == nil && action.Def.Kill == nil {
 				// This is not a kill or network isolation action
 				continue
 			}
-			if !getRemediationTagBool(rule) {
-				// This is not a remediation action
-				continue
-			}
-			agentEventID := getAgentEventID(rule)
+
+			var actionType uint8
+			remediationKey := getRemediationKey(rule)
 
 			if action.Def.NetworkFilter != nil {
-				actionType = remediationActionTypeNetworkIsolation
+				actionType = RemediationTypeNetworkIsolation
 				// If isolation is new, create a new entry in the map
-				if _, exists := p.activeRemediations[agentEventID]; !exists {
-					p.activeRemediations[agentEventID] = &remediationAction{
+				if _, exists := p.activeRemediations[remediationKey]; !exists {
+					p.activeRemediations[remediationKey] = &Remediation{
 						actionType:   actionType,
 						triggered:    false,
 						isolationNew: true,
@@ -204,12 +225,13 @@ func (p *EBPFProbe) handleRemediationStatus(rs *rules.RuleSet) {
 					}
 				} else {
 					// Otherwise, update the entry
-					p.activeRemediations[agentEventID].isolationReApplied = true
+					p.activeRemediations[remediationKey].isolationReApplied = true
 				}
-			} else if action.Def.Kill != nil {
-				actionType = remediationActionTypeKill
+			} else if action.Def.Kill != nil && getRemediationTagBool(rule) {
+				// No need to create kill actions entries here if there is no remediation
+				actionType = RemediationTypeKill
 				// Create a new entry for kill actions
-				p.activeRemediations[agentEventID] = &remediationAction{
+				p.activeRemediations[remediationKey] = &Remediation{
 					actionType: actionType,
 					triggered:  false,
 					scope:      action.Def.Kill.Scope,
@@ -219,93 +241,117 @@ func (p *EBPFProbe) handleRemediationStatus(rs *rules.RuleSet) {
 		}
 	}
 	// After all the rule are laoded, check if some isolation actions were removed
-	for agentEventID, state := range p.activeRemediations {
-		if state.actionType == remediationActionTypeNetworkIsolation && !state.isolationReApplied && !state.isolationNew {
-			networkFilterEvent := NewRemediationEvent(p, agentEventID, "removed", "cancel_network_isolation")
-			p.SendCustomRemediationEvent(networkFilterEvent)
-			delete(p.activeRemediations, agentEventID)
+	for remediationKey, state := range p.activeRemediations {
+		if state.actionType == RemediationTypeNetworkIsolation && !state.isolationReApplied && !state.isolationNew {
+			networkFilterEvent := NewRemediationEvent(p, remediationKey, "removed", "cancel_network_isolation")
+			p.SendRemediationEvent(networkFilterEvent)
+			delete(p.activeRemediations, remediationKey)
 		}
 	}
 }
 
-func (p *EBPFProbe) handleKillRemediaitonAction(rule *rules.Rule, ev *model.Event) {
-	agentEventID := getAgentEventID(rule)
-	if agentEventID != "" && getRemediationTagBool(rule) {
-		if killReport, ok := ev.ActionReports[len(ev.ActionReports)-1].(*KillActionReport); ok {
-			p.activeRemediationsLock.Lock()
-			defer p.activeRemediationsLock.Unlock()
-			remediation, found := p.activeRemediations[agentEventID]
-			// Send network filter action only for remediation events, so when an agent_event_id is set
-
-			// Record that the kill action was triggered
-			if found {
-				remediation.triggered = true
-				remediation.processContext.PID = ev.ProcessContext.Process.Pid
-				remediation.containerContext.ID = string(ev.ProcessContext.Process.ContainerContext.ContainerID)
-				remediation.containerContext.CreatedAt = ev.ProcessContext.Process.ContainerContext.CreatedAt
-				remediation.policy = ""
-				remediation.ruleTags = getTagsFromRule(rule)
-
-			}
-			// Get kill status
-			killReport.RLock()
-			status := string(killReport.Status)
-			killReport.RUnlock()
-			// Send custom event
-			killActionEvent := NewRemediationEvent(p, agentEventID, status, "kill")
-			p.SendCustomRemediationEvent(killActionEvent)
-		}
+func (p *EBPFProbe) HandleKillRemediation(rule *rules.Rule, ev *model.Event) {
+	remediationKey := getRemediationKey(rule)
+	if remediationKey == "" {
+		seclog.Warnf("no rule action key found for rule")
+		return
 	}
-
-}
-
-func (p *EBPFProbe) handleNetworkRemediaitonAction(rule *rules.Rule, ev *model.Event, policy rawpacket.Policy, status string) {
-	agentEventID := getAgentEventID(rule)
-	if agentEventID != "" && getRemediationTagBool(rule) {
-		// Send network filter action only for remediation events, so when an agent_event_id is set
+	if killReport, ok := ev.ActionReports[len(ev.ActionReports)-1].(*KillActionReport); ok {
 		p.activeRemediationsLock.Lock()
 		defer p.activeRemediationsLock.Unlock()
+		remediation, found := p.activeRemediations[remediationKey]
 
-		remediation, found := p.activeRemediations[agentEventID]
-
-		// store that the rule triggered
-		if found {
-			// New isolation: apply it and send the event
+		// Record that the kill action was triggered for remediation
+		if found && getRemediationTagBool(rule) {
 			remediation.triggered = true
-			if remediation.isolationReApplied {
-				// We already re-applied the isolation, no need to send the event
-				return
-			}
-
 			remediation.processContext.PID = ev.ProcessContext.Process.Pid
 			remediation.containerContext.ID = string(ev.ProcessContext.Process.ContainerContext.ContainerID)
 			remediation.containerContext.CreatedAt = ev.ProcessContext.Process.ContainerContext.CreatedAt
-			remediation.policy = policy.String()
-			networkFilterEvent := NewRemediationEvent(p, agentEventID, status, "network_isolation")
-			p.SendCustomRemediationEvent(networkFilterEvent)
+			remediation.policy = ""
+			remediation.ruleTags = getTagsFromRule(rule)
+
+		} else {
+			// Create new entries for kill actions that are not remediation
+			// It will only be used to send an event
+			p.activeRemediations[remediationKey] = &Remediation{
+				actionType: RemediationTypeKill,
+				triggered:  true,
+				processContext: RemediationProcessContext{
+					PID: ev.ProcessContext.Process.Pid,
+				},
+				containerContext: RemediationContainerContext{
+					ID:        string(ev.ProcessContext.Process.ContainerContext.ContainerID),
+					CreatedAt: ev.ProcessContext.Process.ContainerContext.CreatedAt,
+				},
+				scope: rule.Actions[0].Def.Kill.Scope,
+			}
 		}
+
+		// Get kill status
+		killReport.RLock()
+		status := string(killReport.Status)
+		killReport.RUnlock()
+		// Send custom event
+		killActionEvent := NewRemediationEvent(p, remediationKey, status, "kill")
+		p.SendRemediationEvent(killActionEvent)
 	}
+}
+
+func (p *EBPFProbe) HandleNetworkRemediation(rule *rules.Rule, ev *model.Event, policy rawpacket.Policy, status string) {
+	remediationKey := getRemediationKey(rule)
+	if remediationKey == "" {
+		seclog.Warnf("no rule action key found for rule")
+		return
+	}
+	p.activeRemediationsLock.Lock()
+	defer p.activeRemediationsLock.Unlock()
+
+	remediation, found := p.activeRemediations[remediationKey]
+
+	if found {
+		// New isolation: apply it and send the event
+		remediation.triggered = true
+		if remediation.isolationReApplied {
+			// We already re-applied the isolation, no need to send the event
+			return
+		}
+
+		remediation.processContext.PID = ev.ProcessContext.Process.Pid
+		remediation.containerContext.ID = string(ev.ProcessContext.Process.ContainerContext.ContainerID)
+		remediation.containerContext.CreatedAt = ev.ProcessContext.Process.ContainerContext.CreatedAt
+		remediation.policy = policy.String()
+	}
+	// Send an event
+	networkFilterEvent := NewRemediationEvent(p, remediationKey, status, "network_isolation")
+	p.SendRemediationEvent(networkFilterEvent)
 
 }
 
-func (p *EBPFProbe) SendCustomRemediationEvent(re *RemediationEvent) {
+func (p *EBPFProbe) SendRemediationEvent(re *RemediationEvent) {
+	if re == nil {
+		return
+	}
 	customRule := events.NewCustomRule(events.RemediationStatusRuleID, events.RemediationStatusRuleDesc)
 	customEvent := events.NewCustomEvent(model.CustomEventType, re)
 	p.probe.DispatchCustomEvent(customRule, customEvent)
 
 }
-func (p *EBPFProbe) handleRemediationNotTriggered() {
+func (p *EBPFProbe) HandleRemediationNotTriggered() {
 	p.activeRemediationsLock.Lock()
-	for agentEventID, state := range p.activeRemediations {
-		var remediationAction string
+	for remediationKey, state := range p.activeRemediations {
+		if len(remediationKey) > 4 && remediationKey[0:4] != "rem_" {
+			// Only send events for remediation rules
+			continue
+		}
+		var remediation string
 		if !state.triggered {
-			if state.actionType == remediationActionTypeNetworkIsolation {
-				remediationAction = "network_isolation"
-			} else if state.actionType == remediationActionTypeKill {
-				remediationAction = "kill"
+			if state.actionType == RemediationTypeNetworkIsolation {
+				remediation = "network_isolation"
+			} else if state.actionType == RemediationTypeKill {
+				remediation = "kill"
 			}
-			re := NewRemediationEvent(p, agentEventID, "not_triggered", remediationAction)
-			p.SendCustomRemediationEvent(re)
+			re := NewRemediationEvent(p, remediationKey, "not_triggered", remediation)
+			p.SendRemediationEvent(re)
 		}
 	}
 	p.activeRemediationsLock.Unlock()

--- a/pkg/security/probe/remediations_linux_easyjson.go
+++ b/pkg/security/probe/remediations_linux_easyjson.go
@@ -128,7 +128,7 @@ func easyjson71693981DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 			} else {
 				out.Scope = string(in.String())
 			}
-		case "remediation":
+		case "remediation_action":
 			if in.IsNull() {
 				in.Skip()
 			} else {
@@ -220,7 +220,7 @@ func easyjson71693981EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		out.String(string(in.Scope))
 	}
 	{
-		const prefix string = ",\"remediation\":"
+		const prefix string = ",\"remediation_action\":"
 		out.RawString(prefix)
 		out.String(string(in.Remediation))
 	}

--- a/pkg/security/probe/remediations_linux_easyjson.go
+++ b/pkg/security/probe/remediations_linux_easyjson.go
@@ -128,11 +128,11 @@ func easyjson71693981DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 			} else {
 				out.Scope = string(in.String())
 			}
-		case "remediation_action":
+		case "remediation":
 			if in.IsNull() {
 				in.Skip()
 			} else {
-				out.RemediationAction = string(in.String())
+				out.Remediation = string(in.String())
 			}
 		case "status":
 			if in.IsNull() {
@@ -220,9 +220,9 @@ func easyjson71693981EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		out.String(string(in.Scope))
 	}
 	{
-		const prefix string = ",\"remediation_action\":"
+		const prefix string = ",\"remediation\":"
 		out.RawString(prefix)
-		out.String(string(in.RemediationAction))
+		out.String(string(in.Remediation))
 	}
 	{
 		const prefix string = ",\"status\":"

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1393,7 +1393,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 				t.Error("signal timeout")
 			}
 			return nil
-		}, func(rule *rules.Rule, customEvent *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*5, "kill_remediation")
 

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1302,3 +1302,213 @@ func TestActionKillContainerWithSignatureBroadRule(t *testing.T) {
 	}
 	containerKilled = true
 }
+
+func TestRemediationCustomEvents(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if !ebpfLessEnabled {
+		checkKernelCompatibility(t, "agent is running in container mode", func(_ *kernel.Version) bool {
+			return env.IsContainerized()
+		})
+	}
+
+	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "kill_remediation",
+			Expression: `process.file.name == "syscall_tester" && open.file.path == "{{.Root}}/test-kill-remediation"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Kill: &rules.KillDefinition{
+						Signal: "SIGKILL",
+						Scope:  "process",
+					},
+				},
+			},
+			Tags: map[string]string{
+				"remediation_rule": "true",
+				"agent_event_id":   "AZoIdt0EAAAbKF9Rg_3TKKJ",
+				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+				"creator_name":     "Allan Turing",
+				"creator_handle":   "allan.turing@example.com",
+			},
+		},
+		{
+			ID:         "network_remediation",
+			Expression: `exec.file.name == "sleep" && exec.args in ["123"]`,
+			Actions: []*rules.ActionDefinition{
+				{
+					NetworkFilter: &rules.NetworkFilterDefinition{
+						BPFFilter: "port 53",
+						Policy:    "drop",
+						Scope:     "process",
+					},
+				},
+			},
+			Tags: map[string]string{
+				"remediation_rule": "true",
+				"agent_event_id":   "AZoIdt0EAAAbKF9Rg_4IIJ",
+				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+				"creator_name":     "Allan Turing",
+				"creator_handle":   "allan.turing@example.com",
+			},
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("kill-remediation-status", func(t *testing.T) {
+		testFile, _, err := test.Path("test-kill-remediation")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(testFile)
+
+		err = test.GetEventSent(t, func() error {
+			ch := make(chan bool, 1)
+
+			go func() {
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", syscallTester, ";", "sleep", "5")
+				_ = cmd.Run()
+
+				ch <- true
+			}()
+
+			select {
+			case <-ch:
+			case <-time.After(time.Second * 3):
+				t.Error("signal timeout")
+			}
+			return nil
+		}, func(rule *rules.Rule, customEvent *model.Event) bool {
+			return true
+		}, time.Second*5, "kill_remediation")
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = retry.Do(func() error {
+			msg := test.msgSender.getMsg("remediation_status")
+			if msg == nil {
+				return errors.New("not found")
+			}
+
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
+					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.event_type`); err != nil || el != "remediation_status" {
+					t.Errorf("event_type should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_action`); err != nil || el != "kill" {
+					t.Errorf("rule_action should be 'kill': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.status`); err != nil || el != "performed" {
+					t.Errorf("status should be 'performed': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.scope`); err != nil || el != "process" {
+					t.Errorf("scope should be 'process': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.process.pid`); err != nil || el == nil {
+					t.Errorf("process.pid not found: %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.remediation_rule`); err != nil || el != "true" {
+					t.Errorf("rule_tags.remediation_rule should be 'true': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.agent_event_id`); err != nil || el != "AZoIdt0EAAAbKF9Rg_3TKKJ" {
+					t.Errorf("rule_tags.agent_event_id should be 'AZoIdt0EAAAbKF9Rg_3TKKJ': %s => %v", string(msg.Data), err)
+				}
+			})
+
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+	})
+	t.Run("network-isolation-remediation-status", func(t *testing.T) {
+		err = test.GetEventSent(t, func() error {
+			cmd := exec.Command("sleep", "123")
+			if err := cmd.Start(); err != nil {
+				return err
+			}
+			time.Sleep(500 * time.Millisecond)
+
+			if cmd.Process != nil {
+				cmd.Process.Kill()
+			}
+
+			return nil
+		}, func(rule *rules.Rule, customEvent *model.Event) bool {
+			return true
+		}, time.Second*5, "network_remediation")
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = retry.Do(func() error {
+			msg := test.msgSender.getMsg("remediation_status")
+			if msg == nil {
+				return errors.New("not found")
+			}
+
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
+					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.event_type`); err != nil || el != "remediation_status" {
+					t.Errorf("event_type should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_action`); err != nil || el != "network_isolation" {
+					t.Errorf("rule_action should be 'network_isolation': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.status`); err != nil || el != "performed" {
+					t.Errorf("status should be 'performed': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.scope`); err != nil || el != "process" {
+					t.Errorf("scope should be 'process': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.process.pid`); err != nil || el == nil {
+					t.Errorf("process.pid not found: %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.remediation_rule`); err != nil || el != "true" {
+					t.Errorf("rule_tags.remediation_rule should be 'true': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.agent_event_id`); err != nil || el != "AZoIdt0EAAAbKF9Rg_4IIJ" {
+					t.Errorf("rule_tags.agent_event_id should be 'AZoIdt0EAAAbKF9Rg_4IIJ': %s => %v", string(msg.Data), err)
+				}
+			})
+
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+	})
+
+}

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1381,7 +1381,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 				timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 
-				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", syscallTester, ";", "sleep", "5")
+				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";")
 				_ = cmd.Run()
 
 				ch <- true
@@ -1416,7 +1416,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 					t.Errorf("event_type should be 'remediation_status': %s => %v", string(msg.Data), err)
 				}
 
-				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_action`); err != nil || el != "kill" {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.remediation_action`); err != nil || el != "kill" {
 					t.Errorf("rule_action should be 'kill': %s => %v", string(msg.Data), err)
 				}
 
@@ -1458,7 +1458,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 			}
 
 			return nil
-		}, func(rule *rules.Rule, customEvent *model.Event) bool {
+		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
 		}, time.Second*5, "network_remediation")
 
@@ -1481,7 +1481,7 @@ func TestRemediationCustomEvents(t *testing.T) {
 					t.Errorf("event_type should be 'remediation_status': %s => %v", string(msg.Data), err)
 				}
 
-				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_action`); err != nil || el != "network_isolation" {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.remediation_action`); err != nil || el != "network_isolation" {
 					t.Errorf("rule_action should be 'network_isolation': %s => %v", string(msg.Data), err)
 				}
 


### PR DESCRIPTION
### What does this PR do?
This PR allows us to send remediation status events for actions that are not only triggered by the user, but also automatically triggered.

### Motivation
This change unifies the code path for both user-triggered and automatically triggered remediation actions.

### Describe how you validated your changes
I added two tests and validated the changes in the staging environment.
