### PR TITLE
fix(ask-review): Prevent error when single quotes in the requested_teams object

### DIFF
--- a/.github/workflows/ask_review.yml
+++ b/.github/workflows/ask_review.yml
@@ -24,11 +24,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          REQUESTED_TEAMS: ${{ toJSON(github.event.pull_request.requested_teams) }}
         run: |
           options=()
           if [ "${{ github.event.action }}" == "labeled" ] && [ "${{ github.event.label.name }}" == "ask-review" ]; then
             # ask_reviews uses @task(iterable=["team_slugs"]) so we pass --team-slugs multiple times
-            mapfile -t slugs < <(jq -r '.[].slug' <<< '${{ toJSON(github.event.pull_request.requested_teams) }}')
+            mapfile -t slugs < <(jq -r '.[].slug' <<< "$REQUESTED_TEAMS")
             for slug in "${slugs[@]}"; do
               options+=(--team-slugs "$slug")
             done

--- a/.github/workflows/ask_review_bot_pr.yml
+++ b/.github/workflows/ask_review_bot_pr.yml
@@ -8,7 +8,6 @@ on:
       - completed
     branches:
       - dependabot/*
-      - renovate/*
 
 jobs:
   automatic-ask-review:


### PR DESCRIPTION
### What does this PR do?
- Save the `requested_teams` object in `env` to prevent conflicts with quotes in the bash script.
- Remove the addition of the `ask-review` label on `renovate` PR. Review message is now sent when the PR is created.

### Motivation
Prevent failure like [here](https://github.com/DataDog/datadog-agent/actions/runs/21180226611/job/60920205019?pr=45278). The issue come from the description field
```
"description": "Team responsible for Agent's configuration and CLI",
```
resulting in `syntax error near unexpected token '('`


### Describe how you validated your changes
- Addition of `agent-configuration` as requested owner: generated a single message (no for single user)
- Set `ask-review` label: the message was sent as well
<img width="655" height="685" alt="image" src="https://github.com/user-attachments/assets/49d3628e-392c-4767-aa27-07d9a0844dd7" />


### Additional Notes
