### PR TITLE
[AGNTLOG-79] Fixed incorrectly truncated logs at log size boundary

### DIFF
--- a/pkg/logs/internal/decoder/single_line_handler.go
+++ b/pkg/logs/internal/decoder/single_line_handler.go
@@ -51,7 +51,8 @@ func addTruncatedTag(msg *message.Message) {
 func (h *SingleLineHandler) process(msg *message.Message) {
 	lastWasTruncated := h.shouldTruncate
 	content := msg.GetContent()
-	h.shouldTruncate = len(content) >= h.lineLimit
+	// Check if content exceeds limit OR if framer already detected truncation
+	h.shouldTruncate = len(content) > h.lineLimit || msg.ParsingExtra.IsTruncated
 
 	content = bytes.TrimSpace(content)
 

--- a/pkg/logs/internal/decoder/single_line_handler_test.go
+++ b/pkg/logs/internal/decoder/single_line_handler_test.go
@@ -140,3 +140,101 @@ func TestSingleLineHandlerExactLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleLineHandlerFramerIntegration(t *testing.T) {
+	mockConfig := configmock.New(t)
+	truncateTag := message.TruncatedReasonTag("single_line")
+	tagTrunLogsFlag := mockConfig.GetBool("logs_config.tag_truncated_logs")
+	defer mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", tagTrunLogsFlag)
+	mockConfig.SetWithoutSource("logs_config.tag_truncated_logs", true)
+
+	t.Run("Frame 2 should get tag even though framer sets IsTruncated=false", func(t *testing.T) {
+		// This simulates what the framer actually does for a 21-byte log (one over limit of 20):
+		// Frame 1: 20 bytes (forced break), IsTruncated=true
+		// Frame 2: 1 byte (newline found), IsTruncated=false
+		// Frame 3: "next log" (new log line), IsTruncated=false
+
+		var processedMessages []*message.Message
+		h := NewSingleLineHandler(func(m *message.Message) {
+			processedMessages = append(processedMessages, m)
+		}, 20)
+
+		// Frame 1: 20 'a's (forced break by framer)
+		msg1 := message.NewMessage([]byte("aaaaaaaaaaaaaaaaaaaa"), nil, "", time.Now().UnixNano())
+		msg1.ParsingExtra.IsTruncated = true // Framer sets this for forced break
+		h.process(msg1)
+
+		// Frame 2: 1 'a' (newline found by framer)
+		msg2 := message.NewMessage([]byte("a"), nil, "", time.Now().UnixNano())
+		msg2.ParsingExtra.IsTruncated = false // Framer sets FALSE because newline was found
+		h.process(msg2)
+
+		// Frame 3: "next log" (separate log line)
+		msg3 := message.NewMessage([]byte("next log"), nil, "", time.Now().UnixNano())
+		msg3.ParsingExtra.IsTruncated = false
+		h.process(msg3)
+
+		// Verify Frame 1
+		assert.Equal(t, "aaaaaaaaaaaaaaaaaaaa"+string(message.TruncatedFlag), string(processedMessages[0].GetContent()))
+		assert.True(t, processedMessages[0].ParsingExtra.IsTruncated)
+		assert.Equal(t, []string{truncateTag}, processedMessages[0].ParsingExtra.Tags, "Frame 1 should have truncation tag")
+
+		// Verify Frame 2 - CRITICAL: should have tag even though framer set IsTruncated=false
+		assert.Equal(t, string(message.TruncatedFlag)+"a", string(processedMessages[1].GetContent()))
+		assert.True(t, processedMessages[1].ParsingExtra.IsTruncated)
+		assert.Equal(t, []string{truncateTag}, processedMessages[1].ParsingExtra.Tags, "Frame 2 should have truncation tag via handler state machine")
+
+		// Verify Frame 3 - should NOT have markers or tag
+		assert.Equal(t, "next log", string(processedMessages[2].GetContent()))
+		assert.False(t, processedMessages[2].ParsingExtra.IsTruncated)
+		assert.Nil(t, processedMessages[2].ParsingExtra.Tags, "Frame 3 (separate log) should NOT have truncation tag")
+	})
+
+	t.Run("Multiple continuation frames should all get tags", func(t *testing.T) {
+		// This tests a 61-byte log (limit 20) which splits into 4 frames:
+		// Frame 1: 20 bytes (forced break), IsTruncated=true
+		// Frame 2: 20 bytes (forced break), IsTruncated=true
+		// Frame 3: 20 bytes (forced break), IsTruncated=true
+		// Frame 4: 1 byte (newline found), IsTruncated=false
+		// Frame 5: "next log" (new log line), IsTruncated=false
+
+		var processedMessages []*message.Message
+		h := NewSingleLineHandler(func(m *message.Message) {
+			processedMessages = append(processedMessages, m)
+		}, 20)
+
+		// Frame 1
+		msg1 := message.NewMessage([]byte("aaaaaaaaaaaaaaaaaaaa"), nil, "", time.Now().UnixNano())
+		msg1.ParsingExtra.IsTruncated = true
+		h.process(msg1)
+
+		// Frame 2
+		msg2 := message.NewMessage([]byte("aaaaaaaaaaaaaaaaaaaa"), nil, "", time.Now().UnixNano())
+		msg2.ParsingExtra.IsTruncated = true
+		h.process(msg2)
+
+		// Frame 3
+		msg3 := message.NewMessage([]byte("aaaaaaaaaaaaaaaaaaaa"), nil, "", time.Now().UnixNano())
+		msg3.ParsingExtra.IsTruncated = true
+		h.process(msg3)
+
+		// Frame 4 (last frame of truncated log)
+		msg4 := message.NewMessage([]byte("a"), nil, "", time.Now().UnixNano())
+		msg4.ParsingExtra.IsTruncated = false // Framer sets false because newline found
+		h.process(msg4)
+
+		// Frame 5 (separate log)
+		msg5 := message.NewMessage([]byte("next log"), nil, "", time.Now().UnixNano())
+		msg5.ParsingExtra.IsTruncated = false
+		h.process(msg5)
+
+		// Verify all frames of truncated log have tag
+		assert.Equal(t, []string{truncateTag}, processedMessages[0].ParsingExtra.Tags)
+		assert.Equal(t, []string{truncateTag}, processedMessages[1].ParsingExtra.Tags)
+		assert.Equal(t, []string{truncateTag}, processedMessages[2].ParsingExtra.Tags)
+		assert.Equal(t, []string{truncateTag}, processedMessages[3].ParsingExtra.Tags, "Frame 4 should have tag via state machine")
+
+		// Verify separate log does NOT have tag
+		assert.Nil(t, processedMessages[4].ParsingExtra.Tags, "Frame 5 (separate log) should NOT have tag")
+	})
+}

--- a/pkg/logs/internal/decoder/single_line_handler_test.go
+++ b/pkg/logs/internal/decoder/single_line_handler_test.go
@@ -100,9 +100,9 @@ func TestSingleLineHandlerProcess(t *testing.T) {
 
 func TestSingleLineHandlerExactLimit(t *testing.T) {
 	scenarios := []struct {
-		name     string
-		input    []string
-		expected []string
+		name           string
+		input          []string
+		expected       []string
 		expIsTruncated []bool
 	}{
 		{

--- a/pkg/logs/internal/framer/docker_stream.go
+++ b/pkg/logs/internal/framer/docker_stream.go
@@ -21,14 +21,14 @@ type dockerStreamMatcher struct {
 	contentLenLimit int
 }
 
-// FindFrame implements EndLineMatcher#FindFrame.
-func (s *dockerStreamMatcher) FindFrame(buf []byte, seen int) ([]byte, int) {
+// FindFrame implements FrameMatcher#FindFrame.
+func (s *dockerStreamMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {
 	for i := seen; i < len(buf); i++ {
 		if buf[i] == '\n' && !s.matchHeader([]byte{}, buf[:i]) {
-			return buf[:i], i + 1
+			return buf[:i], i + 1, false
 		}
 	}
-	return nil, 0
+	return nil, 0, false
 }
 
 // When a newline (in byte is 10) is matching, an additional check need to

--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -186,15 +186,9 @@ func (fr *Framer) Process(input *message.Message) {
 		owned := make([]byte, len(content))
 		copy(owned, content)
 
-		// Create a fresh ParsingExtra for this frame with a deep copy
-		parsingExtra := message.ParsingExtra{
-			Timestamp:   input.ParsingExtra.Timestamp,
-			IsPartial:   input.ParsingExtra.IsPartial,
-			IsTruncated: isTruncated, // Set our detected truncation status
-			IsMultiLine: input.ParsingExtra.IsMultiLine,
-			IsMRFAllow:  input.ParsingExtra.IsMRFAllow,
-			Tags:        append([]string(nil), input.ParsingExtra.Tags...),
-		}
+		// Copy ParsingExtra and override frame-specific fields
+		parsingExtra := input.ParsingExtra
+		parsingExtra.IsTruncated = isTruncated
 
 		c := &message.Message{
 			MessageContent: message.MessageContent{

--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -193,7 +193,7 @@ func (fr *Framer) Process(input *message.Message) {
 			IsTruncated: isTruncated, // Set our detected truncation status
 			IsMultiLine: input.ParsingExtra.IsMultiLine,
 			IsMRFAllow:  input.ParsingExtra.IsMRFAllow,
-			Tags:        nil, // Start with empty tags, handler will add if needed
+			Tags:        append([]string(nil), input.ParsingExtra.Tags...),
 		}
 
 		c := &message.Message{

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -266,7 +266,7 @@ func TestContentLenLimit(t *testing.T) {
 		input := []byte(strings.Repeat("a", contentLenLimit) + "\n")
 		lines := []string{strings.Repeat("a", contentLenLimit)}
 		lens := []int{contentLenLimit + 1}
-	
+
 		gotContent := []string{}
 		gotLens := []int{}
 		gotTruncated := []bool{}
@@ -278,12 +278,12 @@ func TestContentLenLimit(t *testing.T) {
 		fr := NewFramer(outputFn, UTF8Newline, contentLenLimit)
 		logMessage := message.NewMessage(input, nil, "", 0)
 		fr.Process(logMessage)
-	
+
 		require.Equal(t, lines, gotContent)
 		require.Equal(t, lens, gotLens)
 		require.Equal(t, []bool{false}, gotTruncated, "Log exactly at limit should NOT be truncated")
 	})
-	
+
 	t.Run("one-byte-over-should-truncate", func(t *testing.T) {
 		input := []byte(strings.Repeat("a", contentLenLimit+1) + "\n")
 		lines := []string{strings.Repeat("a", contentLenLimit), "a"}

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -262,6 +262,49 @@ func TestContentLenLimit(t *testing.T) {
 		t.Run("two-byte chunks", test(contentLenLimit, chunk(input, 2), lines, lens))
 		t.Run("one-byte chunks", test(contentLenLimit, chunk(input, 1), lines, lens))
 	})
+	t.Run("exact-with-newline-should-not-truncate", func(t *testing.T) {
+		input := []byte(strings.Repeat("a", contentLenLimit) + "\n")
+		lines := []string{strings.Repeat("a", contentLenLimit)}
+		lens := []int{contentLenLimit + 1}
+	
+		gotContent := []string{}
+		gotLens := []int{}
+		gotTruncated := []bool{}
+		outputFn := func(msg *message.Message, rawDataLen int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+			gotLens = append(gotLens, rawDataLen)
+			gotTruncated = append(gotTruncated, msg.ParsingExtra.IsTruncated)
+		}
+		fr := NewFramer(outputFn, UTF8Newline, contentLenLimit)
+		logMessage := message.NewMessage(input, nil, "", 0)
+		fr.Process(logMessage)
+	
+		require.Equal(t, lines, gotContent)
+		require.Equal(t, lens, gotLens)
+		require.Equal(t, []bool{false}, gotTruncated, "Log exactly at limit should NOT be truncated")
+	})
+	
+	t.Run("one-byte-over-should-truncate", func(t *testing.T) {
+		input := []byte(strings.Repeat("a", contentLenLimit+1) + "\n")
+		lines := []string{strings.Repeat("a", contentLenLimit), "a"}
+		lens := []int{contentLenLimit, 2}
+
+		gotContent := []string{}
+		gotLens := []int{}
+		gotTruncated := []bool{}
+		outputFn := func(msg *message.Message, rawDataLen int) {
+			gotContent = append(gotContent, string(msg.GetContent()))
+			gotLens = append(gotLens, rawDataLen)
+			gotTruncated = append(gotTruncated, msg.ParsingExtra.IsTruncated)
+		}
+		fr := NewFramer(outputFn, UTF8Newline, contentLenLimit)
+		logMessage := message.NewMessage(input, nil, "", 0)
+		fr.Process(logMessage)
+
+		require.Equal(t, lines, gotContent)
+		require.Equal(t, lens, gotLens)
+		require.Equal(t, []bool{true, false}, gotTruncated, "First frame truncated, second not")
+	})
 }
 
 func TestLineBreakIncomingData(t *testing.T) {

--- a/pkg/logs/internal/framer/framer_test.go
+++ b/pkg/logs/internal/framer/framer_test.go
@@ -303,7 +303,7 @@ func TestContentLenLimit(t *testing.T) {
 
 		require.Equal(t, lines, gotContent)
 		require.Equal(t, lens, gotLens)
-		require.Equal(t, []bool{true, false}, gotTruncated, "First frame truncated, second not")
+		require.Equal(t, []bool{true, false}, gotTruncated, "First frame truncated, second frame completes the line")
 	})
 }
 

--- a/pkg/logs/internal/framer/matcher.go
+++ b/pkg/logs/internal/framer/matcher.go
@@ -8,10 +8,11 @@ package framer
 // FrameMatcher finds frames in a buffer
 type FrameMatcher interface {
 	// Find a frame in a prefix of buf, and return the slice containing the content
-	// of that frame, together with the total number of bytes in that frame.  Return
-	// `nil, 0` when no complete frame is present in buf.
+	// of that frame, together with the total number of bytes in that frame, and whether
+	// the frame was truncated due to exceeding the content length limit.
+	// Return `nil, 0, false` when no complete frame is present in buf.
 	//
 	// The `seen` argument is the length of `buf` last time this function was called,
 	// and can be used to avoid repeating work when looking for a frame terminator.
-	FindFrame(buf []byte, seen int) ([]byte, int)
+	FindFrame(buf []byte, seen int) (content []byte, rawDataLen int, wasTruncated bool)
 }

--- a/pkg/logs/internal/framer/matcher_test.go
+++ b/pkg/logs/internal/framer/matcher_test.go
@@ -16,9 +16,10 @@ import (
 func testFindFrame(t *testing.T, m FrameMatcher, data []byte, contentLen, rawDataLen int) {
 	expContent := data[:contentLen]
 	for seen := 0; seen < rawDataLen; seen++ {
-		gotContent, gotRawDataLen := m.FindFrame(data, seen)
+		gotContent, gotRawDataLen, wasTruncated := m.FindFrame(data, seen)
 		assert.Equal(t, expContent, gotContent, "for seen=%d", seen)
 		assert.Equal(t, rawDataLen, gotRawDataLen, "for seen=%d", seen)
+		assert.False(t, wasTruncated, "should not be truncated for seen=%d", seen)
 	}
 }
 
@@ -27,15 +28,17 @@ func TestOneByteNewLineMatcher_FindFrame(t *testing.T) {
 }
 
 func TestOneByteNewLineMatcher_FindFrame_none(t *testing.T) {
-	content, rawDataLen := (&oneByteNewLineMatcher{contentLenLimit: 100}).FindFrame([]byte("abcd1234"), 0)
+	content, rawDataLen, wasTruncated := (&oneByteNewLineMatcher{contentLenLimit: 100}).FindFrame([]byte("abcd1234"), 0)
 	assert.Nil(t, content)
 	assert.Equal(t, 0, rawDataLen)
+	assert.False(t, wasTruncated)
 }
 
 func TestOneByteNewLineMatcher_FindFrame_cll(t *testing.T) {
-	content, rawDataLen := (&oneByteNewLineMatcher{contentLenLimit: 10}).FindFrame([]byte("abcd1234abcd1234\n"), 0)
+	content, rawDataLen, wasTruncated := (&oneByteNewLineMatcher{contentLenLimit: 10}).FindFrame([]byte("abcd1234abcd1234\n"), 0)
 	assert.Equal(t, []byte("abcd1234ab"), content)
 	assert.Equal(t, 10, rawDataLen)
+	assert.True(t, wasTruncated, "should be truncated when content exceeds limit")
 }
 
 func TestTwoByteNewlineMatcher_FindFrame_UTF16LE(t *testing.T) {
@@ -63,9 +66,10 @@ func TestTwoByteNewlineMatcher_FindFrame_cll(t *testing.T) {
 		0x00, 0x41, 0x00, 0x40, 0x00, 0x44, // "BAD" (no newline)
 	}
 	m := &twoByteNewLineMatcher{contentLenLimit: 6, newline: Utf16beEOL}
-	content, rawDataLen := m.FindFrame(input, 0)
+	content, rawDataLen, wasTruncated := m.FindFrame(input, 0)
 	assert.Equal(t, input[:6], content)
 	assert.Equal(t, 6, rawDataLen)
+	assert.True(t, wasTruncated, "should be truncated when content exceeds limit")
 }
 
 func TestTwoByteNewlineMatcher_FindFrame_cll_odd(t *testing.T) {
@@ -75,9 +79,10 @@ func TestTwoByteNewlineMatcher_FindFrame_cll_odd(t *testing.T) {
 		0x00, 0x41, 0x00, 0x40, 0x00, 0x44, // "BAD" (no newline)
 	}
 	m := &twoByteNewLineMatcher{contentLenLimit: 7, newline: Utf16beEOL}
-	content, rawDataLen := m.FindFrame(input, 0)
+	content, rawDataLen, wasTruncated := m.FindFrame(input, 0)
 	assert.Equal(t, input[:6], content) // 7 rounded down to 6
 	assert.Equal(t, 6, rawDataLen)
+	assert.True(t, wasTruncated, "should be truncated when content exceeds limit")
 }
 
 func TestTwoByteNewlineMatcher_FindFrame_Misaligned(t *testing.T) {

--- a/pkg/logs/internal/framer/no_framing.go
+++ b/pkg/logs/internal/framer/no_framing.go
@@ -9,6 +9,6 @@ package framer
 type noFramingMatcher struct{}
 
 // FindFrame considers the given bytes buffer as one full frame.
-func (m *noFramingMatcher) FindFrame(buf []byte, _ int) ([]byte, int) {
-	return buf, len(buf)
+func (m *noFramingMatcher) FindFrame(buf []byte, _ int) ([]byte, int, bool) {
+	return buf, len(buf), false
 }

--- a/pkg/logs/internal/framer/onebyte.go
+++ b/pkg/logs/internal/framer/onebyte.go
@@ -17,20 +17,21 @@ type oneByteNewLineMatcher struct {
 	contentLenLimit int
 }
 
-// FindFrame implements EndLineMatcher#FindFrame.
-func (ob *oneByteNewLineMatcher) FindFrame(buf []byte, seen int) ([]byte, int) {
+// FindFrame implements FrameMatcher#FindFrame.
+func (ob *oneByteNewLineMatcher) FindFrame(buf []byte, seen int) ([]byte, int, bool) {
 	nl := bytes.IndexByte(buf[seen:], '\n')
 	if nl == -1 {
-		return nil, 0
+		return nil, 0, false
 	}
 
 	// limit the returned line to contentLenLimit bytes
 	eol := nl + seen
 	if eol > ob.contentLenLimit {
-		return buf[:ob.contentLenLimit], ob.contentLenLimit
+		// Newline found beyond the limit - truncate and mark as truncated
+		return buf[:ob.contentLenLimit], ob.contentLenLimit, true
 	}
 
 	// return the content without the newline, but count the newline in the raw
 	// length
-	return buf[:eol], eol + 1
+	return buf[:eol], eol + 1, false
 }

--- a/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
+++ b/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
@@ -12,3 +12,8 @@ fixes:
     limit (default 900KB) were incorrectly marked as truncated. This caused the
     ``...TRUNCATED...`` marker to appear in logs that fit within the size limit,
     and incorrectly marked the subsequent log line as a truncated remainder.
+
+    Additionally, improved truncation detection to only mark frames that are actually
+    truncated, rather than all frames from a split log line. This makes truncation
+    metrics more accurate and allows ``exclude_at_match`` rules with truncation filters
+    to work more precisely.

--- a/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
+++ b/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
@@ -12,8 +12,6 @@ fixes:
     limit (default 900KB) were incorrectly marked as truncated. This caused the
     ``...TRUNCATED...`` marker to appear in logs that fit within the size limit,
     and incorrectly marked the subsequent log line as a truncated remainder.
-
-    Additionally, improved truncation detection to only mark frames that are actually
-    truncated, rather than all frames from a split log line. This makes truncation
-    metrics more accurate and allows ``exclude_at_match`` rules with truncation filters
-    to work more precisely.
+    Additionally, improved truncation detection by extending the FrameMatcher interface
+    to explicitly signal when content is truncated, ensuring consistent truncation state
+    across the framer and handler components.

--- a/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
+++ b/releasenotes/notes/fixed-log-boundary-truncation-state-7ffbc82c8e17e917.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug where log lines exactly at the ``logs_config.max_message_size_bytes``
+    limit (default 900KB) were incorrectly marked as truncated. This caused the
+    ``...TRUNCATED...`` marker to appear in logs that fit within the size limit,
+    and incorrectly marked the subsequent log line as a truncated remainder.


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where log lines exactly at the `logs_config.max_message_size_bytes` limit (default 900KB) were incorrectly marked as truncated. This caused:
- False truncation markers (`...TRUNCATED...`) to appear in logs that fit within the size limit
- The next log in the sequence to be incorrectly marked as a truncated remainder
- False positives in truncation telemetry metrics
  
## Motivation

[Ticket](https://datadoghq.atlassian.net/jira/software/c/projects/AGNTLOG/boards/8654?quickFilter=10125&selectedIssue=AGNTLOG-79)

A log line containing exactly 900,000 bytes (the default `max_message_size_bytes`) should not be marked as truncated, since it fits within the configured limit. However, the agent was incorrectly treating logs at the exact boundary as over the limit, using `>=` instead of `>` comparison.

Additionally, the framer component was unable to detect when the line matcher silently truncated content, leading to inconsistent truncation state between components.

## Root Cause

The bug had three interrelated issues:

  Three interrelated issues:

  1. **Matcher Silent Truncation** (`pkg/logs/internal/framer/onebyte.go`): When a newline is found beyond the limit, the matcher truncated content but didn't signal truncation occurred.

  2. **No Truncation Signal in Interface** (`pkg/logs/internal/framer/matcher.go`): The `FrameMatcher` interface only returned `(content []byte, rawDataLen int)` with no way to signal truncation. The framer only set `IsTruncated=true` when forcing breaks, missing matcher-truncated frames.

  3. **Wrong Boundary Check** (`pkg/logs/internal/decoder/single_line_handler.go:54`): Used `>=` instead of `>`, marking logs exactly at the limit as truncated.

  **Combined Effect:** For a 900,000-byte log, the matcher found the newline within limit, the framer didn't detect truncation, but the handler's `>=` comparison incorrectly marked it as truncated, causing the next unrelated log to get a `...TRUNCATED...` prefix.

## The Fix

1. **Extended `FrameMatcher` interface** to return explicit truncation status:
     ```go
     // Before: FindFrame(buf []byte, seen int) (content []byte, rawDataLen int)
     // After:  FindFrame(buf []byte, seen int) (content []byte, rawDataLen int, wasTruncated bool)

2. Updated all 4 matcher implementations to explicitly signal when they truncate content.
3. Fixed boundary check in handler from >= to > and added framer flag check:
  h.shouldTruncate = len(content) > h.lineLimit || msg.ParsingExtra.IsTruncated

## Describe how you validated your changes

### Unit Tests

- Added exact-with-newline-should-not-truncate test: validates 900,000-byte log is not truncated
- Added one-byte-over-should-truncate test: validates 900,001-byte log is correctly split and marked
- Updated all matcher tests to validate wasTruncated return value
- Added handler integration tests validating behavior across frame boundaries

### Manual QA

**Test Setup**:

Created test configuration at `dev/dist/datadog.yaml`:
```yaml
api_key: "YOUR_API_KEY"
hostname: "YOUR_HOSTNAME"

log_level: debug
logs_enabled: true
logs_config:
  max_message_size_bytes: 100  # Set low for easy testing (default is 900000)
  tag_truncated_logs: true
  auto_multi_line_detection_tagging: false  # Required to use SingleLineHandler
```

Created log configuration at `dev/dist/conf.d/custom_logs.d/conf.yaml`:
```yaml
logs:
  - type: file
    path: /tmp/test-logs/*.log
    service: test-truncation
    source: manual-test
```

**Test Script**:

Used the following test script to validate the fix:

```bash
#!/bin/bash

echo "=========================================="
echo "Log Truncation Bug Fix - Manual QA Test"
echo "=========================================="
echo ""

# Clean up old files
rm -f agent-qa-output.log qa-results.txt /tmp/test-logs/*.log

echo "Starting agent FIRST..."
./bin/agent/agent run -c dev/dist/datadog.yaml > agent-qa-output.log 2>&1 &
AGENT_PID=$!
echo "✓ Agent started (PID: $AGENT_PID)"
echo ""

# Wait for agent to initialize
echo "Waiting 10 seconds for agent to initialize..."
sleep 10

# NOW create test logs (agent is already watching)
echo "Creating test logs NOW (agent is watching)..."
mkdir -p /tmp/test-logs

# Test 1: Exactly 100 bytes (should NOT be truncated)
python3 -c "print('a' * 100, end='')" > /tmp/test-logs/exact.log
echo "" >> /tmp/test-logs/exact.log
echo "next normal log" >> /tmp/test-logs/exact.log

# Test 2: 101 bytes (should BE truncated)
python3 -c "print('b' * 101, end='')" > /tmp/test-logs/over.log
echo "" >> /tmp/test-logs/over.log
echo "remainder log" >> /tmp/test-logs/over.log

echo "✓ Test logs created"
echo ""

# Wait for logs to be processed and sent
echo "Waiting 20 seconds for logs to be processed and sent to Datadog..."
sleep 20

# Kill agent
echo "Stopping agent..."
kill $AGENT_PID 2>/dev/null
wait $AGENT_PID 2>/dev/null
echo "✓ Agent stopped"
echo ""

# Check what was actually processed
echo "=========================================="
echo "AGENT PROCESSING RESULTS"
echo "=========================================="
echo ""

echo "Files tailed:"
grep "Starting a new tailer" agent-qa-output.log | tail -5

echo ""
echo "Lines read:"
grep "read.*bytes and.*lines" agent-qa-output.log | tail -5

echo ""
echo "Logs sent to Datadog:"
grep -i "logs sent\|log batch" agent-qa-output.log | tail -10

echo ""
echo "=========================================="
echo "TO VERIFY THE FIX:"
echo "=========================================="
echo "1. Go to Datadog: https://app.datadoghq.com/logs (datadogdev for internal devs)"
echo "2. Search for: service:test-truncation"
echo "3. Look for logs with 'aaaa' (100 bytes. should not have truncation marker)"
echo "4. Look for logs with 'bbbb' (101 bytes. should have '...TRUNCATED...' marker)"
echo ""
echo "Expected results:"
echo "  - 100 'a's log: no truncation indicator"
echo "  - 101 'b's log: has truncation indicator"
echo ""
echo "Full agent output saved to: agent-qa-output.log"
echo ""
```

**Results**:

Built and ran agent:
```bash
dda inv agent.build --rebuild --build-exclude=systemd
./test-truncation-qa.sh
```

Agent logs confirm successful processing:
```
Starting a new tailer for: /tmp/test-logs/exact.log (offset: 0, whence: 0)
Starting a new tailer for: /tmp/test-logs/over.log (offset: 0, whence: 0)
Closed /tmp/test-logs/exact.log ... read 116 bytes and 2 lines
Closed /tmp/test-logs/over.log ... read 119 bytes and 2 lines
```

**Datadog UI Verification**:

<img width="1501" height="190" alt="image" src="https://github.com/user-attachments/assets/fe0b5571-73a6-4084-b5fd-321130fd0364" />

**Test Case 1: Exactly 100 bytes** 
- Log content: `aaaaaaa...` (100 'a's)
- Result: **no** `...TRUNCATED...` marker
- Tags: **no** `truncated:single_line` tag
- Next log: "next normal log" with no truncation markers

**Test Case 2: 101 bytes** 
- Log content: `bbbbbbb...TRUNCATED...` (101 'b's with marker)
- Result: **has** `...TRUNCATED...` marker appended and prepended to next b in log
- Tags: **has** `truncated:single_line` tags
- Next log: "remainder log" correctly shows remainder + no marker & no truncation tag 🙂