### PR TITLE
Add collection of AWS Spot preemption events

### DIFF
--- a/cmd/agent/dist/conf.d/cloud_hostinfo.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/cloud_hostinfo.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
+++ b/comp/metadata/inventoryhost/inventoryhostimpl/inventoryhost.go
@@ -254,7 +254,7 @@ func (ih *invHost) fillData() {
 	ih.data.DmiBoardAssetTag = dmi.GetBoardAssetTag()
 	ih.data.DmiBoardVendor = dmi.GetBoardVendor()
 
-	cloudProvider, cloudAccountID := cloudproviders.DetectCloudProvider(context.Background(), ih.conf.GetBool("inventories_collect_cloud_provider_account_id"), ih.log)
+	cloudProvider, cloudAccountID := cloudproviders.DetectCloudProvider(context.Background(), ih.conf.GetBool("inventories_collect_cloud_provider_account_id"))
 	ih.data.CloudProvider = cloudProvider
 	ih.data.CloudProviderAccountID = cloudAccountID
 

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package hostinfo implements a check that collects host-local information
+// from cloud provider metadata services (e.g., preemption events for spot instances).
+package hostinfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+// CheckName is the name of the check
+const CheckName = "cloud_hostinfo"
+
+// PreemptionEventType is the event type for preemption events
+const PreemptionEventType = "HostPreemption"
+
+// Check collects host information from cloud provider metadata services
+type Check struct {
+	core.CheckBase
+
+	cloudProvider         string
+	cloudProviderOnce     sync.Once
+	terminationTime       time.Time
+	preemptionUnsupported bool // Set to true when preemption detection is not supported or instance is not preemptible
+}
+
+// For testing purposes
+var (
+	detectCloudProviderFn      = cloudproviders.DetectCloudProvider
+	getPreemptionTerminationFn = cloudproviders.GetPreemptionTerminationTime
+	uptime                     = host.Uptime
+)
+
+// Factory creates a new check factory
+func Factory() option.Option[func() check.Check] {
+	return option.New(newCheck)
+}
+
+func newCheck() check.Check {
+	return &Check{
+		CheckBase: core.NewCheckBase(CheckName),
+	}
+}
+
+// Run executes the check
+func (c *Check) Run() error {
+	sender, err := c.GetSender()
+	if err != nil {
+		return fmt.Errorf("get sender: %w", err)
+	}
+
+	// Check for preemption events (e.g., AWS Spot, GCE Preemptible, Azure Spot)
+	c.checkPreemptionEvents(sender)
+
+	sender.Commit()
+
+	return nil
+}
+
+// checkPreemptionEvents checks for scheduled preemption termination and emits an event if found
+func (c *Check) checkPreemptionEvents(sender sender.Sender) {
+	ctx := context.Background()
+
+	// Detect cloud provider once, avoid blocking `Configure()`
+	c.cloudProviderOnce.Do(func() {
+		c.cloudProvider, _ = detectCloudProviderFn(ctx, false)
+	})
+	if c.cloudProvider == "" {
+		return
+	}
+
+	// If preemption is unsupported for this instance, don't poll
+	if c.preemptionUnsupported {
+		return
+	}
+
+	// If termination time is already set, don't check again
+	if !c.terminationTime.IsZero() {
+		return
+	}
+
+	terminationTime, err := getPreemptionTerminationFn(ctx, c.cloudProvider)
+	if err != nil {
+		// Check if we should stop polling for preemption events
+		if errors.Is(err, cloudproviders.ErrNotPreemptible) || errors.Is(err, cloudproviders.ErrPreemptionUnsupported) {
+			c.preemptionUnsupported = true
+			log.Debugf("Preemption detection disabled, cloud provider: %s, error: %s", c.cloudProvider, err)
+		}
+		log.Tracef("Preemption detection returned an error (usually expected), cloud provider: %s, error: %s", c.cloudProvider, err)
+		return
+	}
+
+	// Store termination time to avoid emitting duplicate events
+	c.terminationTime = terminationTime
+
+	// If termination time is in the past, don't emit event
+	timeUntilTermination := int(math.Ceil(time.Until(terminationTime).Seconds()))
+	if timeUntilTermination < 0 {
+		return
+	}
+
+	// Get current uptime for the event text
+	uptimeSeconds, err := uptime()
+	if err != nil {
+		log.Warnf("Could not retrieve uptime to enrich preemption event, error: %s", err)
+		uptimeSeconds = 0
+	}
+
+	// Emit event for preemption termination
+	ev := event.Event{
+		Title:          "Instance Preemption",
+		Text:           fmt.Sprintf("This instance is scheduled for preemption at: %s, uptime: %d seconds", terminationTime.UTC().Format(time.RFC3339), uptimeSeconds+uint64(timeUntilTermination)),
+		Priority:       event.PriorityNormal,
+		AlertType:      event.AlertTypeInfo,
+		SourceTypeName: "system",
+		EventType:      PreemptionEventType,
+	}
+	sender.Event(ev)
+	log.Infof("Instance preemption detected, will terminate at: %s", terminationTime.UTC().Format(time.RFC3339))
+}

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
@@ -1,0 +1,250 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hostinfo
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/metrics/event"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+)
+
+func uptimeSampler() (uint64, error) {
+	return 555, nil
+}
+
+func resetTestVars() {
+	detectCloudProviderFn = cloudproviders.DetectCloudProvider
+	getPreemptionTerminationFn = cloudproviders.GetPreemptionTerminationTime
+	uptime = host.Uptime
+}
+
+func TestHostInfoCheckNoCloudProvider(t *testing.T) {
+	defer resetTestVars()
+
+	// Mock cloud provider detection to return empty (no cloud provider)
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "", ""
+	}
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	// No Event should be sent when no cloud provider is detected
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 0)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostInfoCheckWithPreemptionTermination(t *testing.T) {
+	defer resetTestVars()
+
+	terminationTime := time.Now().Add(2 * time.Minute).UTC().Truncate(time.Second)
+
+	// Mock cloud provider detection to return AWS
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	// Mock preemption termination to return a scheduled termination
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return terminationTime, nil
+	}
+
+	// Mock uptime
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Event", mock.MatchedBy(func(ev event.Event) bool {
+		return ev.Title == "Instance Preemption" &&
+			ev.AlertType == event.AlertTypeInfo &&
+			ev.EventType == PreemptionEventType
+	})).Return().Times(1)
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostInfoCheckNoPreemptionScheduled(t *testing.T) {
+	defer resetTestVars()
+
+	// Mock cloud provider detection to return AWS
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	// Mock preemption termination to return no termination scheduled
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no preemption scheduled")
+	}
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	// No Event should be sent
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 0)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostInfoCheckPreemptionEventSentOnlyOnce(t *testing.T) {
+	defer resetTestVars()
+
+	terminationTime := time.Now().Add(2 * time.Minute).UTC().Truncate(time.Second)
+
+	// Mock cloud provider detection to return AWS
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	// Mock preemption termination to return a scheduled termination
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return terminationTime, nil
+	}
+
+	// Mock uptime
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	// Event should only be sent once
+	mockSender.On("Event", mock.MatchedBy(func(ev event.Event) bool {
+		return ev.Title == "Instance Preemption" &&
+			ev.AlertType == event.AlertTypeInfo &&
+			ev.EventType == PreemptionEventType
+	})).Return().Times(1)
+	mockSender.On("Commit").Return()
+
+	// Run the check twice
+	check.Run()
+	check.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 2)
+}
+
+func TestHostInfoCheckNotPreemptibleStopsPolling(t *testing.T) {
+	defer resetTestVars()
+
+	callCount := 0
+
+	// Mock cloud provider detection to return AWS
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	// Mock preemption termination to return ErrNotPreemptible
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		callCount++
+		return time.Time{}, cloudproviders.ErrNotPreemptible
+	}
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Commit").Return()
+
+	// Run the check three times
+	check.Run()
+	check.Run()
+	check.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 0)
+	mockSender.AssertNumberOfCalls(t, "Commit", 3)
+
+	// Preemption function should only be called once, then polling stops
+	if callCount != 1 {
+		t.Errorf("expected getPreemptionTerminationFn to be called 1 time, got %d", callCount)
+	}
+}
+
+func TestHostInfoCheckPreemptionUnsupportedStopsPolling(t *testing.T) {
+	defer resetTestVars()
+
+	callCount := 0
+
+	// Mock cloud provider detection to return an unsupported provider
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "UnsupportedCloud", ""
+	}
+
+	// Mock preemption termination to return ErrPreemptionUnsupported
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		callCount++
+		return time.Time{}, cloudproviders.ErrPreemptionUnsupported
+	}
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Commit").Return()
+
+	// Run the check three times
+	check.Run()
+	check.Run()
+	check.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 0)
+	mockSender.AssertNumberOfCalls(t, "Commit", 3)
+
+	// Preemption function should only be called once, then polling stops
+	if callCount != 1 {
+		t.Errorf("expected getPreemptionTerminationFn to be called 1 time, got %d", callCount)
+	}
+}

