### PR TITLE
Fix `trap` error logging by moving to individual scripts

### DIFF
--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -45,6 +45,11 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 Invoke-BuildScript `
     -BuildOutOfSource $BuildOutOfSource `
     -InstallDeps $InstallDeps `

--- a/tasks/winbuildscripts/Build-OmnibusTarget.ps1
+++ b/tasks/winbuildscripts/Build-OmnibusTarget.ps1
@@ -42,6 +42,11 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 Invoke-BuildScript `
     -BuildOutOfSource $BuildOutOfSource `
     -InstallDeps $InstallDeps `

--- a/tasks/winbuildscripts/Invoke-IntegrationTests.ps1
+++ b/tasks/winbuildscripts/Invoke-IntegrationTests.ps1
@@ -26,6 +26,11 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 Invoke-BuildScript `
     -BuildOutOfSource $BuildOutOfSource `
     -InstallDeps $InstallDeps `

--- a/tasks/winbuildscripts/Invoke-Linters.ps1
+++ b/tasks/winbuildscripts/Invoke-Linters.ps1
@@ -28,6 +28,11 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 Invoke-BuildScript `
     -BuildOutOfSource $BuildOutOfSource `
     -InstallDeps $InstallDeps `

--- a/tasks/winbuildscripts/Invoke-UnitTests.ps1
+++ b/tasks/winbuildscripts/Invoke-UnitTests.ps1
@@ -44,6 +44,11 @@ param(
 
 . "$PSScriptRoot\common.ps1"
 
+trap {
+    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
+    continue
+}
+
 Invoke-BuildScript `
     -BuildOutOfSource $BuildOutOfSource `
     -InstallDeps $InstallDeps `

--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -1,8 +1,3 @@
-trap {
-    Write-Host "trap: $($_.InvocationInfo.Line.Trim()) - $_" -ForegroundColor Yellow
-    continue
-}
-
 <#
 .SYNOPSIS
 Copies files from C:\mnt into C:\buildroot\datadog-agent and sets the current directory to the buildroot.


### PR DESCRIPTION
### What does this PR do?
Moves the `trap` statement from `common.ps1` to each individual script that dot-sources it. This fixes the issue where errors were not being logged because PowerShell **trap statements don't work when dot-sourced**.

### Motivation
The `trap` statement added in #44103 to log errors in Windows build scripts was not working as intended. Despite being defined in `common.ps1` and dot-sourced by other scripts, the trap never fired when errors occurred.

PowerShell trap statements indeed turn out to be scoped to "compilation units", which means they don't propagate when dot-sourced. This is a known issue without envisioned remediation:
- https://github.com/PowerShell/PowerShell/issues/5342
- https://github.com/PowerShell/PowerShell/issues/25742

The original implementation in `common.ps1` had no effect, leaving Windows CI job failures with minimal diagnostic information, such as https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1367534001 for instance.

### Describe how you validated your changes
Run any of the affected Windows build scripts with intentional errors (e.g., invalid paths) and verify that trap output appears in yellow showing the failed command and error message.