### PR TITLE
Add a linter to validate the CI_IMAGE comes from the right branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1128,10 +1128,10 @@ workflow:
     compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_ci_changes:
-  changes:
-    paths:
-      - .gitlab-ci.yml
-    compare_to: $COMPARE_TO_BRANCH
+  - changes:
+      paths:
+        - .gitlab-ci.yml
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1127,6 +1127,12 @@ workflow:
       - .gitlab/**/.*
     compare_to: $COMPARE_TO_BRANCH
 
+.on_gitlab_ci_changes:
+  changes:
+    paths:
+      - .gitlab-ci.yml
+    compare_to: $COMPARE_TO_BRANCH
+
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]
   - !reference [.on_mergequeue]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to
-  CI_IMAGE_BTF_GEN: v91623141-e13c2467
+  CI_IMAGE_BTF_GEN: v91623141-76de87bd
   CI_IMAGE_BTF_GEN_SUFFIX: ""
   CI_IMAGE_DOCKER_X64: v91623141-e13c2467
   CI_IMAGE_DOCKER_X64_SUFFIX: ""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1128,10 +1128,10 @@ workflow:
     compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_ci_changes:
-  - changes:
-      paths:
-        - .gitlab-ci.yml
-      compare_to: $COMPARE_TO_BRANCH
+  changes:
+    paths:
+      - .gitlab-ci.yml
+    compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1127,11 +1127,11 @@ workflow:
       - .gitlab/**/.*
     compare_to: $COMPARE_TO_BRANCH
 
-.on_gitlab_ci_changes:
-  changes:
-    paths:
-      - .gitlab-ci.yml
-    compare_to: $COMPARE_TO_BRANCH
+#.on_gitlab_ci_changes:
+#  changes:
+#    paths:
+#      - .gitlab-ci.yml
+#    compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,7 +128,7 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to
-  CI_IMAGE_BTF_GEN: v91623141-76de87bd
+  CI_IMAGE_BTF_GEN: v91623141-e13c2467
   CI_IMAGE_BTF_GEN_SUFFIX: ""
   CI_IMAGE_DOCKER_X64: v91623141-e13c2467
   CI_IMAGE_DOCKER_X64_SUFFIX: ""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1127,11 +1127,11 @@ workflow:
       - .gitlab/**/.*
     compare_to: $COMPARE_TO_BRANCH
 
-#.on_gitlab_ci_changes:
-#  changes:
-#    paths:
-#      - .gitlab-ci.yml
-#    compare_to: $COMPARE_TO_BRANCH
+.on_gitlab_ci_changes:
+  changes:
+    paths:
+      - .gitlab-ci.yml
+    compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -1,14 +1,15 @@
 *                                    @DataDog/agent-devx
 
 # CI / DevX
-test_and_lint_gitlab_configuration   @DataDog/agent-devx
-test_gitlab_compare_to               @DataDog/agent-devx
-invoke_unit_tests                    @DataDog/agent-devx
-skip-ci-check                        @DataDog/agent-devx
-slack_teams_channels_check           @DataDog/agent-devx
-lint*                                @DataDog/agent-devx
-notify*                              @DataDog/agent-devx
-check_modules_replace                @DataDog/agent-devx
+test_and_lint_gitlab_configuration       @DataDog/agent-devx
+test_gitlab_compare_to                   @DataDog/agent-devx
+invoke_unit_tests                        @DataDog/agent-devx
+skip-ci-check                            @DataDog/agent-devx
+slack_teams_channels_check               @DataDog/agent-devx
+lint*                                    @DataDog/agent-devx
+notify*                                  @DataDog/agent-devx
+check_modules_replace                    @DataDog/agent-devx
+validate_buildimages_branch_consistency  @DataDog/agent-devx
 
 # Deps build
 build_clang_*                        @DataDog/ebpf-platform

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -9,7 +9,7 @@ slack_teams_channels_check               @DataDog/agent-devx
 lint*                                    @DataDog/agent-devx
 notify*                                  @DataDog/agent-devx
 check_modules_replace                    @DataDog/agent-devx
-validate_buildimages_branch_consistency  @DataDog/agent-devx
+validate_buildimages_branch_consistency  @DataDog/agent-delivery
 
 # Deps build
 build_clang_*                        @DataDog/ebpf-platform

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -74,6 +74,7 @@ validate_experiment_systemd_units:
 
 validate_buildimages_branch_consistency:
   extends: .lint
