### PR TITLE
consolidate fx options for system-probe

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -256,8 +256,10 @@
 /cmd/system-probe/modules/ping*         @DataDog/ndm-core
 /cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
 /cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
+/cmd/system-probe/windows/              @DataDog/windows-products
 /cmd/system-probe/windows_resources/    @DataDog/windows-products
 /cmd/system-probe/main_windows*.go      @DataDog/windows-products
+/cmd/system-probe/subcommands/run/command_windows*  @DataDog/windows-products
 /cmd/system-probe/subcommands/runtime/  @DataDog/agent-security
 /cmd/system-probe/subcommands/usm/      @DataDog/universal-service-monitoring
 /cmd/system-probe/subcommands/ebpf/     @DataDog/ebpf-platform @DataDog/universal-service-monitoring

--- a/cmd/system-probe/main_windows.go
+++ b/cmd/system-probe/main_windows.go
@@ -9,62 +9,23 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/subcommands"
-	runsubcmd "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run"
-	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/windows/service"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/servicemain"
 )
-
-type service struct {
-	servicemain.DefaultSettings
-	errChan <-chan error
-	ctxChan chan context.Context
-}
-
-func (s *service) Name() string {
-	return config.ServiceName
-}
-
-func (s *service) Init() error {
-	s.ctxChan = make(chan context.Context)
-
-	errChan, err := runsubcmd.StartSystemProbeWithDefaults(s.ctxChan)
-	if err != nil {
-		if errors.Is(err, runsubcmd.ErrNotEnabled) {
-			return fmt.Errorf("%w: %w", servicemain.ErrCleanStopAfterInit, err)
-		}
-		return err
-	}
-
-	s.errChan = errChan
-
-	return nil
-}
-
-func (s *service) Run(ctx context.Context) error {
-	// send context to background agent goroutine so we can stop the agent
-	s.ctxChan <- ctx
-	// wait for agent to stop
-	return <-s.errChan
-}
 
 func main() {
 	// if command line arguments are supplied, even in a non-interactive session,
 	// then just execute that.  Used when the service is executing the executable,
 	// for instance to trigger a restart.
-	if len(os.Args) == 1 {
-		if servicemain.RunningAsWindowsService() {
-			servicemain.Run(&service{})
-			return
-		}
+	if len(os.Args) == 1 && servicemain.RunningAsWindowsService() {
+		servicemain.Run(service.NewWindowsService())
+		return
 	}
 	defer log.Flush()
 

--- a/cmd/system-probe/subcommands/config/command.go
+++ b/cmd/system-probe/subcommands/config/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	fetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
@@ -52,6 +53,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values
 				core.Bundle(),
+				secretsnoopfx.Module(),
 			)
 		}
 	}

--- a/cmd/system-probe/subcommands/debug/command.go
+++ b/cmd/system-probe/subcommands/debug/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
@@ -55,6 +56,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values
 				core.Bundle(),
+				secretsnoopfx.Module(),
 			)
 		},
 	}

--- a/cmd/system-probe/subcommands/modrestart/command.go
+++ b/cmd/system-probe/subcommands/modrestart/command.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
@@ -52,6 +53,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				// no need to provide sysprobe logger since ForOneShot ignores config values
 				core.Bundle(),
