### PR TITLE
Update the internal image templates the agent and the otel-agent

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -36,7 +36,7 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
-  IMAGE_VERSION: tmpl-v19
+  IMAGE_VERSION: tmpl-v20
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 
@@ -47,7 +47,7 @@
   RELEASE_PROD: "true"
 
 .ot_standalone_variables: &ot_standalone_variables
-  IMAGE_VERSION: tmpl-v4
+  IMAGE_VERSION: tmpl-v5
   IMAGE_NAME: otel-agent
   TMPL_SRC_REPO: ci/datadog-agent/otel-agent
 


### PR DESCRIPTION
### What does this PR do?

Update the internal image templates the agent and the otel-agent

### Motivation

Make use of https://github.com/DataDog/images/pull/8575

<table>
<tr>
 <td>Latest nightly: registry.ddbuild.io/images/otel-agent:main-0ae2e9f8
 <td>This PR: registry.ddbuild.io/images/otel-agent:dev-florentclarret-BARX-1543-agent-secret-backend-switcher-534a6ee8
<tr>
 <td>Total Image size: 378 MB and 9 layers
 <td>Total Image size: 362 MB and 8 layers
</table>

### Describe how you validated your changes

### Additional Notes
