### PR TITLE
Add trailing slash on config endpoint to avoid redirect

### DIFF
--- a/comp/core/configsync/configsyncimpl/module.go
+++ b/comp/core/configsync/configsyncimpl/module.go
@@ -75,7 +75,7 @@ func newComponent(deps dependencies) (configsync.Component, error) {
 		compURL = &url.URL{
 			Scheme: "https+unix", // +unix gets trimmed by the ipc client and indicates to use agent_ipc.socket_path in the ipc client
 			Host:   "localhost:", // this is required for using the mTLS cert validating the hostname in the request
-			Path:   "/config/v1",
+			Path:   "/config/v1/",
 		}
 	} else {
 		host := deps.Config.GetString("agent_ipc.host")
@@ -88,7 +88,7 @@ func newComponent(deps dependencies) (configsync.Component, error) {
 		compURL = &url.URL{
 			Scheme: "https",
 			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
-			Path:   "/config/v1",
+			Path:   "/config/v1/",
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?
Add trailing slash on the config endpoint to avoid http redirect.

### Motivation
The request was being redirected from `/config/v1` to `/config/v1/`, since that's the registered route. Adding a trailing slash will prevent redirects. 

### Describe how you validated your changes
CI

### Additional Notes