+				secretsnoopfx.Module(),
 			)
 		},
 	}

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -48,7 +48,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	remoteWorkloadfilterfx "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-remote"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
@@ -101,68 +100,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Long:  `Runs the system-probe in the foreground`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return fxutil.OneShot(run,
+				fx.Invoke(func(_ log.Component) {
+					ddruntime.SetMaxProcs()
+				}),
 				fx.Supply(config.NewAgentParams(globalParams.DatadogConfFilePath())),
-				// Force FX to load Datadog configuration before System Probe config.
-				// This is necessary because the 'software_inventory.enabled' setting is defined in the Datadog configuration.
-				// Without this explicit dependency, FX might initialize System Probe's config first, causing pkgconfigsetup.Datadog().GetBool()
-				// to return default values instead of the actual configuration.
-				fx.Provide(func(_ config.Component) sysprobeconfigimpl.Params {
-					return sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath))
-				}),
-				fx.Supply(log.ForDaemon(command.LoggerName, "log_file", common.DefaultLogFile)),
-				fx.Supply(rcclient.Params{AgentName: "system-probe", AgentVersion: version.AgentVersion, IsSystemProbe: true}),
-				secretsnoopfx.Module(),
-				statsd.Module(),
-				config.Module(),
-				telemetryimpl.Module(),
-				sysprobeconfigimpl.Module(),
-				rcclientimpl.Module(),
-				fx.Provide(func(config config.Component, sysprobeconfig sysprobeconfig.Component) healthprobe.Options {
-					return healthprobe.Options{
-						Port:           sysprobeconfig.SysProbeObject().HealthPort,
-						LogsGoroutines: config.GetBool("log_all_goroutines_when_unhealthy"),
-					}
-				}),
-				healthprobefx.Module(),
-				systemprobeloggerfx.Module(),
-				// workloadmeta setup
-				wmcatalog.GetCatalog(),
-				workloadmetafx.Module(workloadmeta.Params{
-					AgentType: workloadmeta.Remote,
-				}),
-				remoteWorkloadfilterfx.Module(),
-				ipcfx.ModuleReadWrite(),
-				// Provide tagger module
-				remoteTaggerFx.Module(tagger.NewRemoteParams()),
-				autoexitimpl.Module(),
-				pidimpl.Module(),
+				fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(globalParams.ConfFilePath), sysprobeconfigimpl.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath))),
 				fx.Supply(pidimpl.NewParams(cliParams.pidfilePath)),
-				fx.Provide(func(sysprobeconfig sysprobeconfig.Component) settings.Params {
-					profilingGoRoutines := commonsettings.NewProfilingGoroutines()
-					profilingGoRoutines.ConfigPrefix = configPrefix
-
-					return settings.Params{
-						Settings: map[string]settings.RuntimeSetting{
-							"log_level":                       commonsettings.NewLogLevelRuntimeSetting(),
-							"runtime_mutex_profile_fraction":  &commonsettings.RuntimeMutexProfileFraction{ConfigPrefix: configPrefix},
-							"runtime_block_profile_rate":      &commonsettings.RuntimeBlockProfileRate{ConfigPrefix: configPrefix},
-							"internal_profiling_goroutines":   profilingGoRoutines,
-							commonsettings.MaxDumpSizeConfKey: &commonsettings.ActivityDumpRuntimeSetting{ConfigKey: commonsettings.MaxDumpSizeConfKey},
-							"internal_profiling":              &commonsettings.ProfilingRuntimeSetting{SettingName: "internal_profiling", Service: "system-probe", ConfigPrefix: configPrefix},
-						},
-						Config: sysprobeconfig,
-					}
-				}),
-				settingsimpl.Module(),
-				logscompressionfx.Module(),
-				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
-					return statsd.CreateForHostPort(configutils.GetBindHost(config), config.GetInt("dogstatsd_port"))
-				}),
-				remotehostnameimpl.Module(),
-				configsyncimpl.Module(configsyncimpl.NewParams(configSyncTimeout, true, configSyncTimeout)),
-				remoteagentfx.Module(),
-				fxinstrumentation.Module(),
-				localtraceroute.Module(),
+				getSharedFxOption(),
 			)
 		},
 	}
@@ -171,140 +115,18 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	return []*cobra.Command{runCmd}
 }
 
