### PR TITLE
Use pr author name for review notif if actor is bot

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -58,6 +58,8 @@ def ask_reviews(_, pr_id, team_slugs):
     events = list(pr.get_issue_events())
     last_event = events[-1]
     actor = last_event.actor.name or last_event.actor.login
+    if "[bot]" in actor:
+        actor = pr.user.name
     for channel, reviewers in channels.items():
         stop_updating = ""
         if (pr.user.login == "renovate[bot]" or pr.user.login == "mend[bot]") and pr.title.startswith(


### PR DESCRIPTION
### What does this PR do?
Use the PR author name for the ask review notification if the "actor" is a bot.

### Motivation
I've seen notifications saying that <bot> asked for review, which is weird and not very informative, using the author name in that case is better.

### Describe how you validated your changes

### Additional Notes
