### PR TITLE
[CWS] fix and re-enable a flaky test

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -955,6 +955,10 @@ func TestActionKillContainerWithSignature(t *testing.T) {
 		t.Skip("Skip test spawning docker containers on docker")
 	}
 
+	checkKernelCompatibility(t, "skip on CentOS7", func(kv *kernel.Version) bool {
+		return kv.IsRH7Kernel()
+	})
+
 	if _, err := whichNonFatal("docker"); err != nil {
 		t.Skip("Skip test where docker is unavailable")
 	}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -512,6 +512,7 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 			}
 			select {
 			case line := <-linesCh:
+				t.Logf("dnsloop line: %s", line)
 				if strings.Contains(line, "DNS_OK") {
 					dnsOK = true
 					foundAny = true

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -463,6 +463,9 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)
 
+	// Use a local UDP port for testing - no external network dependency
+	const udpTestPort = "5555"
+
 	// Initial rule to capture signature when syscall_tester starts
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -500,8 +503,8 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 		}()
 	}
 
-	// Helper function to drain all buffered lines and return the last DNS status
-	drainAndReadDNSStatus := func(timeout time.Duration) (dnsOK bool, err error) {
+	// Helper function to drain all buffered lines and return the last UDP status
+	drainAndReadUDPStatus := func(timeout time.Duration) (udpOK bool, err error) {
 		deadline := time.Now().Add(timeout)
 		foundAny := false
 
@@ -512,48 +515,47 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 			}
 			select {
 			case line := <-linesCh:
-				t.Logf("dnsloop line: %s", line)
-				if strings.Contains(line, "DNS_OK") {
-					dnsOK = true
+				if strings.Contains(line, "UDP_OK") {
+					udpOK = true
 					foundAny = true
-				} else if strings.Contains(line, "DNS_FAIL") {
-					dnsOK = false
+				} else if strings.Contains(line, "UDP_FAIL") {
+					udpOK = false
 					foundAny = true
 				}
 			case <-linesErrCh:
 				if foundAny {
-					return dnsOK, nil
+					return udpOK, nil
 				}
 				return false, errors.New("reader error")
 			case <-time.After(remaining):
 				if foundAny {
-					return dnsOK, nil
+					return udpOK, nil
 				}
-				return false, errors.New("timeout reading DNS status")
+				return false, errors.New("timeout reading UDP status")
 			}
 		}
 		if foundAny {
-			return dnsOK, nil
+			return udpOK, nil
 		}
-		return false, errors.New("timeout reading DNS status")
+		return false, errors.New("timeout reading UDP status")
 	}
 