-  rules: !reference [.on_gitlab_ci_changes]
+  rules:
+    - !reference [.on_gitlab_ci_changes]
   script:
     - dda inv -- -e linter.buildimages-branch-consistency

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -72,8 +72,8 @@ validate_experiment_systemd_units:
   script:
     - dda inv -- -e installer.generate-experiment-units --check
 
-#validate_buildimages_branch_consistency:
-#  extends: .lint
-#  rules: !reference [.on_gitlab_ci_changes]
-#  script:
-#    - dda inv -- -e linter.buildimages-branch-consistency
+validate_buildimages_branch_consistency:
+  extends: .lint
+  rules: !reference [.on_gitlab_ci_changes]
+  script:
+    - dda inv -- -e linter.buildimages-branch-consistency

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -71,3 +71,9 @@ validate_experiment_systemd_units:
   rules: !reference [.on_installer_systemd_changes]
   script:
     - dda inv -- -e installer.generate-experiment-units --check
+
+validate_buildimages_branch_consistency:
+  extends: .lint
+  rules: !reference [.on_gitlab_ci_changes]
+  script:
+    - dda inv -- -e linter.buildimages-branch-consistency

--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -72,8 +72,8 @@ validate_experiment_systemd_units:
   script:
     - dda inv -- -e installer.generate-experiment-units --check
 
-validate_buildimages_branch_consistency:
-  extends: .lint
-  rules: !reference [.on_gitlab_ci_changes]
-  script:
-    - dda inv -- -e linter.buildimages-branch-consistency
+#validate_buildimages_branch_consistency:
+#  extends: .lint
+#  rules: !reference [.on_gitlab_ci_changes]
+#  script:
+#    - dda inv -- -e linter.buildimages-branch-consistency

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -760,6 +760,7 @@ def _extract_ci_image_variables():
             content = f.read()
             # Find CI image variables with commit hashes
             import re
+
             pattern = r'^\s*(CI_IMAGE_[A-Z_0-9]+):\s*v\d+-([a-f0-9]{8})\s*$'
             for line in content.splitlines():
                 match = re.match(pattern, line)
@@ -768,7 +769,7 @@ def _extract_ci_image_variables():
                     ci_image_vars[var_name] = commit_hash
     except Exception as e:
         print(f"{color_message('Error', 'red')}: Could not read .gitlab-ci.yml: {e}")
-        raise Exit(code=1)
+        raise Exit(code=1) from e
 
     return ci_image_vars
 
@@ -803,11 +804,7 @@ def buildimages_branch_consistency(ctx):
         try:
             # Clone the repository once
             print("Cloning buildimages repository...")
-            clone_result = ctx.run(
-                f"git clone {buildimages_repo_url} {temp_dir}/buildimages",
-                hide=True,
-                warn=True
-            )
+            clone_result = ctx.run(f"git clone {buildimages_repo_url} {temp_dir}/buildimages", hide=True, warn=True)
 
             if clone_result.return_code != 0:
                 print(f"{color_message('Error', 'red')}: Failed to clone buildimages repository")
@@ -815,13 +812,13 @@ def buildimages_branch_consistency(ctx):
 
             # Check if the target branch exists
             branch_check = ctx.run(
-                f"cd {temp_dir}/buildimages && git branch -r | grep -q origin/{compare_to_branch}",
-                hide=True,
-                warn=True
+                f"cd {temp_dir}/buildimages && git branch -r | grep -q origin/{compare_to_branch}", hide=True, warn=True
             )
 
             if branch_check.return_code != 0:
-                print(f"{color_message('Error', 'red')}: Branch '{compare_to_branch}' does not exist in buildimages repository")
+                print(
+                    f"{color_message('Error', 'red')}: Branch '{compare_to_branch}' does not exist in buildimages repository"
+                )
                 raise Exit(code=1)
 
             print(f"Checking commits against branch '{compare_to_branch}'...")
