### PR TITLE
[#incident-48257] Adjust MSI package quality gates

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -9,7 +9,7 @@ static_quality_gate_agent_heroku_amd64:
   max_on_wire_size: 88.45 MiB
 static_quality_gate_agent_msi:
   max_on_disk_size: 982.08 MiB
-  max_on_wire_size: 143.02 MiB
+  max_on_wire_size: 143.27 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 708.38 MiB
   max_on_wire_size: 177.66 MiB


### PR DESCRIPTION
### What does this PR do?
As a temporary countermeasure and in order to buy us some time to understand what's wrong with reference measurements, this bumps `max_on_wire_size` by ~256 KiB for MSI packages.

### Motivation
#incident-48257

### Additional Notes
Agent Build will of course continue stabilizing how sizes are computed and compared.