-// run starts the main loop.
-func run(log log.Component, _ config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, _ pid.Component, _ healthprobe.Component, _ autoexit.Component, settings settings.Component, _ ipc.Component, deps module.FactoryDependencies) error {
-	defer func() {
-		stopSystemProbe()
-	}()
-
-	// prepare go runtime
-	ddruntime.SetMaxProcs()
-
-	if sysprobeconfig.GetBool("system_probe_config.disable_thp") {
-		if err := ddruntime.DisableTransparentHugePages(); err != nil {
-			log.Warnf("cannot disable transparent huge pages, performance may be degraded: %s", err)
-		}
-	}
-
-	// Setup a channel to catch OS signals
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-
-	// Make a channel to exit the function
-	stopCh := make(chan error)
-
-	go func() {
-		// Set up the signals async, so we can start the system-probe
-		select {
-		case <-signals.Stopper:
-			log.Info("Received stop command, shutting down...")
-			stopCh <- nil
-		case <-signals.ErrorStopper:
-			_ = log.Critical("system-probe has encountered an error, shutting down...")
-			stopCh <- errors.New("shutting down because of an error")
-		case sig := <-signalCh:
-			log.Infof("Received signal '%s', shutting down...", sig)
-			stopCh <- nil
-		}
-	}()
-
-	// By default, systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
-	// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
-	// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
-	sigpipeCh := make(chan os.Signal, 1)
-	signal.Notify(sigpipeCh, syscall.SIGPIPE)
-	go func() {
-		//nolint:revive
-		for range sigpipeCh {
-			// intentionally drain channel
-		}
-	}()
-
-	if err := startSystemProbe(log, telemetry, sysprobeconfig, rcclient, settings, deps); err != nil {
-		if errors.Is(err, ErrNotEnabled) {
-			// A sleep is necessary to ensure that supervisor registers this process as "STARTED"
-			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
-			// http://supervisord.org/subprocess.html#process-states
-			time.Sleep(5 * time.Second)
-			return nil
-		}
-		return err
-	}
-	return <-stopCh
-}
-
-// StartSystemProbeWithDefaults is a temporary way for other packages to use startSystemProbe.
-// Starts the agent in the background and then returns.
-//
-// @ctxChan
-//   - After starting the agent the background goroutine waits for a context from
-//     this channel, then stops the agent when the context is cancelled.
-//
-// Returns an error channel that can be used to wait for the agent to stop and get the result.
-func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error, error) {
-	errChan := make(chan error)
-
-	// run startSystemProbe in the background
-	go func() {
-		err := runSystemProbe(ctxChan, errChan)
-		// notify main routine that this is done, so cleanup can happen
-		errChan <- err
-	}()
-
-	// Wait for startSystemProbe to complete, or for an error
-	err := <-errChan
-	if err != nil {
-		// startSystemProbe or fx.OneShot failed, caller does not need errChan
-		return nil, err
-	}
-
-	// startSystemProbe succeeded. provide errChan to caller so they can wait for fxutil.OneShot to stop
-	return errChan, nil
-}
-
-func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
-	return fxutil.OneShot(
-		func(log log.Component, _ config.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, _ healthprobe.Component, settings settings.Component, deps module.FactoryDependencies) error {
-			defer StopSystemProbeWithDefaults()
-			err := startSystemProbe(log, telemetry, sysprobeconfig, rcclient, settings, deps)
-			if err != nil {
-				return err
-			}
-
-			// notify outer that startAgent finished
-			errChan <- err
-			// wait for context
-			ctx := <-ctxChan
-
-			// Wait for stop signal
-			select {
-			case <-signals.Stopper:
-				log.Info("Received stop command, shutting down...")
-			case <-signals.ErrorStopper:
-				_ = log.Critical("The Agent has encountered an error, shutting down...")
-			case <-ctx.Done():
-				log.Info("Received stop from service manager, shutting down...")
-			}
-
-			return nil
-		},
-		// no config file path specification in this situation
-		fx.Supply(config.NewAgentParams("")),
-		// Force FX to load Datadog configuration before System Probe config.
-		// This is necessary because the 'software_inventory.enabled' setting is defined in the Datadog configuration.
-		// Without this explicit dependency, FX might initialize System Probe's config first, causing pkgconfigsetup.Datadog().GetBool()
-		// to return default values instead of the actual configuration.
-		fx.Provide(func(_ config.Component) sysprobeconfigimpl.Params {
-			return sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))
-		}),
+func getSharedFxOption() fx.Option {
+	return fx.Options(
 		fx.Supply(log.ForDaemon(command.LoggerName, "log_file", common.DefaultLogFile)),
+		config.Module(),
+		sysprobeconfigimpl.Module(),
+		systemprobeloggerfx.Module(),
+		telemetryimpl.Module(),
+		pidimpl.Module(),
 		fx.Supply(rcclient.Params{AgentName: "system-probe", AgentVersion: version.AgentVersion, IsSystemProbe: true}),
 		secretsnoopfx.Module(),
-		rcclientimpl.Module(),
-		config.Module(),
-		telemetryimpl.Module(),
 		statsd.Module(),
-		sysprobeconfigimpl.Module(),
+		rcclientimpl.Module(),
 		fx.Provide(func(config config.Component, sysprobeconfig sysprobeconfig.Component) healthprobe.Options {
 			return healthprobe.Options{
 				Port:           sysprobeconfig.SysProbeObject().HealthPort,
@@ -312,16 +134,14 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 			}
 		}),
 		healthprobefx.Module(),
-		// workloadmeta setup
 		wmcatalog.GetCatalog(),
 		workloadmetafx.Module(workloadmeta.Params{
 			AgentType: workloadmeta.Remote,
 		}),
 		remoteWorkloadfilterfx.Module(),
 		ipcfx.ModuleReadWrite(),
-		// Provide tagger module
 		remoteTaggerFx.Module(tagger.NewRemoteParams()),
-		systemprobeloggerfx.Module(),
+		autoexitimpl.Module(),
 		fx.Provide(func(sysprobeconfig sysprobeconfig.Component) settings.Params {
 			profilingGoRoutines := commonsettings.NewProfilingGoroutines()
 			profilingGoRoutines.ConfigPrefix = configPrefix
@@ -344,59 +164,123 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 			return statsd.CreateForHostPort(configutils.GetBindHost(config), config.GetInt("dogstatsd_port"))
 		}),
 		remotehostnameimpl.Module(),
+		configsyncimpl.Module(configsyncimpl.NewParams(configSyncTimeout, true, configSyncTimeout)),
+		remoteagentfx.Module(),
+		fxinstrumentation.Module(),
 		localtraceroute.Module(),
 	)
 }
 
