### PR TITLE
[CWS] simplify `TestHostname`

### DIFF
--- a/pkg/security/tests/misc_test.go
+++ b/pkg/security/tests/misc_test.go
@@ -14,10 +14,8 @@ import (
 	"runtime"
 	"testing"
 
-	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
 )
 
 func TestEnv(t *testing.T) {
@@ -60,16 +58,9 @@ func TestOsOrigin(t *testing.T) {
 func TestHostname(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	ipcComp := ipcmock.New(t)
-
-	hostname, err := hostnameutils.GetHostname(ipcComp)
-	if err != nil || hostname == "" {
-		hostname = "unknown"
-	}
-
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_hostname",
-		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/test-hostname" && event.hostname == "%s"`, hostname),
+		Expression: `open.file.path == "{{.Root}}/test-hostname" && event.hostname == "functional_tests_host"`,
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{ruleDef})


### PR DESCRIPTION
### What does this PR do?

`hostnameutils.GetHostname` always return in functional tests (because of https://github.com/DataDog/datadog-agent/blob/main/pkg/security/utils/hostnameutils/hostname_functests.go). As such there is no need to query it again and we can hardcode it directly in the rule.

The end goal of this is to fully remove the hostnameutils package in favor of the remote hostname component.

### Motivation

### Describe how you validated your changes

### Additional Notes
