### PR TITLE
Display relevant category failures on PR comments for static quality gates

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -461,7 +461,6 @@ def display_pr_comment(
         if gate["error_type"] is None:
             if is_neutral:
                 # Neutral changes go to collapsed section (just show current size)
-                gate_metrics = metric_handler.metrics.get(gate['name'], {})
                 current_disk = gate_metrics.get("current_on_disk_size")
                 if current_disk is not None:
                     current_mib = current_disk / (1024 * 1024)

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -342,8 +342,8 @@ def get_change_metrics(
 
     # Build limit bounds string based on whether change is neutral
     if is_neutral:
-        # For neutral changes, just show the current size (bolded)
-        limit_bounds_str = f"**{current_mib:.3f}** MiB"
+        # For neutral changes, show the current size (bolded) → limit
+        limit_bounds_str = f"**{current_mib:.3f}** MiB → {max_mib:.3f}"
     elif baseline_mib is not None:
         # For meaningful changes, show: baseline → current (bold) → limit
         limit_bounds_str = f"{baseline_mib:.3f} → **{current_mib:.3f}** → {max_mib:.3f}"

--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -1468,8 +1468,8 @@ class TestGetChangeMetrics(unittest.TestCase):
 
         self.assertEqual("neutral", change_str)
         self.assertTrue(is_neutral)
-        # Neutral shows only current size (bolded), no arrows
-        self.assertEqual("**150.000** MiB", limit_bounds)
+        # Neutral shows current size and upper bound
+        self.assertEqual("**150.000** MiB → 200.000", limit_bounds)
 
     def test_small_delta_below_threshold_neutral(self):
         """Should show neutral when delta is below 2 KiB threshold."""
@@ -1483,10 +1483,8 @@ class TestGetChangeMetrics(unittest.TestCase):
 
         self.assertEqual("neutral", change_str)
         self.assertTrue(is_neutral)
-        # Neutral shows only current size (bolded), no arrows
-        self.assertIn("**", limit_bounds)
-        self.assertIn("MiB", limit_bounds)
-        self.assertNotIn("→", limit_bounds)
+        # Neutral shows current size and upper bound
+        self.assertEqual("**150.000** MiB → 200.000", limit_bounds)
 
     def test_small_delta_kib_above_threshold(self):
         """Should show delta in KiB for changes above threshold."""
@@ -1579,8 +1577,8 @@ class TestGetWireChangeMetrics(unittest.TestCase):
 
         self.assertEqual("neutral", change_str)
         self.assertTrue(is_neutral)
-        self.assertIn("**", limit_bounds)
-        self.assertNotIn("→", limit_bounds)
+        # Neutral shows current size and upper bound
+        self.assertEqual("**100.000** MiB → 150.000", limit_bounds)
 
     def test_missing_gate(self):
         """Should return N/A when gate is not found."""

--- a/tasks/unit_tests/static_quality_gates_tests.py
+++ b/tasks/unit_tests/static_quality_gates_tests.py
@@ -1071,6 +1071,54 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         wire_section_start = body.find('On-wire sizes (compressed)')
         self.assertIn('gateA', body[wire_section_start:])
 
+    @patch("tasks.quality_gates.pr_commenter")
+    def test_error_on_wire_displays_uncollapsed_on_error_section(self, pr_commenter_mock):
+        """Test that when only the on-wire size is violating a specific gate
+        (and not the on-disk size for that same gate),
+        The uncollapsed error actually shows the data for the on-wire size violation (only)."""
+        c = MockContext()
+        gate_metric_handler = GateMetricHandler("main", "dev")
+
+        # current-on-disk < max-on-disk and current-on-wire > max-on-wire
+        gate_metric_handler.metrics["gateA"] = {
+            "current_on_disk_size": 95 * 1024 * 1024,
+            "max_on_disk_size": 100 * 1024 * 1024,
+            "relative_on_disk_size": 5 * 1024 * 1024,
+            "current_on_wire_size": 50 * 1024 * 1024,
+            "max_on_wire_size": 49 * 1024 * 1024,
+            "relative_on_wire_size": 2 * 1024 * 1024,
+        }
+
+        mock_pr = MagicMock()
+        mock_pr.number = 12345
+        display_pr_comment(
+            c,
+            False,
+            [
+                {'name': 'gateA', 'error_type': 'AssertionError', 'message': 'some_msg_A'},
+            ],
+            gate_metric_handler,
+            "value",
+            mock_pr,
+        )
+        pr_commenter_mock.assert_called_once()
+        call_args = pr_commenter_mock.call_args
+        body = call_args[1]['body']
+        expected = "\n".join(
+            [
+                "||Quality gate|Change|Size (prev → **curr** → max)|",
+                "|--|--|--|--|",
+                "|❌|gateA (on wire)|+2.0 MiB (4.17% increase)|48.000 → **50.000** → 49.000|",
+                "<details>",
+                "<summary>Gate failure full details</summary>",
+                "",
+                "|Quality gate|Error type|Error message|",
+                "|----|---|--------|",
+                "|gateA|AssertionError|some_msg_A|",
+            ]
+        )
+        self.assertIn(expected.strip(), body)
+
 
 class TestOnDiskImageSizeCalculation(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
### What does this PR do?

For static quality gates comments, it handles the case where an on-wire gate is violated (and the on-disk variant is not), such that it prominently displays the relevant data instead of the on-disk size.

It also adds the upper bound on "neutral" results, to make the more informative, and due to what's shown in the Motivation section below.

### Motivation

Users reported misleading info, where a violation of an on-wire gate resulted on the data about the on-disk being displayed in the uncollapsed section, with no obvious sign of what's wrong:
([link to comment](https://github.com/DataDog/datadog-agent/pull/45233#issuecomment-3769462337))
<img width="752" height="260" alt="image" src="https://github.com/user-attachments/assets/5c9c322c-5be6-4781-a691-887c70a9debd" />

After the first iteration of this change, I realized that not showing the upper bound for neutral changes leads again to unhelpful information being shown:

<img width="496" height="94" alt="image" src="https://github.com/user-attachments/assets/1c09a4d6-e50b-45e4-aa47-53ca6f588a26" />

### Describe how you validated your changes

Ran existing test suite and added a test for this specific case.

### Additional Notes
