### PR TITLE
[ AGNTLOG-498 ] Fix tcp default port assignment for EU endpoints

### DIFF
--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -58,6 +58,11 @@ const OTelCollectorIntakeOrigin IntakeOrigin = "otel-collector"
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
+	"agent-intake.logs.datadoghq.com.": 10516,
+	"agent-intake.logs.datadoghq.eu.":  443,
+	"agent-intake.logs.datad0g.com.":   10516,
+	"agent-intake.logs.datad0g.eu.":    443,
+
 	"agent-intake.logs.datadoghq.com": 10516,
 	"agent-intake.logs.datadoghq.eu":  443,
 	"agent-intake.logs.datad0g.com":   10516,

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -1249,3 +1249,70 @@ func (suite *ConfigTestSuite) TestBatchWaitSubsecondValues() {
 	suite.Nil(err)
 	suite.Equal(pkgconfigsetup.DefaultBatchWait*time.Second, endpoints.BatchWait, "BatchWait should fallback to default for too-large values")
 }
+
+func (suite *ConfigTestSuite) TestTCPEndpointsPortLookup() {
+	// This test verifies that TCP endpoints are constructed with the correct ports
+	// when the logsEndpoints map is looked up with hostnames that have trailing dots (FQDNs).
+	// The trailing dots are added by GetMainEndpoint when convert_dd_site_fqdn.enabled is true.
+
+	tests := []struct {
+		name         string
+		site         string
+		expectedHost string
+		expectedPort int
+	}{
+		{
+			name:         "datadoghq.com site",
+			site:         "datadoghq.com",
+			expectedHost: "agent-intake.logs.datadoghq.com.",
+			expectedPort: 10516,
+		},
+		{
+			name:         "datadoghq.eu site",
+			site:         "datadoghq.eu",
+			expectedHost: "agent-intake.logs.datadoghq.eu.",
+			expectedPort: 443,
+		},
+		{
+			name:         "datadoghq.eu with-a-dot site",
+			site:         "datadoghq.eu.",
+			expectedHost: "agent-intake.logs.datadoghq.eu.",
+			expectedPort: 443,
+		},
+		{
+			name:         "datad0g.com site",
+			site:         "datad0g.com",
+			expectedHost: "agent-intake.logs.datad0g.com.",
+			expectedPort: 10516,
+		},
+		{
+			name:         "datad0g.eu site",
+			site:         "datad0g.eu",
+			expectedHost: "agent-intake.logs.datad0g.eu.",
+			expectedPort: 443,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			suite.config.SetWithoutSource("api_key", "test-key")
+			suite.config.SetWithoutSource("site", tt.site)
+			suite.config.SetWithoutSource("convert_dd_site_fqdn.enabled", true) // FQDN is enabled by default
+
+			endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+
+			suite.Nil(err)
+			suite.Equal(tt.expectedHost, endpoints.Main.Host, "Host should match expected FQDN with trailing dot")
+			suite.Equal(tt.expectedPort, endpoints.Main.Port, "Port should match the value from logsEndpoints map")
+
+			suite.config.SetWithoutSource("api_key", "test-key")
+			suite.config.SetWithoutSource("site", tt.site)
+			suite.config.SetWithoutSource("convert_dd_site_fqdn.enabled", false)
+
+			endpoints, err = buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+
+			suite.Nil(err)
+			suite.Equal(tt.expectedPort, endpoints.Main.Port, "Port should match the value from logsEndpoints map")
+		})
+	}
+}

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -47,7 +47,7 @@ func (suite *EndpointsTestSuite) TestLogsEndpointConfig() {
 	endpoints, err = BuildEndpoints(suite.config, HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.eu.", endpoints.Main.Host)
-	suite.Equal(10516, endpoints.Main.Port)
+	suite.Equal(443, endpoints.Main.Port)
 
 	suite.config.SetWithoutSource("logs_config.dd_url", "custom.logs.datadoghq.co.jp")
 	suite.Equal("custom.logs.datadoghq.co.jp", pkgconfigutils.GetMainEndpoint(suite.config, tcpEndpointPrefix, "logs_config.dd_url"))

--- a/releasenotes/notes/fix-eu-tcp-defaults-7638aaf6881a4792.yaml
+++ b/releasenotes/notes/fix-eu-tcp-defaults-7638aaf6881a4792.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Change the Log Agent default TCP port for datadoghq.eu from the incorrect value of 10516 to the correct 443.
+


### PR DESCRIPTION
### What does this PR do?
As of agent version 7.67.0, the default TCP port assigned by the Logs Agent to datadoghq.eu has been errantly set to 10516, which is not a valid configuration for the eu endpoint and cannot receive logs. This change reverts that back to the valid 443 port.

### Motivation

### Describe how you validated your changes
CI/unit test addition/manual validation sending logs to eu with the default tcp configuration

### Additional Notes