-	// Start dnsloop in background and capture the signature
+	// Start udploop in background and capture the signature
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var dnsloopCmd *exec.Cmd
+	var udploopCmd *exec.Cmd
 	var stdout io.ReadCloser
 	var capturedSignature string
 
 	test.WaitSignalFromRule(t, func() error {
-		dnsloopCmd = exec.CommandContext(ctx, syscallTester, "dnsloop", "google.com")
+		udploopCmd = exec.CommandContext(ctx, syscallTester, "udploop", udpTestPort)
 		var err error
-		stdout, err = dnsloopCmd.StdoutPipe()
+		stdout, err = udploopCmd.StdoutPipe()
 		if err != nil {
 			return err
 		}
-		return dnsloopCmd.Start()
+		return udploopCmd.Start()
 	}, func(event *model.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_rule_capture_signature")
 		capturedSignature = event.FieldHandlers.ResolveSignature(event)
@@ -561,8 +563,8 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 
 	defer func() {
 		cancel()
-		if dnsloopCmd != nil {
-			dnsloopCmd.Wait()
+		if udploopCmd != nil {
+			udploopCmd.Wait()
 		}
 	}()
 
@@ -573,10 +575,10 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 	reader := bufio.NewReader(stdout)
 	startLineReader(reader)
 
-	// Step 1: Verify DNS works before isolation
-	dnsOK, err := drainAndReadDNSStatus(10 * time.Second)
-	if err != nil || !dnsOK {
-		t.Fatalf("DNS should work before isolation: dnsOK=%v, err=%v", dnsOK, err)
+	// Step 1: Verify UDP works before isolation
+	udpOK, err := drainAndReadUDPStatus(10 * time.Second)
+	if err != nil || !udpOK {
+		t.Fatalf("UDP should work before isolation: udpOK=%v, err=%v", udpOK, err)
 	}
 
 	// Step 2: Apply network isolation rule with signature matching
@@ -591,7 +593,7 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 			Actions: []*rules.ActionDefinition{
 				{
 					NetworkFilter: &rules.NetworkFilterDefinition{
-						BPFFilter: "port 53",
+						BPFFilter: "port " + udpTestPort,
 						Scope:     "process",
 						Policy:    "drop",
 					},
@@ -613,10 +615,10 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 	// Wait for the filter to be applied
 	time.Sleep(3 * time.Second)
 
-	// Step 3: Verify DNS fails for the now-isolated process
-	dnsOK, err = drainAndReadDNSStatus(10 * time.Second)
-	if err == nil && dnsOK {
-		t.Error("Step 3: DNS should fail for isolated process")
+	// Step 3: Verify UDP fails for the now-isolated process
+	udpOK, err = drainAndReadUDPStatus(10 * time.Second)
+	if err == nil && udpOK {
+		t.Error("Step 3: UDP should fail for isolated process")
 	}
 
 	// Step 4: Remove the network isolation rule
@@ -637,10 +639,10 @@ func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
 	// Wait for the filter to be removed
 	time.Sleep(2 * time.Second)
 
-	// Step 5: Verify DNS works again on the same process
-	dnsOK, err = drainAndReadDNSStatus(10 * time.Second)
-	if err != nil || !dnsOK {
-		t.Errorf("Step 5: DNS should work after removing network filter: dnsOK=%v, err=%v", dnsOK, err)
+	// Step 5: Verify UDP works again on the same process
+	udpOK, err = drainAndReadUDPStatus(10 * time.Second)
+	if err != nil || !udpOK {
+		t.Errorf("Step 5: UDP should work after removing network filter: udpOK=%v, err=%v", udpOK, err)
 	}
 }
 

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -459,8 +459,6 @@ func TestRawPacketActionWithSignature(t *testing.T) {
 }
 
 func TestRawPacketActionProcessScopeWithSignature(t *testing.T) {
-	t.Skip("This test is flaky, let's skip it for now")
-
 	SkipIfNotAvailable(t)
 
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -1760,6 +1760,145 @@ int test_prctl_setname(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+// Shared state for udploop between threads
+static volatile int udp_received = 0;
+static volatile int udp_running = 1;
+
+struct udploop_args {
+    int port;
+};
+
+void *udp_server_thread(void *arg) {
+    struct udploop_args *args = (struct udploop_args *)arg;
+    int port = args->port;
+    int sockfd;
+    struct sockaddr_in server_addr, client_addr;
+    socklen_t client_len = sizeof(client_addr);
+    char buffer[64];
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        perror("server socket");
+        return NULL;
+    }
+
+    // Allow address reuse
+    int opt = 1;
+    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    // Set receive timeout to avoid blocking forever
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 500000; // 500ms
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(port);
+
+    if (bind(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        perror("server bind");
+        close(sockfd);
+        return NULL;
+    }
+
+    while (udp_running) {
+        ssize_t n = recvfrom(sockfd, buffer, sizeof(buffer) - 1, 0,
+                             (struct sockaddr *)&client_addr, &client_len);
+        if (n > 0) {
+            udp_received = 1;
+        }
+        // On timeout (n < 0 && errno == EAGAIN), just loop
+    }
+
+    close(sockfd);
+    return NULL;
+}
+
+void *udp_client_thread(void *arg) {
+    struct udploop_args *args = (struct udploop_args *)arg;
+    int port = args->port;
+    int sockfd;
+    struct sockaddr_in server_addr;
+    const char *msg = "ping";
+
+    sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        perror("client socket");
+        return NULL;
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    server_addr.sin_port = htons(port);
+
+    while (udp_running) {
+        sendto(sockfd, msg, strlen(msg), 0,
+               (struct sockaddr *)&server_addr, sizeof(server_addr));
+        sleep(1);
+    }
+
+    close(sockfd);
+    return NULL;
+}
+
+int test_udploop(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: udploop <port>\n");
+        return EXIT_FAILURE;
+    }
+
+    int port = atoi(argv[1]);
+    if (port <= 1024 || port > 65535) {
+        fprintf(stderr, "Port must be between 1025 and 65535\n");
+        return EXIT_FAILURE;
+    }
+
+    struct udploop_args args;
+    args.port = port;
+
+    pthread_t server_tid, client_tid;
+
+    // Start server thread first
+    if (pthread_create(&server_tid, NULL, udp_server_thread, &args) != 0) {
+        perror("pthread_create server");
+        return EXIT_FAILURE;
+    }
+
+    // Give server time to bind
+    usleep(100000); // 100ms
+
+    // Start client thread
+    if (pthread_create(&client_tid, NULL, udp_client_thread, &args) != 0) {
+        perror("pthread_create client");
+        udp_running = 0;
+        pthread_join(server_tid, NULL);
+        return EXIT_FAILURE;
+    }
+
+    // Main loop: check every second if we received packets
+    while (1) {
+        sleep(1);
+
+        if (udp_received) {
+            udp_received = 0;
+            printf("UDP_OK: received packet on port %d\n", port);
+        } else {
+            printf("UDP_FAIL: no packet received on port %d\n", port);
+        }
+        fflush(stdout);
+    }
+
+    // Never reached, but for completeness
+    udp_running = 0;
+    pthread_join(server_tid, NULL);
+    pthread_join(client_tid, NULL);
+
+    return EXIT_SUCCESS;
+}
+
 int test_dnsloop(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr, "Please specify a domain to resolve\n");
@@ -1904,6 +2043,8 @@ int main(int argc, char **argv) {
             exit_code = test_pause(sub_argc, sub_argv);
         } else if (strcmp(cmd, "prctl-setname") == 0) {
             exit_code = test_prctl_setname(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "udploop") == 0) {
+            exit_code = test_udploop(sub_argc, sub_argv);
         } else if (strcmp(cmd, "dnsloop") == 0) {
             exit_code = test_dnsloop(sub_argc, sub_argv);
         } else {


### PR DESCRIPTION
### What does this PR do?

Fixed `TestRawPacketActionProcessScopeWithSignature` test by not relying on a loop of distant DNS requests, and re-enable it.
Also skip `TestActionKillContainerWithSignature` on centos7 (where cgroup resolution is flaky)

### Motivation

### Describe how you validated your changes

### Additional Notes