-// StopSystemProbeWithDefaults is a temporary way for other packages to use stopAgent.
-func StopSystemProbeWithDefaults() {
-	stopSystemProbe()
+// run starts the main loop.
+func run(
+	_ config.Component,
+	rcclient rcclient.Component,
+	_ pid.Component,
+	_ healthprobe.Component,
+	_ autoexit.Component,
+	settings settings.Component,
+	_ ipc.Component,
+	deps module.FactoryDependencies,
+) error {
+	defer stopSystemProbe()
+
+	if deps.SysprobeConfig.GetBool("system_probe_config.disable_thp") {
+		if err := ddruntime.DisableTransparentHugePages(); err != nil {
+			deps.Log.Warnf("cannot disable transparent huge pages, performance may be degraded: %s", err)
+		}
+	}
+
+	// Setup a channel to catch OS signals
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Make a channel to exit the function
+	stopCh := make(chan error)
+
+	go func() {
+		// Set up the signals async, so we can start the system-probe
+		select {
+		case <-signals.Stopper:
+			deps.Log.Info("Received stop command, shutting down...")
+			stopCh <- nil
+		case <-signals.ErrorStopper:
+			_ = deps.Log.Critical("system-probe has encountered an error, shutting down...")
+			stopCh <- errors.New("shutting down because of an error")
+		case sig := <-signalCh:
+			deps.Log.Infof("Received signal '%s', shutting down...", sig)
+			stopCh <- nil
+		}
+	}()
+
+	// By default, systemd redirects the stdout to journald. When journald is stopped or crashes we receive a SIGPIPE signal.
+	// Go ignores SIGPIPE signals unless it is when stdout or stdout is closed, in this case the agent is stopped.
+	// We never want the agent to stop upon receiving SIGPIPE, so we intercept the SIGPIPE signals and just discard them.
+	sigpipeCh := make(chan os.Signal, 1)
+	signal.Notify(sigpipeCh, syscall.SIGPIPE)
+	go func() {
+		//nolint:revive
+		for range sigpipeCh {
+			// intentionally drain channel
+		}
+	}()
+
+	if err := startSystemProbe(rcclient, settings, deps); err != nil {
+		if errors.Is(err, ErrNotEnabled) {
+			// A sleep is necessary to ensure that supervisor registers this process as "STARTED"
+			// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
+			// http://supervisord.org/subprocess.html#process-states
+			time.Sleep(5 * time.Second)
+			return nil
+		}
+		return err
+	}
+	return <-stopCh
 }
 
 // startSystemProbe Initializes the system-probe process
-func startSystemProbe(log log.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, settings settings.Component, deps module.FactoryDependencies) error {
+func startSystemProbe(rcclient rcclient.Component, settings settings.Component, deps module.FactoryDependencies) error {
 	var err error
-	cfg := sysprobeconfig.SysProbeObject()
+	cfg := deps.SysprobeConfig.SysProbeObject()
 
-	log.Infof("starting system-probe v%v", version.AgentVersion)
+	deps.Log.Infof("starting system-probe v%v", version.AgentVersion)
 
-	logUserAndGroupID(log)
+	logUserAndGroupID(deps.Log)
 	// Exit if system probe is disabled
 	if cfg.ExternalSystemProbe || !cfg.Enabled {
-		log.Info("system probe not enabled. exiting")
+		deps.Log.Info("system probe not enabled. exiting")
 		return ErrNotEnabled
 	}
 
-	if err := coredump.Setup(sysprobeconfig); err != nil {
-		log.Warnf("cannot setup core dumps: %s, core dumps might not be available after a crash", err)
+	if err := coredump.Setup(deps.SysprobeConfig); err != nil {
+		deps.Log.Warnf("cannot setup core dumps: %s, core dumps might not be available after a crash", err)
 	}
 
-	if sysprobeconfig.GetBool("system_probe_config.memory_controller.enabled") {
-		memoryPressureLevels := sysprobeconfig.GetStringMapString("system_probe_config.memory_controller.pressure_levels")
-		memoryThresholds := sysprobeconfig.GetStringMapString("system_probe_config.memory_controller.thresholds")
-		hierarchy := sysprobeconfig.GetString("system_probe_config.memory_controller.hierarchy")
+	if deps.SysprobeConfig.GetBool("system_probe_config.memory_controller.enabled") {
+		memoryPressureLevels := deps.SysprobeConfig.GetStringMapString("system_probe_config.memory_controller.pressure_levels")
+		memoryThresholds := deps.SysprobeConfig.GetStringMapString("system_probe_config.memory_controller.thresholds")
+		hierarchy := deps.SysprobeConfig.GetString("system_probe_config.memory_controller.hierarchy")
 		common.MemoryMonitor, err = utils.NewMemoryMonitor(hierarchy, env.IsContainerized(), memoryPressureLevels, memoryThresholds)
 		if err != nil {
-			log.Warnf("cannot set up memory controller: %s", err)
+			deps.Log.Warnf("cannot set up memory controller: %s", err)
 		} else {
 			common.MemoryMonitor.Start()
 		}
 	}
 
-	setupInternalProfiling(settings, sysprobeconfig, configPrefix, log)
+	setupInternalProfiling(settings, deps.SysprobeConfig, configPrefix, deps.Log)
 
 	if isValidPort(cfg.DebugPort) {
 		if cfg.TelemetryEnabled {
-			http.Handle("/telemetry", telemetry.Handler())
-			telemetry.RegisterCollector(ebpftelemetry.NewDebugFsStatCollector())
+			http.Handle("/telemetry", deps.Telemetry.Handler())
+			deps.Telemetry.RegisterCollector(ebpftelemetry.NewDebugFsStatCollector())
 			if pc := ebpftelemetry.NewPerfUsageCollector(); pc != nil {
-				telemetry.RegisterCollector(pc)
+				deps.Telemetry.RegisterCollector(pc)
 			}
 			if lcc := ddebpf.NewLockContentionCollector(); lcc != nil {
-				telemetry.RegisterCollector(lcc)
+				deps.Telemetry.RegisterCollector(lcc)
 			}
 			if ec := ebpftelemetry.NewEBPFErrorsCollector(); ec != nil {
-				telemetry.RegisterCollector(ec)
+				deps.Telemetry.RegisterCollector(ec)
 			}
 		}
 		go func() {
@@ -405,13 +289,13 @@ func startSystemProbe(log log.Component, telemetry telemetry.Component, sysprobe
 				Handler: http.DefaultServeMux,
 			}
 			if err := common.ExpvarServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				log.Errorf("error creating expvar server on %v: %v", common.ExpvarServer.Addr, err)
+				deps.Log.Errorf("error creating expvar server on %v: %v", common.ExpvarServer.Addr, err)
 			}
 		}()
 	}
 
-	if err = api.StartServer(cfg, settings, telemetry, rcclient, deps); err != nil {
-		return log.Criticalf("error while starting api server, exiting: %v", err)
+	if err = api.StartServer(cfg, settings, rcclient, deps); err != nil {
+		return deps.Log.Criticalf("error while starting api server, exiting: %v", err)
 	}
 	return nil
 }

--- a/cmd/system-probe/subcommands/run/command_windows.go
+++ b/cmd/system-probe/subcommands/run/command_windows.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package run
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	healthprobe "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
+	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
+	"github.com/DataDog/datadog-agent/comp/core/settings"
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// StartSystemProbeWithDefaults is a temporary way for windows to use startSystemProbe.
+// Starts the agent in the background and then returns.
+//
+// @ctxChan
+//   - After starting the agent the background goroutine waits for a context from
+//     this channel, then stops the agent when the context is cancelled.
+//
+// Returns an error channel that can be used to wait for the agent to stop and get the result.
+func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error, error) {
+	errChan := make(chan error)
+
+	// run startSystemProbe in the background
+	go func() {
+		err := runSystemProbe(ctxChan, errChan)
+		// notify main routine that this is done, so cleanup can happen
+		errChan <- err
+	}()
+
+	// Wait for startSystemProbe to complete, or for an error
+	err := <-errChan
+	if err != nil {
+		// startSystemProbe or fx.OneShot failed, caller does not need errChan
+		return nil, err
+	}
+
+	// startSystemProbe succeeded. provide errChan to caller so they can wait for fxutil.OneShot to stop
+	return errChan, nil
+}
+
+func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
+	return fxutil.OneShot(
+		func(
+			_ config.Component,
+			rcclient rcclient.Component,
+			_ healthprobe.Component,
+			settings settings.Component,
+			deps module.FactoryDependencies,
+		) error {
+			defer stopSystemProbe()
+			err := startSystemProbe(rcclient, settings, deps)
+			if err != nil {
+				return err
+			}
+
+			// notify outer that startAgent finished
+			errChan <- err
+			// wait for context
+			ctx := <-ctxChan
+
+			// Wait for stop signal
+			select {
+			case <-signals.Stopper:
+				deps.Log.Info("Received stop command, shutting down...")
+			case <-signals.ErrorStopper:
+				_ = deps.Log.Critical("The Agent has encountered an error, shutting down...")
+			case <-ctx.Done():
+				deps.Log.Info("Received stop from service manager, shutting down...")
+			}
+
+			return nil
+		},
+		fx.Supply(config.NewAgentParams("")),
+		fx.Supply(sysprobeconfigimpl.NewParams(sysprobeconfigimpl.WithSysProbeConfFilePath(""))),
+		fx.Supply(pidimpl.NewParams("")),
+		getSharedFxOption(),
+	)
+}

--- a/cmd/system-probe/subcommands/run/command_windows_test.go
+++ b/cmd/system-probe/subcommands/run/command_windows_test.go
@@ -1,22 +1,21 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 package run
 
 import (
-	_ "net/http/pprof"
+	"context"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestRunCommand(t *testing.T) {
-	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
-		[]string{"run"},
-		run,
-		func() {})
+func TestStartSystemProbe(t *testing.T) {
+	fxutil.TestOneShot(t, func() {
+		ctxChan := make(<-chan context.Context)
+		errChan := make(chan error)
+		_ = runSystemProbe(ctxChan, errChan)
+	})
 }

--- a/cmd/system-probe/subcommands/usm/shared.go
+++ b/cmd/system-probe/subcommands/usm/shared.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	sysconfigimpl "github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -40,6 +41,7 @@ func makeOneShotCommand(
 					LogParams: log.ForOneShot(command.LoggerName, "off", false),
 				}),
 				core.Bundle(),
+				secretsnoopfx.Module(),
 			)
 		},
 		SilenceUsage: true,

