### PR TITLE
discovery: Fix flake in fallback test

### DIFF
--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -163,6 +163,11 @@ filegroup(
     srcs = glob(["testdata/**/*"]),
 )
 
+filegroup(
+    name = "mock_system_probe",
+    srcs = ["testdata/fallback/mock-system-probe.sh"],
+)
+
 # Unit tests embedded in source files
 rust_test(
     name = "dd_discovery_test",
@@ -184,13 +189,16 @@ rust_test(
 rust_test(
     name = "fallback_integration_test",
     srcs = ["tests/fallback_integration_test.rs"],
-    # Make the sd-agent binary available to the test at runtime
-    data = [":sd-agent"],
+    data = [
+        ":mock_system_probe",
+        ":sd-agent",
+    ],
     edition = "2024",
     # Set compile-time environment variable pointing to sd-agent binary
     # This mimics Cargo's CARGO_BIN_EXE_* behavior
     rustc_env = {
         "CARGO_BIN_EXE_sd-agent": "$(rootpath :sd-agent)",
+        "MOCK_SYSTEM_PROBE": "$(rootpath :mock_system_probe)",
     },
     deps = [
         "@crates//:tempfile",

--- a/pkg/discovery/module/rust/testdata/fallback/mock-system-probe.sh
+++ b/pkg/discovery/module/rust/testdata/fallback/mock-system-probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Mock system-probe that echoes arguments to a marker file
+# Usage: mock-system-probe.sh <marker_file> [args...]
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <marker_file> [args...]" >&2
+  exit 1
+fi
+
+marker_file="$1"
+shift
+
+echo "system-probe called with args: " "$@" > "$marker_file"
+exit 0


### PR DESCRIPTION
There is a subtle race when the fallback tests are run in parallel which
leads to sd-agent sometimes failing to execute the mock system-probe
script due to ETXTBSY: if a fork(2) happens in some other thread while
the script file is open (for writing), then that child could continue
holding the fd open for a short while leading to the execution of the
script to fail (in a different child) with ETXTBSY (see this JDK issue
for a discussion of a similar problem:
https://bugs.openjdk.org/browse/JDK-8068370).

Fix it by just using a static script for the mock system-probe.
