### PR TITLE
[AGENTCFG-575] Sending an array payload to /api/v1/check_run

### DIFF
--- a/pkg/diagnose/connectivity/endpoint_info.go
+++ b/pkg/diagnose/connectivity/endpoint_info.go
@@ -53,7 +53,7 @@ func getEndpointsInfo(cfg model.Reader) []endpointInfo {
 		log.Fatalf("Failed to marshal SketchPayload: %v", err)
 	}
 
-	checkRunPayload := []byte("{\"check\": \"test\", \"status\": 0}")
+	checkRunPayload := []byte("[{\"check\": \"test\", \"status\": 0}]")
 
 	jsonCT := "application/json"
 	protoCT := "application/x-protobuf"

--- a/test/fakeintake/aggregator/checkRunAggregator_test.go
+++ b/test/fakeintake/aggregator/checkRunAggregator_test.go
@@ -30,6 +30,14 @@ func TestCheckRun(t *testing.T) {
 		assert.Empty(t, checks)
 	})
 
+	t.Run("parseCheckRunPayload should parse array with single check run", func(t *testing.T) {
+		checks, err := ParseCheckRunPayload(api.Payload{Data: []byte("[{\"check\": \"test\", \"status\": 0}]"), Encoding: encodingEmpty})
+		assert.NoError(t, err)
+		assert.Len(t, checks, 1)
+		assert.Equal(t, "test", checks[0].Check)
+		assert.Equal(t, 0, checks[0].Status)
+	})
+
 	t.Run("parseCheckRunPayload should return valid checks on valid ", func(t *testing.T) {
 		checks, err := ParseCheckRunPayload(api.Payload{Data: checkRunData, Encoding: encodingDeflate})
 		assert.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Refer to [[BUG] Datadog agent uses invalid payload to check /api/v1/check_run endpoint](https://github.com/DataDog/datadog-agent/issues/42124)--essentially an array is expected to be sent as a payload for a service check, but it is not in this case, causing the OTEL receiver to fail to unmarshal the payload. This PR changes the payload to be an array.

### Motivation

### Describe how you validated your changes

Added a unit test case and manually verified on a running agent.

### Additional Notes
