### PR TITLE
Remove unneeded extra_package_file for debian/redhat postinstall scripts

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -282,10 +282,6 @@ end
 
 # all flavors use the same package scripts
 if linux_target?
-  if do_build && !do_package
-    extra_package_file "#{Omnibus::Config.project_root}/package-scripts/agent-deb"
-    extra_package_file "#{Omnibus::Config.project_root}/package-scripts/agent-rpm"
-  end
   if do_package
     if debian_target?
       package_scripts_path "#{Omnibus::Config.project_root}/package-scripts/agent-deb"


### PR DESCRIPTION
If we do_package is false, there is no need for the instal scripts, since we will not build the .deb or .rpm file.

Context: I'm trying to come up with the plan for moving the package building to bazel, and need to understand where all the files get gathered.

There were some questions about redundant code in https://github.com/DataDog/datadog-agent/pull/25885
This may also apply.