### PR TITLE
Remove unnecessary gitlab test

### DIFF
--- a/.gitlab/build/source_test/linux.yml
+++ b/.gitlab/build/source_test/linux.yml
@@ -78,24 +78,6 @@ tests_nodetreemodel:
     # This env var enables the NTM config implementation
     DD_CONF_NODETREEMODEL: enable
 
-tests_nodetreemodel_unmarshal:
-  extends:
-    - .rtloader_tests
-    - .linux_tests
-    - .linux_x64
-  after_script:
-    - !reference [.upload_junit_source]
-    - !reference [.upload_coverage]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.except_disable_unit_tests]
-    - !reference [.fast_on_dev_branch_only]
-  variables:
-    CONDA_ENV: ddpy3
-    # This env var enables the pkg/config/structure to unmarshal config
-    DD_CONF_NODETREEMODEL: unmarshal
-
 tests_flavor_iot_linux-x64:
   extends:
     - .rtloader_tests


### PR DESCRIPTION
### What does this PR do?

Using the new common implementation between viper and NTM is not the default. Settting DD_CONF_NODETREEMODEL=unmarshal has not impact anymore, no need to keep the dedicated test case.