### PR TITLE
[NCM] Add device profile: TMOS

### DIFF
--- a/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
@@ -1,0 +1,54 @@
+{
+  "commands": [
+    {
+      "type": "running",
+      "values": [
+        "cat /config/partitions/*/bigip*.conf"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "^([\\s\\t]*)secret \\S+",
+            "replacement": "${1}secret <secret removed>"
+          },
+          {
+            "regex": "^([\\s\\t]*\\S*)password \\S+",
+            "replacement": "${1}password <secret removed>"
+          },
+          {
+            "regex": "^([\\s\\t]*\\S*)passphrase \\S+",
+            "replacement": "${1}passphrase <secret removed>"
+          },
+          {
+            "regex": "^(\\s*)community \\S+",
+            "replacement": "${1}community <secret removed>"
+          },
+          {
+            "regex": "^(\\s*)community-name \\S+",
+            "replacement": "${1}community-name <secret removed>"
+          },
+          {
+            "regex": "^([\\s\\t]*\\S*)encrypted \\S+$",
+            "replacement": "${1}encrypted <secret removed>"
+          }
+        ]
+      }
+    },
+    {
+      "type": "metadata",
+      "values": [],
+      "processing_rules": {
+        "metadata": [
+          {
+
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
@@ -11,6 +11,13 @@
 
           }
         ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "^sys global-settings\\s*{"
+          }
+
+        ],
         "redaction": [
           {
             "regex": "^([\\s\\t]*)secret \\S+",

--- a/pkg/networkconfigmanagement/profile/default_profiles_test.go
+++ b/pkg/networkconfigmanagement/profile/default_profiles_test.go
@@ -60,6 +60,12 @@ func Test_DefaultProfiles_Running(t *testing.T) {
 				Timestamp: 1767709263,
 			},
 		},
+		{
+			name:                      "TMOS",
+			profile:                   DefaultProfile("tmos"),
+			fixture:                   loadFixture("tmos", Running),
+			expectedExtractedMetadata: &ExtractedMetadata{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
@@ -1,3 +1,7 @@
+sys global-settings {
+    hostname bigip1.example.net
+}
+
 ltm virtual /Common/web_vip {
     destination 10.10.20.30:https
     ip-protocol tcp

--- a/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
@@ -1,0 +1,43 @@
+ltm virtual /Common/web_vip {
+    destination 10.10.20.30:https
+    ip-protocol tcp
+    pool /Common/web_pool
+    profiles {
+        /Common/http { }
+        /Common/clientssl {
+            passphrase <secret removed>
+        }
+    }
+}
+
+ltm pool /Common/web_pool {
+    members {
+        10.10.30.10:80 {
+            address 10.10.30.10
+        }
+    }
+}
+
+sys snmp {
+    communities {
+        public {
+            community <secret removed>
+        }
+        secure {
+            community-name <secret removed>
+        }
+    }
+}
+
+auth user admin {
+    password <secret removed>
+    encrypted <secret removed>
+}
+
+radius-server /Common/radius1 {
+    secret <secret removed>
+}
+
+tacacs-server /Common/tac1 {
+    secret <secret removed>
+}

--- a/pkg/networkconfigmanagement/profile/fixtures/tmos/running/initial.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/tmos/running/initial.txt
@@ -1,3 +1,7 @@
+sys global-settings {
+    hostname bigip1.example.net
+}
+
 ltm virtual /Common/web_vip {
     destination 10.10.20.30:https
     ip-protocol tcp

--- a/pkg/networkconfigmanagement/profile/fixtures/tmos/running/initial.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/tmos/running/initial.txt
@@ -1,0 +1,43 @@
+ltm virtual /Common/web_vip {
+    destination 10.10.20.30:https
+    ip-protocol tcp
+    pool /Common/web_pool
+    profiles {
+        /Common/http { }
+        /Common/clientssl {
+            passphrase mySuperSecretPassphrase
+        }
+    }
+}
+
+ltm pool /Common/web_pool {
+    members {
+        10.10.30.10:80 {
+            address 10.10.30.10
+        }
+    }
+}
+
+sys snmp {
+    communities {
+        public {
+            community publicString
+        }
+        secure {
+            community-name mySecretCommunity
+        }
+    }
+}
+
+auth user admin {
+    password $1$kjsdf9234kjsdf9234
+    encrypted $M$YxZk9AABBBCCC112233445566
+}
+
+radius-server /Common/radius1 {
+    secret myRadiusSharedSecret
+}
+
+tacacs-server /Common/tac1 {
+    secret anotherTacacsSecret
+}


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/NDINT-421

Add device profile for TMOS devices (F5)
* reference model from oxidized: [`tmos.rb`](https://github.com/ytti/oxidized/blob/master/lib/oxidized/model/tmos.rb)
* oxidized did not have any test specs to reference for configuration examples :-(
  * they usually live in this directory with the model prefixed ([here](https://github.com/ytti/oxidized/tree/master/spec/model/data))
* generated config example from chatgpt - i just gave context about f5, link to oxidized model and asked for a config example since the others i found online were very short / basically CLI commands only
  * hope to have more concrete (even if sanitized) examples from customers to draw from moving forward, not certain if we have any f5 devices to compare to

### Motivation

### Describe how you validated your changes

### Additional Notes
