### PR TITLE
[CWS] fix selftests on 2510

### DIFF
--- a/pkg/security/probe/selftests/tester_linux.go
+++ b/pkg/security/probe/selftests/tester_linux.go
@@ -69,6 +69,8 @@ func createTargetFile() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	// remove to let the open selftest create the file
+	_ = os.Remove(targetFile.Name())
 
 	return targetFile.Name(), tmpDir, targetFile.Close()
 }


### PR DESCRIPTION
### What does this PR do?

Make sure the `touch` command used for the open selftest actually create the file. On Ubuntu 25.10 the touch binary doesn't open the file if already existing.

### Motivation

### Describe how you validated your changes

### Additional Notes
