### PR TITLE
Add metrics origins for battery integration

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -338,6 +338,7 @@ const (
 	MetricSourceHuggingFaceTgi
 	MetricSourceIbmSpectrumLsf
 	MetricSourceDatadogOperator
+	MetricSourceBattery
 
 	// OpenTelemetry Collector receivers
 	MetricSourceOpenTelemetryCollectorUnknown
@@ -1126,6 +1127,8 @@ func (ms MetricSource) String() string {
 		return "wlan"
 	case MetricSourceWindowsCertificateStore:
 		return "windows_certificate"
+	case MetricSourceBattery:
+		return "battery"
 	default:
 		return "<unknown>"
 	}
@@ -1810,6 +1813,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceWlan
 	case "windows_certificate":
 		return MetricSourceWindowsCertificateStore
+	case "battery":
+		return MetricSourceBattery
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -364,7 +364,8 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceBentoMl,
 		metrics.MetricSourceHuggingFaceTgi,
 		metrics.MetricSourceIbmSpectrumLsf,
-		metrics.MetricSourceDatadogOperator:
+		metrics.MetricSourceDatadogOperator,
+		metrics.MetricSourceBattery:
 		return 11 // integrationMetrics
 	case metrics.MetricSourceGPU:
 		return 72 // ref: https://github.com/DataDog/dd-source/blob/276882b71d84785ec89c31973046ab66d5a01807/domains/metrics/shared/libs/proto/origin/origin.proto#L427
@@ -1132,6 +1133,8 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 503
 	case metrics.MetricSourcePerfect:
 		return 504
+	case metrics.MetricSourceBattery:
+		return 511
 	default:
 		return 0
 	}

--- a/releasenotes/notes/add-battery-metrics-origins-9d0d4a631ac4fc22.yaml
+++ b/releasenotes/notes/add-battery-metrics-origins-9d0d4a631ac4fc22.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Add metrics origins for battery integration.


### PR DESCRIPTION
### What does this PR do?
Follow up PR to https://github.com/DataDog/dd-source/pull/333191.
Adds metrics origins for battery integration.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2214

### Describe how you validated your changes

### Additional Notes
