### PR TITLE
feat(dependabot): Force updates out of business working days

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,6 +23,7 @@ updates:
       - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
     groups:
       franz-go:
@@ -58,6 +59,7 @@ updates:
       - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/gohai
@@ -75,6 +77,7 @@ updates:
       - dependency-name: golang.org/x/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/obfuscate
@@ -92,6 +95,7 @@ updates:
       - dependency-name: golang.org/x/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/security/secl
@@ -107,6 +111,7 @@ updates:
       - dependency-name: golang.org/x/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /internal/tools
@@ -141,6 +146,7 @@ updates:
       - dependency-name: golang.org/x/*
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /test/new-e2e
@@ -171,6 +177,7 @@ updates:
 
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /test/fakeintake
@@ -183,6 +190,7 @@ updates:
       - dev/testing
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
     ignore:
       # Ignore golang.org/x/... deps to avoid noise, they are updated together, pretty regularly
@@ -197,6 +205,7 @@ updates:
       - dev/testing
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: github-actions
     directory: /
@@ -209,6 +218,7 @@ updates:
       - dev/tooling
     schedule:
       interval: weekly
+      day: saturday
     open-pull-requests-limit: 100
   - package-ecosystem: maven
     directory: Dockerfiles/agent/bouncycastle-fips
@@ -218,6 +228,7 @@ updates:
       - changelog/no-changelog
     schedule:
       interval: weekly
+      day: saturday
     ignore:
       - dependency-name: org.bouncycaslte:*
         # Ignore preview versions


### PR DESCRIPTION
### What does this PR do?
Moves the dependabot updates to `saturday` which is out of business hours for nearly everyone.

### Motivation
Prevent impact on the CI workload because of dependabot updates

### Describe how you validated your changes
n/a, this is just configuration update described [here](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#day)

### Additional Notes
