### PR TITLE
[CNM-4230] Add maxActive to eBPF conntracker to avoid potential conntrack_args map leak from kretprobes.

### DIFF
--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -47,7 +47,12 @@ var zero uint32
 
 var tuplePool = ddsync.NewDefaultTypedPool[netebpf.ConntrackTuple]()
 
-const ebpfConntrackerModuleName = "network_tracer__ebpf_conntracker"
+const (
+	ebpfConntrackerModuleName = "network_tracer__ebpf_conntracker"
+
+	// maxActive configures the maximum number of instances of the kretprobe-probed functions handled simultaneously.
+	maxActive = 512
+)
 
 var defaultBuckets = []float64{10, 25, 50, 75, 100, 250, 500, 1000, 10000}
 
@@ -496,6 +501,7 @@ func getManager(cfg *config.Config, buf io.ReaderAt, opts manager.Options, build
 	if cfg.AttachKprobesWithKprobeEventsABI {
 		opts.DefaultKprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
 	}
+	opts.DefaultKProbeMaxActive = maxActive
 
 	pid, err := kernel.RootNSPID()
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?
Add maxActive to eBPF conntracker to pass to the eBPF manager to increase the maximum number of concurrent instances of kretprobe-probed functions.  This is similar to what the tracer does, but it uses a separate eBPF manager so it is needed separately here. 

### Motivation
To avoid the case where on a busy system there is the potential for conntrack_args map leaks from conntrack probes if the kprobe is run but the kretprobe is missed because maxActive is too low.

### Describe how you validated your changes
Unit tests, KMTs, manually tested with new image on GKE Autopilot cluster.

### Additional Notes
