### PR TITLE
[EBPF-1031] gpu: fix core and memory reporting in MIG devices

### DIFF
--- a/pkg/gpu/integrationtests/mig_test.go
+++ b/pkg/gpu/integrationtests/mig_test.go
@@ -66,7 +66,6 @@ func TestMIGParentChildCoreCount(t *testing.T) {
 		physDev, ok := device.(*safenvml.PhysicalDevice)
 		require.True(t, ok, "Device should be a PhysicalDevice")
 
-
 		if !physDev.HasMIGFeatureEnabled || len(physDev.MIGChildren) == 0 {
 			t.Logf("Physical device %s has no MIG children, core count is %d", physDev.GetDeviceInfo().UUID, physDev.GetDeviceInfo().CoreCount)
 			continue

--- a/pkg/gpu/integrationtests/mig_test.go
+++ b/pkg/gpu/integrationtests/mig_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package integrationtests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+)
+
+func requireMIGTests(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("RUN_MIG_TESTS") == "" {
+		t.Skip("Skipping MIG tests: RUN_MIG_TESTS environment variable not set")
+	}
+}
+
+// TestMIGDeviceListing tests that MIG devices can be listed and have valid properties.
+func TestMIGDeviceListing(t *testing.T) {
+	testutil.RequireGPU(t)
+	requireMIGTests(t)
+
+	lib := initNVML(t)
+	cache := safenvml.NewDeviceCache(safenvml.WithDeviceCacheLib(lib))
+
+	migDevices, err := cache.AllMigDevices()
+	require.NoError(t, err, "Should be able to get MIG devices")
+	require.NotEmpty(t, migDevices, "Should have at least one MIG device")
+
+	for _, device := range migDevices {
+		info := device.GetDeviceInfo()
+		t.Logf("MIG device %s has %d cores", info.UUID, info.CoreCount)
+		require.NotEmpty(t, info.UUID, "MIG device UUID should not be empty")
+		require.NotEmpty(t, info.Name, "MIG device name should not be empty")
+
+		// We cannot know for sure the real expected value, but we can be sure that it's greater than 500. This way we avoid
+		// issues when we're just reporing the number of multiprocessors instead of the actual number of cores.
+		require.Greater(t, info.CoreCount, 500, "MIG device should have more than 500 cores")
+	}
+}
+
+// TestMIGParentChildCoreCount tests that the parent device's core count equals
+// the sum of its MIG children's core counts.
+func TestMIGParentChildCoreCount(t *testing.T) {
+	testutil.RequireGPU(t)
+	requireMIGTests(t)
+
+	lib := initNVML(t)
+	cache := safenvml.NewDeviceCache(safenvml.WithDeviceCacheLib(lib))
+
+	physicalDevices, err := cache.AllPhysicalDevices()
+	require.NoError(t, err, "Should be able to get physical devices")
+
+	foundMIGParent := false
+	for _, device := range physicalDevices {
+		physDev, ok := device.(*safenvml.PhysicalDevice)
+		require.True(t, ok, "Device should be a PhysicalDevice")
+
+
+		if !physDev.HasMIGFeatureEnabled || len(physDev.MIGChildren) == 0 {
+			t.Logf("Physical device %s has no MIG children, core count is %d", physDev.GetDeviceInfo().UUID, physDev.GetDeviceInfo().CoreCount)
+			continue
+		}
+
+		foundMIGParent = true
+		parentInfo := physDev.GetDeviceInfo()
+
+		childCoreSum := 0
+		for _, migChild := range physDev.MIGChildren {
+			childInfo := migChild.GetDeviceInfo()
+			childCoreSum += childInfo.CoreCount
+		}
+
+		require.Equal(t, parentInfo.CoreCount, childCoreSum,
+			"Parent device core count should equal sum of MIG children core counts")
+		t.Logf("Parent device %s has %d cores, sum of MIG children core counts is %d", parentInfo.UUID, parentInfo.CoreCount, childCoreSum)
+	}
+
+	require.True(t, foundMIGParent, "Should have at least one physical device with MIG enabled and children")
+}

--- a/pkg/gpu/integrationtests/mig_test.go
+++ b/pkg/gpu/integrationtests/mig_test.go
@@ -44,7 +44,7 @@ func TestMIGDeviceListing(t *testing.T) {
 		require.NotEmpty(t, info.Name, "MIG device name should not be empty")
 
 		// We cannot know for sure the real expected value, but we can be sure that it's greater than 500. This way we avoid
-		// issues when we're just reporing the number of multiprocessors instead of the actual number of cores.
+		// issues when we're just reporting the number of multiprocessors instead of the actual number of cores.
 		require.Greater(t, info.CoreCount, 500, "MIG device should have more than 500 cores")
 	}
 }

