### PR TITLE
[ACTP] scrub private action runner private key

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -271,7 +271,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	)
 	exactKeyReplacer.LastUpdated = parseVersion("7.70.2")
 
-	// Private key replacer (
+	// Private key replacer (for instance private action runner)
 	privateKeyReplacer := matchYAMLKeyEnding(
 		`private_key`,
 		[]string{"private_key"},

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -271,6 +271,14 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	)
 	exactKeyReplacer.LastUpdated = parseVersion("7.70.2")
 
+	// Private key replacer (
+	privateKeyReplacer := matchYAMLKeyEnding(
+		`private_key`,
+		[]string{"private_key"},
+		[]byte(`$1 "********"`),
+	)
+	privateKeyReplacer.LastUpdated = parseVersion("7.76.0")
+
 	scrubber.AddReplacer(SingleLine, hintedAPIKeyReplacer)
 	scrubber.AddReplacer(SingleLine, hintedAPPKeyReplacer)
 	scrubber.AddReplacer(SingleLine, hintedBearerReplacer)
@@ -280,6 +288,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	scrubber.AddReplacer(SingleLine, httpHeaderAuthReplacer)
 	scrubber.AddReplacer(SingleLine, httpHeaderSecretReplacer)
 	scrubber.AddReplacer(SingleLine, exactKeyReplacer)
+	scrubber.AddReplacer(SingleLine, privateKeyReplacer)
 	scrubber.AddReplacer(SingleLine, apiKeyReplacerYAML)
 	scrubber.AddReplacer(SingleLine, apiKeyReplacer)
 	scrubber.AddReplacer(SingleLine, appKeyReplacerYAML)

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -986,3 +986,10 @@ func TestNewHTTPHeaderAndExactKeys(t *testing.T) {
 		`some-other-key: also_not_scrubbed`,
 		`some-other-key: also_not_scrubbed`)
 }
+
+func TestPrivateActionRunnerPrivateKey(t *testing.T) {
+	// Test private action runner key configuration
+	assertClean(t,
+		`privateactionrunner.private_key: abc123def456`,
+		`privateactionrunner.private_key: "********"`)
+}

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -990,6 +990,6 @@ func TestNewHTTPHeaderAndExactKeys(t *testing.T) {
 func TestPrivateActionRunnerPrivateKey(t *testing.T) {
 	// Test private action runner key configuration
 	assertClean(t,
-		`privateactionrunner.private_key: abc123def456`,
-		`privateactionrunner.private_key: "********"`)
+		`private_key: abc123def456`,
+		`private_key: "********"`)
 }


### PR DESCRIPTION
### What does this PR do?

Adds configuration to scrub private keys for private action runner

### Motivation

They are sensitive and should not be user facing

### Describe how you validated your changes

Run a local version and validated that the private key gets properly scrubbed in "view agents"

### Additional Notes
