### PR TITLE
[pkg/clusteragent/autoscaling/cluster] Emit events from cluster scaling controller

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -203,17 +203,14 @@ func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInter
 		// Get NodeClass. If there's none or more than one, then we should not create the NodePool
 		ncList, err := c.Client.Resource(nodeClassGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			c.eventRecorder.Eventf(knp, corev1.EventTypeWarning, model.FailedNodepoolCreateEventReason, "Failed to list NodeClasses: %v", err)
 			return fmt.Errorf("unable to list NodeClasses: %w", err)
 		}
 
 		if len(ncList.Items) == 0 {
-			c.eventRecorder.Eventf(knp, corev1.EventTypeWarning, model.FailedNodepoolCreateEventReason, "No NodeClasses found, NodePool cannot be created")
 			return errors.New("no NodeClasses found, NodePool cannot be created")
 		}
 
 		if len(ncList.Items) > 1 {
-			c.eventRecorder.Eventf(knp, corev1.EventTypeWarning, model.FailedNodepoolCreateEventReason, "Too many NodeClasses found (%v), NodePool cannot be created", len(ncList.Items))
 			return fmt.Errorf("too many NodeClasses found (%v), NodePool cannot be created", len(ncList.Items))
 		}
 
@@ -223,13 +220,11 @@ func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInter
 
 	npUnstr, err := convertNodePoolToUnstructured(knp)
 	if err != nil {
-		c.eventRecorder.Eventf(knp, corev1.EventTypeWarning, model.FailedNodepoolCreateEventReason, "Failed to convert NodePool to unstructured: %v", err)
 		return err
 	}
 
 	_, err = c.Client.Resource(nodePoolGVR).Create(ctx, npUnstr, metav1.CreateOptions{})
 	if err != nil {
-		c.eventRecorder.Eventf(knp, corev1.EventTypeWarning, model.FailedNodepoolCreateEventReason, "Failed to create NodePool: %v", err)
 		return fmt.Errorf("unable to create NodePool: %s, err: %v", npi.Name(), err)
 	}
 