--- a/pkg/collector/corechecks/system/uptime/uptime.go
+++ b/pkg/collector/corechecks/system/uptime/uptime.go
@@ -17,7 +17,7 @@ import (
 // CheckName is the name of the check
 const CheckName = "uptime"
 
-// Check doesn't need additional fields
+// Check reports system uptime
 type Check struct {
 	core.CheckBase
 }

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -21,6 +21,7 @@ import (
 	snmpscanmanager "github.com/DataDog/datadog-agent/comp/snmpscanmanager/def"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/agentprofiling"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cloud/hostinfo"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetesapiserver"
@@ -77,6 +78,7 @@ func RegisterChecks(store workloadmeta.Component, filterStore workloadfilter.Com
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
+	corecheckLoader.RegisterCheck(hostinfo.CheckName, hostinfo.Factory())
 	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
 	corecheckLoader.RegisterCheck(wlan.CheckName, wlan.Factory())

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
-	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
 	configsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/kubelet"
@@ -47,25 +47,25 @@ var cloudProviderDetectors = []cloudProviderDetector{
 }
 
 // DetectCloudProvider detects the cloud provider where the agent is running in order:
-func DetectCloudProvider(ctx context.Context, collectAccountID bool, l logcomp.Component) (string, string) {
+func DetectCloudProvider(ctx context.Context, collectAccountID bool) (string, string) {
 	for _, cloudDetector := range cloudProviderDetectors {
 		if cloudDetector.callback(ctx) {
-			l.Infof("Cloud provider %s detected", cloudDetector.name)
+			log.Infof("Cloud provider %s detected", cloudDetector.name)
 
 			// fetch the account ID for this cloud provider
 			if collectAccountID && cloudDetector.accountIDCallback != nil {
 				accountID, err := cloudDetector.accountIDCallback(ctx)
 				if err != nil {
-					l.Debugf("Could not detect cloud provider account ID: %v", err)
+					log.Debugf("Could not detect cloud provider account ID: %v", err)
 				} else if accountID != "" {
-					l.Infof("Detecting cloud provider account ID from %s: %+q", cloudDetector.name, accountID)
+					log.Infof("Detecting cloud provider account ID from %s: %+q", cloudDetector.name, accountID)
 					return cloudDetector.name, accountID
 				}
 			}
 			return cloudDetector.name, ""
 		}
 	}
-	l.Info("No cloud provider detected")
+	log.Info("No cloud provider detected")
 	return "", ""
 }
 
@@ -129,8 +129,10 @@ var hostAliasesDetectors = []cloudProviderAliasesDetector{
 	{name: kubernetes.CloudProviderName, callback: kubernetes.GetHostAliases},
 }
 
-var hostAliasMutex = sync.Mutex{}
-var hostAliasLogOnce = true
+var (
+	hostAliasMutex   = sync.Mutex{}
+	hostAliasLogOnce = true
+)
 
 // GetHostAliases returns the hostname aliases and the name of the possible cloud providers
 func GetHostAliases(ctx context.Context) ([]string, string) {
@@ -295,4 +297,41 @@ func GetHostID(ctx context.Context, cloudProviderName string) string {
 		return callback(ctx)
 	}
 	return ""
+}
+
+type cloudProviderPreemptionDetector func(context.Context) (time.Time, error)
+
+var preemptionDetectors = map[string]cloudProviderPreemptionDetector{
+	ec2.CloudProviderName: ec2.GetSpotTerminationTime,
+}
+
+// ErrNotPreemptible is returned when the instance is not a preemptible instance
+// (e.g., not an AWS Spot instance, not a GCE Preemptible instance).
+// When this error is returned, callers should stop polling for preemption events.
+var ErrNotPreemptible = errors.New("instance is not preemptible")
+
+// ErrPreemptionUnsupported is returned when preemption detection is not supported
+// for the given cloud provider.
+var ErrPreemptionUnsupported = errors.New("preemption detection not supported for this cloud provider")
+
+// GetPreemptionTerminationTime returns the scheduled termination time for a preemptible instance
+// (e.g., AWS Spot, GCE Preemptible, Azure Spot).
+// Returns ErrNotPreemptible if the instance is not preemptible.
+// Returns ErrPreemptionUnsupported if the cloud provider doesn't support preemption detection.
+// For now only EC2 is supported.
+func GetPreemptionTerminationTime(ctx context.Context, cloudProviderName string) (time.Time, error) {
+	callback, found := preemptionDetectors[cloudProviderName]
+	if !found {
+		return time.Time{}, ErrPreemptionUnsupported
+	}
+
+	terminationTime, err := callback(ctx)
+	if err != nil {
+		// Map cloud-provider-specific errors to generic errors
+		if errors.Is(err, ec2.ErrNotSpotInstance) {
+			return time.Time{}, ErrNotPreemptible
+		}
+		return time.Time{}, err
+	}
+	return terminationTime, nil
 }

--- a/pkg/util/cloudproviders/cloudproviders_test.go
+++ b/pkg/util/cloudproviders/cloudproviders_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 
@@ -167,5 +168,63 @@ func TestCloudProviderInstanceType(t *testing.T) {
 	assert.False(t, detector1Called, "instance type callback for 'detector1' should not be called")
 	assert.False(t, detector2Called, "instance type callback for 'detector2' should not be called")
 	assert.Equal(t, "", instanceType)
+	clearDetectors()
+}
+
+func TestCloudProviderPreemptionTerminationTime(t *testing.T) {
+	origDetectors := preemptionDetectors
+	defer func() { preemptionDetectors = origDetectors }()
+
+	expectedTime := time.Now()
+
+	detector1Called := false
+	detector2Called := false
+	clearDetectors := func() {
+		detector1Called = false
+		detector2Called = false
+	}
+
+	preemptionDetectors = map[string]cloudProviderPreemptionDetector{
+		"detector1": func(_ context.Context) (time.Time, error) {
+			detector1Called = true
+			return expectedTime, nil
+		},
+		"detector2": func(_ context.Context) (time.Time, error) {
+			detector2Called = true
+			return time.Time{}, errors.New("no preemption scheduled")
+		},
+	}
+
+	// Case 1: known cloud provider "detector1" with termination scheduled
+	terminationTime, err := GetPreemptionTerminationTime(context.TODO(), "detector1")
+	assert.True(t, detector1Called, "preemption callback for 'detector1' was not called")
+	assert.False(t, detector2Called, "preemption callback for 'detector2' should not be called")
+	require.NoError(t, err)
+	assert.Equal(t, expectedTime, terminationTime)
+	clearDetectors()
+
+	// Case 2: known cloud provider "detector2" with no termination scheduled (returns error)
+	terminationTime, err = GetPreemptionTerminationTime(context.TODO(), "detector2")
+	assert.False(t, detector1Called, "preemption callback for 'detector1' should not be called")
+	assert.True(t, detector2Called, "preemption callback for 'detector2' was not called")
+	require.Error(t, err)
+	assert.Equal(t, time.Time{}, terminationTime)
+	clearDetectors()
+
+	// Case 3: unknown provider should return error
+	terminationTime, err = GetPreemptionTerminationTime(context.TODO(), "unknown")
+	assert.False(t, detector1Called, "preemption callback for 'detector1' should not be called")
+	assert.False(t, detector2Called, "preemption callback for 'detector2' should not be called")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+	assert.Equal(t, time.Time{}, terminationTime)
+	clearDetectors()
+
+	// Case 4: empty cloud provider should return error
+	terminationTime, err = GetPreemptionTerminationTime(context.TODO(), "")
+	assert.False(t, detector1Called, "preemption callback for 'detector1' should not be called")
+	assert.False(t, detector2Called, "preemption callback for 'detector2' should not be called")
+	require.Error(t, err)
+	assert.Equal(t, time.Time{}, terminationTime)
 	clearDetectors()
 }

--- a/pkg/util/ec2/spot.go
+++ b/pkg/util/ec2/spot.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ec2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
+	ec2internal "github.com/DataDog/datadog-agent/pkg/util/ec2/internal"
+)
+
+const (
+	imdsSpotInstanceAction = "/spot/instance-action"
+	imdsInstanceLifeCycle  = "/instance-life-cycle"
+	instanceLifeCycleSpot  = "spot"
+)
+
+// ErrNotSpotInstance is returned when the instance is not a spot instance
+var ErrNotSpotInstance = errors.New("instance is not a spot instance")
+
+// spotInstanceAction represents the response from the spot/instance-action IMDS endpoint
+type spotInstanceAction struct {
+	Action string `json:"action"`
+	Time   string `json:"time"`
+}
+
+var instanceLifeCycleFetcher = cachedfetch.Fetcher{
+	Name: "EC2 Instance Life Cycle",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return ec2internal.GetMetadataItem(ctx, imdsInstanceLifeCycle, ec2internal.UseIMDSv2(), false)
+	},
+}
+
+// IsSpotInstance returns true if the current EC2 instance is a spot instance
+func IsSpotInstance(ctx context.Context) (bool, error) {
+	lifecycle, err := instanceLifeCycleFetcher.FetchString(ctx)
+	if err != nil {
+		return false, fmt.Errorf("unable to retrieve instance-life-cycle from IMDS: %w", err)
+	}
+	return lifecycle == instanceLifeCycleSpot, nil
+}
+
+// GetSpotTerminationTime returns the scheduled termination time for a spot instance.
+// If the instance is not a spot instance, it returns ErrNotSpotInstance.
+// If no termination is scheduled, it returns an error (typically a 404 from IMDS).
+// Docs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-instance-termination-notices.html
+func GetSpotTerminationTime(ctx context.Context) (time.Time, error) {
+	// First check if this is a spot instance
+	isSpot, err := IsSpotInstance(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to determine instance type: %w", err)
+	}
+	if !isSpot {
+		return time.Time{}, ErrNotSpotInstance
+	}
+
+	res, err := ec2internal.GetMetadataItem(ctx, imdsSpotInstanceAction, ec2internal.UseIMDSv2(), false)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to retrieve spot instance-action from IMDS: %w", err)
+	}
+
+	var action spotInstanceAction
+	if err := json.Unmarshal([]byte(res), &action); err != nil {
+		return time.Time{}, fmt.Errorf("unable to parse spot instance-action response: %w", err)
+	}
+
+	terminationTime, err := time.Parse(time.RFC3339, action.Time)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to parse termination time %q: %w", action.Time, err)
+	}
+
+	return terminationTime, nil
+}

