### PR TITLE
Running xperf during agent install in installer e2e tests

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -615,7 +615,7 @@ func (s *testAgentUpgradeSuite) installPreviousAgentVersion(opts ...installerwin
 		installerwindows.WithMSILogFile("install-previous-version.log"),
 	}
 	options = append(options, opts...)
-	s.Require().NoError(s.InstallWithXperf(options...))
+	s.InstallWithXperf(options...)
 
 	// sanity check: make sure we did indeed install the stable version
 	s.Require().Host(s.Env().RemoteHost).
@@ -634,9 +634,7 @@ func (s *testAgentUpgradeSuite) installCurrentAgentVersion(opts ...installerwind
 		installerwindows.WithMSILogFile("install-current-version.log"),
 	}
 	options = append(options, opts...)
-	s.Require().NoError(s.InstallWithXperf(
-		options...,
-	))
+	s.InstallWithXperf(options...)
 
 	// sanity check: make sure we did indeed install the stable version
 	s.Require().Host(s.Env().RemoteHost).

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -615,7 +615,7 @@ func (s *testAgentUpgradeSuite) installPreviousAgentVersion(opts ...installerwin
 		installerwindows.WithMSILogFile("install-previous-version.log"),
 	}
 	options = append(options, opts...)
-	s.Require().NoError(s.Installer().Install(options...))
+	s.Require().NoError(s.InstallWithXperf(options...))
 
 	// sanity check: make sure we did indeed install the stable version
 	s.Require().Host(s.Env().RemoteHost).
@@ -634,7 +634,7 @@ func (s *testAgentUpgradeSuite) installCurrentAgentVersion(opts ...installerwind
 		installerwindows.WithMSILogFile("install-current-version.log"),
 	}
 	options = append(options, opts...)
-	s.Require().NoError(s.Installer().Install(
+	s.Require().NoError(s.InstallWithXperf(
 		options...,
 	))
 

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
@@ -26,7 +26,7 @@ func (s *baseInstallerPackageSuite) freshInstall() {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.Installer().Install(
+	s.Require().NoError(s.InstallWithXperf(
 		installerwindows.WithMSILogFile("fresh-install.log"),
 	))
 

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
@@ -26,9 +26,9 @@ func (s *baseInstallerPackageSuite) freshInstall() {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.InstallWithXperf(
+	s.InstallWithXperf(
 		installerwindows.WithMSILogFile("fresh-install.log"),
-	))
+	)
 
 	// Assert
 	s.requireInstalled()

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -101,7 +101,7 @@ func (s *testInstallerSuite) installWithExistingConfigFile(logFilename string) {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.Installer().Install(
+	s.Require().NoError(s.InstallWithXperf(
 		installerwindows.WithMSILogFile(logFilename),
 	))
 
@@ -116,7 +116,7 @@ func (s *testInstallerSuite) repair() {
 	s.Require().NoError(s.Env().RemoteHost.Remove(consts.BinaryPath))
 
 	// Act
-	s.Require().NoError(s.Installer().Install(
+	s.Require().NoError(s.InstallWithXperf(
 		installerwindows.WithMSILogFile("repair.log"),
 	))
 

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/install_test.go
@@ -101,9 +101,9 @@ func (s *testInstallerSuite) installWithExistingConfigFile(logFilename string) {
 	// Arrange
 
 	// Act
-	s.Require().NoError(s.InstallWithXperf(
+	s.InstallWithXperf(
 		installerwindows.WithMSILogFile(logFilename),
-	))
+	)
 
 	// Assert
 	s.requireInstalled()
@@ -116,9 +116,9 @@ func (s *testInstallerSuite) repair() {
 	s.Require().NoError(s.Env().RemoteHost.Remove(consts.BinaryPath))
 
 	// Act
-	s.Require().NoError(s.InstallWithXperf(
+	s.InstallWithXperf(
 		installerwindows.WithMSILogFile("repair.log"),
-	))
+	)
 
 	// Assert
 	s.requireInstalled()


### PR DESCRIPTION
### What does this PR do?
Enabled xperf on installer e2e tests to collect additional trace data. This is to investigate an increase of the following error in Windows e2e tests:
```
A timeout was reached (30000 milliseconds) while waiting for the Datadog Agent service to connect.
```

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2314

### Describe how you validated your changes
Check failed e2e test results and their artifacts for the xperf outputs

### Additional Notes