--- a/pkg/clusteragent/autoscaling/cluster/controller_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller_test.go
@@ -10,8 +10,9 @@ package cluster
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/cluster/model"
 )
 
 func TestIsCreatedByDatadog(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/cluster/model/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/const.go
@@ -1,3 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build kubeapiserver
+
 package model
 
 const (

--- a/pkg/clusteragent/autoscaling/cluster/model/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/const.go
@@ -12,8 +12,6 @@ const (
 	SuccessfulNodepoolCreateEventReason = "SuccessfulNodepoolCreate"
 	// SuccessfulNodepoolUpdateEventReason is the event reason when a nodepool is updated successfully
 	SuccessfulNodepoolUpdateEventReason = "SuccessfulNodepoolUpdate"
-	// FailedNodepoolCreateEventReason is the event reason when a nodepool creation fails
-	FailedNodepoolCreateEventReason = "FailedNodepoolCreate"
 	// FailedNodepoolUpdateEventReason is the event reason when a nodepool update fails
 	FailedNodepoolUpdateEventReason = "FailedNodepoolUpdate"
 )

--- a/pkg/clusteragent/autoscaling/cluster/model/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/const.go
@@ -1,0 +1,12 @@
+package model
+
+const (
+	// SuccessfulNodepoolCreateEventReason is the event reason when a nodepool is created successfully
+	SuccessfulNodepoolCreateEventReason = "SuccessfulNodepoolCreate"
+	// SuccessfulNodepoolUpdateEventReason is the event reason when a nodepool is updated successfully
+	SuccessfulNodepoolUpdateEventReason = "SuccessfulNodepoolUpdate"
+	// FailedNodepoolCreateEventReason is the event reason when a nodepool creation fails
+	FailedNodepoolCreateEventReason = "FailedNodepoolCreate"
+	// FailedNodepoolUpdateEventReason is the event reason when a nodepool update fails
+	FailedNodepoolUpdateEventReason = "FailedNodepoolUpdate"
+)

--- a/pkg/clusteragent/autoscaling/cluster/model/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/const.go
@@ -10,8 +10,6 @@ package model
 const (
 	// SuccessfulNodepoolCreateEventReason is the event reason when a nodepool is created successfully
 	SuccessfulNodepoolCreateEventReason = "SuccessfulNodepoolCreate"
-	// FailedNodepoolCreateEventReason is the event reason when a nodepool creation fails
-	FailedNodepoolCreateEventReason = "FailedNodepoolCreate"
 	// SuccessfulNodepoolUpdateEventReason is the event reason when a nodepool is updated successfully
 	SuccessfulNodepoolUpdateEventReason = "SuccessfulNodepoolUpdate"
 	// FailedNodepoolUpdateEventReason is the event reason when a nodepool update fails

--- a/pkg/clusteragent/autoscaling/cluster/model/const.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/const.go
@@ -10,8 +10,14 @@ package model
 const (
 	// SuccessfulNodepoolCreateEventReason is the event reason when a nodepool is created successfully
 	SuccessfulNodepoolCreateEventReason = "SuccessfulNodepoolCreate"
+	// FailedNodepoolCreateEventReason is the event reason when a nodepool creation fails
+	FailedNodepoolCreateEventReason = "FailedNodepoolCreate"
 	// SuccessfulNodepoolUpdateEventReason is the event reason when a nodepool is updated successfully
 	SuccessfulNodepoolUpdateEventReason = "SuccessfulNodepoolUpdate"
 	// FailedNodepoolUpdateEventReason is the event reason when a nodepool update fails
 	FailedNodepoolUpdateEventReason = "FailedNodepoolUpdate"
+	// SuccessfulNodepoolDeleteEventReason is the event reason when a nodepool is deleted successfully
+	SuccessfulNodepoolDeleteEventReason = "SuccessfulNodepoolDelete"
+	// FailedNodepoolDeleteEventReason is the event reason when a nodepool deletion fails
+	FailedNodepoolDeleteEventReason = "FailedNodepoolDelete"
 )

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -277,9 +277,14 @@ func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) (bool, m
 		if r.Key == corev1.LabelInstanceTypeStable {
 			instanceTypeLabelExists = true
 			r.Operator = "In"
-			if !slices.Equal(r.Values, npi.recommendedInstanceTypes) {
+			originalInstanceTypes := r.Values
+			recommendedInstanceTypes := npi.RecommendedInstanceTypes()
+			slices.Sort(originalInstanceTypes)
+			slices.Sort(recommendedInstanceTypes)
+
+			if !slices.Equal(originalInstanceTypes, recommendedInstanceTypes) {
 				isUpdated = true
-				r.Values = npi.recommendedInstanceTypes
+				r.Values = recommendedInstanceTypes
 			}
 		}
 
@@ -295,7 +300,7 @@ func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) (bool, m
 		updatedRequirements = append(updatedRequirements, map[string]any{
 			"key":      corev1.LabelInstanceTypeStable,
 			"operator": "In",
-			"values":   npi.recommendedInstanceTypes,
+			"values":   npi.RecommendedInstanceTypes(),
 		})
 	}
 

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -268,7 +268,8 @@ func BuildReplicaNodePool(knp *karpenterv1.NodePool, npi NodePoolInternal) {
 }
 
 // BuildNodePoolPatch is used to construct a JSON patch if the NodePool requirements have changed
-func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) (bool, map[string]any) {
+// returns a nil patch if the NodePool requirements have not changed
+func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) map[string]any {
 	isUpdated := false
 	// Build requirements patch, only updating values for the instance types
 	updatedRequirements := []map[string]any{}
@@ -305,7 +306,7 @@ func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) (bool, m
 	}
 
 	if !isUpdated {
-		return false, map[string]any{}
+		return nil
 	}
 
 	patchData := map[string]any{
@@ -328,5 +329,5 @@ func BuildNodePoolPatch(np *karpenterv1.NodePool, npi NodePoolInternal) (bool, m
 		},
 	}
 
-	return isUpdated, patchData
+	return patchData
 }

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -298,11 +298,10 @@ func TestBuildReplicaNodePool(t *testing.T) {
 
 func TestBuildNodePoolPatch(t *testing.T) {
 	tests := []struct {
-		name              string
-		nodePool          karpenterv1.NodePool
-		minNodePool       NodePoolInternal
-		expectedPatch     map[string]any
-		expectedIsUpdated bool
+		name          string
+		nodePool      karpenterv1.NodePool
+		minNodePool   NodePoolInternal
+		expectedPatch map[string]any
 	}{
 		{
 			name: "instance type requirements have changed",
@@ -396,7 +395,6 @@ func TestBuildNodePoolPatch(t *testing.T) {
 					},
 				},
 			},
-			expectedIsUpdated: true,
 		},
 		{
 			name: "instance type requirements have not changed",
@@ -421,8 +419,7 @@ func TestBuildNodePoolPatch(t *testing.T) {
 					},
 				},
 			},
-			expectedPatch:     map[string]any{},
-			expectedIsUpdated: false,
+			expectedPatch: nil,
 		},
 		{
 			name: "instance type requirements do not exist",
@@ -464,15 +461,13 @@ func TestBuildNodePoolPatch(t *testing.T) {
 					},
 				},
 			},
