### PR TITLE
[SGPUM-27] gpu: exclude containerd from eBPF probes

### DIFF
--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -468,7 +468,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 		ScanProcessesInterval:          cfg.ScanProcessesInterval,
 		EnablePeriodicScanNewProcesses: true,
 		EnableDetailedLogging:          cfg.AttacherDetailedLogs,
-		ExcludeTargets:                 uprobes.ExcludeInternal | uprobes.ExcludeSelf,
+		ExcludeTargets:                 uprobes.ExcludeInternal | uprobes.ExcludeSelf | uprobes.ExcludeBuildkit | uprobes.ExcludeContainerdTmp,
 	}
 }
 

--- a/releasenotes/notes/containerd-gpu-2fbe69d44054d81a.yaml
+++ b/releasenotes/notes/containerd-gpu-2fbe69d44054d81a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    GPU: fix an issue where containerd image creation could be blocked sporadically when advanced eBPF metrics are enabled


### PR DESCRIPTION
### What does this PR do?

Adds containerd and buildkit exclusions to the uprobe attacher in GPUm probe.

### Motivation

Avoid blocking temporary containerd mounts.

### Describe how you validated your changes

Exclusion already covered by existing uprobe attacher tests.

### Additional Notes