--- a/pkg/gpu/safenvml/cache_test.go
+++ b/pkg/gpu/safenvml/cache_test.go
@@ -210,7 +210,7 @@ func TestDeviceCacheAllPhysicalDevices(t *testing.T) {
 
 	for i, device := range physicalDevices {
 		require.Equal(t, testutil.GPUUUIDs[i], device.GetDeviceInfo().UUID)
-		require.Equal(t, testutil.GPUCores[i], device.GetDeviceInfo().CoreCount)
+		require.Equal(t, testutil.GPUCores[i], device.GetDeviceInfo().CoreCount, "device %d core count incorrect", i)
 		require.Equal(t, i, device.GetDeviceInfo().Index)
 	}
 }

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -45,8 +45,6 @@ type SafeDevice interface {
 	// GetGpuInstanceId returns the GPU instance ID for MIG devices
 	//nolint:revive // Maintaining consistency with go-nvml API naming
 	GetGpuInstanceId() (int, error)
-	// GetGpuInstancePossiblePlacements returns possible placements for a GPU instance profile
-	GetGpuInstancePossiblePlacements(info *nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstancePlacement, error)
 	// GetGpuInstanceProfileInfo returns the profile info for the given GPU instance profile ID
 	GetGpuInstanceProfileInfo(profile int) (nvml.GpuInstanceProfileInfo, error)
 	// GetIndex returns the index of the device

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -45,6 +45,10 @@ type SafeDevice interface {
 	// GetGpuInstanceId returns the GPU instance ID for MIG devices
 	//nolint:revive // Maintaining consistency with go-nvml API naming
 	GetGpuInstanceId() (int, error)
+	// GetGpuInstancePossiblePlacements returns possible placements for a GPU instance profile
+	GetGpuInstancePossiblePlacements(info *nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstancePlacement, error)
+	// GetGpuInstanceProfileInfo returns the profile info for the given GPU instance profile ID
+	GetGpuInstanceProfileInfo(profile int) (nvml.GpuInstanceProfileInfo, error)
 	// GetIndex returns the index of the device
 	GetIndex() (int, error)
 	// GetMaxClockInfo returns the maximum clock speed for the given clock type
@@ -205,12 +209,30 @@ func NewPhysicalDevice(dev nvml.Device) (*PhysicalDevice, error) {
 			return nil, err
 		}
 
-		// If the device is MIG enabled, we need to sum the memory and core count of all its children
-		// because the corresponding APIs we use below return "UNKNOWN_ERROR"
-		for _, migChild := range device.MIGChildren {
-			device.Memory += migChild.Memory
-			device.CoreCount += migChild.CoreCount
+		// If the device is MIG enabled, we cannot know the memory and core
+		// count of the device directly. However, we can query one of the MIG
+		// profiles, and see how many of them fit into the device. An important
+		// thing to note is that this can return a lower number of cores than
+		// what the device without MIG reports, at least in A100 devices.
+		// There's no official documentation that mentions why this is, but
+		// there are references to some compute instances being "reserved" for
+		// other purposes in NVIDIA's official docs: For example,
+		// https://docs.nvidia.com/datacenter/tesla/mig-user-guide/concepts.html
+		// mentions that memory slices are "one eighth" of the total memory,
+		// while compute slices are "one seventh". In both cases, it's mentioned
+		// that it's "roughly" that partition.
+		//
+		// However, it's still a reasonable approximation, specially because
+		// using the instance profiles will give us the total capacity available
+		// to MIG instances, without reporting cores that can never be used when
+		// MIG is enabled.
+		profileInfo, err := device.SafeDevice.GetGpuInstanceProfileInfo(0)
+		if err != nil {
+			return nil, fmt.Errorf("error getting MIG device profile info: %w", err)
 		}
+
+		device.Memory = uint64(profileInfo.MemorySizeMB) * 1024 * 1024 * uint64(profileInfo.InstanceCount)
+		device.CoreCount = int(profileInfo.MultiprocessorCount) * int(profileInfo.InstanceCount) * coresPerMultiprocessor(device.Architecture)
 	} else {
 		cores, err := device.SafeDevice.GetNumGpuCores()
 		if err != nil {
@@ -256,6 +278,7 @@ func (d *PhysicalDevice) fillMigChildren() error {
 		migChildDevice.SMVersion = d.SMVersion
 		migChildDevice.Parent = d
 		migChildDevice.Architecture = d.Architecture
+		migChildDevice.CoreCount *= coresPerMultiprocessor(d.Architecture)
 
 		gpuInstanceID, err := migChildDevice.GetGpuInstanceId()
 		if err != nil {
@@ -336,4 +359,14 @@ func (d *DeviceInfo) fillPhysicalDeviceData(dev SafeDevice) error {
 	d.SMVersion = uint32(major*10 + minor)
 
 	return nil
+}
+
+// coresPerMultiprocessor returns the number of cores per multiprocessor for a given SM version. It's a fallback
+// for MIG-enabled devices where the API doesn't work. For that reason, it only returns values for SM versions
+// that support MIG
+func coresPerMultiprocessor(arch nvml.DeviceArchitecture) int {
+	if arch <= nvml.DEVICE_ARCH_AMPERE {
+		return 64
+	}
+	return 128
 }

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -115,6 +115,22 @@ func (d *safeDeviceImpl) GetGpuInstanceId() (int, error) {
 	return id, NewNvmlAPIErrorOrNil("GetGpuInstanceId", ret)
 }
 
+func (d *safeDeviceImpl) GetGpuInstancePossiblePlacements(info *nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstancePlacement, error) {
+	if err := d.lib.lookup(toNativeName("GetGpuInstancePossiblePlacements")); err != nil {
+		return nil, err
+	}
+	placements, ret := d.nvmlDevice.GetGpuInstancePossiblePlacements(info)
+	return placements, NewNvmlAPIErrorOrNil("GetGpuInstancePossiblePlacements", ret)
+}
+
+func (d *safeDeviceImpl) GetGpuInstanceProfileInfo(profile int) (nvml.GpuInstanceProfileInfo, error) {
+	if err := d.lib.lookup(toNativeName("GetGpuInstanceProfileInfo")); err != nil {
+		return nvml.GpuInstanceProfileInfo{}, err
+	}
+	info, ret := d.nvmlDevice.GetGpuInstanceProfileInfo(profile)
+	return info, NewNvmlAPIErrorOrNil("GetGpuInstanceProfileInfo", ret)
+}
+
 func (d *safeDeviceImpl) GetIndex() (int, error) {
 	if err := d.lib.lookup(toNativeName("GetIndex")); err != nil {
 		return 0, err

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -115,14 +115,6 @@ func (d *safeDeviceImpl) GetGpuInstanceId() (int, error) {
 	return id, NewNvmlAPIErrorOrNil("GetGpuInstanceId", ret)
 }
 
-func (d *safeDeviceImpl) GetGpuInstancePossiblePlacements(info *nvml.GpuInstanceProfileInfo) ([]nvml.GpuInstancePlacement, error) {
-	if err := d.lib.lookup(toNativeName("GetGpuInstancePossiblePlacements")); err != nil {
-		return nil, err
-	}
-	placements, ret := d.nvmlDevice.GetGpuInstancePossiblePlacements(info)
-	return placements, NewNvmlAPIErrorOrNil("GetGpuInstancePossiblePlacements", ret)
-}
-
 func (d *safeDeviceImpl) GetGpuInstanceProfileInfo(profile int) (nvml.GpuInstanceProfileInfo, error) {
 	if err := d.lib.lookup(toNativeName("GetGpuInstanceProfileInfo")); err != nil {
 		return nvml.GpuInstanceProfileInfo{}, err

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -66,7 +66,6 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetFanSpeed"),
 		toNativeName("GetFieldValues"),
 		toNativeName("GetGpuInstanceId"),
-		toNativeName("GetGpuInstancePossiblePlacements"),
 		toNativeName("GetGpuInstanceProfileInfo"),
 		toNativeName("GetMaxClockInfo"),
 		toNativeName("GetMaxMigDeviceCount"),

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -66,6 +66,8 @@ func getNonCriticalAPIs() []string {
 		toNativeName("GetFanSpeed"),
 		toNativeName("GetFieldValues"),
 		toNativeName("GetGpuInstanceId"),
+		toNativeName("GetGpuInstancePossiblePlacements"),
+		toNativeName("GetGpuInstanceProfileInfo"),
 		toNativeName("GetMaxClockInfo"),
 		toNativeName("GetMaxMigDeviceCount"),
 		toNativeName("GetMemoryBusWidth"),

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -344,8 +344,8 @@ func TestGetStatsNormalization(t *testing.T) {
 	// Create two processes that each use 80% of GPU cores and 60% of memory
 	pid1 := uint32(1)
 	pid2 := uint32(2)
-	numThreads := uint64(testutil.DefaultGpuCores * 0.8)
-	memSize := uint64(float64(testutil.DefaultTotalMemory) * 0.6)
+	numThreads := uint64(testutil.DefaultGpuCores * 8 / 10)
+	memSize := uint64(testutil.DefaultTotalMemory * 6 / 10)
 
 	// Add kernels and memory allocations for both processes
 	for _, pid := range []uint32{pid1, pid2} {

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -187,6 +187,9 @@ func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Devi
 			return nvml.EventTypeAll, nvml.SUCCESS
 		},
 		GetGpuInstanceProfileInfoFunc: func(profile int) (nvml.GpuInstanceProfileInfo, nvml.Return) {
+			if profile != 0 {
+				return nvml.GpuInstanceProfileInfo{}, nvml.ERROR_INVALID_ARGUMENT
+			}
 			return DefaultMIGProfileInfo, nvml.SUCCESS
 		},
 	}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -101,6 +101,13 @@ var MIGChildrenUUIDs = map[int][]string{
 	6: {"MIG-22222222-1234-1234-1234-123456789014", "MIG-33333333-1234-1234-1234-123456789015", "MIG-44444444-1234-1234-1234-123456789016", "MIG-55555555-1234-1234-1234-123456789017"},
 }
 
+// DefaultMIGProfileInfo is the profile info for the default MIG device returned by the mock.
+var DefaultMIGProfileInfo = nvml.GpuInstanceProfileInfo{
+	MemorySizeMB:        1024,
+	InstanceCount:       1,
+	MultiprocessorCount: 10,
+}
+
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
 func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Device {
 	mock := &nvmlmock.Device{
@@ -178,6 +185,9 @@ func GetDeviceMock(deviceIdx int, opts ...func(*nvmlmock.Device)) *nvmlmock.Devi
 		},
 		GetSupportedEventTypesFunc: func() (uint64, nvml.Return) {
 			return nvml.EventTypeAll, nvml.SUCCESS
+		},
+		GetGpuInstanceProfileInfoFunc: func(profile int) (nvml.GpuInstanceProfileInfo, nvml.Return) {
+			return DefaultMIGProfileInfo, nvml.SUCCESS
 		},
 	}
 

--- a/releasenotes/notes/gpu-mig-core-e7f58edfd92c36e7.yaml
+++ b/releasenotes/notes/gpu-mig-core-e7f58edfd92c36e7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    GPU: MIG devices and parents are now reporting correct core and memory limits.


### PR DESCRIPTION
### What does this PR do?

This PR fixes how core and memory capacities are reported in MIG-enabled and MIG devices. There are two changes:

- We reported multiprocessor count instead of total core count. The usual API, `GetNumGpuCores`, is not available in neither of these cases so we have to fall back to a hardcoded number of cores per multiprocessor.
- Core and memory limits for the parent device were calculated from the MIG children. However, it's possible to have resources unassigned to MIG devices. We have changed the code so that we calculate core and memory based on the number of instances that can be created for the base profile.

### Motivation

Fix limit reporting.

### Describe how you validated your changes

Manually validated in MIG hosts. There are some unit tests added that will not run automatically as we don't have MIG support in CI, but can be used for manual validation.

### Additional Notes