### PR TITLE
experimental gates: exclude pipeline ID from the report filename

### DIFF
--- a/.gitlab/build/packaging/common.yml
+++ b/.gitlab/build/packaging/common.yml
@@ -43,6 +43,7 @@
 
     # Extract report prefix from gate name (e.g. static_quality_gate_agent_rpm_amd64 -> agent_rpm_amd64)
     REPORT_PREFIX="${STATIC_QUALITY_GATE_NAME#static_quality_gate_}"
+    REPORT_FILENAME="${REPORT_PREFIX}_size_report_${CI_PIPELINE_ID}_${CI_COMMIT_SHA:0:8}.yml"
 
     for package_file in $PACKAGE_PATTERN; do
       if [[ -f "$package_file" ]]; then
@@ -53,7 +54,7 @@
           --package-path "$package_file" \
           --gate-name "$STATIC_QUALITY_GATE_NAME" \
           --build-job-name "$CI_JOB_NAME" \
-          --output-path "${REPORT_PREFIX}_size_report_${CI_PIPELINE_ID}_${CI_COMMIT_SHA:0:8}.yml" \
+          --output-path "${REPORT_FILENAME}" \
           --debug || { echo "⚠️  Package measurement failed for $package_file"; exit 1; }
 
         echo "✅ Package measurement completed"
@@ -62,8 +63,8 @@
         BUCKET_BASE_PATH="s3://dd-ci-artefacts-build-stable/datadog-agent/static_quality_gates/GATE_REPORTS/${CI_COMMIT_SHA}"
         echo "Uploading report to ${BUCKET_BASE_PATH}"
         aws s3 cp --only-show-errors --region us-east-1 --sse AES256 \
-          "${REPORT_PREFIX}_size_report_${CI_PIPELINE_ID}_${CI_COMMIT_SHA:0:8}.yml" \
-          "${BUCKET_BASE_PATH}/${REPORT_PREFIX}_size_report_${CI_PIPELINE_ID}_${CI_COMMIT_SHA:0:8}.yml"
+          "${REPORT_FILENAME}" \
+          "${BUCKET_BASE_PATH}/${REPORT_FILENAME}"
       else
         echo "⚠️  No package found matching pattern: $PACKAGE_PATTERN"; exit 1;
       fi

--- a/.gitlab/build/packaging/common.yml
+++ b/.gitlab/build/packaging/common.yml
@@ -43,7 +43,7 @@
 
     # Extract report prefix from gate name (e.g. static_quality_gate_agent_rpm_amd64 -> agent_rpm_amd64)
     REPORT_PREFIX="${STATIC_QUALITY_GATE_NAME#static_quality_gate_}"
-    REPORT_FILENAME="${REPORT_PREFIX}_size_report_${CI_PIPELINE_ID}_${CI_COMMIT_SHA:0:8}.yml"
+    REPORT_FILENAME="${REPORT_PREFIX}_size_report_${CI_COMMIT_SHA:0:8}.yml"
 
     for package_file in $PACKAGE_PATTERN; do
       if [[ -f "$package_file" ]]; then

--- a/.gitlab/build/packaging/common.yml
+++ b/.gitlab/build/packaging/common.yml
@@ -12,7 +12,7 @@
   if [[ -n "$STATIC_QUALITY_GATE_NAME" ]]; then
     echo "📊 Starting package measurement..."
 
-    # If the gate name contains "suse", use the SUSE package directory, 
+    # If the gate name contains "suse", use the SUSE package directory,
     # otherwise use the default package directory
     [[ "$STATIC_QUALITY_GATE_NAME" == *"suse"* ]] && \
     BASE_PACKAGE_DIR="$OMNIBUS_PACKAGE_DIR_SUSE" || \
@@ -26,7 +26,7 @@
     fi
 
     # RPM uses x86_64 and aarch64 for architecture.
-    # If STATIC_QUALITY_GATE_ARCH is set (which is the case for RPM packages), use it, 
+    # If STATIC_QUALITY_GATE_ARCH is set (which is the case for RPM packages), use it,
     # otherwise use PACKAGE_ARCH (which is the architecture of the package)
     ARCH_VAR="${STATIC_QUALITY_GATE_ARCH:-${PACKAGE_ARCH}}"
 


### PR DESCRIPTION
### What does this PR do?

Don't include the pipeline ID in the package report generated by our experimental gates

### Motivation

We'd like to compare reports across commits, but to do so we need to be able to fetch the parent commit's report.
Having the pipeline ID in there makes it needlessly harder than it needs to be

### Describe how you validated your changes

### Additional Notes
