### PR TITLE
Add sd-agent in discovery gitignore

### DIFF
--- a/pkg/discovery/module/rust/.gitignore
+++ b/pkg/discovery/module/rust/.gitignore
@@ -1,1 +1,2 @@
 target
+sd-agent


### PR DESCRIPTION
### What does this PR do?
When we try to build system-probe, we now have an additional file that was not in the `gitignored`. 

### Motivation
Avoid any manual deletion of this file before doing a commit.