### PR TITLE
add application and update errors

### DIFF
--- a/comp/notableevents/impl/collector.go
+++ b/comp/notableevents/impl/collector.go
@@ -75,15 +75,6 @@ func getEventDefinitions() []eventDefinition {
 			Message:   "The system has rebooted without cleanly shutting down first",
 		},
 		{
-			Provider:  "Microsoft-Windows-WER-SystemErrorReporting",
-			EventID:   1001,
-			Channel:   "System",
-			QueryBody: `    <Select Path="System">*[System[Provider[@Name='Microsoft-Windows-WER-SystemErrorReporting'] and EventID=1001]]</Select>`,
-			EventType: "System crash",
-			Title:     "System crash (BSOD)",
-			Message:   "The system experienced a blue screen crash (BugCheck)",
-		},
-		{
 			Provider:      "Application Error",
 			EventID:       1000,
 			Channel:       "Application",
@@ -104,23 +95,38 @@ func getEventDefinitions() []eventDefinition {
 			FormatPayload: formatAppHangPayload,
 		},
 		{
-			Provider:  "Microsoft-Windows-WindowsUpdateClient",
-			EventID:   20,
-			Channel:   "Microsoft-Windows-WindowsUpdateClient/Operational",
-			QueryBody: `    <Select Path="Microsoft-Windows-WindowsUpdateClient/Operational">*[System[Provider[@Name='Microsoft-Windows-WindowsUpdateClient'] and EventID=20]]</Select>`,
-			EventType: "Failed Windows update",
-			Title:     "Failed Windows update",
-			Message:   "A Windows Update installation failed",
+			Provider:      "Microsoft-Windows-WindowsUpdateClient",
+			EventID:       20,
+			Channel:       "System",
+			QueryBody:     `    <Select Path="System">*[System[Provider[@Name='Microsoft-Windows-WindowsUpdateClient'] and EventID=20]]</Select>`,
+			EventType:     "Failed Windows update",
+			Title:         "Failed Windows update",
+			Message:       "A Windows Update installation failed",
+			FormatPayload: formatWindowsUpdateFailedPayload,
 		},
 		{
-			Provider:      "MsiInstaller",
-			EventID:       11708,
-			Channel:       "Application",
-			QueryBody:     `    <Select Path="Application">*[System[Provider[@Name='MsiInstaller'] and EventID=11708]]</Select>`,
+			Provider: "MsiInstaller",
+			EventID:  1033,
+			Channel:  "Application",
+			QueryBody: `
+	<Select Path="Application">*[System[Provider[@Name='MsiInstaller'] and EventID=1033]]</Select>
+    <Suppress Path="Application">*[System[Provider[@Name='MsiInstaller'] and EventID=1033] and EventData/Data[4]='0']</Suppress>`,
 			EventType:     "Failed application installation",
 			Title:         "Failed application installation",
 			Message:       "An application installation (MSI) failed",
-			FormatPayload: formatMsiInstallerPayload,
+			FormatPayload: formatMsiInstaller1033Payload,
+		},
+		{
+			Provider: "MsiInstaller",
+			EventID:  1034,
+			Channel:  "Application",
+			QueryBody: `
+	<Select Path="Application">*[System[Provider[@Name='MsiInstaller'] and EventID=1034]]</Select>
+    <Suppress Path="Application">*[System[Provider[@Name='MsiInstaller'] and EventID=1034] and EventData/Data[4]='0']</Suppress>`,
+			EventType:     "Failed application removal",
+			Title:         "Failed application removal",
+			Message:       "An application removal (MSI) failed",
+			FormatPayload: formatMsiInstaller1034Payload,
 		},
 	}
 	return e

