### PR TITLE
attacher: do not report 'unknown error' for failure to attach to non-existent processes

### DIFF
--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -127,6 +127,9 @@ var (
 	// ErrPathIsAlreadyRegistered is the error resulting if the
 	// path is already in the file registry.
 	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
+
+	// ErrProcessDoesNotExist is the error resulting if the process does not exist anymore.
+	ErrProcessDoesNotExist = errors.New("process does not exist")
 )
 
 // UnknownAttachmentError is an error that is not one of the expected errors, a
@@ -179,6 +182,13 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 
 	path, err := NewFilePath(r.procRoot, namespacedPath, pid)
 	if err != nil {
+		// Distinguish errors between "process does not exist anymore" and "file is not found"
+		// by checking if the process root directory exists.
+		processRoot := fmt.Sprintf("%s/%d", r.procRoot, pid)
+		if _, statErr := os.Stat(processRoot); statErr != nil {
+			return ErrProcessDoesNotExist
+		}
+
 		return NewUnknownAttachmentError(fmt.Errorf("error creating file path for PID %d: %w", pid, err))
 	}
 

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
-	"strconv"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
+	"strconv"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -334,6 +334,34 @@ func TestNoBlockErrEnvironment(t *testing.T) {
 	// been blocked since we retruned an error wrapping ErrEnvironment.
 	assert.Equal(t, 2, registerRecorder.CallsForPathID(pathID))
 	assert.Contains(t, r.GetRegisteredProcesses(), pid)
+}
+
+func TestRegisterDistinguishProcessDoesNotExistFromOtherErrors(t *testing.T) {
+	r := newFileRegistry()
+	r.procRoot = t.TempDir() // fake procfs
+
+	const pid = uint32(4242)
+	missingNamespacedPath := "/does-not-exist"
+
+	t.Run("process_gone_returns_ErrProcessDoesNotExist", func(t *testing.T) {
+		// NewFilePath will fail because the target path doesn't exist, and since
+		// /<procRoot>/<pid> also doesn't exist we should return ErrProcessDoesNotExist.
+		err := r.Register(missingNamespacedPath, pid, IgnoreCB, IgnoreCB, IgnoreCB)
+		require.ErrorIs(t, err, ErrProcessDoesNotExist)
+	})
+
+	t.Run("process_alive_returns_UnknownAttachmentError_for_missing_file", func(t *testing.T) {
+		// Make /<procRoot>/<pid> exist, but keep /root/<namespacedPath> missing so
+		// NewFilePath still fails.
+		require.NoError(t, os.MkdirAll(filepath.Join(r.procRoot, strconv.Itoa(int(pid))), 0o755))
+
+		err := r.Register(missingNamespacedPath, pid, IgnoreCB, IgnoreCB, IgnoreCB)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, ErrProcessDoesNotExist)
+
+		var unknown *UnknownAttachmentError
+		require.ErrorAs(t, err, &unknown)
+	})
 }
 
 func TestFilePathInCallbackArgument(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

When registering a file path fails in the file registry, we differentiate errors due to the process not existing anymore from other types of errors. The uprobe attacher has a function (`shouldLogRegistryError`) that will not report expected errors (i.e., those that aren't `UnknownAttachmentErrors`).

### Motivation

Logs coming from this were generating a lot of noise despite being behind a log limiter (~3k errors per hour in `stripe.us1.staging.dog`). With this PR, we eliminate the logs from events that we expect to happen (i.e., short lived processes that finish before we can inspect them) and keep the ones that can signal other possible errors (e.g., wrong paths being reported).

### Describe how you validated your changes

Added a unit test to validate the behavior.

### Additional Notes
