### PR TITLE
[CSPM] drop capabilities before running oscap-io

### DIFF
--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -35,6 +35,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	complianceCmd.AddCommand(CheckCommand(globalParams))
 	complianceCmd.AddCommand(complianceLoadCommand(globalParams))
+	addPlatformSpecificCommands(complianceCmd, globalParams)
 
 	return []*cobra.Command{complianceCmd}
 }

--- a/cmd/security-agent/subcommands/compliance/command_linux.go
+++ b/cmd/security-agent/subcommands/compliance/command_linux.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+)
+
+// addPlatformSpecificCommands adds Linux-specific compliance subcommands
+func addPlatformSpecificCommands(complianceCmd *cobra.Command, globalParams *command.GlobalParams) {
+	complianceCmd.AddCommand(oscapExecCommand(globalParams))
+}

--- a/cmd/security-agent/subcommands/compliance/command_nonlinux.go
+++ b/cmd/security-agent/subcommands/compliance/command_nonlinux.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix && !linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+)
+
+// addPlatformSpecificCommands adds platform-specific compliance subcommands (no-op on non-Linux)
+func addPlatformSpecificCommands(_ *cobra.Command, _ *command.GlobalParams) {
+	// No platform-specific commands on non-Linux Unix systems
+}

--- a/cmd/security-agent/subcommands/compliance/oscapexec.go
+++ b/cmd/security-agent/subcommands/compliance/oscapexec.go
@@ -19,7 +19,7 @@ func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "oscap-exec <binary-path> [args...]",
 		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
-		Long:   "Internal command that drops all capabilities except CAP_SYS_CHROOT before executing oscap-io. This command should not be called directly by users.",
+		Long:   "Internal command that drops capabilities before executing oscap-io. This command should not be called directly by users.",
 		Hidden: true,
 		Args:   cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/security-agent/subcommands/compliance/oscapexec.go
+++ b/cmd/security-agent/subcommands/compliance/oscapexec.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
+	"github.com/DataDog/datadog-agent/pkg/compliance/cli"
+)
+
+// oscapExecCommand returns the 'compliance oscap-exec' command
+func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "oscap-exec <binary-path> [args...]",
+		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
+		Long:   "Internal command that drops all capabilities except CAP_SYS_CHROOT before executing oscap-io. This command should not be called directly by users.",
+		Hidden: true,
+		Args:   cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return cli.RunOscapExec(args)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -34,6 +34,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 
 	complianceCmd.AddCommand(CheckCommand(globalParams))
 	complianceCmd.AddCommand(complianceLoadCommand(globalParams))
+	addPlatformSpecificCommands(complianceCmd, globalParams)
 
 	return []*cobra.Command{complianceCmd}
 }

--- a/cmd/system-probe/subcommands/compliance/command_linux.go
+++ b/cmd/system-probe/subcommands/compliance/command_linux.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+)
+
+// addPlatformSpecificCommands adds Linux-specific compliance subcommands
+func addPlatformSpecificCommands(complianceCmd *cobra.Command, globalParams *command.GlobalParams) {
+	complianceCmd.AddCommand(oscapExecCommand(globalParams))
+}

--- a/cmd/system-probe/subcommands/compliance/command_nonlinux.go
+++ b/cmd/system-probe/subcommands/compliance/command_nonlinux.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix && !linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+)
+
+// addPlatformSpecificCommands adds platform-specific compliance subcommands (no-op on non-Linux)
+func addPlatformSpecificCommands(_ *cobra.Command, _ *command.GlobalParams) {
+	// No platform-specific commands on non-Linux Unix systems
+}

--- a/cmd/system-probe/subcommands/compliance/oscapexec.go
+++ b/cmd/system-probe/subcommands/compliance/oscapexec.go
@@ -19,7 +19,7 @@ func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "oscap-exec <binary-path> [args...]",
 		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
-		Long:   "Internal command that drops all capabilities except CAP_SYS_CHROOT before executing oscap-io. This command should not be called directly by users.",
+		Long:   "Internal command that drops capabilities before executing oscap-io. This command should not be called directly by users.",
 		Hidden: true,
 		Args:   cobra.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cmd/system-probe/subcommands/compliance/oscapexec.go
+++ b/cmd/system-probe/subcommands/compliance/oscapexec.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package compliance
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
+	"github.com/DataDog/datadog-agent/pkg/compliance/cli"
+)
+
+// oscapExecCommand returns the 'compliance oscap-exec' command
+func oscapExecCommand(_ *command.GlobalParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "oscap-exec <binary-path> [args...]",
+		Short:  "Execute oscap-io with dropped capabilities (internal use only)",
+		Long:   "Internal command that drops all capabilities except CAP_SYS_CHROOT before executing oscap-io. This command should not be called directly by users.",
+		Hidden: true,
+		Args:   cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return cli.RunOscapExec(args)
+		},
+	}
+
+	return cmd
+}