--- a/cmd/system-probe/windows/service/service.go
+++ b/cmd/system-probe/windows/service/service.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+// Package service implements the Windows Service for the system-probe
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	runsubcmd "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/servicemain"
+)
+
+type service struct {
+	servicemain.DefaultSettings
+	errChan <-chan error
+	ctxChan chan context.Context
+}
+
+// NewWindowsService returns the service entry for the system-probe
+func NewWindowsService() servicemain.Service {
+	return &service{}
+}
+
+func (s *service) Name() string {
+	return config.ServiceName
+}
+
+func (s *service) Init() error {
+	s.ctxChan = make(chan context.Context)
+
+	errChan, err := runsubcmd.StartSystemProbeWithDefaults(s.ctxChan)
+	if err != nil {
+		if errors.Is(err, runsubcmd.ErrNotEnabled) {
+			return fmt.Errorf("%w: %w", servicemain.ErrCleanStopAfterInit, err)
+		}
+		return err
+	}
+
+	s.errChan = errChan
+
+	return nil
+}
+
+func (s *service) Run(ctx context.Context) error {
+	// send context to background agent goroutine so we can stop the system-probe
+	s.ctxChan <- ctx
+	// wait for system-probe to stop
+	return <-s.errChan
+}

--- a/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
+++ b/comp/core/sysprobeconfig/sysprobeconfigimpl/config.go
@@ -10,6 +10,7 @@ package sysprobeconfigimpl
 import (
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -42,6 +43,8 @@ type dependencies struct {
 	fx.In
 
 	Params Params
+	// Enforce loading order between core agent config and system-probe config
+	CoreConfig config.Component
 }
 
 func setupConfig(sysProbeConfFilePath string, fleetPoliciesDirPath string) (*sysconfigtypes.Config, error) {

--- a/pkg/pidfile/pidfile_darwin.go
+++ b/pkg/pidfile/pidfile_darwin.go
@@ -13,8 +13,3 @@ import (
 func isProcess(pid int) bool {
 	return syscall.Kill(pid, 0) == nil
 }
-
-// Path returns a suitable location for the pidfile under OSX
-func Path() string {
-	return "/var/run/datadog/datadog-agent.pid"
-}

--- a/pkg/pidfile/pidfile_nix.go
+++ b/pkg/pidfile/pidfile_nix.go
@@ -18,8 +18,3 @@ func isProcess(pid int) bool {
 	_, err := os.Stat(filepath.Join("/proc", strconv.Itoa(pid)))
 	return err == nil
 }
-
-// Path returns a suitable location for the pidfile under Linux
-func Path() string {
-	return "/var/run/datadog/datadog-agent.pid"
-}

--- a/pkg/pidfile/pidfile_windows.go
+++ b/pkg/pidfile/pidfile_windows.go
@@ -6,21 +6,10 @@
 package pidfile
 
 import (
-	"path/filepath"
-
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 // isProcess checks to see if a given pid is currently valid in the process table
 func isProcess(pid int) bool {
 	return winutil.IsProcess(pid)
-}
-
-// Path returns a suitable location for the pidfile under Windows
-func Path() string {
-	pd, err := winutil.GetProgramDataDir()
-	if err == nil {
-		return filepath.Join(pd, "datadog-agent.pid")
-	}
-	return "c:\\ProgramData\\DataDog\\datadog-agent.pid"
 }


### PR DESCRIPTION
### What does this PR do?

- Consolidates the common fx options for system-probe into a single list.
- Adds `config.Component` as a dependency of `sysprobeconfig.Component` to ensure load ordering.
- Minor refactoring to match core agent logic

### Motivation

Prevent issues where the unix list was updated and the windows list was not.

### Describe how you validated your changes

Existing tests.

### Additional Notes
