### PR TITLE
dyninst/irgen: track the compile unit for inlined root ranges

### DIFF
--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -288,10 +288,10 @@ func generateIR(
 				pcRange: pcRange,
 			})
 		}
-		for _, inlined := range sp.inlinePCRanges {
-			for _, pcRange := range inlined.RootRanges {
+		for _, inlined := range sp.inlined {
+			for _, pcRange := range inlined.inlinedPCRanges.RootRanges {
 				lineSearchRanges = append(lineSearchRanges, lineSearchRange{
-					unit:    sp.unit,
+					unit:    inlined.unit,
 					pcRange: pcRange,
 				})
 			}
@@ -1317,7 +1317,12 @@ func materializePending(
 			ID:                p.id,
 			Name:              p.name,
 			OutOfLinePCRanges: p.outOfLinePCRanges,
-			InlinePCRanges:    p.inlinePCRanges,
+		}
+		for _, inlined := range p.inlined {
+			if len(inlined.inlinedPCRanges.Ranges) == 0 {
+				continue
+			}
+			sp.InlinePCRanges = append(sp.InlinePCRanges, inlined.inlinedPCRanges)
 		}
 		// First, create variables defined directly under the subprogram/abstract DIEs.
 		variableByOffset := make(map[dwarf.Offset]*ir.Variable, len(p.variables))
@@ -1671,7 +1676,6 @@ type pendingSubprogram struct {
 	variables         []*dwarf.Entry
 	name              string
 	outOfLinePCRanges []ir.PCRange
-	inlinePCRanges    []ir.InlinePCRanges
 
 	// Inlined instances associated with this (abstract) subprogram.
 	inlined    []*inlinedSubprogram
@@ -2069,7 +2073,6 @@ type abstractSubprogram struct {
 	name       string
 	// Aggregated ranges from out-of-line and inlined instances.
 	outOfLinePCRanges []ir.PCRange
-	inlinePCRanges    []ir.InlinePCRanges
 	// Variables defined under the abstract DIE keyed by DIE offset.
 	variables map[dwarf.Offset]*dwarf.Entry
 	// Inlined instances discovered for this abstract subprogram.
@@ -2101,6 +2104,7 @@ func (v *abstractSubprogramVisitor) pop(_ *dwarf.Entry, _ visitor) error {
 }
 
 type inlinedSubprogram struct {
+	unit           *dwarf.Entry
 	abstractOrigin dwarf.Offset
 	// Exactly one of the following is non-nil. If this is an out-of-line instance,
 	// outOfLinePCRanges are set. Otherwise, inlinedPCRanges are set.
@@ -2196,11 +2200,11 @@ func convertAbstractSubprogramsToPending(
 			RootRanges: ctx.rootRanges,
 		}
 		abs.inlined = append(abs.inlined, &inlinedSubprogram{
+			unit:            ctx.unitEntry,
 			abstractOrigin:  ctx.abstractOrigin,
 			inlinedPCRanges: ranges,
 			variables:       ctx.variables,
 		})
-		abs.inlinePCRanges = append(abs.inlinePCRanges, ranges)
 	}
 
 	for ctx, err := range iterConcreteSubprograms(
@@ -2231,6 +2235,7 @@ func convertAbstractSubprogramsToPending(
 			continue
 		}
 		outOfLine := &inlinedSubprogram{
+			unit:              ctx.unitEntry,
 			abstractOrigin:    ctx.abstractOrigin,
 			outOfLinePCRanges: ctx.entryRanges,
 			variables:         ctx.variables,
@@ -2260,7 +2265,6 @@ func convertAbstractSubprogramsToPending(
 			subprogramEntry:   nil,
 			name:              abs.name,
 			outOfLinePCRanges: abs.outOfLinePCRanges,
-			inlinePCRanges:    abs.inlinePCRanges,
 			inlined:           abs.inlined,
 			variables:         varVars,
 			probesCfgs:        abs.probesCfgs,
@@ -2280,6 +2284,7 @@ func convertAbstractSubprogramsToPending(
 // contains it.
 type concreteSubprogramContext struct {
 	abstractOrigin dwarf.Offset
+	unitEntry      *dwarf.Entry
 	entry          *dwarf.Entry
 	entryRanges    []ir.PCRange
 	reader         *dwarf.Reader
@@ -2337,6 +2342,7 @@ func iterConcreteSubprograms(
 ) iter.Seq2[concreteSubprogramContext, error] {
 	var (
 		unitIdx               int
+		unitEntry             *dwarf.Entry
 		concreteSubprogramIdx int
 		currentSubprogram     struct {
 			offset dwarf.Offset
@@ -2357,6 +2363,7 @@ func iterConcreteSubprograms(
 			(unitIdx+1 >= len(units) || units[unitIdx+1] > refOffset) {
 			return nil // no advancement needed
 		}
+		unitEntry = nil
 		found, _ := slices.BinarySearch(units[unitIdx:], refOffset)
 		if found == 0 {
 			return fmt.Errorf("ref %#x precedes first unit", refOffset)
@@ -2364,7 +2371,8 @@ func iterConcreteSubprograms(
 		unitIdx += found - 1
 		reader = d.Reader()
 		reader.Seek(units[unitIdx])
-		if _, err := reader.Next(); err != nil {
+		var err error
+		if unitEntry, err = reader.Next(); err != nil {
 			return fmt.Errorf("failed to get next entry: %w", err)
 		}
 		return nil
@@ -2488,6 +2496,7 @@ func iterConcreteSubprograms(
 				entry:          entry,
 				entryRanges:    inlinedPCRanges,
 				variables:      variableVisitor.variableEntries,
+				unitEntry:      unitEntry,
 			}, nil) {
 				return
 			}
@@ -3936,7 +3945,8 @@ func collectLineDataForRange(
 	// work unless we're at the beginning of a sequence.
 	//
 	// TODO: Find a way to seek to the first entry in a range rather
-	// than just
+	// than just the entry that covers this PC. See
+	// https://github.com/golang/go/issues/73996.
 	err := lineReader.SeekPC(r[0], &lineEntry)
 	// If we find that we have a hole, then we'll have our hands on
 	// a reader that's positioned after our PC. We can then seek to

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1368 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0xd02932"
+              Frameless: true
+            - PC: "0xd0548b"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -7789,6 +7810,15 @@ Subprograms:
             - Range: 0xd04b8c..0xd04cc5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xd0548b..0xd05492]
+          RootRanges: [0xd05340..0xd054ce]
+        - Ranges: [0xd02932..0xd02936, 0xd02937..0xd0293e]
+          RootRanges: [0xd02920..0xd0293f]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 132
@@ -10741,6 +10771,9 @@ Types:
       GoRuntimeType: 1.005632e+06
       GoKind: 22
       Pointee: 673 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1368
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.stackC]
@@ -24118,20 +24151,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1367
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1368
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -24119,7 +24119,19 @@ Types:
       GoRuntimeType: 952224
       GoKind: 5
 MaxTypeID: 1367
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1543 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0xcd3c41"
+              Frameless: true
+            - PC: "0xcd67ab"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -7789,6 +7810,15 @@ Subprograms:
             - Range: 0xcd5eac..0xcd5fe5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcd67ab..0xcd67b2]
+          RootRanges: [0xcd6660..0xcd67ee]
+        - Ranges: [0xcd3c41..0xcd3c49]
+          RootRanges: [0xcd3c40..0xcd3c4a]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 137
@@ -11046,6 +11076,9 @@ Types:
       GoRuntimeType: 1.043872e+06
       GoKind: 22
       Pointee: 810 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1543
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.stackC]
@@ -25878,20 +25911,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1542
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1543
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -25879,7 +25879,19 @@ Types:
       GoRuntimeType: 990432
       GoKind: 5
 MaxTypeID: 1542
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1562 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0xcd8541"
+              Frameless: true
+            - PC: "0xcdb02b"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -7789,6 +7810,15 @@ Subprograms:
             - Range: 0xcda78c..0xcda8c5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xcdb02b..0xcdb032]
+          RootRanges: [0xcdaee0..0xcdb06e]
+        - Ranges: [0xcd8541..0xcd8549]
+          RootRanges: [0xcd8540..0xcd854a]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 139
@@ -11113,6 +11143,9 @@ Types:
       GoRuntimeType: 1.048416e+06
       GoKind: 22
       Pointee: 823 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1562
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.stackC]
@@ -26105,20 +26138,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1561
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1562
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -26106,7 +26106,19 @@ Types:
       GoRuntimeType: 994944
       GoKind: 5
 MaxTypeID: 1561
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -26096,7 +26096,19 @@ Types:
       GoRuntimeType: 1.004e+06
       GoKind: 5
 MaxTypeID: 1557
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:
     G: 23 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -970,6 +970,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1558 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0xce4881"
+              Frameless: true
+            - PC: "0xce73ee"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -7771,6 +7792,15 @@ Subprograms:
             - Range: 0xce6ae7..0xce6c25
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0xce73ee..0xce73f5]
+          RootRanges: [0xce72a0..0xce742e]
+        - Ranges: [0xce4881..0xce4889]
+          RootRanges: [0xce4880..0xce488a]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 145
@@ -11104,6 +11134,9 @@ Types:
       GoRuntimeType: 1.057408e+06
       GoKind: 22
       Pointee: 825 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1558
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.stackC]
@@ -26095,20 +26128,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.004e+06
       GoKind: 5
-MaxTypeID: 1557
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1558
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:
     G: 23 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,11 +12,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1330 EventRootType Probe[main.stackC]
-          InjectionPoints: [{PC: "0x8928f8", Frameless: false}]
+          InjectionPoints: [{PC: "0x892908", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1331 EventRootType Probe[main.stackC]Return
-          InjectionPoints: [{PC: "0x89292c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89293c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
     - id: testAny
@@ -31,11 +31,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1196 EventRootType Probe[main.testAny]
-          InjectionPoints: [{PC: "0x88dd58", Frameless: false}]
+          InjectionPoints: [{PC: "0x88dd68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1197 EventRootType Probe[main.testAny]Return
-          InjectionPoints: [{PC: "0x88dd84", Frameless: false}]
+          InjectionPoints: [{PC: "0x88dd94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -56,11 +56,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1199 EventRootType Probe[main.testAnyPtr]
-          InjectionPoints: [{PC: "0x88ddd8", Frameless: false}]
+          InjectionPoints: [{PC: "0x88dde8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1200 EventRootType Probe[main.testAnyPtr]Return
-          InjectionPoints: [{PC: "0x88de04", Frameless: false}]
+          InjectionPoints: [{PC: "0x88de14", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -80,11 +80,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1301 EventRootType Probe[main.testArrayArgAndReturn]
-          InjectionPoints: [{PC: "0x89165c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89166c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1302 EventRootType Probe[main.testArrayArgAndReturn]Return
-          InjectionPoints: [{PC: "0x8916f4", Frameless: false}]
+          InjectionPoints: [{PC: "0x891704", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -105,7 +105,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1147 EventRootType Probe[main.testArrayEmptyStructs]
-          InjectionPoints: [{PC: "0x88c360", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c370", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -126,7 +126,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1143 EventRootType Probe[main.testArrayOfArrays]
-          InjectionPoints: [{PC: "0x88c320", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c330", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -147,7 +147,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1145 EventRootType Probe[main.testArrayOfArraysOfArrays]
-          InjectionPoints: [{PC: "0x88c340", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c350", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -168,7 +168,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1208 EventRootType Probe[main.testArrayOfMaps]
-          InjectionPoints: [{PC: "0x88e440", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e450", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -189,7 +189,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1144 EventRootType Probe[main.testArrayOfStrings]
-          InjectionPoints: [{PC: "0x88c330", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c340", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -209,7 +209,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1146 EventRootType Probe[main.testArrayOfStructs]
-          InjectionPoints: [{PC: "0x88c350", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c360", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -230,11 +230,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1228 EventRootType Probe[main.testAtomicAdd]
-          InjectionPoints: [{PC: "0x88fb30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fb40", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1229 EventRootType Probe[main.testAtomicAdd]Return
-          InjectionPoints: [{PC: "0x88fb6c", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fb7c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -255,11 +255,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1165 EventRootType Probe[main.testBigStruct]
-          InjectionPoints: [{PC: "0x88c8b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c8c0", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1166 EventRootType Probe[main.testBigStruct]Return
-          InjectionPoints: [{PC: "0x88c8c8", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c8d8", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -280,7 +280,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1132 EventRootType Probe[main.testBoolArray]
-          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -301,7 +301,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1129 EventRootType Probe[main.testByteArray]
-          InjectionPoints: [{PC: "0x88c240", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c250", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -322,7 +322,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1230 EventRootType Probe[main.testChannel]
-          InjectionPoints: [{PC: "0x88fb70", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{c}'
@@ -351,7 +351,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1226 EventRootType Probe[main.testCombinedByte]
-          InjectionPoints: [{PC: "0x88f8b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88f8c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{w}, {x}, {y}'
@@ -382,7 +382,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1238 EventRootType Probe[main.testCycle]
-          InjectionPoints: [{PC: "0x88fe20", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{t}'
@@ -403,7 +403,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1171 EventRootType Probe[main.testDeepMap1]
-          InjectionPoints: [{PC: "0x88cc90", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -424,7 +424,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1172 EventRootType Probe[main.testDeepMap7]
-          InjectionPoints: [{PC: "0x88cca0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -445,7 +445,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1167 EventRootType Probe[main.testDeepPtr1]
-          InjectionPoints: [{PC: "0x88c980", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c990", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -466,7 +466,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1168 EventRootType Probe[main.testDeepPtr7]
-          InjectionPoints: [{PC: "0x88c990", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c9a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -487,7 +487,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1169 EventRootType Probe[main.testDeepSlice1]
-          InjectionPoints: [{PC: "0x88cb30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -508,7 +508,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1170 EventRootType Probe[main.testDeepSlice7]
-          InjectionPoints: [{PC: "0x88cb40", Frameless: true}]
+          InjectionPoints: [{PC: "0x88cb50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -529,7 +529,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1318 EventRootType Probe[main.testEmptySlice]
-          InjectionPoints: [{PC: "0x892520", Frameless: true}]
+          InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -555,7 +555,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1321 EventRootType Probe[main.testEmptySliceOfStructs]
-          InjectionPoints: [{PC: "0x892550", Frameless: true}]
+          InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -582,7 +582,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1344 EventRootType Probe[main.testEmptyString]
-          InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -603,7 +603,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1355 EventRootType Probe[main.testEmptyStruct]
-          InjectionPoints: [{PC: "0x892d50", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -623,7 +623,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1356 EventRootType Probe[main.testEmptyStructPointer]
-          InjectionPoints: [{PC: "0x892d60", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d70", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -644,7 +644,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1198 EventRootType Probe[main.testError]
-          InjectionPoints: [{PC: "0x88ddb0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ddc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -665,11 +665,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1180 EventRootType Probe[main.testEsotericHeap]
-          InjectionPoints: [{PC: "0x88d358", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d368", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1181 EventRootType Probe[main.testEsotericHeap]Return
-          InjectionPoints: [{PC: "0x88d394", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d3a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -690,11 +690,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1178 EventRootType Probe[main.testEsotericStack]
-          InjectionPoints: [{PC: "0x88d26c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d27c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1179 EventRootType Probe[main.testEsotericStack]Return
-          InjectionPoints: [{PC: "0x88d2dc", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d2ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{e}'
@@ -715,11 +715,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1190 EventRootType Probe[main.testFrameless]
-          InjectionPoints: [{PC: "0x88da80", Frameless: true}]
+          InjectionPoints: [{PC: "0x88da90", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1191 EventRootType Probe[main.testFrameless]Return
-          InjectionPoints: [{PC: "0x88da88", Frameless: true}]
+          InjectionPoints: [{PC: "0x88da98", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -740,11 +740,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1192 EventRootType Probe[main.testFramelessArray]
-          InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88daac", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1193 EventRootType Probe[main.testFramelessArray]Return
-          InjectionPoints: [{PC: "0x88dad8", Frameless: false}]
+          InjectionPoints: [{PC: "0x88dae8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -768,7 +768,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1194 EventRootType Probe[main.testFramelessArray]Line
-          InjectionPoints: [{PC: "0x88da9c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88daac", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -789,11 +789,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1182 EventRootType Probe[main.testInlinedBA]
-          InjectionPoints: [{PC: "0x88d798", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d7a8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1183 EventRootType Probe[main.testInlinedBA]Return
-          InjectionPoints: [{PC: "0x88d7f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d800", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -819,11 +819,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1184 EventRootType Probe[main.testInlinedBB]
-          InjectionPoints: [{PC: "0x88d828", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d838", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1185 EventRootType Probe[main.testInlinedBB]Return
-          InjectionPoints: [{PC: "0x88d8b0", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d8c0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}'
@@ -849,11 +849,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1186 EventRootType Probe[main.testInlinedBBA]
-          InjectionPoints: [{PC: "0x88d8f8", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d908", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1187 EventRootType Probe[main.testInlinedBBA]Return
-          InjectionPoints: [{PC: "0x88d934", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d944", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -874,7 +874,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1360 EventRootType Probe[main.testInlinedBBB]
-          InjectionPoints: [{PC: "0x88d878", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d888", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBBB
@@ -891,11 +891,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1188 EventRootType Probe[main.testInlinedBC]
-          InjectionPoints: [{PC: "0x88d978", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d988", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1189 EventRootType Probe[main.testInlinedBC]Return
-          InjectionPoints: [{PC: "0x88da68", Frameless: false}]
+          InjectionPoints: [{PC: "0x88da78", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBC
@@ -912,7 +912,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1361 EventRootType Probe[main.testInlinedBCA]
-          InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -932,7 +932,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1362 EventRootType Probe[main.testInlinedBCA]Line
-          InjectionPoints: [{PC: "0x88d97c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCA
@@ -949,7 +949,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1363 EventRootType Probe[main.testInlinedBCB]
-          InjectionPoints: [{PC: "0x88da30", Frameless: false}]
+          InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -969,7 +969,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1364 EventRootType Probe[main.testInlinedBCB]Line
-          InjectionPoints: [{PC: "0x88da30", Frameless: false}]
+          InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testInlinedBCB
@@ -988,20 +988,20 @@ Probes:
         - Kind: Entry
           Type: 1357 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
-            - PC: "0x88d5f8"
+            - PC: "0x88d608"
               Frameless: false
-            - PC: "0x88d66c"
+            - PC: "0x88d67c"
               Frameless: false
-            - PC: "0x88d7b8"
+            - PC: "0x88d7c8"
               Frameless: false
-            - PC: "0x88d834"
+            - PC: "0x88d844"
               Frameless: false
-            - PC: "0x88d8fc"
+            - PC: "0x88d90c"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 1358 EventRootType Probe[main.testInlinedPrint]Return
-          InjectionPoints: [{PC: "0x88d630", Frameless: false}]
+          InjectionPoints: [{PC: "0x88d640", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1026,15 +1026,15 @@ Probes:
         - Kind: Line
           Type: 1359 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
-            - PC: "0x88d5f8"
+            - PC: "0x88d608"
               Frameless: false
-            - PC: "0x88d66c"
+            - PC: "0x88d67c"
               Frameless: false
-            - PC: "0x88d7b8"
+            - PC: "0x88d7c8"
               Frameless: false
-            - PC: "0x88d834"
+            - PC: "0x88d844"
               Frameless: false
-            - PC: "0x88d8fc"
+            - PC: "0x88d90c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1056,7 +1056,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1365 EventRootType Probe[main.testInlinedSq]
-          InjectionPoints: [{PC: "0x88da84", Frameless: true}]
+          InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1080,7 +1080,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1366 EventRootType Probe[main.testInlinedSq]Line
-          InjectionPoints: [{PC: "0x88da84", Frameless: true}]
+          InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1103,9 +1103,9 @@ Probes:
         - Kind: Entry
           Type: 1367 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
-            - PC: "0x88dab4"
+            - PC: "0x88dac4"
               Frameless: false
-            - PC: "0x88db4c"
+            - PC: "0x88db5c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -1127,7 +1127,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1135 EventRootType Probe[main.testInt16Array]
-          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1148,7 +1148,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1136 EventRootType Probe[main.testInt32Array]
-          InjectionPoints: [{PC: "0x88c2b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1169,7 +1169,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1137 EventRootType Probe[main.testInt64Array]
-          InjectionPoints: [{PC: "0x88c2c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1190,7 +1190,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1134 EventRootType Probe[main.testInt8Array]
-          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1211,7 +1211,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1133 EventRootType Probe[main.testIntArray]
-          InjectionPoints: [{PC: "0x88c280", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c290", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1232,7 +1232,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1195 EventRootType Probe[main.testInterface]
-          InjectionPoints: [{PC: "0x88dd30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88dd40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{b}'
@@ -1252,11 +1252,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1299 EventRootType Probe[main.testLargeArgAndReturn]
-          InjectionPoints: [{PC: "0x891480", Frameless: false}]
+          InjectionPoints: [{PC: "0x891490", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1300 EventRootType Probe[main.testLargeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x8915d8", Frameless: false}]
+          InjectionPoints: [{PC: "0x8915e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -1277,7 +1277,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1232 EventRootType Probe[main.testLinkedList]
-          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -1301,7 +1301,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1175 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88ccec", Frameless: false}]
+          InjectionPoints: [{PC: "0x88ccfc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1322,7 +1322,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1176 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88cd80", Frameless: false}]
+          InjectionPoints: [{PC: "0x88cd90", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1343,7 +1343,7 @@ Probes:
       events:
         - Kind: Line
           Type: 1177 EventRootType Probe[main.testLongFunctionWithChangingState]Line
-          InjectionPoints: [{PC: "0x88ce2c", Frameless: false}]
+          InjectionPoints: [{PC: "0x88ce3c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testLongFunctionWithChangingState
@@ -1385,11 +1385,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1305 EventRootType Probe[main.testManyArgsArrayReturn]
-          InjectionPoints: [{PC: "0x89198c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89199c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1306 EventRootType Probe[main.testManyArgsArrayReturn]Return
-          InjectionPoints: [{PC: "0x891afc", Frameless: false}]
+          InjectionPoints: [{PC: "0x891b0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}'
@@ -1450,7 +1450,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1206 EventRootType Probe[main.testMapArrayToArray]
-          InjectionPoints: [{PC: "0x88e420", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e430", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1471,7 +1471,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1213 EventRootType Probe[main.testMapEmbeddedMaps]
-          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e490", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1492,7 +1492,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1223 EventRootType Probe[main.testMapEmptyKey]
-          InjectionPoints: [{PC: "0x88e520", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e530", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1513,7 +1513,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1225 EventRootType Probe[main.testMapEmptyKeyAndValue]
-          InjectionPoints: [{PC: "0x88e540", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e550", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1534,7 +1534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1224 EventRootType Probe[main.testMapEmptyValue]
-          InjectionPoints: [{PC: "0x88e530", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1555,7 +1555,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1210 EventRootType Probe[main.testMapIntToInt]
-          InjectionPoints: [{PC: "0x88e460", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e470", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1576,7 +1576,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1222 EventRootType Probe[main.testMapLargeKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e510", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1597,7 +1597,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1221 EventRootType Probe[main.testMapLargeKeySmallValue]
-          InjectionPoints: [{PC: "0x88e500", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e510", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1620,7 +1620,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1211 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e470", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1643,7 +1643,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1212 EventRootType Probe[main.testMapMassive]
-          InjectionPoints: [{PC: "0x88e470", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e480", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1664,7 +1664,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1220 EventRootType Probe[main.testMapSmallKeyLargeValue]
-          InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e500", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1685,7 +1685,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1219 EventRootType Probe[main.testMapSmallKeySmallValue]
-          InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1706,7 +1706,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1204 EventRootType Probe[main.testMapStringToInt]
-          InjectionPoints: [{PC: "0x88e400", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e410", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1727,7 +1727,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1205 EventRootType Probe[main.testMapStringToSlice]
-          InjectionPoints: [{PC: "0x88e410", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e420", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1748,7 +1748,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1203 EventRootType Probe[main.testMapStringToStruct]
-          InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e400", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1769,7 +1769,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1214 EventRootType Probe[main.testMapWithLinkedList]
-          InjectionPoints: [{PC: "0x88e490", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1790,7 +1790,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1217 EventRootType Probe[main.testMapWithSmallKeyAndValue]
-          InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1811,7 +1811,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1218 EventRootType Probe[main.testMapWithSmallKeyAndValueMassive]
-          InjectionPoints: [{PC: "0x88e4d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1832,7 +1832,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1215 EventRootType Probe[main.testMapWithSmallValue]
-          InjectionPoints: [{PC: "0x88e4a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -1855,7 +1855,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1216 EventRootType Probe[main.testMapWithSmallValueMassive]
-          InjectionPoints: [{PC: "0x88e4b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e4c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{redactMyEntries}'
@@ -1876,7 +1876,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1341 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1898,7 +1898,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1342 EventRootType Probe[main.testMassiveString]
-          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -1944,11 +1944,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1307 EventRootType Probe[main.testMixedArgsStackReturn]
-          InjectionPoints: [{PC: "0x891b80", Frameless: false}]
+          InjectionPoints: [{PC: "0x891b90", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1308 EventRootType Probe[main.testMixedArgsStackReturn]Return
-          InjectionPoints: [{PC: "0x891d30", Frameless: false}]
+          InjectionPoints: [{PC: "0x891d40", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {s}'
@@ -2013,11 +2013,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1311 EventRootType Probe[main.testMultipleArrayArgs]
-          InjectionPoints: [{PC: "0x891e5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x891e6c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1312 EventRootType Probe[main.testMultipleArrayArgs]Return
-          InjectionPoints: [{PC: "0x891f00", Frameless: false}]
+          InjectionPoints: [{PC: "0x891f10", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -2047,11 +2047,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1303 EventRootType Probe[main.testMultipleLargeArgs]
-          InjectionPoints: [{PC: "0x891730", Frameless: false}]
+          InjectionPoints: [{PC: "0x891740", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1304 EventRootType Probe[main.testMultipleLargeArgs]Return
-          InjectionPoints: [{PC: "0x891900", Frameless: false}]
+          InjectionPoints: [{PC: "0x891910", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{s1}, {s2}'
@@ -2076,11 +2076,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2115,7 +2115,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1227 EventRootType Probe[main.testMultipleSimpleParams]
-          InjectionPoints: [{PC: "0x88f990", Frameless: true}]
+          InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}, {d}, {e}'
@@ -2155,11 +2155,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1253 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x8909a8", Frameless: false}]
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1254 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a08", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2185,11 +2185,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1255 EventRootType Probe[main.testNamedReturn]
-          InjectionPoints: [{PC: "0x8909a8", Frameless: false}]
+          InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1256 EventRootType Probe[main.testNamedReturn]Return
-          InjectionPoints: [{PC: "0x890a08", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Parameter {i} * 2 = result {result}
@@ -2216,7 +2216,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1351 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -2240,7 +2240,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1352 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString}'
@@ -2270,7 +2270,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1353 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested.anotherString.anotherInt} {x.notAMember}'
@@ -2294,7 +2294,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1354 EventRootType Probe[main.testNestedPointer]
-          InjectionPoints: [{PC: "0x892cf0", Frameless: true}]
+          InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x.nested}'
@@ -2320,7 +2320,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1237 EventRootType Probe[main.testNilPointer]
-          InjectionPoints: [{PC: "0x88fe00", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}, {a}'
@@ -2346,7 +2346,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1325 EventRootType Probe[main.testNilSlice]
-          InjectionPoints: [{PC: "0x892590", Frameless: true}]
+          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -2372,7 +2372,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1322 EventRootType Probe[main.testNilSliceOfStructs]
-          InjectionPoints: [{PC: "0x892560", Frameless: true}]
+          InjectionPoints: [{PC: "0x892570", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -2406,7 +2406,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1324 EventRootType Probe[main.testNilSliceWithOtherParams]
-          InjectionPoints: [{PC: "0x892580", Frameless: true}]
+          InjectionPoints: [{PC: "0x892590", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {s}, {x}'
@@ -2437,7 +2437,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1340 EventRootType Probe[main.testOneStringInStructPointer]
-          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2458,7 +2458,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1233 EventRootType Probe[main.testPointerLoop]
-          InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2479,7 +2479,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1209 EventRootType Probe[main.testPointerToMap]
-          InjectionPoints: [{PC: "0x88e450", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e460", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -2500,7 +2500,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1231 EventRootType Probe[main.testPointerToSimpleStruct]
-          InjectionPoints: [{PC: "0x88fd20", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -2521,18 +2521,18 @@ Probes:
       events:
         - Kind: Entry
           Type: 1249 EventRootType Probe[main.testReturnsAny]
-          InjectionPoints: [{PC: "0x890638", Frameless: false}]
+          InjectionPoints: [{PC: "0x890648", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1250 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
-            - PC: "0x8906d8"
+            - PC: "0x8906e8"
               Frameless: false
-            - PC: "0x890720"
+            - PC: "0x890730"
               Frameless: false
-            - PC: "0x8907e4"
+            - PC: "0x8907f4"
               Frameless: false
-            - PC: "0x8907f8"
+            - PC: "0x890808"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2559,18 +2559,18 @@ Probes:
       events:
         - Kind: Entry
           Type: 1247 EventRootType Probe[main.testReturnsAnyAndError]
-          InjectionPoints: [{PC: "0x8904b8", Frameless: false}]
+          InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1248 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
-            - PC: "0x890524"
+            - PC: "0x890534"
               Frameless: false
-            - PC: "0x890570"
+            - PC: "0x890580"
               Frameless: false
-            - PC: "0x8905b0"
+            - PC: "0x8905c0"
               Frameless: false
-            - PC: "0x8905f0"
+            - PC: "0x890600"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2596,11 +2596,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1277 EventRootType Probe[main.testReturnsArray]
-          InjectionPoints: [{PC: "0x890e8c", Frameless: false}]
+          InjectionPoints: [{PC: "0x890e9c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1278 EventRootType Probe[main.testReturnsArray]Return
-          InjectionPoints: [{PC: "0x890ee0", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ef0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArray
@@ -2616,11 +2616,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1279 EventRootType Probe[main.testReturnsArrayOne]
-          InjectionPoints: [{PC: "0x890f18", Frameless: false}]
+          InjectionPoints: [{PC: "0x890f28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1280 EventRootType Probe[main.testReturnsArrayOne]Return
-          InjectionPoints: [{PC: "0x890f54", Frameless: false}]
+          InjectionPoints: [{PC: "0x890f64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayOne
@@ -2636,11 +2636,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1281 EventRootType Probe[main.testReturnsArrayZero]
-          InjectionPoints: [{PC: "0x890f88", Frameless: false}]
+          InjectionPoints: [{PC: "0x890f98", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1282 EventRootType Probe[main.testReturnsArrayZero]Return
-          InjectionPoints: [{PC: "0x890fc0", Frameless: false}]
+          InjectionPoints: [{PC: "0x890fd0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsArrayZero
@@ -2656,11 +2656,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1285 EventRootType Probe[main.testReturnsBacktrackInt]
-          InjectionPoints: [{PC: "0x891078", Frameless: false}]
+          InjectionPoints: [{PC: "0x891088", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1286 EventRootType Probe[main.testReturnsBacktrackInt]Return
-          InjectionPoints: [{PC: "0x8910dc", Frameless: false}]
+          InjectionPoints: [{PC: "0x8910ec", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBacktrackInt
@@ -2676,11 +2676,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1297 EventRootType Probe[main.testReturnsBoolAndUintptr]
-          InjectionPoints: [{PC: "0x891408", Frameless: false}]
+          InjectionPoints: [{PC: "0x891418", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1298 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
-          InjectionPoints: [{PC: "0x891448", Frameless: false}]
+          InjectionPoints: [{PC: "0x891458", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsBoolAndUintptr
@@ -2696,11 +2696,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1273 EventRootType Probe[main.testReturnsComplex]
-          InjectionPoints: [{PC: "0x890d38", Frameless: false}]
+          InjectionPoints: [{PC: "0x890d48", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1274 EventRootType Probe[main.testReturnsComplex]Return
-          InjectionPoints: [{PC: "0x890d84", Frameless: false}]
+          InjectionPoints: [{PC: "0x890d94", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsComplex
@@ -2717,14 +2717,14 @@ Probes:
       events:
         - Kind: Entry
           Type: 1245 EventRootType Probe[main.testReturnsError]
-          InjectionPoints: [{PC: "0x890438", Frameless: false}]
+          InjectionPoints: [{PC: "0x890448", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1246 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
-            - PC: "0x890468"
+            - PC: "0x890478"
               Frameless: false
-            - PC: "0x89047c"
+            - PC: "0x89048c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2745,11 +2745,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1239 EventRootType Probe[main.testReturnsInt]
-          InjectionPoints: [{PC: "0x890248", Frameless: false}]
+          InjectionPoints: [{PC: "0x890258", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1240 EventRootType Probe[main.testReturnsInt]Return
-          InjectionPoints: [{PC: "0x89028c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89029c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2769,11 +2769,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1243 EventRootType Probe[main.testReturnsIntAndFloat]
-          InjectionPoints: [{PC: "0x890368", Frameless: false}]
+          InjectionPoints: [{PC: "0x890378", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1244 EventRootType Probe[main.testReturnsIntAndFloat]Return
-          InjectionPoints: [{PC: "0x890400", Frameless: false}]
+          InjectionPoints: [{PC: "0x890410", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2793,11 +2793,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1241 EventRootType Probe[main.testReturnsIntPointer]
-          InjectionPoints: [{PC: "0x8902c8", Frameless: false}]
+          InjectionPoints: [{PC: "0x8902d8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1242 EventRootType Probe[main.testReturnsIntPointer]Return
-          InjectionPoints: [{PC: "0x89032c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89033c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -2818,14 +2818,14 @@ Probes:
       events:
         - Kind: Entry
           Type: 1251 EventRootType Probe[main.testReturnsInterface]
-          InjectionPoints: [{PC: "0x890838", Frameless: false}]
+          InjectionPoints: [{PC: "0x890848", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1252 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
-            - PC: "0x890908"
+            - PC: "0x890918"
               Frameless: false
-            - PC: "0x89091c"
+            - PC: "0x89092c"
               Frameless: false
           Condition: null
       probeTemplate:
@@ -2846,11 +2846,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1275 EventRootType Probe[main.testReturnsLargeStruct]
-          InjectionPoints: [{PC: "0x890dc0", Frameless: false}]
+          InjectionPoints: [{PC: "0x890dd0", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1276 EventRootType Probe[main.testReturnsLargeStruct]Return
-          InjectionPoints: [{PC: "0x890e54", Frameless: false}]
+          InjectionPoints: [{PC: "0x890e64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsLargeStruct
@@ -2866,11 +2866,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1271 EventRootType Probe[main.testReturnsManyFloats]
-          InjectionPoints: [{PC: "0x890c78", Frameless: false}]
+          InjectionPoints: [{PC: "0x890c88", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1272 EventRootType Probe[main.testReturnsManyFloats]Return
-          InjectionPoints: [{PC: "0x890cfc", Frameless: false}]
+          InjectionPoints: [{PC: "0x890d0c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsManyFloats
@@ -2886,11 +2886,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1289 EventRootType Probe[main.testReturnsMixed]
-          InjectionPoints: [{PC: "0x8911f8", Frameless: false}]
+          InjectionPoints: [{PC: "0x891208", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1290 EventRootType Probe[main.testReturnsMixed]Return
-          InjectionPoints: [{PC: "0x891250", Frameless: false}]
+          InjectionPoints: [{PC: "0x891260", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixed
@@ -2906,11 +2906,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1283 EventRootType Probe[main.testReturnsMixedStruct]
-          InjectionPoints: [{PC: "0x890ff8", Frameless: false}]
+          InjectionPoints: [{PC: "0x891008", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1284 EventRootType Probe[main.testReturnsMixedStruct]Return
-          InjectionPoints: [{PC: "0x891040", Frameless: false}]
+          InjectionPoints: [{PC: "0x891050", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMixedStruct
@@ -2926,11 +2926,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1295 EventRootType Probe[main.testReturnsMultipleFloats]
-          InjectionPoints: [{PC: "0x891388", Frameless: false}]
+          InjectionPoints: [{PC: "0x891398", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1296 EventRootType Probe[main.testReturnsMultipleFloats]Return
-          InjectionPoints: [{PC: "0x8913cc", Frameless: false}]
+          InjectionPoints: [{PC: "0x8913dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsMultipleFloats
@@ -2946,11 +2946,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1293 EventRootType Probe[main.testReturnsOnlyFloat]
-          InjectionPoints: [{PC: "0x891318", Frameless: false}]
+          InjectionPoints: [{PC: "0x891328", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1294 EventRootType Probe[main.testReturnsOnlyFloat]Return
-          InjectionPoints: [{PC: "0x891358", Frameless: false}]
+          InjectionPoints: [{PC: "0x891368", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsOnlyFloat
@@ -2966,11 +2966,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1269 EventRootType Probe[main.testReturnsPrimitives]
-          InjectionPoints: [{PC: "0x890be8", Frameless: false}]
+          InjectionPoints: [{PC: "0x890bf8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1270 EventRootType Probe[main.testReturnsPrimitives]Return
-          InjectionPoints: [{PC: "0x890c40", Frameless: false}]
+          InjectionPoints: [{PC: "0x890c50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsPrimitives
@@ -2986,11 +2986,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1291 EventRootType Probe[main.testReturnsStructWithArray]
-          InjectionPoints: [{PC: "0x89128c", Frameless: false}]
+          InjectionPoints: [{PC: "0x89129c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1292 EventRootType Probe[main.testReturnsStructWithArray]Return
-          InjectionPoints: [{PC: "0x8912e0", Frameless: false}]
+          InjectionPoints: [{PC: "0x8912f0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsStructWithArray
@@ -3006,11 +3006,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1287 EventRootType Probe[main.testReturnsWideStruct]
-          InjectionPoints: [{PC: "0x891120", Frameless: false}]
+          InjectionPoints: [{PC: "0x891130", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1288 EventRootType Probe[main.testReturnsWideStruct]Return
-          InjectionPoints: [{PC: "0x8911c4", Frameless: false}]
+          InjectionPoints: [{PC: "0x8911d4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: testReturnsWideStruct
@@ -3027,7 +3027,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1130 EventRootType Probe[main.testRuneArray]
-          InjectionPoints: [{PC: "0x88c250", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3061,11 +3061,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{result2}{i}{result}{i}{i}{result2}{result}'
@@ -3110,7 +3110,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1151 EventRootType Probe[main.testSingleBool]
-          InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3131,7 +3131,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1149 EventRootType Probe[main.testSingleByte]
-          InjectionPoints: [{PC: "0x88c6b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3152,7 +3152,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1162 EventRootType Probe[main.testSingleFloat32]
-          InjectionPoints: [{PC: "0x88c780", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c790", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3173,7 +3173,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1163 EventRootType Probe[main.testSingleFloat64]
-          InjectionPoints: [{PC: "0x88c790", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3194,7 +3194,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1152 EventRootType Probe[main.testSingleInt]
-          InjectionPoints: [{PC: "0x88c6e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3215,7 +3215,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1154 EventRootType Probe[main.testSingleInt16]
-          InjectionPoints: [{PC: "0x88c700", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c710", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: parameter = {x}
@@ -3237,7 +3237,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1155 EventRootType Probe[main.testSingleInt32]
-          InjectionPoints: [{PC: "0x88c710", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c720", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3258,7 +3258,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1156 EventRootType Probe[main.testSingleInt64]
-          InjectionPoints: [{PC: "0x88c720", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c730", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3286,7 +3286,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1153 EventRootType Probe[main.testSingleInt8]
-          InjectionPoints: [{PC: "0x88c6f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c700", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: parameter = {x}{x}{x}
@@ -3316,7 +3316,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1150 EventRootType Probe[main.testSingleRune]
-          InjectionPoints: [{PC: "0x88c6c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c6d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3337,7 +3337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1332 EventRootType Probe[main.testSingleString]
-          InjectionPoints: [{PC: "0x892950", Frameless: true}]
+          InjectionPoints: [{PC: "0x892960", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3358,7 +3358,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1157 EventRootType Probe[main.testSingleUint]
-          InjectionPoints: [{PC: "0x88c730", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c740", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3379,7 +3379,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1159 EventRootType Probe[main.testSingleUint16]
-          InjectionPoints: [{PC: "0x88c750", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c760", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3400,7 +3400,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1160 EventRootType Probe[main.testSingleUint32]
-          InjectionPoints: [{PC: "0x88c760", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c770", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3421,7 +3421,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1161 EventRootType Probe[main.testSingleUint64]
-          InjectionPoints: [{PC: "0x88c770", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c780", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3442,7 +3442,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1158 EventRootType Probe[main.testSingleUint8]
-          InjectionPoints: [{PC: "0x88c740", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c750", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3463,7 +3463,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1328 EventRootType Probe[main.testSliceEmptyStructs]
-          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -3484,7 +3484,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1319 EventRootType Probe[main.testSliceOfSlices]
-          InjectionPoints: [{PC: "0x892530", Frameless: true}]
+          InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -3505,7 +3505,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1207 EventRootType Probe[main.testSmallMap]
-          InjectionPoints: [{PC: "0x88e430", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e440", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{m}'
@@ -3525,11 +3525,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1267 EventRootType Probe[main.testSomeNamedReturn]
-          InjectionPoints: [{PC: "0x890b18", Frameless: false}]
+          InjectionPoints: [{PC: "0x890b28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1268 EventRootType Probe[main.testSomeNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ba4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890bb4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{i}'
@@ -3549,11 +3549,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1309 EventRootType Probe[main.testStackArgRegReturns]
-          InjectionPoints: [{PC: "0x891db8", Frameless: false}]
+          InjectionPoints: [{PC: "0x891dc8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1310 EventRootType Probe[main.testStackArgRegReturns]Return
-          InjectionPoints: [{PC: "0x891e1c", Frameless: false}]
+          InjectionPoints: [{PC: "0x891e2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3574,7 +3574,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1131 EventRootType Probe[main.testStringArray]
-          InjectionPoints: [{PC: "0x88c260", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c270", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3595,7 +3595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1236 EventRootType Probe[main.testStringPointer]
-          InjectionPoints: [{PC: "0x88fde0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{z}'
@@ -3616,7 +3616,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1323 EventRootType Probe[main.testStringSlice]
-          InjectionPoints: [{PC: "0x892570", Frameless: true}]
+          InjectionPoints: [{PC: "0x892580", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3637,7 +3637,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1173 EventRootType Probe[main.testStringType1]
-          InjectionPoints: [{PC: "0x88ccb0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3658,7 +3658,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1174 EventRootType Probe[main.testStringType2]
-          InjectionPoints: [{PC: "0x88ccc0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88ccd0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3679,11 +3679,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1349 EventRootType Probe[main.testStruct]
-          InjectionPoints: [{PC: "0x892c50", Frameless: true}]
+          InjectionPoints: [{PC: "0x892c60", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1350 EventRootType Probe[main.testStruct]Return
-          InjectionPoints: [{PC: "0x892c6c", Frameless: true}]
+          InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -3709,7 +3709,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1320 EventRootType Probe[main.testStructSlice]
-          InjectionPoints: [{PC: "0x892540", Frameless: true}]
+          InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}, {a}'
@@ -3735,7 +3735,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1201 EventRootType Probe[main.testStructWithAny]
-          InjectionPoints: [{PC: "0x88de30", Frameless: true}]
+          InjectionPoints: [{PC: "0x88de40", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s}'
@@ -3755,11 +3755,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1313 EventRootType Probe[main.testStructWithArrayArg]
-          InjectionPoints: [{PC: "0x891f3c", Frameless: false}]
+          InjectionPoints: [{PC: "0x891f4c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1314 EventRootType Probe[main.testStructWithArrayArg]Return
-          InjectionPoints: [{PC: "0x891fcc", Frameless: false}]
+          InjectionPoints: [{PC: "0x891fdc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{arg}'
@@ -3780,11 +3780,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1347 EventRootType Probe[main.testStructWithCyclicMaps]
-          InjectionPoints: [{PC: "0x892b60", Frameless: true}]
+          InjectionPoints: [{PC: "0x892b70", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1348 EventRootType Probe[main.testStructWithCyclicMaps]Return
-          InjectionPoints: [{PC: "0x892b78", Frameless: true}]
+          InjectionPoints: [{PC: "0x892b88", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3804,7 +3804,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1346 EventRootType Probe[main.testStructWithCyclicSlices]
-          InjectionPoints: [{PC: "0x892b50", Frameless: true}]
+          InjectionPoints: [{PC: "0x892b60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -3830,7 +3830,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1202 EventRootType Probe[main.testStructWithMap]
-          InjectionPoints: [{PC: "0x88e3e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88e3f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{s} {@duration}'
@@ -3861,7 +3861,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1329 EventRootType Probe[main.testSubslices]
-          InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8925d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{as}, {bs}, {cs}'
@@ -3900,7 +3900,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1345 EventRootType Probe[main.testSubstrings]
-          InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}, {c}'
@@ -3932,11 +3932,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{nonexistentVariable}'
@@ -3956,11 +3956,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{unsupportedExpression}'
@@ -3982,11 +3982,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
-          InjectionPoints: [{PC: "0x890a48", Frameless: false}]
+          InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
-          InjectionPoints: [{PC: "0x890ad4", Frameless: false}]
+          InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: Executed main.testMultipleNamedReturn, it took {@duration}ms
@@ -4014,7 +4014,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1333 EventRootType Probe[main.testThreeStrings]
-          InjectionPoints: [{PC: "0x892960", Frameless: true}]
+          InjectionPoints: [{PC: "0x892970", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}, {y}, {z}'
@@ -4045,11 +4045,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892970", Frameless: true}]
+          InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892988", Frameless: true}]
+          InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4078,11 +4078,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
-          InjectionPoints: [{PC: "0x892970", Frameless: true}]
+          InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
           Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
-          InjectionPoints: [{PC: "0x892988", Frameless: true}]
+          InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4113,7 +4113,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1338 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x892990", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4142,7 +4142,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1339 EventRootType Probe[main.testThreeStringsInStructPointer]
-          InjectionPoints: [{PC: "0x892990", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a.a} {a.b} {a.c}'
@@ -4173,7 +4173,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1164 EventRootType Probe[main.testTypeAlias]
-          InjectionPoints: [{PC: "0x88c7a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c7b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4194,7 +4194,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1140 EventRootType Probe[main.testUint16Array]
-          InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c300", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4215,7 +4215,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1141 EventRootType Probe[main.testUint32Array]
-          InjectionPoints: [{PC: "0x88c300", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c310", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4236,7 +4236,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1142 EventRootType Probe[main.testUint64Array]
-          InjectionPoints: [{PC: "0x88c310", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c320", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4257,7 +4257,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1139 EventRootType Probe[main.testUint8Array]
-          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2f0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4278,7 +4278,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1138 EventRootType Probe[main.testUintArray]
-          InjectionPoints: [{PC: "0x88c2d0", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c2e0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4299,7 +4299,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1235 EventRootType Probe[main.testUintPointer]
-          InjectionPoints: [{PC: "0x88fd70", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fd80", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4320,7 +4320,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1317 EventRootType Probe[main.testUintSlice]
-          InjectionPoints: [{PC: "0x892510", Frameless: true}]
+          InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{u}'
@@ -4341,7 +4341,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1343 EventRootType Probe[main.testUnitializedString]
-          InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4362,7 +4362,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1234 EventRootType Probe[main.testUnsafePointer]
-          InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
+          InjectionPoints: [{PC: "0x88fd60", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{x}'
@@ -4383,7 +4383,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1148 EventRootType Probe[main.testVeryLargeArray]
-          InjectionPoints: [{PC: "0x88c380", Frameless: true}]
+          InjectionPoints: [{PC: "0x88c390", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}'
@@ -4404,7 +4404,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1326 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4425,7 +4425,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 1327 EventRootType Probe[main.testVeryLargeSlice]
-          InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
+          InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
         TemplateString: '{xs}'
@@ -4450,11 +4450,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 1315 EventRootType Probe[main.testZeroSizeArgAndReturn]
-          InjectionPoints: [{PC: "0x892008", Frameless: false}]
+          InjectionPoints: [{PC: "0x892018", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 1316 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
-          InjectionPoints: [{PC: "0x892074", Frameless: false}]
+          InjectionPoints: [{PC: "0x892084", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: '{a}, {b}'
@@ -4471,409 +4471,409 @@ Probes:
 Subprograms:
     - ID: 1
       Name: main.testByteArray
-      OutOfLinePCRanges: [0x88c240..0x88c250]
+      OutOfLinePCRanges: [0x88c250..0x88c260]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88c240..0x88c250
+            - Range: 0x88c250..0x88c260
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 2
       Name: main.testRuneArray
-      OutOfLinePCRanges: [0x88c250..0x88c260]
+      OutOfLinePCRanges: [0x88c260..0x88c270]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88c250..0x88c260
+            - Range: 0x88c260..0x88c270
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 3
       Name: main.testStringArray
-      OutOfLinePCRanges: [0x88c260..0x88c270]
+      OutOfLinePCRanges: [0x88c270..0x88c280]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0x88c260..0x88c270
+            - Range: 0x88c270..0x88c280
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 4
       Name: main.testBoolArray
-      OutOfLinePCRanges: [0x88c270..0x88c280]
+      OutOfLinePCRanges: [0x88c280..0x88c290]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 ArrayType [2]bool
           Locations:
-            - Range: 0x88c270..0x88c280
+            - Range: 0x88c280..0x88c290
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 5
       Name: main.testIntArray
-      OutOfLinePCRanges: [0x88c280..0x88c290]
+      OutOfLinePCRanges: [0x88c290..0x88c2a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x88c280..0x88c290
+            - Range: 0x88c290..0x88c2a0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 6
       Name: main.testInt8Array
-      OutOfLinePCRanges: [0x88c290..0x88c2a0]
+      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 ArrayType [2]int8
           Locations:
-            - Range: 0x88c290..0x88c2a0
+            - Range: 0x88c2a0..0x88c2b0
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 7
       Name: main.testInt16Array
-      OutOfLinePCRanges: [0x88c2a0..0x88c2b0]
+      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 ArrayType [2]int16
           Locations:
-            - Range: 0x88c2a0..0x88c2b0
+            - Range: 0x88c2b0..0x88c2c0
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 8
       Name: main.testInt32Array
-      OutOfLinePCRanges: [0x88c2b0..0x88c2c0]
+      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 ArrayType [2]int32
           Locations:
-            - Range: 0x88c2b0..0x88c2c0
+            - Range: 0x88c2c0..0x88c2d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 9
       Name: main.testInt64Array
-      OutOfLinePCRanges: [0x88c2c0..0x88c2d0]
+      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 ArrayType [2]int64
           Locations:
-            - Range: 0x88c2c0..0x88c2d0
+            - Range: 0x88c2d0..0x88c2e0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 10
       Name: main.testUintArray
-      OutOfLinePCRanges: [0x88c2d0..0x88c2e0]
+      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 110 ArrayType [2]uint
           Locations:
-            - Range: 0x88c2d0..0x88c2e0
+            - Range: 0x88c2e0..0x88c2f0
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 11
       Name: main.testUint8Array
-      OutOfLinePCRanges: [0x88c2e0..0x88c2f0]
+      OutOfLinePCRanges: [0x88c2f0..0x88c300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 ArrayType [2]uint8
           Locations:
-            - Range: 0x88c2e0..0x88c2f0
+            - Range: 0x88c2f0..0x88c300
               Pieces: [{Size: 2, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 12
       Name: main.testUint16Array
-      OutOfLinePCRanges: [0x88c2f0..0x88c300]
+      OutOfLinePCRanges: [0x88c300..0x88c310]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 ArrayType [2]uint16
           Locations:
-            - Range: 0x88c2f0..0x88c300
+            - Range: 0x88c300..0x88c310
               Pieces: [{Size: 4, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 13
       Name: main.testUint32Array
-      OutOfLinePCRanges: [0x88c300..0x88c310]
+      OutOfLinePCRanges: [0x88c310..0x88c320]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 ArrayType [2]uint32
           Locations:
-            - Range: 0x88c300..0x88c310
+            - Range: 0x88c310..0x88c320
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 14
       Name: main.testUint64Array
-      OutOfLinePCRanges: [0x88c310..0x88c320]
+      OutOfLinePCRanges: [0x88c320..0x88c330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 52 ArrayType [2]uint64
           Locations:
-            - Range: 0x88c310..0x88c320
+            - Range: 0x88c320..0x88c330
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 15
       Name: main.testArrayOfArrays
-      OutOfLinePCRanges: [0x88c320..0x88c330]
+      OutOfLinePCRanges: [0x88c330..0x88c340]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 113 ArrayType [2][2]int
           Locations:
-            - Range: 0x88c320..0x88c330
+            - Range: 0x88c330..0x88c340
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 16
       Name: main.testArrayOfStrings
-      OutOfLinePCRanges: [0x88c330..0x88c340]
+      OutOfLinePCRanges: [0x88c340..0x88c350]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 104 ArrayType [2]string
           Locations:
-            - Range: 0x88c330..0x88c340
+            - Range: 0x88c340..0x88c350
               Pieces: [{Size: 32, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 17
       Name: main.testArrayOfArraysOfArrays
-      OutOfLinePCRanges: [0x88c340..0x88c350]
+      OutOfLinePCRanges: [0x88c350..0x88c360]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 114 ArrayType [2][2][2]int
           Locations:
-            - Range: 0x88c340..0x88c350
+            - Range: 0x88c350..0x88c360
               Pieces: [{Size: 64, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 18
       Name: main.testArrayOfStructs
-      OutOfLinePCRanges: [0x88c350..0x88c360]
+      OutOfLinePCRanges: [0x88c360..0x88c370]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 115 ArrayType [2]main.nestedStruct
           Locations:
-            - Range: 0x88c350..0x88c360
+            - Range: 0x88c360..0x88c370
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 19
       Name: main.testArrayEmptyStructs
-      OutOfLinePCRanges: [0x88c360..0x88c370]
+      OutOfLinePCRanges: [0x88c370..0x88c380]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 117 ArrayType [2]struct {}
           Locations:
-            - Range: 0x88c360..0x88c370
+            - Range: 0x88c370..0x88c380
               Pieces: [{Size: 0, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 20
       Name: main.testVeryLargeArray
-      OutOfLinePCRanges: [0x88c380..0x88c390]
+      OutOfLinePCRanges: [0x88c390..0x88c3a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 119 ArrayType [100]uint
           Locations:
-            - Range: 0x88c380..0x88c390
+            - Range: 0x88c390..0x88c3a0
               Pieces: [{Size: 800, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 21
       Name: main.testSingleByte
-      OutOfLinePCRanges: [0x88c6b0..0x88c6c0]
+      OutOfLinePCRanges: [0x88c6c0..0x88c6d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88c6b0..0x88c6c0
+            - Range: 0x88c6c0..0x88c6d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 22
       Name: main.testSingleRune
-      OutOfLinePCRanges: [0x88c6c0..0x88c6d0]
+      OutOfLinePCRanges: [0x88c6d0..0x88c6e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88c6c0..0x88c6d0
+            - Range: 0x88c6d0..0x88c6e0
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 23
       Name: main.testSingleBool
-      OutOfLinePCRanges: [0x88c6d0..0x88c6e0]
+      OutOfLinePCRanges: [0x88c6e0..0x88c6f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88c6d0..0x88c6e0
+            - Range: 0x88c6e0..0x88c6f0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 24
       Name: main.testSingleInt
-      OutOfLinePCRanges: [0x88c6e0..0x88c6f0]
+      OutOfLinePCRanges: [0x88c6f0..0x88c700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88c6e0..0x88c6f0
+            - Range: 0x88c6f0..0x88c700
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 25
       Name: main.testSingleInt8
-      OutOfLinePCRanges: [0x88c6f0..0x88c700]
+      OutOfLinePCRanges: [0x88c700..0x88c710]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x88c6f0..0x88c700
+            - Range: 0x88c700..0x88c710
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 26
       Name: main.testSingleInt16
-      OutOfLinePCRanges: [0x88c700..0x88c710]
+      OutOfLinePCRanges: [0x88c710..0x88c720]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x88c700..0x88c710
+            - Range: 0x88c710..0x88c720
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 27
       Name: main.testSingleInt32
-      OutOfLinePCRanges: [0x88c710..0x88c720]
+      OutOfLinePCRanges: [0x88c720..0x88c730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88c710..0x88c720
+            - Range: 0x88c720..0x88c730
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 28
       Name: main.testSingleInt64
-      OutOfLinePCRanges: [0x88c720..0x88c730]
+      OutOfLinePCRanges: [0x88c730..0x88c740]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x88c720..0x88c730
+            - Range: 0x88c730..0x88c740
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 29
       Name: main.testSingleUint
-      OutOfLinePCRanges: [0x88c730..0x88c740]
+      OutOfLinePCRanges: [0x88c740..0x88c750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88c730..0x88c740
+            - Range: 0x88c740..0x88c750
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 30
       Name: main.testSingleUint8
-      OutOfLinePCRanges: [0x88c740..0x88c750]
+      OutOfLinePCRanges: [0x88c750..0x88c760]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88c740..0x88c750
+            - Range: 0x88c750..0x88c760
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 31
       Name: main.testSingleUint16
-      OutOfLinePCRanges: [0x88c750..0x88c760]
+      OutOfLinePCRanges: [0x88c760..0x88c770]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x88c750..0x88c760
+            - Range: 0x88c760..0x88c770
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 32
       Name: main.testSingleUint32
-      OutOfLinePCRanges: [0x88c760..0x88c770]
+      OutOfLinePCRanges: [0x88c770..0x88c780]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x88c760..0x88c770
+            - Range: 0x88c770..0x88c780
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 33
       Name: main.testSingleUint64
-      OutOfLinePCRanges: [0x88c770..0x88c780]
+      OutOfLinePCRanges: [0x88c780..0x88c790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88c770..0x88c780
+            - Range: 0x88c780..0x88c790
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
       Name: main.testSingleFloat32
-      OutOfLinePCRanges: [0x88c780..0x88c790]
+      OutOfLinePCRanges: [0x88c790..0x88c7a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88c780..0x88c790
+            - Range: 0x88c790..0x88c7a0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 35
       Name: main.testSingleFloat64
-      OutOfLinePCRanges: [0x88c790..0x88c7a0]
+      OutOfLinePCRanges: [0x88c7a0..0x88c7b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x88c790..0x88c7a0
+            - Range: 0x88c7a0..0x88c7b0
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 36
       Name: main.testTypeAlias
-      OutOfLinePCRanges: [0x88c7a0..0x88c7b0]
+      OutOfLinePCRanges: [0x88c7b0..0x88c7c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 120 BaseType main.typeAlias
           Locations:
-            - Range: 0x88c7a0..0x88c7b0
+            - Range: 0x88c7b0..0x88c7c0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 37
       Name: main.testBigStruct
-      OutOfLinePCRanges: [0x88c8b0..0x88c8d0]
+      OutOfLinePCRanges: [0x88c8c0..0x88c8e0]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 121 StructureType main.bigStruct
           Locations:
-            - Range: 0x88c8b0..0x88c8d0
+            - Range: 0x88c8c0..0x88c8e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4890,35 +4890,35 @@ Subprograms:
           Role: Parameter
     - ID: 38
       Name: main.testDeepPtr1
-      OutOfLinePCRanges: [0x88c980..0x88c990]
+      OutOfLinePCRanges: [0x88c990..0x88c9a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 125 StructureType main.deepPtr1
           Locations:
-            - Range: 0x88c980..0x88c990
+            - Range: 0x88c990..0x88c9a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 39
       Name: main.testDeepPtr7
-      OutOfLinePCRanges: [0x88c990..0x88c9a0]
+      OutOfLinePCRanges: [0x88c9a0..0x88c9b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 128 PointerType *main.deepPtr7
           Locations:
-            - Range: 0x88c990..0x88c9a0
+            - Range: 0x88c9a0..0x88c9b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 40
       Name: main.testDeepSlice1
-      OutOfLinePCRanges: [0x88cb30..0x88cb40]
+      OutOfLinePCRanges: [0x88cb40..0x88cb50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 130 StructureType main.deepSlice1
           Locations:
-            - Range: 0x88cb30..0x88cb40
+            - Range: 0x88cb40..0x88cb50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -4929,115 +4929,115 @@ Subprograms:
           Role: Parameter
     - ID: 41
       Name: main.testDeepSlice7
-      OutOfLinePCRanges: [0x88cb40..0x88cb50]
+      OutOfLinePCRanges: [0x88cb50..0x88cb60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 134 PointerType *main.deepSlice7
           Locations:
-            - Range: 0x88cb40..0x88cb50
+            - Range: 0x88cb50..0x88cb60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 42
       Name: main.testDeepMap1
-      OutOfLinePCRanges: [0x88cc90..0x88cca0]
+      OutOfLinePCRanges: [0x88cca0..0x88ccb0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 136 StructureType main.deepMap1
           Locations:
-            - Range: 0x88cc90..0x88cca0
+            - Range: 0x88cca0..0x88ccb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 43
       Name: main.testDeepMap7
-      OutOfLinePCRanges: [0x88cca0..0x88ccb0]
+      OutOfLinePCRanges: [0x88ccb0..0x88ccc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 144 PointerType *main.deepMap7
           Locations:
-            - Range: 0x88cca0..0x88ccb0
+            - Range: 0x88ccb0..0x88ccc0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 44
       Name: main.testStringType1
-      OutOfLinePCRanges: [0x88ccb0..0x88ccc0]
+      OutOfLinePCRanges: [0x88ccc0..0x88ccd0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 146 PointerType *main.stringType1
           Locations:
-            - Range: 0x88ccb0..0x88ccc0
+            - Range: 0x88ccc0..0x88ccd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 45
       Name: main.testStringType2
-      OutOfLinePCRanges: [0x88ccc0..0x88ccd0]
+      OutOfLinePCRanges: [0x88ccd0..0x88cce0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 148 PointerType **main.stringType2
           Locations:
-            - Range: 0x88ccc0..0x88ccd0
+            - Range: 0x88ccd0..0x88cce0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 46
       Name: main.testLongFunctionWithChangingState
-      OutOfLinePCRanges: [0x88ccd0..0x88ced0]
+      OutOfLinePCRanges: [0x88cce0..0x88cee0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd98..0x88cda8
+            - Range: 0x88cda8..0x88cdb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88ce48..0x88ce58
+            - Range: 0x88ce58..0x88ce68
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
         - Name: aPerArch
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd80..0x88cd84
+            - Range: 0x88cd90..0x88cd94
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cd84..0x88cda8
+            - Range: 0x88cd94..0x88cdb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cda8..0x88ce3c
+            - Range: 0x88cdb8..0x88ce4c
               Pieces: [{Size: 8, Op: {CfaOffset: -160}}]
-            - Range: 0x88ce3c..0x88ce44
+            - Range: 0x88ce4c..0x88ce54
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88ce44..0x88ced0
+            - Range: 0x88ce54..0x88cee0
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
           Role: Local
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88cd7c..0x88cd84
+            - Range: 0x88cd8c..0x88cd94
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cd84..0x88cd84
+            - Range: 0x88cd94..0x88cd94
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x88cd84..0x88cda8
+            - Range: 0x88cd94..0x88cdb8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x88cda8..0x88ce3c
+            - Range: 0x88cdb8..0x88ce4c
               Pieces: [{Size: 8, Op: {CfaOffset: -176}}]
-            - Range: 0x88ce3c..0x88ce40
+            - Range: 0x88ce4c..0x88ce50
               Pieces: [{Size: 8, Op: {CfaOffset: -168}}]
-            - Range: 0x88ce40..0x88ce44
+            - Range: 0x88ce50..0x88ce54
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88ce44..0x88ce58
+            - Range: 0x88ce54..0x88ce68
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
-            - Range: 0x88ce58..0x88ced0
+            - Range: 0x88ce68..0x88cee0
               Pieces: [{Size: 8, Op: {CfaOffset: -184}}]
           Role: Local
     - ID: 47
       Name: main.testEsotericStack
-      OutOfLinePCRanges: [0x88d250..0x88d340]
+      OutOfLinePCRanges: [0x88d260..0x88d350]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 150 StructureType main.esotericStack
           Locations:
-            - Range: 0x88d250..0x88d298
+            - Range: 0x88d260..0x88d2a8
               Pieces:
                 - Size: 4
                   Op: {RegNo: 0, Shift: 0}
@@ -5057,7 +5057,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d298..0x88d29c
+            - Range: 0x88d2a8..0x88d2ac
               Pieces:
                 - Size: 4
                   Op: null
@@ -5077,7 +5077,7 @@ Subprograms:
                   Op: {RegNo: 7, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
-            - Range: 0x88d29c..0x88d2a0
+            - Range: 0x88d2ac..0x88d2b0
               Pieces:
                 - Size: 4
                   Op: null
@@ -5100,138 +5100,138 @@ Subprograms:
           Role: Parameter
     - ID: 48
       Name: main.testEsotericHeap
-      OutOfLinePCRanges: [0x88d340..0x88d3c0]
+      OutOfLinePCRanges: [0x88d350..0x88d3d0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 154 PointerType *main.esotericHeap
           Locations:
-            - Range: 0x88d340..0x88d378
+            - Range: 0x88d350..0x88d388
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 49
       Name: main.testInlinedBA
-      OutOfLinePCRanges: [0x88d780..0x88d810]
+      OutOfLinePCRanges: [0x88d790..0x88d820]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d780..0x88d7b8
+            - Range: 0x88d790..0x88d7c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 50
       Name: main.testInlinedBB
-      OutOfLinePCRanges: [0x88d810..0x88d8e0]
+      OutOfLinePCRanges: [0x88d820..0x88d8f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d810..0x88d82c
+            - Range: 0x88d820..0x88d83c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d810..0x88d83c
+            - Range: 0x88d820..0x88d84c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: z
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d82c..0x88d83c
+            - Range: 0x88d83c..0x88d84c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d83c..0x88d8e0
+            - Range: 0x88d84c..0x88d8f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
     - ID: 51
       Name: main.testInlinedBBA
-      OutOfLinePCRanges: [0x88d8e0..0x88d960]
+      OutOfLinePCRanges: [0x88d8f0..0x88d970]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d8e0..0x88d904
+            - Range: 0x88d8f0..0x88d914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 52
       Name: main.testInlinedBC
-      OutOfLinePCRanges: [0x88d960..0x88da80]
+      OutOfLinePCRanges: [0x88d970..0x88da90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d9c8..0x88d9d0
+            - Range: 0x88d9d8..0x88d9e0
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d9d0..0x88d9e8
+            - Range: 0x88d9e0..0x88d9f8
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
-            - Range: 0x88d9e8..0x88d9fc
+            - Range: 0x88d9f8..0x88da0c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d9c4..0x88d9cc
+            - Range: 0x88d9d4..0x88d9dc
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d9cc..0x88d9e8
+            - Range: 0x88d9dc..0x88d9f8
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
-            - Range: 0x88d9e8..0x88d9f8
+            - Range: 0x88d9f8..0x88da08
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 53
       Name: main.testFrameless
-      OutOfLinePCRanges: [0x88da80..0x88da90]
+      OutOfLinePCRanges: [0x88da90..0x88daa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da80..0x88da88
+            - Range: 0x88da90..0x88da98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da80..0x88da88
+            - Range: 0x88da90..0x88da98
               Pieces: []
-            - Range: 0x88da88..0x88da89
+            - Range: 0x88da98..0x88da99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88da89..0x88da90
+            - Range: 0x88da99..0x88daa0
               Pieces: []
           Role: Return
     - ID: 54
       Name: main.testFramelessArray
-      OutOfLinePCRanges: [0x88da90..0x88daf0]
+      OutOfLinePCRanges: [0x88daa0..0x88db00]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88da90..0x88daf0
+            - Range: 0x88daa0..0x88db00
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da90..0x88dad8
+            - Range: 0x88daa0..0x88dae8
               Pieces: []
-            - Range: 0x88dad8..0x88dad9
+            - Range: 0x88dae8..0x88dae9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88dad9..0x88daf0
+            - Range: 0x88dae9..0x88db00
               Pieces: []
           Role: Return
     - ID: 55
       Name: main.testInterface
-      OutOfLinePCRanges: [0x88dd30..0x88dd40]
+      OutOfLinePCRanges: [0x88dd40..0x88dd50]
       InlinePCRanges: []
       Variables:
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x88dd30..0x88dd40
+            - Range: 0x88dd40..0x88dd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5240,19 +5240,19 @@ Subprograms:
           Role: Parameter
     - ID: 56
       Name: main.testAny
-      OutOfLinePCRanges: [0x88dd40..0x88ddb0]
+      OutOfLinePCRanges: [0x88dd50..0x88ddc0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x88dd40..0x88dd70
+            - Range: 0x88dd50..0x88dd80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dd70..0x88dd74
+            - Range: 0x88dd80..0x88dd84
               Pieces:
                 - Size: 8
                   Op: null
@@ -5262,26 +5262,26 @@ Subprograms:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88dd40..0x88dd84
+            - Range: 0x88dd50..0x88dd94
               Pieces: []
-            - Range: 0x88dd84..0x88dd85
+            - Range: 0x88dd94..0x88dd95
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88dd85..0x88ddb0
+            - Range: 0x88dd95..0x88ddc0
               Pieces: []
           Role: Return
     - ID: 57
       Name: main.testError
-      OutOfLinePCRanges: [0x88ddb0..0x88ddc0]
+      OutOfLinePCRanges: [0x88ddc0..0x88ddd0]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x88ddb0..0x88ddc0
+            - Range: 0x88ddc0..0x88ddd0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5290,38 +5290,38 @@ Subprograms:
           Role: Parameter
     - ID: 58
       Name: main.testAnyPtr
-      OutOfLinePCRanges: [0x88ddc0..0x88de30]
+      OutOfLinePCRanges: [0x88ddd0..0x88de40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 158 PointerType *interface {}
           Locations:
-            - Range: 0x88ddc0..0x88ddf0
+            - Range: 0x88ddd0..0x88de00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88ddc0..0x88de04
+            - Range: 0x88ddd0..0x88de14
               Pieces: []
-            - Range: 0x88de04..0x88de05
+            - Range: 0x88de14..0x88de15
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x88de05..0x88de30
+            - Range: 0x88de15..0x88de40
               Pieces: []
           Role: Return
     - ID: 59
       Name: main.testStructWithAny
-      OutOfLinePCRanges: [0x88de30..0x88de40]
+      OutOfLinePCRanges: [0x88de40..0x88de50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 159 StructureType main.structWithAny
           Locations:
-            - Range: 0x88de30..0x88de40
+            - Range: 0x88de40..0x88de50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5330,171 +5330,160 @@ Subprograms:
           Role: Parameter
     - ID: 60
       Name: main.testStructWithMap
-      OutOfLinePCRanges: [0x88e3e0..0x88e3f0]
+      OutOfLinePCRanges: [0x88e3f0..0x88e400]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 160 StructureType main.structWithMap
           Locations:
-            - Range: 0x88e3e0..0x88e3f0
+            - Range: 0x88e3f0..0x88e400
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 61
       Name: main.testMapStringToStruct
-      OutOfLinePCRanges: [0x88e3f0..0x88e400]
+      OutOfLinePCRanges: [0x88e400..0x88e410]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 166 GoMapType map[string]main.nestedStruct
           Locations:
-            - Range: 0x88e3f0..0x88e400
+            - Range: 0x88e400..0x88e410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 62
       Name: main.testMapStringToInt
-      OutOfLinePCRanges: [0x88e400..0x88e410]
+      OutOfLinePCRanges: [0x88e410..0x88e420]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0x88e400..0x88e410
+            - Range: 0x88e410..0x88e420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 63
       Name: main.testMapStringToSlice
-      OutOfLinePCRanges: [0x88e410..0x88e420]
+      OutOfLinePCRanges: [0x88e420..0x88e430]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 176 GoMapType map[string][]string
           Locations:
-            - Range: 0x88e410..0x88e420
+            - Range: 0x88e420..0x88e430
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 64
       Name: main.testMapArrayToArray
-      OutOfLinePCRanges: [0x88e420..0x88e430]
+      OutOfLinePCRanges: [0x88e430..0x88e440]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 181 GoMapType map[[4]string][2]int
           Locations:
-            - Range: 0x88e420..0x88e430
+            - Range: 0x88e430..0x88e440
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 65
       Name: main.testSmallMap
-      OutOfLinePCRanges: [0x88e430..0x88e440]
+      OutOfLinePCRanges: [0x88e440..0x88e450]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 171 GoMapType map[string]int
           Locations:
-            - Range: 0x88e430..0x88e440
+            - Range: 0x88e440..0x88e450
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 66
       Name: main.testArrayOfMaps
-      OutOfLinePCRanges: [0x88e440..0x88e450]
+      OutOfLinePCRanges: [0x88e450..0x88e460]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 186 ArrayType [2]map[string]int
           Locations:
-            - Range: 0x88e440..0x88e450
+            - Range: 0x88e450..0x88e460
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 67
       Name: main.testPointerToMap
-      OutOfLinePCRanges: [0x88e450..0x88e460]
+      OutOfLinePCRanges: [0x88e460..0x88e470]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 187 PointerType *map[string]int
           Locations:
-            - Range: 0x88e450..0x88e460
+            - Range: 0x88e460..0x88e470
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 68
       Name: main.testMapIntToInt
-      OutOfLinePCRanges: [0x88e460..0x88e470]
+      OutOfLinePCRanges: [0x88e470..0x88e480]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 161 GoMapType map[int]int
           Locations:
-            - Range: 0x88e460..0x88e470
+            - Range: 0x88e470..0x88e480
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 69
       Name: main.testMapMassive
-      OutOfLinePCRanges: [0x88e470..0x88e480]
-      InlinePCRanges: []
-      Variables:
-        - Name: redactMyEntries
-          Type: 188 GoMapType map[string][]main.structWithMap
-          Locations:
-            - Range: 0x88e470..0x88e480
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 70
-      Name: main.testMapEmbeddedMaps
       OutOfLinePCRanges: [0x88e480..0x88e490]
       InlinePCRanges: []
       Variables:
-        - Name: m
+        - Name: redactMyEntries
           Type: 188 GoMapType map[string][]main.structWithMap
           Locations:
             - Range: 0x88e480..0x88e490
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 70
+      Name: main.testMapEmbeddedMaps
+      OutOfLinePCRanges: [0x88e490..0x88e4a0]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 188 GoMapType map[string][]main.structWithMap
+          Locations:
+            - Range: 0x88e490..0x88e4a0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
     - ID: 71
       Name: main.testMapWithLinkedList
-      OutOfLinePCRanges: [0x88e490..0x88e4a0]
+      OutOfLinePCRanges: [0x88e4a0..0x88e4b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 193 GoMapType map[bool]main.node
           Locations:
-            - Range: 0x88e490..0x88e4a0
+            - Range: 0x88e4a0..0x88e4b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 72
       Name: main.testMapWithSmallValue
-      OutOfLinePCRanges: [0x88e4a0..0x88e4b0]
-      InlinePCRanges: []
-      Variables:
-        - Name: m
-          Type: 198 GoMapType map[int]uint8
-          Locations:
-            - Range: 0x88e4a0..0x88e4b0
-              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-          Role: Parameter
-    - ID: 73
-      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x88e4b0..0x88e4c0]
       InlinePCRanges: []
       Variables:
-        - Name: redactMyEntries
+        - Name: m
           Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0x88e4b0..0x88e4c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 74
-      Name: main.testMapWithSmallKeyAndValue
+    - ID: 73
+      Name: main.testMapWithSmallValueMassive
       OutOfLinePCRanges: [0x88e4c0..0x88e4d0]
       InlinePCRanges: []
       Variables:
-        - Name: m
-          Type: 203 GoMapType map[uint8]uint8
+        - Name: redactMyEntries
+          Type: 198 GoMapType map[int]uint8
           Locations:
             - Range: 0x88e4c0..0x88e4d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 75
-      Name: main.testMapWithSmallKeyAndValueMassive
+    - ID: 74
+      Name: main.testMapWithSmallKeyAndValue
       OutOfLinePCRanges: [0x88e4d0..0x88e4e0]
       InlinePCRanges: []
       Variables:
@@ -5504,8 +5493,8 @@ Subprograms:
             - Range: 0x88e4d0..0x88e4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 76
-      Name: main.testMapSmallKeySmallValue
+    - ID: 75
+      Name: main.testMapWithSmallKeyAndValueMassive
       OutOfLinePCRanges: [0x88e4e0..0x88e4f0]
       InlinePCRanges: []
       Variables:
@@ -5515,128 +5504,139 @@ Subprograms:
             - Range: 0x88e4e0..0x88e4f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
+    - ID: 76
+      Name: main.testMapSmallKeySmallValue
+      OutOfLinePCRanges: [0x88e4f0..0x88e500]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 203 GoMapType map[uint8]uint8
+          Locations:
+            - Range: 0x88e4f0..0x88e500
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
     - ID: 77
       Name: main.testMapSmallKeyLargeValue
-      OutOfLinePCRanges: [0x88e4f0..0x88e500]
+      OutOfLinePCRanges: [0x88e500..0x88e510]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 208 GoMapType map[uint8][4]int
           Locations:
-            - Range: 0x88e4f0..0x88e500
+            - Range: 0x88e500..0x88e510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 78
       Name: main.testMapLargeKeySmallValue
-      OutOfLinePCRanges: [0x88e500..0x88e510]
+      OutOfLinePCRanges: [0x88e510..0x88e520]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 213 GoMapType map[[4]int]uint8
           Locations:
-            - Range: 0x88e500..0x88e510
+            - Range: 0x88e510..0x88e520
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 79
       Name: main.testMapLargeKeyLargeValue
-      OutOfLinePCRanges: [0x88e510..0x88e520]
+      OutOfLinePCRanges: [0x88e520..0x88e530]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 218 GoMapType map[[4]int][4]int
           Locations:
-            - Range: 0x88e510..0x88e520
+            - Range: 0x88e520..0x88e530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 80
       Name: main.testMapEmptyKey
-      OutOfLinePCRanges: [0x88e520..0x88e530]
+      OutOfLinePCRanges: [0x88e530..0x88e540]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 223 GoMapType map[struct {}]int
           Locations:
-            - Range: 0x88e520..0x88e530
+            - Range: 0x88e530..0x88e540
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 81
       Name: main.testMapEmptyValue
-      OutOfLinePCRanges: [0x88e530..0x88e540]
+      OutOfLinePCRanges: [0x88e540..0x88e550]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 228 GoMapType map[int]struct {}
           Locations:
-            - Range: 0x88e530..0x88e540
+            - Range: 0x88e540..0x88e550
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 82
       Name: main.testMapEmptyKeyAndValue
-      OutOfLinePCRanges: [0x88e540..0x88e550]
+      OutOfLinePCRanges: [0x88e550..0x88e560]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 233 GoMapType map[struct {}]struct {}
           Locations:
-            - Range: 0x88e540..0x88e550
+            - Range: 0x88e550..0x88e560
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 83
       Name: main.testCombinedByte
-      OutOfLinePCRanges: [0x88f8b0..0x88f8c0]
+      OutOfLinePCRanges: [0x88f8c0..0x88f8d0]
       InlinePCRanges: []
       Variables:
         - Name: w
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f8b0..0x88f8c0
+            - Range: 0x88f8c0..0x88f8d0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f8b0..0x88f8c0
+            - Range: 0x88f8c0..0x88f8d0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: y
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x88f8b0..0x88f8c0
+            - Range: 0x88f8c0..0x88f8d0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 84
       Name: main.testMultipleSimpleParams
-      OutOfLinePCRanges: [0x88f990..0x88f9a0]
+      OutOfLinePCRanges: [0x88f9a0..0x88f9b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88f9a0..0x88f9b0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88f9a0..0x88f9b0
               Pieces: [{Size: 1, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: c
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88f9a0..0x88f9b0
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: d
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88f9a0..0x88f9b0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: e
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x88f990..0x88f9a0
+            - Range: 0x88f9a0..0x88f9b0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -5645,56 +5645,56 @@ Subprograms:
           Role: Parameter
     - ID: 85
       Name: main.testAtomicAdd
-      OutOfLinePCRanges: [0x88fb30..0x88fb70]
+      OutOfLinePCRanges: [0x88fb40..0x88fb80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88fb30..0x88fb6c
+            - Range: 0x88fb40..0x88fb7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x88fb30..0x88fb6c
+            - Range: 0x88fb40..0x88fb7c
               Pieces: []
-            - Range: 0x88fb6c..0x88fb6d
+            - Range: 0x88fb7c..0x88fb7d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88fb6d..0x88fb70
+            - Range: 0x88fb7d..0x88fb80
               Pieces: []
           Role: Return
     - ID: 86
       Name: main.testChannel
-      OutOfLinePCRanges: [0x88fb70..0x88fb80]
+      OutOfLinePCRanges: [0x88fb80..0x88fb90]
       InlinePCRanges: []
       Variables:
         - Name: c
           Type: 238 GoChannelType chan bool
           Locations:
-            - Range: 0x88fb70..0x88fb80
+            - Range: 0x88fb80..0x88fb90
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 87
       Name: main.testPointerToSimpleStruct
-      OutOfLinePCRanges: [0x88fd20..0x88fd30]
+      OutOfLinePCRanges: [0x88fd30..0x88fd40]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 239 PointerType *main.structWithTwoValues
           Locations:
-            - Range: 0x88fd20..0x88fd30
+            - Range: 0x88fd30..0x88fd40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 88
       Name: main.testLinkedList
-      OutOfLinePCRanges: [0x88fd30..0x88fd40]
+      OutOfLinePCRanges: [0x88fd40..0x88fd50]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 241 StructureType main.node
           Locations:
-            - Range: 0x88fd30..0x88fd40
+            - Range: 0x88fd40..0x88fd50
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -5703,243 +5703,243 @@ Subprograms:
           Role: Parameter
     - ID: 89
       Name: main.testPointerLoop
-      OutOfLinePCRanges: [0x88fd40..0x88fd50]
+      OutOfLinePCRanges: [0x88fd50..0x88fd60]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 242 PointerType *main.node
           Locations:
-            - Range: 0x88fd40..0x88fd50
+            - Range: 0x88fd50..0x88fd60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 90
       Name: main.testUnsafePointer
-      OutOfLinePCRanges: [0x88fd50..0x88fd60]
+      OutOfLinePCRanges: [0x88fd60..0x88fd70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 VoidPointerType unsafe.Pointer
           Locations:
-            - Range: 0x88fd50..0x88fd60
+            - Range: 0x88fd60..0x88fd70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 91
       Name: main.testUintPointer
-      OutOfLinePCRanges: [0x88fd70..0x88fd80]
+      OutOfLinePCRanges: [0x88fd80..0x88fd90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 PointerType *uint
           Locations:
-            - Range: 0x88fd70..0x88fd80
+            - Range: 0x88fd80..0x88fd90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 92
       Name: main.testStringPointer
-      OutOfLinePCRanges: [0x88fde0..0x88fdf0]
+      OutOfLinePCRanges: [0x88fdf0..0x88fe00]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 88 PointerType *string
           Locations:
-            - Range: 0x88fde0..0x88fdf0
+            - Range: 0x88fdf0..0x88fe00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 93
       Name: main.testNilPointer
-      OutOfLinePCRanges: [0x88fe00..0x88fe10]
+      OutOfLinePCRanges: [0x88fe10..0x88fe20]
       InlinePCRanges: []
       Variables:
         - Name: z
           Type: 5 PointerType *bool
           Locations:
-            - Range: 0x88fe00..0x88fe10
+            - Range: 0x88fe10..0x88fe20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: a
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x88fe00..0x88fe10
+            - Range: 0x88fe10..0x88fe20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
     - ID: 94
       Name: main.testCycle
-      OutOfLinePCRanges: [0x88fe20..0x88fe30]
+      OutOfLinePCRanges: [0x88fe30..0x88fe40]
       InlinePCRanges: []
       Variables:
         - Name: t
           Type: 243 PointerType *main.t
           Locations:
-            - Range: 0x88fe20..0x88fe30
+            - Range: 0x88fe30..0x88fe40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 95
       Name: main.testReturnsInt
-      OutOfLinePCRanges: [0x890230..0x8902b0]
+      OutOfLinePCRanges: [0x890240..0x8902c0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890230..0x89024c
+            - Range: 0x890240..0x89025c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890230..0x89028c
+            - Range: 0x890240..0x89029c
               Pieces: []
-            - Range: 0x89028c..0x89028d
+            - Range: 0x89029c..0x89029d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89028d..0x8902b0
+            - Range: 0x89029d..0x8902c0
               Pieces: []
           Role: Return
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89024c..0x890258
+            - Range: 0x89025c..0x890268
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890258..0x8902b0
+            - Range: 0x890268..0x8902c0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
     - ID: 96
       Name: main.testReturnsIntPointer
-      OutOfLinePCRanges: [0x8902b0..0x890350]
+      OutOfLinePCRanges: [0x8902c0..0x890360]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8902b0..0x8902d4
+            - Range: 0x8902c0..0x8902e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902d4..0x890350
+            - Range: 0x8902e4..0x890360
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8902b0..0x89032c
+            - Range: 0x8902c0..0x89033c
               Pieces: []
-            - Range: 0x89032c..0x89032d
+            - Range: 0x89033c..0x89033d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x89032d..0x890350
+            - Range: 0x89033d..0x890360
               Pieces: []
           Role: Return
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8902d8..0x8902f4
+            - Range: 0x8902e8..0x890304
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8902f4..0x890350
+            - Range: 0x890304..0x890360
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
     - ID: 97
       Name: main.testReturnsIntAndFloat
-      OutOfLinePCRanges: [0x890350..0x890420]
+      OutOfLinePCRanges: [0x890360..0x890430]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890350..0x8903a8
+            - Range: 0x890360..0x8903b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890350..0x890400
+            - Range: 0x890360..0x890410
               Pieces: []
-            - Range: 0x890400..0x890401
+            - Range: 0x890410..0x890411
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890401..0x890420
+            - Range: 0x890411..0x890430
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890350..0x890420, Pieces: []}]
+          Locations: [{Range: 0x890360..0x890430, Pieces: []}]
           Role: Return
         - Name: resultInt
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89036c..0x8903ac
+            - Range: 0x89037c..0x8903bc
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8903ac..0x890420
+            - Range: 0x8903bc..0x890430
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
         - Name: resultFloat
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x89037c..0x8903ac
+            - Range: 0x89038c..0x8903bc
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
-            - Range: 0x8903ac..0x890420
+            - Range: 0x8903bc..0x890430
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
     - ID: 98
       Name: main.testReturnsError
-      OutOfLinePCRanges: [0x890420..0x8904a0]
+      OutOfLinePCRanges: [0x890430..0x8904b0]
       InlinePCRanges: []
       Variables:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x890420..0x890444
+            - Range: 0x890430..0x890454
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x890420..0x890468
+            - Range: 0x890430..0x890478
               Pieces: []
-            - Range: 0x890468..0x890469
+            - Range: 0x890478..0x890479
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890469..0x89047c
+            - Range: 0x890479..0x89048c
               Pieces: []
-            - Range: 0x89047c..0x89047d
+            - Range: 0x89048c..0x89048d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89047d..0x8904a0
+            - Range: 0x89048d..0x8904b0
               Pieces: []
           Role: Return
     - ID: 99
       Name: main.testReturnsAnyAndError
-      OutOfLinePCRanges: [0x8904a0..0x890620]
+      OutOfLinePCRanges: [0x8904b0..0x890630]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904a0..0x8904f8
+            - Range: 0x8904b0..0x890508
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8904f8..0x8904fc
+            - Range: 0x890508..0x89050c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890554..0x890558
+            - Range: 0x890564..0x890568
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: null
-            - Range: 0x890584..0x890588
+            - Range: 0x890594..0x890598
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905c4..0x8905c8
+            - Range: 0x8905d4..0x8905d8
               Pieces:
                 - Size: 8
                   Op: null
@@ -5949,112 +5949,112 @@ Subprograms:
         - Name: failed
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8904a0..0x8904f4
+            - Range: 0x8904b0..0x890504
               Pieces: [{Size: 1, Op: {RegNo: 2, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x8904a0..0x890524
+            - Range: 0x8904b0..0x890534
               Pieces: []
-            - Range: 0x890524..0x890525
+            - Range: 0x890534..0x890535
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890525..0x890570
+            - Range: 0x890535..0x890580
               Pieces: []
-            - Range: 0x890570..0x890571
+            - Range: 0x890580..0x890581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890571..0x8905b0
+            - Range: 0x890581..0x8905c0
               Pieces: []
-            - Range: 0x8905b0..0x8905b1
+            - Range: 0x8905c0..0x8905c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905b1..0x8905f0
+            - Range: 0x8905c1..0x890600
               Pieces: []
-            - Range: 0x8905f0..0x8905f1
+            - Range: 0x890600..0x890601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8905f1..0x890620
+            - Range: 0x890601..0x890630
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 18 GoInterfaceType error
           Locations:
-            - Range: 0x8904a0..0x890524
+            - Range: 0x8904b0..0x890534
               Pieces: []
-            - Range: 0x890524..0x890525
+            - Range: 0x890534..0x890535
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890525..0x890570
+            - Range: 0x890535..0x890580
               Pieces: []
-            - Range: 0x890570..0x890571
+            - Range: 0x890580..0x890581
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x890571..0x8905b0
+            - Range: 0x890581..0x8905c0
               Pieces: []
-            - Range: 0x8905b0..0x8905b1
+            - Range: 0x8905c0..0x8905c1
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8905b1..0x8905f0
+            - Range: 0x8905c1..0x890600
               Pieces: []
-            - Range: 0x8905f0..0x8905f1
+            - Range: 0x890600..0x890601
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x8905f1..0x890620
+            - Range: 0x890601..0x890630
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890554..0x89055c
+            - Range: 0x890564..0x89056c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
     - ID: 100
       Name: main.testReturnsAny
-      OutOfLinePCRanges: [0x890620..0x890820]
+      OutOfLinePCRanges: [0x890630..0x890830]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890620..0x89067c
+            - Range: 0x890630..0x89068c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89067c..0x890680
+            - Range: 0x89068c..0x890690
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890680..0x890820
+            - Range: 0x890690..0x890830
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -6064,429 +6064,429 @@ Subprograms:
         - Name: ~r0
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890620..0x8906d8
+            - Range: 0x890630..0x8906e8
               Pieces: []
-            - Range: 0x8906d8..0x8906d9
+            - Range: 0x8906e8..0x8906e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8906d9..0x890720
+            - Range: 0x8906e9..0x890730
               Pieces: []
-            - Range: 0x890720..0x890721
+            - Range: 0x890730..0x890731
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890721..0x8907e4
+            - Range: 0x890731..0x8907f4
               Pieces: []
-            - Range: 0x8907e4..0x8907e5
+            - Range: 0x8907f4..0x8907f5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8907e5..0x8907f8
+            - Range: 0x8907f5..0x890808
               Pieces: []
-            - Range: 0x8907f8..0x8907f9
+            - Range: 0x890808..0x890809
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x8907f9..0x890820
+            - Range: 0x890809..0x890830
               Pieces: []
           Role: Return
         - Name: val
           Type: 9 BaseType int
           Locations:
-            - Range: 0x89070c..0x890714
+            - Range: 0x89071c..0x890724
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
         - Name: '&result'
           Type: 94 PointerType *int
           Locations:
-            - Range: 0x8906bc..0x8906d8
+            - Range: 0x8906cc..0x8906e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 101
       Name: main.testReturnsInterface
-      OutOfLinePCRanges: [0x890820..0x890990]
+      OutOfLinePCRanges: [0x890830..0x8909a0]
       InlinePCRanges: []
       Variables:
         - Name: v
           Type: 152 GoEmptyInterfaceType interface {}
           Locations:
-            - Range: 0x890820..0x89085c
+            - Range: 0x890830..0x89086c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89085c..0x8908bc
+            - Range: 0x89086c..0x8908cc
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x8908bc..0x890928
+            - Range: 0x8908cc..0x890938
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x890928..0x890950
+            - Range: 0x890938..0x890960
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890950..0x890954
+            - Range: 0x890960..0x890964
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890954..0x890990
+            - Range: 0x890964..0x8909a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: ~r0
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890820..0x890908
+            - Range: 0x890830..0x890918
               Pieces: []
-            - Range: 0x890908..0x890909
+            - Range: 0x890918..0x890919
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x890909..0x89091c
+            - Range: 0x890919..0x89092c
               Pieces: []
-            - Range: 0x89091c..0x89091d
+            - Range: 0x89092c..0x89092d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89091d..0x890990
+            - Range: 0x89092d..0x8909a0
               Pieces: []
           Role: Return
         - Name: b
           Type: 157 GoInterfaceType main.behavior
           Locations:
-            - Range: 0x890820..0x89085c
+            - Range: 0x890830..0x89086c
               Pieces:
                 - Size: 8
                   Op: null
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89085c..0x8908ac
+            - Range: 0x89086c..0x8908bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908ac..0x8908bc
+            - Range: 0x8908bc..0x8908cc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x8908bc..0x890914
+            - Range: 0x8908cc..0x890924
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: -64}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890914..0x890918
+            - Range: 0x890924..0x890928
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x890918..0x89091c
+            - Range: 0x890928..0x89092c
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
-            - Range: 0x89091c..0x890990
+            - Range: 0x89092c..0x8909a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
     - ID: 102
       Name: main.testNamedReturn
-      OutOfLinePCRanges: [0x890990..0x890a30]
+      OutOfLinePCRanges: [0x8909a0..0x890a40]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890990..0x8909ac
+            - Range: 0x8909a0..0x8909bc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890990..0x890a08
+            - Range: 0x8909a0..0x890a18
               Pieces: []
-            - Range: 0x890a08..0x890a09
+            - Range: 0x890a18..0x890a19
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890a09..0x890a30
+            - Range: 0x890a19..0x890a40
               Pieces: []
           Role: Return
     - ID: 103
       Name: main.testMultipleNamedReturn
-      OutOfLinePCRanges: [0x890a30..0x890b00]
+      OutOfLinePCRanges: [0x890a40..0x890b10]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a30..0x890a80
+            - Range: 0x890a40..0x890a90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: result
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a30..0x890ad4
+            - Range: 0x890a40..0x890ae4
               Pieces: []
-            - Range: 0x890ad4..0x890ad5
+            - Range: 0x890ae4..0x890ae5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890ad5..0x890b00
+            - Range: 0x890ae5..0x890b10
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890a30..0x890ad4
+            - Range: 0x890a40..0x890ae4
               Pieces: []
-            - Range: 0x890ad4..0x890ad5
+            - Range: 0x890ae4..0x890ae5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890ad5..0x890b00
+            - Range: 0x890ae5..0x890b10
               Pieces: []
           Role: Return
     - ID: 104
       Name: main.testSomeNamedReturn
-      OutOfLinePCRanges: [0x890b00..0x890bd0]
+      OutOfLinePCRanges: [0x890b10..0x890be0]
       InlinePCRanges: []
       Variables:
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b00..0x890b40
+            - Range: 0x890b10..0x890b50
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890b40..0x890bd0
+            - Range: 0x890b50..0x890be0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b00..0x890ba4
+            - Range: 0x890b10..0x890bb4
               Pieces: []
-            - Range: 0x890ba4..0x890ba5
+            - Range: 0x890bb4..0x890bb5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890ba5..0x890bd0
+            - Range: 0x890bb5..0x890be0
               Pieces: []
           Role: Return
         - Name: result2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b00..0x890ba4
+            - Range: 0x890b10..0x890bb4
               Pieces: []
-            - Range: 0x890ba4..0x890ba5
+            - Range: 0x890bb4..0x890bb5
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890ba5..0x890bd0
+            - Range: 0x890bb5..0x890be0
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x890b00..0x890ba4
+            - Range: 0x890b10..0x890bb4
               Pieces: []
-            - Range: 0x890ba4..0x890ba5
+            - Range: 0x890bb4..0x890bb5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890ba5..0x890bd0
+            - Range: 0x890bb5..0x890be0
               Pieces: []
           Role: Return
     - ID: 105
       Name: main.testReturnsPrimitives
-      OutOfLinePCRanges: [0x890bd0..0x890c60]
+      OutOfLinePCRanges: [0x890be0..0x890c70]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 89 BaseType int16
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 2, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 13 BaseType int32
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 4, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 14 BaseType int64
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 1, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 2, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 4, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 10 BaseType uint64
           Locations:
-            - Range: 0x890bd0..0x890c40
+            - Range: 0x890be0..0x890c50
               Pieces: []
-            - Range: 0x890c40..0x890c41
+            - Range: 0x890c50..0x890c51
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x890c41..0x890c60
+            - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
     - ID: 106
       Name: main.testReturnsManyFloats
-      OutOfLinePCRanges: [0x890c60..0x890d20]
+      OutOfLinePCRanges: [0x890c70..0x890d30]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r5
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r6
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r7
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r8
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r9
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r10
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r11
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r12
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r13
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: ~r14
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: onlyOnAmd64_16
           Type: 17 BaseType float64
-          Locations: [{Range: 0x890c60..0x890d20, Pieces: []}]
+          Locations: [{Range: 0x890c70..0x890d30, Pieces: []}]
           Role: Return
         - Name: bothArmAndAmd64
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x890c60..0x890cfc
+            - Range: 0x890c70..0x890d0c
               Pieces: []
-            - Range: 0x890cfc..0x890cfd
+            - Range: 0x890d0c..0x890d0d
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x890cfd..0x890d20
+            - Range: 0x890d0d..0x890d30
               Pieces: []
           Role: Return
     - ID: 107
       Name: main.testReturnsComplex
-      OutOfLinePCRanges: [0x890d20..0x890da0]
+      OutOfLinePCRanges: [0x890d30..0x890db0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 90 BaseType complex64
-          Locations: [{Range: 0x890d20..0x890da0, Pieces: []}]
+          Locations: [{Range: 0x890d30..0x890db0, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 91 BaseType complex128
-          Locations: [{Range: 0x890d20..0x890da0, Pieces: []}]
+          Locations: [{Range: 0x890d30..0x890db0, Pieces: []}]
           Role: Return
     - ID: 108
       Name: main.testReturnsLargeStruct
-      OutOfLinePCRanges: [0x890da0..0x890e70]
+      OutOfLinePCRanges: [0x890db0..0x890e80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x890da0..0x890e54
+            - Range: 0x890db0..0x890e64
               Pieces: []
-            - Range: 0x890e54..0x890e55
+            - Range: 0x890e64..0x890e65
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6508,173 +6508,173 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x890e55..0x890e70
+            - Range: 0x890e65..0x890e80
               Pieces: []
           Role: Return
     - ID: 109
       Name: main.testReturnsArray
-      OutOfLinePCRanges: [0x890e70..0x890f00]
+      OutOfLinePCRanges: [0x890e80..0x890f10]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x890e70..0x890ee0
+            - Range: 0x890e80..0x890ef0
               Pieces: []
-            - Range: 0x890ee0..0x890ee1
+            - Range: 0x890ef0..0x890ef1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x890ee1..0x890f00
+            - Range: 0x890ef1..0x890f10
               Pieces: []
           Role: Return
     - ID: 110
       Name: main.testReturnsArrayOne
-      OutOfLinePCRanges: [0x890f00..0x890f70]
+      OutOfLinePCRanges: [0x890f10..0x890f80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 247 ArrayType [1]int
           Locations:
-            - Range: 0x890f00..0x890f54
+            - Range: 0x890f10..0x890f64
               Pieces: []
-            - Range: 0x890f54..0x890f55
+            - Range: 0x890f64..0x890f65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x890f55..0x890f70
+            - Range: 0x890f65..0x890f80
               Pieces: []
           Role: Return
     - ID: 111
       Name: main.testReturnsArrayZero
-      OutOfLinePCRanges: [0x890f70..0x890fe0]
+      OutOfLinePCRanges: [0x890f80..0x890ff0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x890f70..0x890fc0
+            - Range: 0x890f80..0x890fd0
               Pieces: []
-            - Range: 0x890fc0..0x890fc1
+            - Range: 0x890fd0..0x890fd1
               Pieces: []
-            - Range: 0x890fc1..0x890fe0
+            - Range: 0x890fd1..0x890ff0
               Pieces: []
           Role: Return
     - ID: 112
       Name: main.testReturnsMixedStruct
-      OutOfLinePCRanges: [0x890fe0..0x891060]
+      OutOfLinePCRanges: [0x890ff0..0x891070]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 249 StructureType main.mixedStruct
-          Locations: [{Range: 0x890fe0..0x891060, Pieces: []}]
+          Locations: [{Range: 0x890ff0..0x891070, Pieces: []}]
           Role: Return
     - ID: 113
       Name: main.testReturnsBacktrackInt
-      OutOfLinePCRanges: [0x891060..0x891100]
+      OutOfLinePCRanges: [0x891070..0x891110]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r4
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r5
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r6
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r7
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
         - Name: ~r8
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891060..0x8910dc
+            - Range: 0x891070..0x8910ec
               Pieces: []
-            - Range: 0x8910dc..0x8910dd
+            - Range: 0x8910ec..0x8910ed
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8910dd..0x891100
+            - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
     - ID: 114
       Name: main.testReturnsWideStruct
-      OutOfLinePCRanges: [0x891100..0x8911e0]
+      OutOfLinePCRanges: [0x891110..0x8911f0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 250 StructureType main.wideStruct
           Locations:
-            - Range: 0x891100..0x8911c4
+            - Range: 0x891110..0x8911d4
               Pieces: []
-            - Range: 0x8911c4..0x8911c5
+            - Range: 0x8911d4..0x8911d5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6698,127 +6698,127 @@ Subprograms:
                   Op: {RegNo: 9, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 10, Shift: 0}
-            - Range: 0x8911c5..0x8911e0
+            - Range: 0x8911d5..0x8911f0
               Pieces: []
           Role: Return
     - ID: 115
       Name: main.testReturnsMixed
-      OutOfLinePCRanges: [0x8911e0..0x891270]
+      OutOfLinePCRanges: [0x8911f0..0x891280]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8911e0..0x891250
+            - Range: 0x8911f0..0x891260
               Pieces: []
-            - Range: 0x891250..0x891251
+            - Range: 0x891260..0x891261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891251..0x891270
+            - Range: 0x891261..0x891280
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8911e0..0x891270, Pieces: []}]
+          Locations: [{Range: 0x8911f0..0x891280, Pieces: []}]
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x8911e0..0x891250
+            - Range: 0x8911f0..0x891260
               Pieces: []
-            - Range: 0x891250..0x891251
+            - Range: 0x891260..0x891261
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891251..0x891270
+            - Range: 0x891261..0x891280
               Pieces: []
           Role: Return
         - Name: ~r3
           Type: 17 BaseType float64
-          Locations: [{Range: 0x8911e0..0x891270, Pieces: []}]
+          Locations: [{Range: 0x8911f0..0x891280, Pieces: []}]
           Role: Return
         - Name: ~r4
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8911e0..0x891250
+            - Range: 0x8911f0..0x891260
               Pieces: []
-            - Range: 0x891250..0x891251
+            - Range: 0x891260..0x891261
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x891251..0x891270
+            - Range: 0x891261..0x891280
               Pieces: []
           Role: Return
     - ID: 116
       Name: main.testReturnsStructWithArray
-      OutOfLinePCRanges: [0x891270..0x891300]
+      OutOfLinePCRanges: [0x891280..0x891310]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891270..0x8912e0
+            - Range: 0x891280..0x8912f0
               Pieces: []
-            - Range: 0x8912e0..0x8912e1
+            - Range: 0x8912f0..0x8912f1
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
-            - Range: 0x8912e1..0x891300
+            - Range: 0x8912f1..0x891310
               Pieces: []
           Role: Return
     - ID: 117
       Name: main.testReturnsOnlyFloat
-      OutOfLinePCRanges: [0x891300..0x891370]
+      OutOfLinePCRanges: [0x891310..0x891380]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891300..0x891370, Pieces: []}]
+          Locations: [{Range: 0x891310..0x891380, Pieces: []}]
           Role: Return
     - ID: 118
       Name: main.testReturnsMultipleFloats
-      OutOfLinePCRanges: [0x891370..0x8913f0]
+      OutOfLinePCRanges: [0x891380..0x891400]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 16 BaseType float32
-          Locations: [{Range: 0x891370..0x8913f0, Pieces: []}]
+          Locations: [{Range: 0x891380..0x891400, Pieces: []}]
           Role: Return
         - Name: ~r1
           Type: 17 BaseType float64
-          Locations: [{Range: 0x891370..0x8913f0, Pieces: []}]
+          Locations: [{Range: 0x891380..0x891400, Pieces: []}]
           Role: Return
     - ID: 119
       Name: main.testReturnsBoolAndUintptr
-      OutOfLinePCRanges: [0x8913f0..0x891460]
+      OutOfLinePCRanges: [0x891400..0x891470]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x8913f0..0x891448
+            - Range: 0x891400..0x891458
               Pieces: []
-            - Range: 0x891448..0x891449
+            - Range: 0x891458..0x891459
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891449..0x891460
+            - Range: 0x891459..0x891470
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 1 BaseType uintptr
           Locations:
-            - Range: 0x8913f0..0x891448
+            - Range: 0x891400..0x891458
               Pieces: []
-            - Range: 0x891448..0x891449
+            - Range: 0x891458..0x891459
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891449..0x891460
+            - Range: 0x891459..0x891470
               Pieces: []
           Role: Return
     - ID: 120
       Name: main.testLargeArgAndReturn
-      OutOfLinePCRanges: [0x891460..0x891640]
+      OutOfLinePCRanges: [0x891470..0x891650]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891460..0x8914cc
+            - Range: 0x891470..0x8914dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6840,7 +6840,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8914cc..0x8914e0
+            - Range: 0x8914dc..0x8914f0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6862,7 +6862,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8914e0..0x8914e4
+            - Range: 0x8914f0..0x8914f4
               Pieces:
                 - Size: 8
                   Op: null
@@ -6888,9 +6888,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891460..0x8915d8
+            - Range: 0x891470..0x8915e8
               Pieces: []
-            - Range: 0x8915d8..0x8915d9
+            - Range: 0x8915e8..0x8915e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6912,39 +6912,39 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x8915d9..0x891640
+            - Range: 0x8915e9..0x891650
               Pieces: []
           Role: Return
     - ID: 121
       Name: main.testArrayArgAndReturn
-      OutOfLinePCRanges: [0x891640..0x891710]
+      OutOfLinePCRanges: [0x891650..0x891720]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891640..0x891710
+            - Range: 0x891650..0x891720
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891640..0x8916f4
+            - Range: 0x891650..0x891704
               Pieces: []
-            - Range: 0x8916f4..0x8916f5
+            - Range: 0x891704..0x891705
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x8916f5..0x891710
+            - Range: 0x891705..0x891720
               Pieces: []
           Role: Return
     - ID: 122
       Name: main.testMultipleLargeArgs
-      OutOfLinePCRanges: [0x891710..0x891970]
+      OutOfLinePCRanges: [0x891720..0x891980]
       InlinePCRanges: []
       Variables:
         - Name: s1
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891710..0x891780
+            - Range: 0x891720..0x891790
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6966,7 +6966,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891780..0x891794
+            - Range: 0x891790..0x8917a4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -6988,7 +6988,7 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891794..0x891798
+            - Range: 0x8917a4..0x8917a8
               Pieces:
                 - Size: 8
                   Op: null
@@ -7014,15 +7014,15 @@ Subprograms:
         - Name: s2
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891710..0x891970
+            - Range: 0x891720..0x891980
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891710..0x891900
+            - Range: 0x891720..0x891910
               Pieces: []
-            - Range: 0x891900..0x891901
+            - Range: 0x891910..0x891911
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7044,175 +7044,175 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891901..0x891970
+            - Range: 0x891911..0x891980
               Pieces: []
           Role: Return
     - ID: 123
       Name: main.testManyArgsArrayReturn
-      OutOfLinePCRanges: [0x891970..0x891b60]
+      OutOfLinePCRanges: [0x891980..0x891b70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 72}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 80}}]
           Role: Parameter
         - Name: i
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891970..0x8919e8
+            - Range: 0x891980..0x8919f8
               Pieces: [{Size: 8, Op: {RegNo: 8, Shift: 0}}]
-            - Range: 0x8919e8..0x891b60
+            - Range: 0x8919f8..0x891b70
               Pieces: [{Size: 8, Op: {CfaOffset: 88}}]
           Role: Parameter
         - Name: ~r0
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891970..0x891afc
+            - Range: 0x891980..0x891b0c
               Pieces: []
-            - Range: 0x891afc..0x891afd
+            - Range: 0x891b0c..0x891b0d
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
-            - Range: 0x891afd..0x891b60
+            - Range: 0x891b0d..0x891b70
               Pieces: []
           Role: Return
     - ID: 124
       Name: main.testMixedArgsStackReturn
-      OutOfLinePCRanges: [0x891b60..0x891da0]
+      OutOfLinePCRanges: [0x891b70..0x891db0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 16}}]
           Role: Parameter
         - Name: c
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: d
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 32}}]
           Role: Parameter
         - Name: e
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 40}}]
           Role: Parameter
         - Name: f
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 48}}]
           Role: Parameter
         - Name: g
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 6, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 56}}]
           Role: Parameter
         - Name: h
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces: [{Size: 8, Op: {RegNo: 7, Shift: 0}}]
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces: [{Size: 8, Op: {CfaOffset: 64}}]
           Role: Parameter
         - Name: s
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x891b60..0x891be8
+            - Range: 0x891b70..0x891bf8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891be8..0x891da0
+            - Range: 0x891bf8..0x891db0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 72}
@@ -7222,9 +7222,9 @@ Subprograms:
         - Name: ~r0
           Type: 245 StructureType main.largeStruct
           Locations:
-            - Range: 0x891b60..0x891d30
+            - Range: 0x891b70..0x891d40
               Pieces: []
-            - Range: 0x891d30..0x891d31
+            - Range: 0x891d40..0x891d41
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7246,184 +7246,167 @@ Subprograms:
                   Op: {RegNo: 8, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
-            - Range: 0x891d31..0x891da0
+            - Range: 0x891d41..0x891db0
               Pieces: []
           Role: Return
     - ID: 125
       Name: main.testStackArgRegReturns
-      OutOfLinePCRanges: [0x891da0..0x891e40]
+      OutOfLinePCRanges: [0x891db0..0x891e50]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x891da0..0x891e40
+            - Range: 0x891db0..0x891e50
               Pieces: [{Size: 40, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891da0..0x891e1c
+            - Range: 0x891db0..0x891e2c
               Pieces: []
-            - Range: 0x891e1c..0x891e1d
+            - Range: 0x891e2c..0x891e2d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891e1d..0x891e40
+            - Range: 0x891e2d..0x891e50
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891da0..0x891e1c
+            - Range: 0x891db0..0x891e2c
               Pieces: []
-            - Range: 0x891e1c..0x891e1d
+            - Range: 0x891e2c..0x891e2d
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
-            - Range: 0x891e1d..0x891e40
+            - Range: 0x891e2d..0x891e50
               Pieces: []
           Role: Return
         - Name: ~r2
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891da0..0x891e1c
+            - Range: 0x891db0..0x891e2c
               Pieces: []
-            - Range: 0x891e1c..0x891e1d
+            - Range: 0x891e2c..0x891e2d
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
-            - Range: 0x891e1d..0x891e40
+            - Range: 0x891e2d..0x891e50
               Pieces: []
           Role: Return
     - ID: 126
       Name: main.testMultipleArrayArgs
-      OutOfLinePCRanges: [0x891e40..0x891f20]
+      OutOfLinePCRanges: [0x891e50..0x891f30]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891e40..0x891f20
+            - Range: 0x891e50..0x891f30
               Pieces: [{Size: 16, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: b
           Type: 246 ArrayType [3]int
           Locations:
-            - Range: 0x891e40..0x891f20
+            - Range: 0x891e50..0x891f30
               Pieces: [{Size: 24, Op: {CfaOffset: 24}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891e40..0x891f00
+            - Range: 0x891e50..0x891f10
               Pieces: []
-            - Range: 0x891f00..0x891f01
+            - Range: 0x891f10..0x891f11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891f01..0x891f20
+            - Range: 0x891f11..0x891f30
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 106 ArrayType [2]int
           Locations:
-            - Range: 0x891e40..0x891f00
+            - Range: 0x891e50..0x891f10
               Pieces: []
-            - Range: 0x891f00..0x891f01
+            - Range: 0x891f10..0x891f11
               Pieces: [{Size: 16, Op: {CfaOffset: 48}}]
-            - Range: 0x891f01..0x891f20
+            - Range: 0x891f11..0x891f30
               Pieces: []
           Role: Return
     - ID: 127
       Name: main.testStructWithArrayArg
-      OutOfLinePCRanges: [0x891f20..0x891ff0]
+      OutOfLinePCRanges: [0x891f30..0x892000]
       InlinePCRanges: []
       Variables:
         - Name: arg
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891f20..0x891ff0
+            - Range: 0x891f30..0x892000
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891f20..0x891fcc
+            - Range: 0x891f30..0x891fdc
               Pieces: []
-            - Range: 0x891fcc..0x891fcd
+            - Range: 0x891fdc..0x891fdd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x891fcd..0x891ff0
+            - Range: 0x891fdd..0x892000
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 251 StructureType main.structWithArray
           Locations:
-            - Range: 0x891f20..0x891fcc
+            - Range: 0x891f30..0x891fdc
               Pieces: []
-            - Range: 0x891fcc..0x891fcd
+            - Range: 0x891fdc..0x891fdd
               Pieces: [{Size: 24, Op: {CfaOffset: 32}}]
-            - Range: 0x891fcd..0x891ff0
+            - Range: 0x891fdd..0x892000
               Pieces: []
           Role: Return
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891fa0..0x891ff0
+            - Range: 0x891fb0..0x892000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 128
       Name: main.testZeroSizeArgAndReturn
-      OutOfLinePCRanges: [0x891ff0..0x8920a0]
+      OutOfLinePCRanges: [0x892000..0x8920b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 248 ArrayType [0]int
-          Locations: [{Range: 0x891ff0..0x8920a0, Pieces: []}]
+          Locations: [{Range: 0x892000..0x8920b0, Pieces: []}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ff0..0x892030
+            - Range: 0x892000..0x892040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892030..0x89204c
+            - Range: 0x892040..0x89205c
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
-            - Range: 0x89204c..0x892068
+            - Range: 0x89205c..0x892078
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x892068..0x8920a0
+            - Range: 0x892078..0x8920b0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x891ff0..0x892074
+            - Range: 0x892000..0x892084
               Pieces: []
-            - Range: 0x892074..0x892075
+            - Range: 0x892084..0x892085
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x892075..0x8920a0
+            - Range: 0x892085..0x8920b0
               Pieces: []
           Role: Return
         - Name: ~r1
           Type: 248 ArrayType [0]int
           Locations:
-            - Range: 0x891ff0..0x892074
+            - Range: 0x892000..0x892084
               Pieces: []
-            - Range: 0x892074..0x892075
+            - Range: 0x892084..0x892085
               Pieces: []
-            - Range: 0x892075..0x8920a0
+            - Range: 0x892085..0x8920b0
               Pieces: []
           Role: Return
     - ID: 129
       Name: main.testUintSlice
-      OutOfLinePCRanges: [0x892510..0x892520]
-      InlinePCRanges: []
-      Variables:
-        - Name: u
-          Type: 252 GoSliceHeaderType []uint
-          Locations:
-            - Range: 0x892510..0x892520
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 130
-      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x892520..0x892530]
       InlinePCRanges: []
       Variables:
@@ -7439,13 +7422,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
-      Name: main.testSliceOfSlices
+    - ID: 130
+      Name: main.testEmptySlice
       OutOfLinePCRanges: [0x892530..0x892540]
       InlinePCRanges: []
       Variables:
         - Name: u
-          Type: 253 GoSliceHeaderType [][]uint
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0x892530..0x892540
               Pieces:
@@ -7456,13 +7439,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
-      Name: main.testStructSlice
+    - ID: 131
+      Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x892540..0x892550]
       InlinePCRanges: []
       Variables:
-        - Name: xs
-          Type: 255 GoSliceHeaderType []main.structWithNoStrings
+        - Name: u
+          Type: 253 GoSliceHeaderType [][]uint
           Locations:
             - Range: 0x892540..0x892550
               Pieces:
@@ -7473,14 +7456,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-        - Name: a
-          Type: 9 BaseType int
-          Locations:
-            - Range: 0x892540..0x892550
-              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
-          Role: Parameter
-    - ID: 133
-      Name: main.testEmptySliceOfStructs
+    - ID: 132
+      Name: main.testStructSlice
       OutOfLinePCRanges: [0x892550..0x892560]
       InlinePCRanges: []
       Variables:
@@ -7502,8 +7479,8 @@ Subprograms:
             - Range: 0x892550..0x892560
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 134
-      Name: main.testNilSliceOfStructs
+    - ID: 133
+      Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x892560..0x892570]
       InlinePCRanges: []
       Variables:
@@ -7525,13 +7502,13 @@ Subprograms:
             - Range: 0x892560..0x892570
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 135
-      Name: main.testStringSlice
+    - ID: 134
+      Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x892570..0x892580]
       InlinePCRanges: []
       Variables:
-        - Name: s
-          Type: 258 GoSliceHeaderType []string
+        - Name: xs
+          Type: 255 GoSliceHeaderType []main.structWithNoStrings
           Locations:
             - Range: 0x892570..0x892580
               Pieces:
@@ -7542,21 +7519,44 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
+        - Name: a
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x892570..0x892580
+              Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
+          Role: Parameter
+    - ID: 135
+      Name: main.testStringSlice
+      OutOfLinePCRanges: [0x892580..0x892590]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 258 GoSliceHeaderType []string
+          Locations:
+            - Range: 0x892580..0x892590
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
     - ID: 136
       Name: main.testNilSliceWithOtherParams
-      OutOfLinePCRanges: [0x892580..0x892590]
+      OutOfLinePCRanges: [0x892590..0x8925a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x892580..0x892590
+            - Range: 0x892590..0x8925a0
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: s
           Type: 259 GoSliceHeaderType []bool
           Locations:
-            - Range: 0x892580..0x892590
+            - Range: 0x892590..0x8925a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
@@ -7568,33 +7568,16 @@ Subprograms:
         - Name: x
           Type: 12 BaseType uint
           Locations:
-            - Range: 0x892580..0x892590
+            - Range: 0x892590..0x8925a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
     - ID: 137
       Name: main.testNilSlice
-      OutOfLinePCRanges: [0x892590..0x8925a0]
-      InlinePCRanges: []
-      Variables:
-        - Name: xs
-          Type: 260 GoSliceHeaderType []uint16
-          Locations:
-            - Range: 0x892590..0x8925a0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 2, Shift: 0}
-          Role: Parameter
-    - ID: 138
-      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8925a0..0x8925b0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 252 GoSliceHeaderType []uint
+          Type: 260 GoSliceHeaderType []uint16
           Locations:
             - Range: 0x8925a0..0x8925b0
               Pieces:
@@ -7605,13 +7588,13 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
-      Name: main.testSliceEmptyStructs
+    - ID: 138
+      Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8925b0..0x8925c0]
       InlinePCRanges: []
       Variables:
         - Name: xs
-          Type: 261 GoSliceHeaderType []struct {}
+          Type: 252 GoSliceHeaderType []uint
           Locations:
             - Range: 0x8925b0..0x8925c0
               Pieces:
@@ -7622,15 +7605,32 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
+    - ID: 139
+      Name: main.testSliceEmptyStructs
+      OutOfLinePCRanges: [0x8925c0..0x8925d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: xs
+          Type: 261 GoSliceHeaderType []struct {}
+          Locations:
+            - Range: 0x8925c0..0x8925d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
     - ID: 140
       Name: main.testSubslices
-      OutOfLinePCRanges: [0x8925c0..0x8925d0]
+      OutOfLinePCRanges: [0x8925d0..0x8925e0]
       InlinePCRanges: []
       Variables:
         - Name: as
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925c0..0x8925d0
+            - Range: 0x8925d0..0x8925e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7642,7 +7642,7 @@ Subprograms:
         - Name: bs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925c0..0x8925d0
+            - Range: 0x8925d0..0x8925e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
@@ -7654,7 +7654,7 @@ Subprograms:
         - Name: cs
           Type: 252 GoSliceHeaderType []uint
           Locations:
-            - Range: 0x8925c0..0x8925d0
+            - Range: 0x8925d0..0x8925e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
@@ -7665,40 +7665,25 @@ Subprograms:
           Role: Parameter
     - ID: 141
       Name: main.stackC
-      OutOfLinePCRanges: [0x8928e0..0x892950]
+      OutOfLinePCRanges: [0x8928f0..0x892960]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8928e0..0x89292c
+            - Range: 0x8928f0..0x89293c
               Pieces: []
-            - Range: 0x89292c..0x89292d
+            - Range: 0x89293c..0x89293d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0x89292d..0x892950
+            - Range: 0x89293d..0x892960
               Pieces: []
           Role: Return
     - ID: 142
       Name: main.testSingleString
-      OutOfLinePCRanges: [0x892950..0x892960]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x892950..0x892960
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-    - ID: 143
-      Name: main.testThreeStrings
       OutOfLinePCRanges: [0x892960..0x892970]
       InlinePCRanges: []
       Variables:
@@ -7712,10 +7697,25 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
+    - ID: 143
+      Name: main.testThreeStrings
+      OutOfLinePCRanges: [0x892970..0x892980]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x892970..0x892980
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
         - Name: y
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892960..0x892970
+            - Range: 0x892970..0x892980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7725,7 +7725,7 @@ Subprograms:
         - Name: z
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x892960..0x892970
+            - Range: 0x892970..0x892980
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7734,13 +7734,13 @@ Subprograms:
           Role: Parameter
     - ID: 144
       Name: main.testThreeStringsInStruct
-      OutOfLinePCRanges: [0x892970..0x892990]
+      OutOfLinePCRanges: [0x892980..0x8929a0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 263 StructureType main.threeStringStruct
           Locations:
-            - Range: 0x892970..0x892990
+            - Range: 0x892980..0x8929a0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7757,43 +7757,28 @@ Subprograms:
           Role: Parameter
     - ID: 145
       Name: main.testThreeStringsInStructPointer
-      OutOfLinePCRanges: [0x892990..0x8929a0]
+      OutOfLinePCRanges: [0x8929a0..0x8929b0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 264 PointerType *main.threeStringStruct
           Locations:
-            - Range: 0x892990..0x8929a0
+            - Range: 0x8929a0..0x8929b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 146
       Name: main.testOneStringInStructPointer
-      OutOfLinePCRanges: [0x8929a0..0x8929b0]
+      OutOfLinePCRanges: [0x8929b0..0x8929c0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 265 PointerType *main.oneStringStruct
           Locations:
-            - Range: 0x8929a0..0x8929b0
+            - Range: 0x8929b0..0x8929c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 147
       Name: main.testMassiveString
-      OutOfLinePCRanges: [0x8929b0..0x8929c0]
-      InlinePCRanges: []
-      Variables:
-        - Name: x
-          Type: 11 GoStringHeaderType string
-          Locations:
-            - Range: 0x8929b0..0x8929c0
-              Pieces:
-                - Size: 8
-                  Op: {RegNo: 0, Shift: 0}
-                - Size: 8
-                  Op: {RegNo: 1, Shift: 0}
-          Role: Parameter
-    - ID: 148
-      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8929c0..0x8929d0]
       InlinePCRanges: []
       Variables:
@@ -7807,8 +7792,8 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 149
-      Name: main.testEmptyString
+    - ID: 148
+      Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8929d0..0x8929e0]
       InlinePCRanges: []
       Variables:
@@ -7822,12 +7807,12 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 150
-      Name: main.testSubstrings
+    - ID: 149
+      Name: main.testEmptyString
       OutOfLinePCRanges: [0x8929e0..0x8929f0]
       InlinePCRanges: []
       Variables:
-        - Name: a
+        - Name: x
           Type: 11 GoStringHeaderType string
           Locations:
             - Range: 0x8929e0..0x8929f0
@@ -7837,10 +7822,25 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
+    - ID: 150
+      Name: main.testSubstrings
+      OutOfLinePCRanges: [0x8929f0..0x892a00]
+      InlinePCRanges: []
+      Variables:
+        - Name: a
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x8929f0..0x892a00
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+          Role: Parameter
         - Name: b
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929e0..0x8929f0
+            - Range: 0x8929f0..0x892a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
@@ -7850,7 +7850,7 @@ Subprograms:
         - Name: c
           Type: 11 GoStringHeaderType string
           Locations:
-            - Range: 0x8929e0..0x8929f0
+            - Range: 0x8929f0..0x892a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
@@ -7859,24 +7859,24 @@ Subprograms:
           Role: Parameter
     - ID: 151
       Name: main.testStructWithCyclicSlices
-      OutOfLinePCRanges: [0x892b50..0x892b60]
+      OutOfLinePCRanges: [0x892b60..0x892b70]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 267 StructureType main.structWithCyclicSlices
           Locations:
-            - Range: 0x892b50..0x892b60
+            - Range: 0x892b60..0x892b70
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 152
       Name: main.testStructWithCyclicMaps
-      OutOfLinePCRanges: [0x892b60..0x892b80]
+      OutOfLinePCRanges: [0x892b70..0x892b90]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 280 StructureType main.structWithCyclicMaps
           Locations:
-            - Range: 0x892b60..0x892b80
+            - Range: 0x892b70..0x892b90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -7893,13 +7893,13 @@ Subprograms:
           Role: Parameter
     - ID: 153
       Name: main.testStruct
-      OutOfLinePCRanges: [0x892c50..0x892c70]
+      OutOfLinePCRanges: [0x892c60..0x892c80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 311 StructureType main.aStruct
           Locations:
-            - Range: 0x892c50..0x892c70
+            - Range: 0x892c60..0x892c80
               Pieces:
                 - Size: 1
                   Op: {RegNo: 0, Shift: 0}
@@ -7918,113 +7918,113 @@ Subprograms:
           Role: Parameter
     - ID: 154
       Name: main.testNestedPointer
-      OutOfLinePCRanges: [0x892cf0..0x892d00]
+      OutOfLinePCRanges: [0x892d00..0x892d10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 312 PointerType *main.anotherStruct
           Locations:
-            - Range: 0x892cf0..0x892d00
+            - Range: 0x892d00..0x892d10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 155
       Name: main.testEmptyStruct
-      OutOfLinePCRanges: [0x892d50..0x892d60]
+      OutOfLinePCRanges: [0x892d60..0x892d70]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 314 StructureType main.emptyStruct
-          Locations: [{Range: 0x892d50..0x892d60, Pieces: []}]
+          Locations: [{Range: 0x892d60..0x892d70, Pieces: []}]
           Role: Parameter
     - ID: 156
       Name: main.testEmptyStructPointer
-      OutOfLinePCRanges: [0x892d60..0x892d70]
+      OutOfLinePCRanges: [0x892d70..0x892d80]
       InlinePCRanges: []
       Variables:
         - Name: e
           Type: 315 PointerType *main.emptyStruct
           Locations:
-            - Range: 0x892d60..0x892d70
+            - Range: 0x892d70..0x892d80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 157
       Name: main.testInlinedPrint
-      OutOfLinePCRanges: [0x88d5e0..0x88d650]
+      OutOfLinePCRanges: [0x88d5f0..0x88d660]
       InlinePCRanges:
-        - Ranges: [0x88d66c..0x88d6a4]
-          RootRanges: [0x88d650..0x88d6d0]
-        - Ranges: [0x88d7b8..0x88d7f0]
-          RootRanges: [0x88d780..0x88d810]
-        - Ranges: [0x88d834..0x88d86c]
-          RootRanges: [0x88d810..0x88d8e0]
-        - Ranges: [0x88d8fc..0x88d934]
-          RootRanges: [0x88d8e0..0x88d960]
+        - Ranges: [0x88d67c..0x88d6b4]
+          RootRanges: [0x88d660..0x88d6e0]
+        - Ranges: [0x88d7c8..0x88d800]
+          RootRanges: [0x88d790..0x88d820]
+        - Ranges: [0x88d844..0x88d87c]
+          RootRanges: [0x88d820..0x88d8f0]
+        - Ranges: [0x88d90c..0x88d944]
+          RootRanges: [0x88d8f0..0x88d970]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88d5e0..0x88d600
+            - Range: 0x88d5f0..0x88d610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d66c..0x88d674
+            - Range: 0x88d67c..0x88d684
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d7b8..0x88d7c0
+            - Range: 0x88d7c8..0x88d7d0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d82c..0x88d83c
+            - Range: 0x88d83c..0x88d84c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x88d83c..0x88d8e0
+            - Range: 0x88d84c..0x88d8f0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
-            - Range: 0x88d8e0..0x88d904
+            - Range: 0x88d8f0..0x88d914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 158
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88d878..0x88d8b0]
-          RootRanges: [0x88d810..0x88d8e0]
+        - Ranges: [0x88d888..0x88d8c0]
+          RootRanges: [0x88d820..0x88d8f0]
       Variables: []
     - ID: 159
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88d97c..0x88d9c0]
-          RootRanges: [0x88d960..0x88da80]
+        - Ranges: [0x88d98c..0x88d9d0]
+          RootRanges: [0x88d970..0x88da90]
       Variables: []
     - ID: 160
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88da30..0x88da68]
-          RootRanges: [0x88d960..0x88da80]
+        - Ranges: [0x88da40..0x88da78]
+          RootRanges: [0x88d970..0x88da90]
       Variables: []
     - ID: 161
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88da84..0x88da88]
-          RootRanges: [0x88da80..0x88da90]
+        - Ranges: [0x88da94..0x88da98]
+          RootRanges: [0x88da90..0x88daa0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x88da80..0x88da88
+            - Range: 0x88da90..0x88da98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 162
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0x88dab4..0x88dad8]
-          RootRanges: [0x88da90..0x88daf0]
-        - Ranges: [0x88db4c..0x88db74]
-          RootRanges: [0x88daf0..0x88dc40]
+        - Ranges: [0x88dac4..0x88dae8]
+          RootRanges: [0x88daa0..0x88db00]
+        - Ranges: [0x88db5c..0x88db84]
+          RootRanges: [0x88db00..0x88dc50]
       Variables:
         - Name: a
           Type: 156 ArrayType [5]int
           Locations:
-            - Range: 0x88daa0..0x88daf0
+            - Range: 0x88dab0..0x88db00
               Pieces: [{Size: 40, Op: {CfaOffset: -48}}]
-            - Range: 0x88db38..0x88dc40
+            - Range: 0x88db48..0x88dc50
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
 Types:
@@ -24357,7 +24357,19 @@ Types:
       GoRuntimeType: 952416
       GoKind: 5
 MaxTypeID: 1367
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1368 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0x88bd84"
+              Frameless: true
+            - PC: "0x88e328"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -8027,6 +8048,15 @@ Subprograms:
             - Range: 0x88db48..0x88dc50
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x88e328..0x88e334, 0x88e338..0x88e340]
+          RootRanges: [0x88e210..0x88e380]
+        - Ranges: [0x88bd84..0x88bd88, 0x88bd8c..0x88bd94]
+          RootRanges: [0x88bd70..0x88bda0]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 132
@@ -10979,6 +11009,9 @@ Types:
       GoRuntimeType: 1.005824e+06
       GoKind: 22
       Pointee: 673 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1368
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1330
       Name: Probe[main.stackC]
@@ -24356,20 +24389,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1367
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1368
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -26117,7 +26117,19 @@ Types:
       GoRuntimeType: 989760
       GoKind: 5
 MaxTypeID: 1542
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1543 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0x8494b8"
+              Frameless: true
+            - PC: "0x84ba18"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -8027,6 +8048,15 @@ Subprograms:
             - Range: 0x84b248..0x84b350
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x84ba18..0x84ba24, 0x84ba28..0x84ba30]
+          RootRanges: [0x84b900..0x84ba70]
+        - Ranges: [0x8494b8..0x8494bc, 0x8494c0..0x8494c8]
+          RootRanges: [0x8494b0..0x8494d0]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 137
@@ -11284,6 +11314,9 @@ Types:
       GoRuntimeType: 1.0432e+06
       GoKind: 22
       Pointee: 810 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1543
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.stackC]
@@ -26116,20 +26149,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1542
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1543
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -974,6 +974,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1562 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0x805df8"
+              Frameless: true
+            - PC: "0x808158"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -8061,6 +8082,15 @@ Subprograms:
             - Range: 0x807a28..0x807b20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x808158..0x808164, 0x808168..0x808170]
+          RootRanges: [0x808040..0x8081b0]
+        - Ranges: [0x805df8..0x805dfc, 0x805e00..0x805e08]
+          RootRanges: [0x805df0..0x805e10]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 139
@@ -11385,6 +11415,9 @@ Types:
       GoRuntimeType: 1.047712e+06
       GoKind: 22
       Pointee: 823 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1562
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.stackC]
@@ -26377,20 +26410,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1561
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1562
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -26378,7 +26378,19 @@ Types:
       GoRuntimeType: 994240
       GoKind: 5
 MaxTypeID: 1561
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -26358,7 +26358,19 @@ Types:
       GoRuntimeType: 1.003232e+06
       GoKind: 5
 MaxTypeID: 1557
-Issues: []
+Issues:
+    - probe_definition:
+        id: testInlinedFuncFromOtherPackage
+        version: 0
+        type: LOG_PROBE
+        where:
+            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+        tags: ['issue:InvalidDWARF']
+        capture: {maxReferenceDepth: 1}
+        template: testInlinedFuncFromOtherPackage
+        segments: [testInlinedFuncFromOtherPackage]
+        captureSnapshot: true
+      issue: {Kind: 5, Message: ErrUnknownPC}
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:
     G: 23 StructureType runtime.g

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -970,6 +970,27 @@ Probes:
       probeTemplate:
         TemplateString: testInlinedBCB
         Segments: [testInlinedBCB]
+    - id: testInlinedFuncFromOtherPackage
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      template: testInlinedFuncFromOtherPackage
+      segments: [testInlinedFuncFromOtherPackage]
+      captureSnapshot: true
+      subprogram: {subprogram: 163}
+      events:
+        - Kind: Entry
+          Type: 1558 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          InjectionPoints:
+            - PC: "0x802568"
+              Frameless: true
+            - PC: "0x8048e0"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: testInlinedFuncFromOtherPackage
+        Segments: [testInlinedFuncFromOtherPackage]
     - id: testInlinedPrint
       version: 0
       type: LOG_PROBE
@@ -8033,6 +8054,15 @@ Subprograms:
             - Range: 0x804168..0x804260
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
+    - ID: 163
+      Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+      OutOfLinePCRanges: []
+      InlinePCRanges:
+        - Ranges: [0x8048e0..0x8048ec, 0x8048f0..0x8048f8]
+          RootRanges: [0x8047c0..0x804930]
+        - Ranges: [0x802568..0x80256c, 0x802570..0x802578]
+          RootRanges: [0x802560..0x802580]
+      Variables: []
 Types:
     - __kind: PointerType
       ID: 145
@@ -11366,6 +11396,9 @@ Types:
       GoRuntimeType: 1.05664e+06
       GoKind: 22
       Pointee: 825 BaseType vendor/golang.org/x/net/idna.runeError
+    - __kind: EventRootType
+      ID: 1558
+      Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.stackC]
@@ -26357,20 +26390,8 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 5
-MaxTypeID: 1557
-Issues:
-    - probe_definition:
-        id: testInlinedFuncFromOtherPackage
-        version: 0
-        type: LOG_PROBE
-        where:
-            methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
-        tags: ['issue:InvalidDWARF']
-        capture: {maxReferenceDepth: 1}
-        template: testInlinedFuncFromOtherPackage
-        segments: [testInlinedFuncFromOtherPackage]
-        captureSnapshot: true
-      issue: {Kind: 5, Message: ErrUnknownPC}
+MaxTypeID: 1558
+Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:
     G: 23 StructureType runtime.g

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1055,7 +1054,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1043,7 +1042,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1042,7 +1041,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1042,7 +1041,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [13:14] injectible: [13-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1060,7 +1059,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1048,7 +1047,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1047,7 +1046,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/sample.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,6 +1,5 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [15:16] injectible: [16-16]
 	Function: doNothing (main.doNothing) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/slices.go [12:12] injectible: [12-12]
 		Arg: x: []int (declared at line 12, available: [12-12])
 	Function: executeArrayFuncs (main.executeArrayFuncs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/arrays.go [102:129] injectible: [102-117], [119-122], [124-124], [128-129]
@@ -1047,7 +1046,8 @@ Package: main
 		Field: j: int
 		Field: k: int
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib
-	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:13] injectible: [12-13]
+	Function: Foo (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [12:14] injectible: [12-14]
+	Function: InlinedFunc (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go [16:17] injectible: [17-17]
 Package: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
 	Function: FooV2 (github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib%2ev2.FooV2) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2/lib.go [17:18] injectible: [17-18]
 	Type: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2.V2Type

--- a/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
+++ b/pkg/dyninst/testdata/decoded/sample/testInlinedFuncFromOtherPackage.json
@@ -1,0 +1,61 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go",
+            "lineNumber": 17
+          },
+          {
+            "function": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.Foo",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib/lib.go",
+            "lineNumber": 13
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 37
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testInlinedFuncFromOtherPackage",
+          "location": {
+            "method": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc"
+          }
+        }
+      },
+      "evaluationErrors": [
+        {
+          "expr": "@duration",
+          "message": "not available: function was inlined"
+        }
+      ]
+    },
+    "timestamp": "[ts]",
+    "message": "testInlinedFuncFromOtherPackage"
+  }
+]

--- a/pkg/dyninst/testprogs/progs/sample/lib/lib.go
+++ b/pkg/dyninst/testprogs/progs/sample/lib/lib.go
@@ -10,6 +10,7 @@ var dummy int
 //go:noinline
 func Foo() {
 	dummy++
+	InlinedFunc()
 }
 
 func InlinedFunc() {

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2330,5 +2330,3 @@ probes:
     segments:
       - str: "testInlinedFuncFromOtherPackage"
     captureSnapshot: true
-    tags:
-    - "issue:InvalidDWARF"

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2322,3 +2322,13 @@ probes:
         dsl: "@duration"
       - str: "ms"
     captureSnapshot: true
+  - id: testInlinedFuncFromOtherPackage
+    type: LOG_PROBE
+    where:
+      methodName: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
+    template: "testInlinedFuncFromOtherPackage"
+    segments:
+      - str: "testInlinedFuncFromOtherPackage"
+    captureSnapshot: true
+    tags:
+    - "issue:InvalidDWARF"


### PR DESCRIPTION
### What does this PR do?

Prior to this change, we were using the compile unit of the abstract origin
for inlined subroutines when trying to annotate their lines as opposed to the
compile unit for the root ranges where that subroutine instance had been inlined.

### Motivation

This bug prevents users from succeeding with the product when probing inlined functions that are inlined into functions in other packages.

### Describe how you validated your changes

There's testing.

### Additional Notes

See https://dd.slack.com/archives/C01L679F33M/p1768917318946549