### PR TITLE
[CWS] Remove applied status in network isolation

### DIFF
--- a/pkg/security/probe/actions_linux.go
+++ b/pkg/security/probe/actions_linux.go
@@ -111,8 +111,8 @@ type RawPacketActionReport struct {
 type RawPacketActionStatus string
 
 const (
-	RawPacketActionStatusApplied RawPacketActionStatus = "applied"
-	RawPacketActionStatusError   RawPacketActionStatus = "error"
+	RawPacketActionStatusPerformed RawPacketActionStatus = "performed"
+	RawPacketActionStatusError     RawPacketActionStatus = "error"
 )
 
 // IsResolved return if the action is resolved

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3453,7 +3453,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 					seclog.Errorf("failed to setup raw packet action programs: %s", err)
 					reportStatus = RawPacketActionStatusError
 				} else {
-					reportStatus = RawPacketActionStatusApplied
+					reportStatus = RawPacketActionStatusPerformed
 				}
 			}
 

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -267,7 +267,7 @@ func TestRawPacketAction(t *testing.T) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.filter == 'port 53')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
-				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'applied')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.status == 'performed')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 


### PR DESCRIPTION
### What does this PR do?
Replace `applied` status in network isolation by `performed` so the status are the same between kill and isolation actions.
Now, the status for an isolation actions are : 
- performed
- error
