### PR TITLE
Ignore go.work when running gohai tests

### DIFF
--- a/.github/workflows/gohai.yml
+++ b/.github/workflows/gohai.yml
@@ -43,4 +43,6 @@ jobs:
           go-version-file: ${{ matrix.go-file }}
       - name: Test
         # disable go.work to avoid overriding the go version at runtime
-        run: cd pkg/gohai && GOWORK=off go test -tags=test ./...
+        env:
+          GOWORK: off
+        run: cd pkg/gohai && go test -tags=test ./...

--- a/.github/workflows/gohai.yml
+++ b/.github/workflows/gohai.yml
@@ -42,4 +42,5 @@ jobs:
         with:
           go-version-file: ${{ matrix.go-file }}
       - name: Test
-        run: cd pkg/gohai && go test -tags=test ./...
+        # disable go.work to avoid overriding the go version at runtime
+        run: cd pkg/gohai && GOWORK=off go test -tags=test ./...


### PR DESCRIPTION
### What does this PR do?
Set GOWORK=off when running gohai unit tests in github workflow.

### Motivation
When using the go.work file, the toolchain is overridden, which we explicitly don't want in this job.

### Describe how you validated your changes
CI

### Additional Notes