@@ -833,29 +830,35 @@ def buildimages_branch_consistency(ctx):
                 try:
                     # Check if the commit is contained in the target branch
                     result = ctx.run(
-                        f"cd {temp_dir}/buildimages && git branch --contains {commit_hash}",
-                        hide=True,
-                        warn=True
+                        f"cd {temp_dir}/buildimages && git branch --contains {commit_hash}", hide=True, warn=True
                     )
 
                     if result.return_code == 0 and compare_to_branch in result.stdout:
-                        print(f"  {color_message('OK', 'green')}: Commit {commit_hash} found on branch '{compare_to_branch}'")
+                        print(
+                            f"  {color_message('OK', 'green')}: Commit {commit_hash} found on branch '{compare_to_branch}'"
+                        )
                     else:
-                        failures.append(f"{var_name}: commit {commit_hash} not found on branch '{compare_to_branch}' in buildimages repository")
+                        failures.append(
+                            f"{var_name}: commit {commit_hash} not found on branch '{compare_to_branch}' in buildimages repository"
+                        )
 
                 except Exception as e:
                     failures.append(f"{var_name}: error checking commit {commit_hash}: {e}")
 
         except Exception as e:
             print(f"{color_message('Error', 'red')}: Error during repository operations: {e}")
-            raise Exit(code=1)
+            raise Exit(code=1) from e
 
     if failures:
         print(f"\n{color_message('Failures found:', 'red')}")
         for failure in failures:
             print(f"  - {failure}")
-        print(f"\n{color_message('Note:', 'yellow')} This check validates that CI image commits are consistent with the current branch.")
-        print(f"If you're on a release branch (e.g., 7.75.x), the commits should be from the same branch in datadog-agent-buildimages.")
+        print(
+            f"\n{color_message('Note:', 'yellow')} This check validates that CI image commits are consistent with the current branch."
+        )
+        print(
+            "If you're on a release branch (e.g., 7.75.x), the commits should be from the same branch in datadog-agent-buildimages."
+        )
         raise Exit(code=1)
     else:
         print(f"\n{color_message('All CI image commits are consistent with the current branch', 'green')}")

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -761,7 +761,7 @@ def _extract_ci_image_variables():
             # Find CI image variables with commit hashes
             import re
 
-            pattern = r'^\s*(CI_IMAGE_[A-Z_0-9]+):\s*v\d+-([a-f0-9]{8})\s*$'
+            pattern = r'^\s*(CI_IMAGE_[A-Z_0-9]+):\s*v\d+-([a-f0-9]+)\s*$'
             for line in content.splitlines():
                 match = re.match(pattern, line)
                 if match:

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -821,6 +821,17 @@ def buildimages_branch_consistency(ctx):
                 )
                 raise Exit(code=1)
 
+            # Checkout the target branch
+            checkout_result = ctx.run(
+                f"cd {temp_dir}/buildimages && git checkout {compare_to_branch}", hide=True, warn=True
+            )
+
+            if checkout_result.return_code != 0:
+                print(
+                    f"{color_message('Error', 'red')}: Failed to checkout branch '{compare_to_branch}' in buildimages repository"
+                )
+                raise Exit(code=1)
+
             print(f"Checking commits against branch '{compare_to_branch}'...")
 
             # Loop over all CI image variables and check each commit

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -839,7 +839,7 @@ def buildimages_branch_consistency(ctx):
                         # Matches: "  origin/branch-name", "* branch-name", or "  branch-name"
                         escaped_branch = re.escape(compare_to_branch)
                         pattern = rf'^\s*\*?\s*(origin/)?{escaped_branch}$'
-                        
+
                         if re.search(pattern, result.stdout, re.MULTILINE):
                             print(
                                 f"  {color_message('OK', 'green')}: Commit {commit_hash} found on branch '{compare_to_branch}'"

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -844,14 +844,11 @@ def buildimages_branch_consistency(ctx):
                             print(
                                 f"  {color_message('OK', 'green')}: Commit {commit_hash} found on branch '{compare_to_branch}'"
                             )
-                        else:
-                            failures.append(
-                                f"{var_name}: commit {commit_hash} not found on branch '{compare_to_branch}' in buildimages repository"
-                            )
-                    else:
-                        failures.append(
-                            f"{var_name}: commit {commit_hash} not found on branch '{compare_to_branch}' in buildimages repository"
-                        )
+                            continue
+
+                    failures.append(
+                        f"{var_name}: commit {commit_hash} not found on branch '{compare_to_branch}' in buildimages repository"
+                    )
 
                 except Exception as e:
                     failures.append(f"{var_name}: error checking commit {commit_hash}: {e}")

--- a/tasks/unit_tests/linter_tests.py
+++ b/tasks/unit_tests/linter_tests.py
@@ -234,7 +234,7 @@ variables:
             'CI_IMAGE_LINUX': 'e13c2467',
             'CI_IMAGE_DOCKER_X64': 'e13c2467',
             'CI_IMAGE_RPM_ARM64': 'abcd1234',
-            'CI_IMAGE_WIN_LTSC2022_X64': '12345678'
+            'CI_IMAGE_WIN_LTSC2022_X64': '12345678',
         }
 
         self.assertEqual(result, expected)