--- a/pkg/compliance/cli/oscapexec.go
+++ b/pkg/compliance/cli/oscapexec.go
@@ -51,7 +51,7 @@ func RunOscapExec(args []string) error {
 	return nil
 }
 
-// dropCapabilities drops all capabilities except CAP_SYS_CHROOT
+// dropCapabilities drops all capabilities except CAP_SYS_CHROOT and CAP_DAC_OVERRIDE
 func dropCapabilities() error {
 	// Create a new capability set for the current process
 	caps, err := capability.NewPid2(0)
@@ -67,8 +67,8 @@ func dropCapabilities() error {
 	// Clear all capabilities in all sets
 	caps.Clear(capability.CAPS)
 
-	// Set CAP_SYS_CHROOT in all capability sets
-	caps.Set(capability.CAPS, capability.CAP_SYS_CHROOT)
+	// Set CAP_SYS_CHROOT and CAP_DAC_OVERRIDE in all capability sets
+	caps.Set(capability.CAPS, capability.CAP_SYS_CHROOT, capability.CAP_DAC_OVERRIDE)
 
 	// Apply the capability changes
 	if err := caps.Apply(capability.CAPS); err != nil {

--- a/pkg/compliance/cli/oscapexec.go
+++ b/pkg/compliance/cli/oscapexec.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/syndtr/gocapability/capability"
+	"golang.org/x/sys/unix"
+)
+
+// RunOscapExec executes oscap-io with dropped capabilities
+func RunOscapExec(args []string) error {
+	if len(args) < 1 {
+		return errors.New("oscap-exec requires at least one argument (binary path)")
+	}
+
+	binaryPath := args[0]
+	execArgs := args // args[0] will be the binary path (used as argv[0])
+
+	// Verify the binary exists
+	if _, err := os.Stat(binaryPath); err != nil {
+		return fmt.Errorf("oscap-io binary not found at %s: %w", binaryPath, err)
+	}
+
+	// Drop capabilities
+	if err := dropCapabilities(); err != nil {
+		return fmt.Errorf("failed to drop capabilities: %w", err)
+	}
+
+	// Set PR_SET_NO_NEW_PRIVS to prevent privilege escalation
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("failed to set PR_SET_NO_NEW_PRIVS: %w", err)
+	}
+
+	// Execute oscap-io (replaces current process)
+	// Note: syscall.Exec never returns on success
+	if err := syscall.Exec(binaryPath, execArgs, os.Environ()); err != nil {
+		return fmt.Errorf("failed to exec oscap-io at %s: %w", binaryPath, err)
+	}
+
+	// This line should never be reached
+	return nil
+}
+
+// dropCapabilities drops all capabilities except CAP_SYS_CHROOT
+func dropCapabilities() error {
+	// Create a new capability set for the current process
+	caps, err := capability.NewPid2(0)
+	if err != nil {
+		return fmt.Errorf("failed to create capability set: %w", err)
+	}
+
+	// Load current capabilities
+	if err := caps.Load(); err != nil {
+		return fmt.Errorf("failed to load capabilities: %w", err)
+	}
+
+	// Clear all capabilities in all sets
+	caps.Clear(capability.CAPS)
+
+	// Set CAP_SYS_CHROOT in all capability sets
+	caps.Set(capability.CAPS, capability.CAP_SYS_CHROOT)
+
+	// Apply the capability changes
+	if err := caps.Apply(capability.CAPS); err != nil {
+		return fmt.Errorf("failed to apply capability changes: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/compliance/evaluator_xccdf.go
+++ b/pkg/compliance/evaluator_xccdf.go
@@ -116,7 +116,9 @@ func (p *oscapIO) Run(ctx context.Context) error {
 		return err
 	}
 
-	cmd := exec.CommandContext(ctx, binPath, args...)
+	// Build command: /proc/self/exe compliance oscap-exec <oscap-io-path> [args...]
+	execArgs := append([]string{"compliance", "oscap-exec", binPath}, args...)
+	cmd := exec.CommandContext(ctx, "/proc/self/exe", execArgs...)
 	cmd.Dir = filepath.Dir(p.File)
 	cmd.Env = os.Environ()
 	if oscapProbeRoot != "" {


### PR DESCRIPTION
### What does this PR do?

This PR introduces an additional layer of security between the security-agent (or system-probe, whichever is running CSPM benchmarks) and openscap (oscap-io). Instead of launching openscap directly, the parent process is instead dropping capabilities first (keeping only the ones necessary for oscap-io to run correctly) and then finally launches oscap-io.

### Motivation

### Describe how you validated your changes

### Additional Notes
