### PR TITLE
Add JetBrains IDE `*.iml` back to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,8 @@ Dockerfiles/cluster-agent/dist
 Dockerfiles/cluster-agent/security-agent-policies
 pkg/status/template.go
 
-# JetBrains IDE directory
+# JetBrains IDE project files: GoLand, IntelliJ IDEA, PyCharm, etc.
+/*.iml
 /.idea/
 /.ijwb/
 


### PR DESCRIPTION
### Motivation
#45119 rightfully removed Android remnants, but inadvertently removed [`*.iml` JetBrains IDE project files](https://fileinfo.com/extension/iml) from `.gitignore`.

### What does this PR do?
The present change aims at restoring this wee bit, while moving it together with other JetBrains IDE project files.