### PR TITLE
Remove Agent 7 from the Create RC PR workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -40,12 +40,6 @@ jobs:
         run: |
           dda inv -- -e release.check-previous-agent6-rc
 
-      - name: Determine the release active branches
-        id: branches
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "value=[\"6.53.x\"]" >> $GITHUB_OUTPUT
-
   create_rc_pr:
     runs-on: ubuntu-latest
     needs: find_release_branches
@@ -82,10 +76,9 @@ jobs:
           ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
           ATLASSIAN_PASSWORD: ${{ secrets.ATLASSIAN_PASSWORD }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
-          MATRIX: ${{ matrix.value }}
           WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
-          if ! dda inv -- -e release.check-for-changes -r "$MATRIX" $WARNING; then
+          if ! dda inv -- -e release.check-for-changes -r "[\"6.53.x\"]" $WARNING; then
             echo "CHANGES=true" >> $GITHUB_OUTPUT
           else
             echo "CHANGES=false" >> $GITHUB_OUTPUT
@@ -104,8 +97,7 @@ jobs:
       - name: Create RC PR
         if: ${{ needs.find_release_branches.outputs.warning == '' && (steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_QUALIFICATION == 'false')) }}
         env:
-          MATRIX: ${{ matrix.value }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: dda inv -- -e release.create-rc -r "$MATRIX" --patch-version
+        run: dda inv -- -e release.create-rc -r "[\"6.53.x\"]" --patch-version
 

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -10,11 +10,10 @@ permissions: {}
 jobs:
   find_release_branches:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for getting the required OIDC token from GitHub
     environment:
       name: main
-    outputs:
-      branches: ${{ steps.branches.outputs.value }}
-      warning: ${{ steps.warning.outputs.value }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -40,19 +39,6 @@ jobs:
         run: |
           dda inv -- -e release.check-previous-agent6-rc
 
-  create_rc_pr:
-    runs-on: ubuntu-latest
-    needs: find_release_branches
-    if: ${{ needs.find_release_branches.outputs.branches != '[]' && needs.find_release_branches.outputs.branches != '' }}
-    environment:
-      name: main
-    permissions:
-      id-token: write # This is required for getting the required OIDC token from GitHub
-    strategy:
-      matrix:
-        value: ${{fromJSON(needs.find_release_branches.outputs.branches)}}
-      fail-fast: false
-    steps:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:
@@ -76,9 +62,8 @@ jobs:
           ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
           ATLASSIAN_PASSWORD: ${{ secrets.ATLASSIAN_PASSWORD }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
-          WARNING: ${{ needs.find_release_branches.outputs.warning }}
         run: |
-          if ! dda inv -- -e release.check-for-changes -r "[\"6.53.x\"]" $WARNING; then
+          if ! dda inv -- -e release.check-for-changes -r "6.53.x"; then
             echo "CHANGES=true" >> $GITHUB_OUTPUT
           else
             echo "CHANGES=false" >> $GITHUB_OUTPUT
@@ -95,9 +80,9 @@ jobs:
           fi
 
       - name: Create RC PR
-        if: ${{ needs.find_release_branches.outputs.warning == '' && (steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_QUALIFICATION == 'false')) }}
+        if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_QUALIFICATION == 'false') }}
         env:
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: dda inv -- -e release.create-rc -r "[\"6.53.x\"]" --patch-version
+        run: dda inv -- -e release.create-rc -r "6.53.x" --patch-version
 

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -3,12 +3,8 @@ name: Create RC PR
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 14 * * 2,4" # Run on Tuesday and Thursday at 14:00 UTC
-    - cron: "0 8 * * 2,4" # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
     - cron: "0 9 * * 1" # Run Agent 6 workflow on Monday at 09:00 UTC
 
-env:
-  IS_AGENT6_RELEASE: ${{ github.event.schedule == '0 9 * * 1' }}
 permissions: {}
 
 jobs:
@@ -35,7 +31,6 @@ jobs:
           features: legacy-tasks
 
       - name: Check previous agent 6 RC status
-        if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
         env:
           DD_SITE: "datadoghq.com"
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
@@ -49,18 +44,7 @@ jobs:
         id: branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
-            echo "value=[\"6.53.x\"]" >> $GITHUB_OUTPUT
-          else
-            echo "value=$(dda inv -- release.get-unreleased-release-branches)" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Set the warning option
-        id: warning
-        if: github.event.schedule == '0 8 * * 2,4'
-        run: |
-          echo "value=-w" >> $GITHUB_OUTPUT
+        run: echo "value=[\"6.53.x\"]" >> $GITHUB_OUTPUT
 
   create_rc_pr:
     runs-on: ubuntu-latest
@@ -108,7 +92,6 @@ jobs:
           fi
 
       - name: Check if agent 6 is in qualification phase
-        if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
         env:
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
         run: |
@@ -119,14 +102,10 @@ jobs:
           fi
 
       - name: Create RC PR
-        if: ${{ needs.find_release_branches.outputs.warning == '' && (steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false')) }}
+        if: ${{ needs.find_release_branches.outputs.warning == '' && (steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_QUALIFICATION == 'false')) }}
         env:
           MATRIX: ${{ matrix.value }}
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: |
-          if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
-            dda inv -- -e release.create-rc -r "$MATRIX" --patch-version
-          else
-            dda inv -- -e release.create-rc -r "$MATRIX"
-          fi
+        run: dda inv -- -e release.create-rc -r "$MATRIX" --patch-version
+


### PR DESCRIPTION
### What does this PR do?

Remove Agent 7 from the Create RC PR workflow

### Motivation

We don't need it for Agent 7. We want to remove the parts related to it to re-enable it for Agent 6

### Describe how you validated your changes

### Additional Notes

https://datadoghq.atlassian.net/browse/ACIX-1175