@@ -267,11 +267,7 @@ variables:
         with patch('builtins.open', mock_open(read_data=gitlab_ci_content)):
             result = linter._extract_ci_image_variables()
 
-        expected = {
-            'CI_IMAGE_LINUX': 'e13c2467',
-            'CI_IMAGE_DOCKER_X64': 'abcd1234',
-            'CI_IMAGE_RPM_X64': '12ab34cd'
-        }
+        expected = {'CI_IMAGE_LINUX': 'e13c2467', 'CI_IMAGE_DOCKER_X64': 'abcd1234', 'CI_IMAGE_RPM_X64': '12ab34cd'}
 
         self.assertEqual(result, expected)
 
@@ -287,11 +283,7 @@ variables:
         with patch('builtins.open', mock_open(read_data=gitlab_ci_content)):
             result = linter._extract_ci_image_variables()
 
-        expected = {
-            'CI_IMAGE_LINUX': 'e13c2467',
-            'CI_IMAGE_DOCKER_X64': 'abcd1234',
-            'CI_IMAGE_RPM_ARM64': '12ab34cd'
-        }
+        expected = {'CI_IMAGE_LINUX': 'e13c2467', 'CI_IMAGE_DOCKER_X64': 'abcd1234', 'CI_IMAGE_RPM_ARM64': '12ab34cd'}
 
         self.assertEqual(result, expected)
 
@@ -310,7 +302,7 @@ variables:
         expected = {
             'CI_IMAGE_WIN_LTSC2022_X64': 'e13c2467',
             'CI_IMAGE_WIN_LTSC2025_X64': 'abcd1234',
-            'CI_IMAGE_RPM_ARM64': '12ab34cd'
+            'CI_IMAGE_RPM_ARM64': '12ab34cd',
         }
 
         self.assertEqual(result, expected)


### PR DESCRIPTION
# What does this PR do?

This PR adds a new invoke task `linter.buildimages-branch-consistency` and corresponding GitLab CI linter that validates CI image commit hashes in [.gitlab-ci.yml](cci:7://file:///Users/florent.clarret/go/src/github.com/DataDog/datadog-agent/.gitlab-ci.yml:0:0-0:0) are present on the corresponding branch in the `datadog-agent-buildimages` repository. The validation ensures strict branch consistency between the main agent repository and the buildimages repository.

**Key Components:**
- New invoke task that reads `COMPARE_TO_BRANCH` environment variable and validates all `CI_IMAGE_*` variables
- GitLab CI job that automatically runs when [.gitlab-ci.yml](cci:7://file:///Users/florent.clarret/go/src/github.com/DataDog/datadog-agent/.gitlab-ci.yml:0:0-0:0) is modified

### Motivation

Currently, there's no automated validation to ensure that CI image versions (e.g., `v91623141-e13c2467`) in [.gitlab-ci.yml](cci:7://file:///Users/florent.clarret/go/src/github.com/DataDog/datadog-agent/.gitlab-ci.yml:0:0-0:0) correspond to commits that exist on the same branch in the buildimages repository. This can lead to:

- Using build images from the wrong branch (e.g., main branch images on a release branch)
- Build failures
- Inconsistent build environments across branches

The new linter enforces strict branch consistency by failing immediately if the target branch doesn't exist in buildimages (no fallback to main) and validating that each commit hash is actually present on the expected branch using `git branch --contains`.

### Describe how you validated your changes

### Additional Notes

Job example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1368612264

https://datadoghq.atlassian.net/browse/BARX-1546