-			expectedIsUpdated: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resultIsUpdated, resultPatch := BuildNodePoolPatch(&tt.nodePool, tt.minNodePool)
+			resultPatch := BuildNodePoolPatch(&tt.nodePool, tt.minNodePool)
 			assert.Equal(t, tt.expectedPatch, resultPatch, "Resulting patch does not match expected patch")
-			assert.Equal(t, tt.expectedIsUpdated, resultIsUpdated, "Resulting is updated does not match expected is updated")
 		})
 	}
 }

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal_test.go
@@ -413,7 +413,7 @@ func TestBuildNodePoolPatch(t *testing.T) {
 									NodeSelectorRequirement: corev1.NodeSelectorRequirement{
 										Key:      corev1.LabelInstanceTypeStable,
 										Operator: corev1.NodeSelectorOpIn,
-										Values:   []string{"c5.xlarge", "t3.micro"},
+										Values:   []string{"t3.micro", "c5.xlarge"},
 									},
 								},
 							},

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -185,6 +185,12 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 			Source: "datadog-workload-autoscaler",
 		})
 	}
+	if pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled") {
+		k.instance.CollectedEventTypes = append(k.instance.CollectedEventTypes, collectedEventType{
+			Source: "datadog-workload-autoscaler",
+		})
+	}
+
 
 	// When we use both bundled and unbundled transformers, we apply two filters: filtered_event_types and collected_event_types.
 	// When we use only the bundled transformer, we apply filtered_event_types.

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -185,12 +185,11 @@ func (k *KubeASCheck) Configure(senderManager sender.SenderManager, _ uint64, co
 			Source: "datadog-workload-autoscaler",
 		})
 	}
-	if pkgconfigsetup.Datadog().GetBool("autoscaling.workload.enabled") {
+	if pkgconfigsetup.Datadog().GetBool("autoscaling.cluster.enabled") {
 		k.instance.CollectedEventTypes = append(k.instance.CollectedEventTypes, collectedEventType{
-			Source: "datadog-workload-autoscaler",
+			Source: "datadog-cluster-autoscaler",
 		})
 	}
-
 
 	// When we use both bundled and unbundled transformers, we apply two filters: filtered_event_types and collected_event_types.
 	// When we use only the bundled transformer, we apply filtered_event_types.


### PR DESCRIPTION
### What does this PR do?

Add events that get emitted by the cluster scaling controller when a `NodePool` is successfully(/unsuccessfully) created*/patched/deleted. Also adds a check to ensure we only attempt to patch a `NodePool` if the instance type recommendations have changed

[CASCL-896](https://datadoghq.atlassian.net/browse/CASCL-896)

### Motivation

Add more observability / make it easier for users to track live scaling changes

### Describe how you validated your changes
1. Deployed changes
2. Confirmed that events were emitted by `source_component:datadog-cluster-autoscaler` on update/create/delete


### Additional Notes

*I did not add events on creation failure as the event recorder requires passing in a `runtime.Object` the kubernetes event should be attached to. For some failure cases, this means we would need to create a minimal nodepool object for the purposes of passing to the event recorder, e.g.:
```
diff --git a/pkg/clusteragent/autoscaling/cluster/controller.go b/pkg/clusteragent/autoscaling/cluster/controller.go
index 1510479cb5c..042766ca34c 100644
--- a/pkg/clusteragent/autoscaling/cluster/controller.go
+++ b/pkg/clusteragent/autoscaling/cluster/controller.go
@@ -200,6 +200,12 @@ func (c *Controller) createNodePool(ctx context.Context, npi model.NodePoolInter
 		log.Debugf("Building replica of NodePool: %s", npi.Name())
 		model.BuildReplicaNodePool(knp, npi)
 	} else {
+		knp = &karpenterv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: npi.Name(),
+			},
+		}
+
 		// Get NodeClass. If there's none or more than one, then we should not create the NodePool
 		ncList, err := c.Client.Resource(nodeClassGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
```

For now we will log errors on failed creation; if necessary we can revisit this in the future and also choose to emit events on failure

[CASCL-896]: https://datadoghq.atlassian.net/browse/CASCL-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