--- a/comp/notableevents/impl/format.go
+++ b/comp/notableevents/impl/format.go
@@ -79,21 +79,49 @@ func formatMsiExitCode(exitCodeStr string) string {
 
 // formatAppCrashPayload customizes the payload for application crash events (Application Error / Event ID 1000).
 // Extracts the AppName from EventData to create a dynamic title.
+// Supports both Server 2025 (named map fields) and Server 2022 (positional list fields) formats.
+// List format: [0]=AppName, [1]=AppVersion, [2]=AppTimestamp, [3]=FaultModuleName, ...
 func formatAppCrashPayload(payload *eventPayload, eventData map[string]interface{}) {
+	var appName string
+
+	// Try named map fields first (Server 2025)
 	if data := getEventDataMap(eventData); data != nil {
-		if appName, ok := data["AppName"].(string); ok {
-			payload.Title = "Application crash: " + appName
+		appName, _ = data["AppName"].(string)
+	}
+
+	// Fall back to positional list fields (Server 2022)
+	if appName == "" {
+		if dataList := getEventDataList(eventData); len(dataList) > 0 {
+			appName, _ = dataList[0].(string)
 		}
+	}
+
+	if appName != "" {
+		payload.Title = "Application crash: " + appName
 	}
 }
 
 // formatAppHangPayload customizes the payload for application hang events (Application Hang / Event ID 1002).
 // Extracts the AppName from EventData to create a dynamic title.
+// Supports both Server 2025 (named map fields) and Server 2022 (positional list fields) formats.
+// List format: [0]=AppName, [1]=AppVersion, ...
 func formatAppHangPayload(payload *eventPayload, eventData map[string]interface{}) {
+	var appName string
+
+	// Try named map fields first (Server 2025)
 	if data := getEventDataMap(eventData); data != nil {
-		if appName, ok := data["AppName"].(string); ok {
-			payload.Title = "Application hang: " + appName
+		appName, _ = data["AppName"].(string)
+	}
+
+	// Fall back to positional list fields (Server 2022)
+	if appName == "" {
+		if dataList := getEventDataList(eventData); len(dataList) > 0 {
+			appName, _ = dataList[0].(string)
 		}
+	}
+
+	if appName != "" {
+		payload.Title = "Application hang: " + appName
 	}
 }
 

--- a/comp/notableevents/impl/format.go
+++ b/comp/notableevents/impl/format.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+package notableeventsimpl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/util/windowsevent"
+)
+
+// parseEventXML parses Windows Event Log XML into a map structure.
+func parseEventXML(xmlData []byte) (*windowsevent.Map, error) {
+	return windowsevent.NewMapXMLWithOptions(xmlData, windowsevent.TransformOptions{
+		FormatEventData:  true,
+		FormatBinaryData: false, // Skip buggy binary transform
+		NormalizeEventID: true,
+	})
+}
+
+// PayloadFormatter customizes the event payload using data from the parsed event XML.
+// The payload is pre-populated with default values; the formatter can modify any fields.
+type PayloadFormatter func(payload *eventPayload, eventData map[string]interface{})
+
+// getEventDataMap extracts the EventData.Data map from the parsed event (for named data fields).
+// Returns nil if the path doesn't exist or the data is not a map.
+func getEventDataMap(eventMap map[string]interface{}) map[string]interface{} {
+	event, ok := eventMap["Event"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	eventData, ok := event["EventData"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	data, ok := eventData["Data"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return data
+}
+
+// getEventDataList extracts EventData.Data as a list (for unnamed data fields).
+// Returns nil if the path doesn't exist or the data is not a list.
+func getEventDataList(eventMap map[string]interface{}) []interface{} {
+	event, ok := eventMap["Event"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	eventData, ok := event["EventData"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	data, ok := eventData["Data"].([]interface{})
+	if !ok {
+		return nil
+	}
+	return data
+}
+
+// formatAppCrashPayload customizes the payload for application crash events (Application Error / Event ID 1000).
+// Extracts the AppName from EventData to create a dynamic title.
+func formatAppCrashPayload(payload *eventPayload, eventData map[string]interface{}) {
+	if data := getEventDataMap(eventData); data != nil {
+		if appName, ok := data["AppName"].(string); ok {
+			payload.Title = fmt.Sprintf("Application crash: %s", appName)
+		}
+	}
+}
+
+// formatAppHangPayload customizes the payload for application hang events (Application Hang / Event ID 1002).
+// Extracts the AppName from EventData to create a dynamic title.
+func formatAppHangPayload(payload *eventPayload, eventData map[string]interface{}) {
+	if data := getEventDataMap(eventData); data != nil {
+		if appName, ok := data["AppName"].(string); ok {
+			payload.Title = fmt.Sprintf("Application hang: %s", appName)
+		}
+	}
+}
+
+// formatMsiInstallerPayload customizes the payload for MSI installer failure events (MsiInstaller / Event ID 11708).
+// Parses the first Data element which has format: "Product: {Name} -- {Error message}"
+// Sets the title to include the product name and the message to the full error text.
+func formatMsiInstallerPayload(payload *eventPayload, eventData map[string]interface{}) {
+	if dataList := getEventDataList(eventData); len(dataList) > 0 {
+		if text, ok := dataList[0].(string); ok {
+			payload.Message = text
+			// Parse "Product: Name -- Error" format
+			// Example: Product: Slack (Machine - MSI) -- Error 1714. The older version of Slack (Machine - MSI) cannot be removed. Contact your technical support group. System Error 1612.
+			// Example: Product: Datadog Agent -- Automatic downgrades are not supported. Uninstall the current version, and then reinstall the desired version.
+			if strings.HasPrefix(text, "Product: ") {
+				parts := strings.SplitN(text[9:], " -- ", 2)
+				if len(parts) > 0 {
+					payload.Title = fmt.Sprintf("Failed application installation: %s", parts[0])
+				}
+			}
+		}
+	}
+}

--- a/comp/notableevents/impl/format_test.go
+++ b/comp/notableevents/impl/format_test.go
@@ -22,7 +22,7 @@ func TestFormatAppCrashPayload(t *testing.T) {
 		expectedTitle string
 	}{
 		{
-			name: "extracts app name from event XML",
+			name: "extracts app name from named fields (Server 2025)",
 			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 				<System>
 					<Provider Name="Application Error"/>
@@ -31,6 +31,21 @@ func TestFormatAppCrashPayload(t *testing.T) {
 				<EventData>
 					<Data Name="AppName">notepad.exe</Data>
 					<Data Name="AppVersion">10.0.19041.1</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:  "Application crash",
+			expectedTitle: "Application crash: notepad.exe",
+		},
+		{
+			name: "extracts app name from positional list (Server 2022)",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Error"/>
+					<EventID>1000</EventID>
+				</System>
+				<EventData>
+					<Data>notepad.exe</Data>
+					<Data>10.0.20348.2227</Data>
 				</EventData>
 			</Event>`,
 			defaultTitle:  "Application crash",
@@ -83,7 +98,7 @@ func TestFormatAppHangPayload(t *testing.T) {
 		expectedTitle string
 	}{
 		{
-			name: "extracts app name from event XML",
+			name: "extracts app name from named fields (Server 2025)",
 			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
 				<System>
 					<Provider Name="Application Hang"/>
@@ -92,6 +107,21 @@ func TestFormatAppHangPayload(t *testing.T) {
 				<EventData>
 					<Data Name="AppName">explorer.exe</Data>
 					<Data Name="AppVersion">10.0.26100.7019</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:  "Application hang",
+			expectedTitle: "Application hang: explorer.exe",
+		},
+		{
+			name: "extracts app name from positional list (Server 2022)",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Hang"/>
+					<EventID>1002</EventID>
+				</System>
+				<EventData>
+					<Data>explorer.exe</Data>
+					<Data>10.0.20348.1</Data>
 				</EventData>
 			</Event>`,
 			defaultTitle:  "Application hang",

--- a/comp/notableevents/impl/format_test.go
+++ b/comp/notableevents/impl/format_test.go
@@ -1,0 +1,211 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+package notableeventsimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatAppCrashPayload(t *testing.T) {
+	tests := []struct {
+		name          string
+		eventXML      string
+		defaultTitle  string
+		expectedTitle string
+	}{
+		{
+			name: "extracts app name from event XML",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Error"/>
+					<EventID>1000</EventID>
+				</System>
+				<EventData>
+					<Data Name="AppName">notepad.exe</Data>
+					<Data Name="AppVersion">10.0.19041.1</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:  "Application crash",
+			expectedTitle: "Application crash: notepad.exe",
+		},
+		{
+			name: "missing AppName keeps default title",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Error"/>
+					<EventID>1000</EventID>
+				</System>
+				<EventData>
+					<Data Name="AppVersion">10.0.19041.1</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:  "Application crash",
+			expectedTitle: "Application crash",
+		},
+		{
+			name: "empty EventData keeps default title",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Error"/>
+					<EventID>1000</EventID>
+				</System>
+				<EventData></EventData>
+			</Event>`,
+			defaultTitle:  "Application crash",
+			expectedTitle: "Application crash",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMap, err := parseEventXML([]byte(tt.eventXML))
+			require.NoError(t, err)
+
+			payload := &eventPayload{Title: tt.defaultTitle}
+			formatAppCrashPayload(payload, eventMap.Map)
+			assert.Equal(t, tt.expectedTitle, payload.Title)
+		})
+	}
+}
+
+func TestFormatAppHangPayload(t *testing.T) {
+	tests := []struct {
+		name          string
+		eventXML      string
+		defaultTitle  string
+		expectedTitle string
+	}{
+		{
+			name: "extracts app name from event XML",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Hang"/>
+					<EventID>1002</EventID>
+				</System>
+				<EventData>
+					<Data Name="AppName">explorer.exe</Data>
+					<Data Name="AppVersion">10.0.26100.7019</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:  "Application hang",
+			expectedTitle: "Application hang: explorer.exe",
+		},
+		{
+			name: "missing AppName keeps default title",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="Application Hang"/>
+					<EventID>1002</EventID>
+				</System>
+				<EventData></EventData>
+			</Event>`,
+			defaultTitle:  "Application hang",
+			expectedTitle: "Application hang",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMap, err := parseEventXML([]byte(tt.eventXML))
+			require.NoError(t, err)
+
+			payload := &eventPayload{Title: tt.defaultTitle}
+			formatAppHangPayload(payload, eventMap.Map)
+			assert.Equal(t, tt.expectedTitle, payload.Title)
+		})
+	}
+}
+
+func TestFormatMsiInstallerPayload(t *testing.T) {
+	tests := []struct {
+		name            string
+		eventXML        string
+		defaultTitle    string
+		defaultMessage  string
+		expectedTitle   string
+		expectedMessage string
+	}{
+		{
+			name: "parses product name and error from XML",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="MsiInstaller"/>
+					<EventID>11708</EventID>
+				</System>
+				<EventData>
+					<Data>Product: Datadog Agent -- Automatic downgrades are not supported. Uninstall the current version, and then reinstall the desired version.</Data>
+					<Data>(NULL)</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:    "Failed application installation",
+			defaultMessage:  "An application installation (MSI) failed",
+			expectedTitle:   "Failed application installation: Datadog Agent",
+			expectedMessage: "Product: Datadog Agent -- Automatic downgrades are not supported. Uninstall the current version, and then reinstall the desired version.",
+		},
+		{
+			name: "parses product with complex error message",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="MsiInstaller"/>
+					<EventID>11708</EventID>
+				</System>
+				<EventData>
+					<Data>Product: Slack (Machine - MSI) -- Error 1714. The older version of Slack (Machine - MSI) cannot be removed. Contact your technical support group. System Error 1612.</Data>
+					<Data>(NULL)</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:    "Failed application installation",
+			defaultMessage:  "An application installation (MSI) failed",
+			expectedTitle:   "Failed application installation: Slack (Machine - MSI)",
+			expectedMessage: "Product: Slack (Machine - MSI) -- Error 1714. The older version of Slack (Machine - MSI) cannot be removed. Contact your technical support group. System Error 1612.",
+		},
+		{
+			name: "empty EventData keeps defaults",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="MsiInstaller"/>
+					<EventID>11708</EventID>
+				</System>
+				<EventData></EventData>
+			</Event>`,
+			defaultTitle:    "Failed application installation",
+			defaultMessage:  "An application installation (MSI) failed",
+			expectedTitle:   "Failed application installation",
+			expectedMessage: "An application installation (MSI) failed",
+		},
+		{
+			name: "non-standard format keeps default title but sets message",
+			eventXML: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+				<System>
+					<Provider Name="MsiInstaller"/>
+					<EventID>11708</EventID>
+				</System>
+				<EventData>
+					<Data>Some other error format without Product prefix</Data>
+					<Data>(NULL)</Data>
+				</EventData>
+			</Event>`,
+			defaultTitle:    "Failed application installation",
+			defaultMessage:  "An application installation (MSI) failed",
+			expectedTitle:   "Failed application installation",
+			expectedMessage: "Some other error format without Product prefix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMap, err := parseEventXML([]byte(tt.eventXML))
+			require.NoError(t, err)
+
+			payload := &eventPayload{Title: tt.defaultTitle, Message: tt.defaultMessage}
+			formatMsiInstallerPayload(payload, eventMap.Map)
+			assert.Equal(t, tt.expectedTitle, payload.Title)
+			assert.Equal(t, tt.expectedMessage, payload.Message)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Add notable events for
- Application Hang
- Application Error
- Failed Windows Update
- Failed MSI install/uninstall

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1970

### Describe how you validated your changes
on your host, switch subscription to `WithStartMode("oldest")` and it should find a bunch.
in a VM, open notepad and close some of its handles using Process Explorer and it'll trigger `Application Hang`.