--- a/pkg/util/ec2/spot_test.go
+++ b/pkg/util/ec2/spot_test.go
@@ -1,0 +1,212 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ec2
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	ec2internal "github.com/DataDog/datadog-agent/pkg/util/ec2/internal"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+)
+
+func resetSpotTestVars() {
+	instanceLifeCycleFetcher.Reset()
+	resetPackageVars()
+}
+
+func TestIsSpotInstance(t *testing.T) {
+	ctx := context.Background()
+	configmock.New(t)
+
+	tests := []struct {
+		name         string
+		lifecycle    string
+		responseCode int
+		expected     bool
+		expectError  bool
+	}{
+		{
+			name:         "spot instance",
+			lifecycle:    "spot",
+			responseCode: http.StatusOK,
+			expected:     true,
+			expectError:  false,
+		},
+		{
+			name:         "on-demand instance",
+			lifecycle:    "on-demand",
+			responseCode: http.StatusOK,
+			expected:     false,
+			expectError:  false,
+		},
+		{
+			name:         "scheduled instance",
+			lifecycle:    "scheduled",
+			responseCode: http.StatusOK,
+			expected:     false,
+			expectError:  false,
+		},
+		{
+			name:         "IMDS error",
+			lifecycle:    "",
+			responseCode: http.StatusNotFound,
+			expected:     false,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPut:
+					io.WriteString(w, testIMDSToken)
+				case http.MethodGet:
+					if tt.responseCode != http.StatusOK {
+						w.WriteHeader(tt.responseCode)
+						return
+					}
+					io.WriteString(w, tt.lifecycle)
+				}
+			}))
+			defer ts.Close()
+
+			ec2internal.MetadataURL = ts.URL
+			ec2internal.TokenURL = ts.URL
+			ec2internal.Token = httputils.NewAPIToken(ec2internal.GetToken)
+			defer resetSpotTestVars()
+
+			isSpot, err := IsSpotInstance(ctx)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, isSpot)
+			}
+		})
+	}
+}
+
+func TestGetSpotTerminationTime(t *testing.T) {
+	ctx := context.Background()
+	configmock.New(t)
+
+	tests := []struct {
+		name               string
+		instanceLifeCycle  string
+		spotActionCode     int
+		spotActionBody     string
+		expectedTime       time.Time
+		expectError        bool
+		expectNotSpotError bool
+		errorContains      string
+	}{
+		{
+			name:              "valid termination notice",
+			instanceLifeCycle: "spot",
+			spotActionCode:    http.StatusOK,
+			spotActionBody:    `{"action": "terminate", "time": "2017-09-18T08:22:00Z"}`,
+			expectedTime:      time.Date(2017, 9, 18, 8, 22, 0, 0, time.UTC),
+			expectError:       false,
+		},
+		{
+			name:              "valid termination notice with stop action",
+			instanceLifeCycle: "spot",
+			spotActionCode:    http.StatusOK,
+			spotActionBody:    `{"action": "stop", "time": "2024-01-15T12:30:00Z"}`,
+			expectedTime:      time.Date(2024, 1, 15, 12, 30, 0, 0, time.UTC),
+			expectError:       false,
+		},
+		{
+			name:              "no spot termination scheduled (404)",
+			instanceLifeCycle: "spot",
+			spotActionCode:    http.StatusNotFound,
+			spotActionBody:    "",
+			expectError:       true,
+			errorContains:     "unable to retrieve spot instance-action",
+		},
+		{
+			name:              "invalid JSON response",
+			instanceLifeCycle: "spot",
+			spotActionCode:    http.StatusOK,
+			spotActionBody:    `not valid json`,
+			expectError:       true,
+			errorContains:     "unable to parse spot instance-action response",
+		},
+		{
+			name:              "invalid time format",
+			instanceLifeCycle: "spot",
+			spotActionCode:    http.StatusOK,
+			spotActionBody:    `{"action": "terminate", "time": "invalid-time"}`,
+			expectError:       true,
+			errorContains:     "unable to parse termination time",
+		},
+		{
+			name:               "not a spot instance",
+			instanceLifeCycle:  "on-demand",
+			spotActionCode:     http.StatusOK,
+			spotActionBody:     `{"action": "terminate", "time": "2017-09-18T08:22:00Z"}`,
+			expectError:        true,
+			expectNotSpotError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodPut:
+					// Token request
+					io.WriteString(w, testIMDSToken)
+				case http.MethodGet:
+					// Route based on URL path
+					if strings.HasSuffix(r.URL.Path, "/instance-life-cycle") {
+						io.WriteString(w, tt.instanceLifeCycle)
+					} else if strings.HasSuffix(r.URL.Path, "/spot/instance-action") {
+						if tt.spotActionCode != http.StatusOK {
+							w.WriteHeader(tt.spotActionCode)
+							return
+						}
+						io.WriteString(w, tt.spotActionBody)
+					}
+				}
+			}))
+			defer ts.Close()
+
+			ec2internal.MetadataURL = ts.URL
+			ec2internal.TokenURL = ts.URL
+			ec2internal.Token = httputils.NewAPIToken(ec2internal.GetToken)
+			defer resetSpotTestVars()
+
+			terminationTime, err := GetSpotTerminationTime(ctx)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.expectNotSpotError {
+					assert.True(t, errors.Is(err, ErrNotSpotInstance), "expected ErrNotSpotInstance, got: %v", err)
+				} else {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTime, terminationTime)
+			}
+		})
+	}
+}

--- a/releasenotes/notes/preemption-events-4f6a0715d9ff63cb.yaml
+++ b/releasenotes/notes/preemption-events-4f6a0715d9ff63cb.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Datadog Agent now collects AWS Spot preemption events (requires IMDS access) as Datadog events.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -91,6 +91,7 @@ AGENT_CORECHECKS = [
     "versa",
     "network_config_management",
     "battery",
+    "cloud_hostinfo",
 ]
 
 WINDOWS_CORECHECKS = [


### PR DESCRIPTION
### What does this PR do?

Add collection of AWS Spot preemption events. They are normally available 2 minutes before actual preemption, we are checking for preemption every 15s through the `uptime` check.

### Motivation

Provide better insights on Spot instances.

### Describe how you validated your changes

Deploy the Agent on AWS host, with IMDS access, trigger a preemption through Spot request management, the event should show up in Datadog.

<img width="940" height="67" alt="image" src="https://github.com/user-attachments/assets/cb194f9e-c5bf-4033-adc2-31c0d4672b8d" />

### Additional Notes
