### PR TITLE
[AGENTRUN-1001] Implement WithAttrs and WithGroup in slog format handler

### DIFF
--- a/pkg/util/log/slog/handlers/format.go
+++ b/pkg/util/log/slog/handlers/format.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 )
 
 var _ slog.Handler = (*format)(nil)
@@ -17,6 +18,8 @@ var _ slog.Handler = (*format)(nil)
 type format struct {
 	formatter func(ctx context.Context, r slog.Record) string
 	writer    io.Writer
+	attrs     []slog.Attr // precomputed attributes (already wrapped in groups if needed)
+	groups    []string    // currently open groups for future WithAttrs calls
 }
 
 // NewFormat returns a handler that formats records and writes them to an io.Writer.
@@ -26,6 +29,31 @@ func NewFormat(formatter func(ctx context.Context, r slog.Record) string, writer
 
 // Handle writes a record to the writer.
 func (h *format) Handle(ctx context.Context, r slog.Record) error {
+	// If there are open groups, record's attrs must be wrapped in those groups
+	if len(h.groups) > 0 {
+		// Collect record's original attrs
+		var recordAttrs []slog.Attr
+		r.Attrs(func(a slog.Attr) bool {
+			recordAttrs = append(recordAttrs, a)
+			return true
+		})
+
+		// Build final attrs: handler's precomputed attrs + wrapped record attrs
+		finalAttrs := slices.Clone(h.attrs)
+		if len(recordAttrs) > 0 {
+			wrapped := wrapInGroups(h.groups, recordAttrs)
+			finalAttrs = mergeGroupedAttr(finalAttrs, wrapped)
+		}
+
+		// Create a new record with the properly grouped attrs
+		newRecord := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+		newRecord.AddAttrs(finalAttrs...)
+		r = newRecord
+	} else if len(h.attrs) > 0 {
+		// No groups, just add handler's attrs to the record
+		r.AddAttrs(h.attrs...)
+	}
+
 	msg := h.formatter(ctx, r)
 	_, err := h.writer.Write([]byte(msg))
 	return err
@@ -37,11 +65,103 @@ func (h *format) Enabled(context.Context, slog.Level) bool {
 }
 
 // WithAttrs returns a new handler with the given attributes.
-func (h *format) WithAttrs(_attrs []slog.Attr) slog.Handler {
-	panic("not implemented")
+// Per slog.Handler contract, it does not modify the receiver.
+func (h *format) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+
+	// Create a new handler
+	newH := &format{
+		formatter: h.formatter,
+		writer:    h.writer,
+		groups:    h.groups, // safe to share since groups are only appended via WithGroup
+	}
+
+	// Copy existing attrs
+	newH.attrs = make([]slog.Attr, len(h.attrs), len(h.attrs)+len(attrs))
+	copy(newH.attrs, h.attrs)
+
+	// Add new attrs, wrapped in any open groups
+	if len(h.groups) > 0 {
+		wrapped := wrapInGroups(h.groups, attrs)
+		newH.attrs = mergeGroupedAttr(newH.attrs, wrapped)
+	} else {
+		newH.attrs = append(newH.attrs, attrs...)
+	}
+
+	return newH
 }
 
 // WithGroup returns a new handler with the given group name.
-func (h *format) WithGroup(_name string) slog.Handler {
-	panic("not implemented")
+// Per slog.Handler contract, if name is empty it returns the receiver unchanged.
+func (h *format) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
+	// Create a new handler with the group added
+	newH := &format{
+		formatter: h.formatter,
+		writer:    h.writer,
+		attrs:     h.attrs, // safe to share since attrs are only appended via WithAttrs
+	}
+
+	// Copy groups and add new one
+	newH.groups = make([]string, len(h.groups)+1)
+	copy(newH.groups, h.groups)
+	newH.groups[len(h.groups)] = name
+
+	return newH
+}
+
+// wrapInGroups wraps attributes in nested groups (outermost first in groups slice).
+func wrapInGroups(groups []string, attrs []slog.Attr) slog.Attr {
+	// Build from innermost to outermost
+	// groups[0] is outermost, groups[len-1] is innermost
+	result := attrsToAny(attrs)
+	for i := len(groups) - 1; i >= 0; i-- {
+		result = []any{slog.Group(groups[i], result...)}
+	}
+	return result[0].(slog.Attr)
+}
+
+// mergeGroupedAttr merges a new grouped attr into existing attrs.
+// If the new attr is a group and there's an existing group with the same key,
+// the contents are merged recursively. Otherwise, the attr is appended.
+func mergeGroupedAttr(existing []slog.Attr, newAttr slog.Attr) []slog.Attr {
+	if newAttr.Value.Kind() != slog.KindGroup {
+		return append(existing, newAttr)
+	}
+
+	for i, e := range existing {
+		if e.Key == newAttr.Key && e.Value.Kind() == slog.KindGroup {
+			// Found an existing group with the same key - merge contents
+			existingGroup := e.Value.Group()
+			newGroup := newAttr.Value.Group()
+
+			// Merge each attr from newGroup into existingGroup
+			merged := existingGroup
+			for _, na := range newGroup {
+				merged = mergeGroupedAttr(merged, na)
+			}
+
+			// Create a new slice with the merged group
+			result := slices.Clone(existing)
+			result[i] = slog.Group(e.Key, attrsToAny(merged)...)
+			return result
+		}
+	}
+
+	// No existing group with this key, append
+	return append(existing, newAttr)
+}
+
+// attrsToAny converts a slice of slog.Attr to a slice of any for use with slog.Group.
+func attrsToAny(attrs []slog.Attr) []any {
+	result := make([]any, len(attrs))
+	for i, a := range attrs {
+		result[i] = a
+	}
+	return result
 }

--- a/pkg/util/log/slog/handlers/format_test.go
+++ b/pkg/util/log/slog/handlers/format_test.go
@@ -171,3 +171,359 @@ func TestFormatHandlerFormatterUsesContext(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "[12345] test\n", buf.String())
 }
+
+// attrFormatter returns a formatter that outputs message and all attributes
+func attrFormatter() func(ctx context.Context, r slog.Record) string {
+	return func(_ context.Context, r slog.Record) string {
+		var buf bytes.Buffer
+		buf.WriteString(r.Message)
+		r.Attrs(func(a slog.Attr) bool {
+			buf.WriteString(" ")
+			buf.WriteString(attrToString(a))
+			return true
+		})
+		buf.WriteString("\n")
+		return buf.String()
+	}
+}
+
+// attrToString converts an attribute to a string representation
+func attrToString(a slog.Attr) string {
+	if a.Value.Kind() == slog.KindGroup {
+		var buf bytes.Buffer
+		buf.WriteString(a.Key)
+		buf.WriteString("={")
+		first := true
+		for _, ga := range a.Value.Group() {
+			if !first {
+				buf.WriteString(" ")
+			}
+			first = false
+			buf.WriteString(attrToString(ga))
+		}
+		buf.WriteString("}")
+		return buf.String()
+	}
+	return fmt.Sprintf("%s=%v", a.Key, a.Value.Any())
+}
+
+func TestFormatHandlerWithAttrsEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// WithAttrs with empty slice should return the same handler
+	h2 := handler.WithAttrs(nil)
+	assert.Same(t, handler, h2, "WithAttrs(nil) should return same handler")
+
+	h3 := handler.WithAttrs([]slog.Attr{})
+	assert.Same(t, handler, h3, "WithAttrs([]) should return same handler")
+}
+
+func TestFormatHandlerWithGroupEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// WithGroup with empty string should return the same handler
+	h2 := handler.WithGroup("")
+	assert.Same(t, handler, h2, "WithGroup(\"\") should return same handler")
+}
+
+func TestFormatHandlerWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Add attributes
+	h2 := handler.WithAttrs([]slog.Attr{slog.String("a", "1")})
+	require.NotSame(t, handler, h2, "WithAttrs should return new handler")
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg a=1\n", buf.String())
+}
+
+func TestFormatHandlerWithAttrsMultiple(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Add multiple attributes
+	h2 := handler.WithAttrs([]slog.Attr{
+		slog.String("a", "1"),
+		slog.Int("b", 2),
+	})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg a=1 b=2\n", buf.String())
+}
+
+func TestFormatHandlerWithAttrsChained(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Chain multiple WithAttrs calls
+	h2 := handler.WithAttrs([]slog.Attr{slog.String("a", "1")})
+	h3 := h2.WithAttrs([]slog.Attr{slog.String("b", "2")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h3.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg a=1 b=2\n", buf.String())
+}
+
+func TestFormatHandlerWithAttrsAndRecordAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Add handler attributes
+	h2 := handler.WithAttrs([]slog.Attr{slog.String("handler_attr", "h1")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	record.AddAttrs(slog.String("record_attr", "r1"))
+
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	// Record's attrs come first (already on the record), then handler attrs are added
+	assert.Equal(t, "msg record_attr=r1 handler_attr=h1\n", buf.String())
+}
+
+func TestFormatHandlerWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Add a group, then attrs
+	h2 := handler.WithGroup("g").WithAttrs([]slog.Attr{slog.String("a", "1")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	// Attribute 'a' should be wrapped in group 'g'
+	assert.Equal(t, "msg g={a=1}\n", buf.String())
+}
+
+func TestFormatHandlerWithGroupNested(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Nested groups: g1 -> g2 -> attr
+	h2 := handler.WithGroup("g1").WithGroup("g2").WithAttrs([]slog.Attr{slog.String("a", "1")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	// Attribute 'a' should be wrapped in nested groups
+	assert.Equal(t, "msg g1={g2={a=1}}\n", buf.String())
+}
+
+func TestFormatHandlerWithGroupAndAttrsInterleaved(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Pattern: attr -> group -> attr
+	// This is like: logger.With("a", 1).WithGroup("g").With("b", 2)
+	h2 := handler.
+		WithAttrs([]slog.Attr{slog.String("a", "1")}).
+		WithGroup("g").
+		WithAttrs([]slog.Attr{slog.String("b", "2")})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	// 'a' is not in a group, 'b' is in group 'g'
+	assert.Equal(t, "msg a=1 g={b=2}\n", buf.String())
+}
+
+func TestFormatHandlerOriginalUnchanged(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Create derived handlers
+	_ = handler.WithAttrs([]slog.Attr{slog.String("a", "1")})
+	_ = handler.WithGroup("g")
+
+	// Original handler should still work without attrs or groups
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "original", 0)
+	err := handler.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", buf.String())
+}
+
+func TestFormatHandlerDerivedHandlersIndependent(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Create two derived handlers from the same base
+	h1 := handler.WithAttrs([]slog.Attr{slog.String("a", "1")})
+	h2 := handler.WithAttrs([]slog.Attr{slog.String("b", "2")})
+
+	// Test h1
+	record1 := slog.NewRecord(time.Now(), slog.LevelInfo, "msg1", 0)
+	err := h1.Handle(context.Background(), record1)
+	require.NoError(t, err)
+	assert.Equal(t, "msg1 a=1\n", buf.String())
+
+	buf.Reset()
+
+	// Test h2
+	record2 := slog.NewRecord(time.Now(), slog.LevelInfo, "msg2", 0)
+	err = h2.Handle(context.Background(), record2)
+	require.NoError(t, err)
+	assert.Equal(t, "msg2 b=2\n", buf.String())
+}
+
+func TestFormatHandlerWithGroupMultipleAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewFormat(attrFormatter(), &buf)
+
+	// Group with multiple attributes
+	h2 := handler.WithGroup("g").WithAttrs([]slog.Attr{
+		slog.String("a", "1"),
+		slog.Int("b", 2),
+	})
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	err := h2.Handle(context.Background(), record)
+
+	require.NoError(t, err)
+	assert.Equal(t, "msg g={a=1 b=2}\n", buf.String())
+}
+
+// TestFormatHandlerMatchesJSONHandlerBehavior verifies that the format handler's
+// WithAttrs and WithGroup behavior matches the standard slog.JSONHandler.
+// This ensures our implementation follows the slog.Handler contract correctly.
+func TestFormatHandlerMatchesJSONHandlerBehavior(t *testing.T) {
+	// We use slog.JSONHandler as the reference implementation to verify
+	// that our format handler produces the same JSON structure for the same
+	// WithAttrs/WithGroup sequence.
+
+	tests := []struct {
+		name    string
+		setupFn func(h slog.Handler) slog.Handler
+		logArgs []any // additional args to pass to logger.Info
+	}{
+		{
+			name: "WithAttrs single",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{slog.String("key", "value")})
+			},
+		},
+		{
+			name: "WithAttrs multiple",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{
+					slog.String("a", "1"),
+					slog.Int("b", 2),
+					slog.Bool("c", true),
+				})
+			},
+		},
+		{
+			name: "WithAttrs chained",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{slog.String("a", "1")}).
+					WithAttrs([]slog.Attr{slog.String("b", "2")})
+			},
+		},
+		{
+			name: "WithGroup then WithAttrs",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithGroup("g").WithAttrs([]slog.Attr{slog.String("a", "1")})
+			},
+		},
+		{
+			name: "nested groups",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithGroup("g1").WithGroup("g2").WithAttrs([]slog.Attr{slog.String("a", "1")})
+			},
+		},
+		{
+			name: "interleaved attrs and groups",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{slog.String("a", "1")}).
+					WithGroup("g").
+					WithAttrs([]slog.Attr{slog.String("b", "2")})
+			},
+		},
+		{
+			name: "complex interleaving",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{slog.String("root", "r")}).
+					WithGroup("g1").
+					WithAttrs([]slog.Attr{slog.String("in_g1", "1")}).
+					WithGroup("g2").
+					WithAttrs([]slog.Attr{slog.String("in_g2", "2")})
+			},
+		},
+		{
+			name: "WithGroup qualifies record attrs",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithGroup("g")
+			},
+			logArgs: []any{"record_key", "record_value"},
+		},
+		{
+			name: "nested groups qualify record attrs",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithGroup("g1").WithGroup("g2")
+			},
+			logArgs: []any{"deep_key", "deep_value"},
+		},
+		{
+			name: "interleaved with record attrs",
+			setupFn: func(h slog.Handler) slog.Handler {
+				return h.WithAttrs([]slog.Attr{slog.String("a", "1")}).
+					WithGroup("g").
+					WithAttrs([]slog.Attr{slog.String("b", "2")})
+			},
+			logArgs: []any{"c", "3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &slog.HandlerOptions{
+				// Remove time to make output deterministic
+				ReplaceAttr: func(_groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey {
+						return slog.Attr{}
+					}
+					return a
+				},
+			}
+			logMessage := "test"
+
+			// Create a JSON handler and log through it
+			var jsonBuf bytes.Buffer
+			jsonHandler := slog.NewJSONHandler(&jsonBuf, opts)
+			configuredJSON := tt.setupFn(jsonHandler)
+			logger := slog.New(configuredJSON)
+			logger.Info(logMessage, tt.logArgs...)
+
+			// Create a format handler that outputs JSON in the same format
+			var formatBuf bytes.Buffer
+			formatHandler := NewFormat(func(_ context.Context, r slog.Record) string {
+				// Use a temporary JSON handler to format this record
+				var tmpBuf bytes.Buffer
+				tmpHandler := slog.NewJSONHandler(&tmpBuf, opts)
+				_ = tmpHandler.Handle(context.Background(), r)
+				return tmpBuf.String()
+			}, &formatBuf)
+			configuredFormat := tt.setupFn(formatHandler)
+			formatLogger := slog.New(configuredFormat)
+			formatLogger.Info(logMessage, tt.logArgs...)
+
+			// Compare the JSON outputs
+			assert.JSONEq(t, jsonBuf.String(), formatBuf.String(),
+				"format handler should produce same JSON structure as JSONHandler")
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Implement `WithAttrs` and `WithGroup` in the slog format handler.

### Motivation
Eventually be able to set our slog handler as default handler of the slog package.

### Describe how you validated your changes
Added extensive unit tests, in particular tests comparing the implementation with the standard library's loggers to ensure we handle attributes and groups in the same way. 

### Additional Notes
I find the documentation of `WithAttrs` and `WithGroup` ambiguous, and it's really not trivial to handle properly.
