### PR TITLE
feat(ssi): check if the CSI driver supports SSI

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -75,6 +75,10 @@ type Config struct {
 	// This is used for picking a default service name for a given pod,
 	// see [[serviceNameMutator]].
 	podMetaAsTags podMetaAsTags
+
+	// csiEnabled indicates if CSI injection is enabled in the cluster agent configuration.
+	// When false, CSI mode requests will fall back to init_container mode.
+	csiEnabled bool
 }
 
 var excludedContainerNames = map[string]bool{
@@ -110,6 +114,7 @@ func NewConfig(datadogConfig config.Component) (*Config, error) {
 
 	containerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry")
 	mutateUnlabelled := datadogConfig.GetBool("admission_controller.mutate_unlabelled")
+	csiEnabled := datadogConfig.GetBool("csi.enabled")
 
 	return &Config{
 		Webhook:                       NewWebhookConfig(datadogConfig),
@@ -124,6 +129,7 @@ func NewConfig(datadogConfig config.Component) (*Config, error) {
 		profilingClientLibraryMutator: profilingClientLibraryConfigMutators(datadogConfig),
 		containerFilter:               excludedContainerNamesContainerFilter,
 		podMetaAsTags:                 getPodMetaAsTags(datadogConfig),
+		csiEnabled:                    csiEnabled,
 	}, nil
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/csi_config.go
@@ -1,0 +1,136 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// CSI driver ConfigMap constants (must match the CSI driver implementation)
+	csiConfigMapName       = "datadog-csi-driver-config"
+	csiConfigKeyVersion    = "version"
+	csiConfigKeySSIEnabled = "ssi_enabled"
+
+	// Cache TTL to avoid querying the API server too frequently
+	csiConfigCacheTTL = 30 * time.Second
+)
+
+// CSIDriverStatus represents the CSI driver status read from its ConfigMap
+type CSIDriverStatus struct {
+	// Available is true if the CSI driver ConfigMap was found
+	Available bool
+	// Version is the CSI driver version
+	Version string
+	// SSIEnabled is true if SSI/APM injection is enabled in the CSI driver
+	SSIEnabled bool
+}
+
+// csiConfigCache caches the CSI driver status to avoid frequent API calls
+var (
+	csiConfigCache     CSIDriverStatus
+	csiConfigCacheTime time.Time
+	csiConfigCacheMu   sync.RWMutex
+
+	// csiStatusFetcher can be overridden for testing
+	csiStatusFetcher = fetchCSIDriverStatus
+)
+
+// GetCSIDriverStatus returns the CSI driver status by reading its ConfigMap.
+// The ConfigMap is expected to be in the same namespace as the cluster-agent.
+// Results are cached for csiConfigCacheTTL to reduce API server load.
+func GetCSIDriverStatus(ctx context.Context) CSIDriverStatus {
+	// Check cache first
+	csiConfigCacheMu.RLock()
+	if time.Since(csiConfigCacheTime) < csiConfigCacheTTL {
+		status := csiConfigCache
+		csiConfigCacheMu.RUnlock()
+		return status
+	}
+	csiConfigCacheMu.RUnlock()
+
+	// Cache expired, fetch fresh data
+	status := csiStatusFetcher(ctx)
+
+	// Update cache
+	csiConfigCacheMu.Lock()
+	csiConfigCache = status
+	csiConfigCacheTime = time.Now()
+	csiConfigCacheMu.Unlock()
+
+	return status
+}
+
+// fetchCSIDriverStatus fetches the CSI driver status from the API server.
+// It assumes the CSI driver ConfigMap is in the same namespace as the cluster-agent.
+func fetchCSIDriverStatus(ctx context.Context) CSIDriverStatus {
+	apiClient, err := apiserver.GetAPIClient()
+	if err != nil {
+		log.Debugf("Failed to get API client for CSI driver status: %v", err)
+		return CSIDriverStatus{Available: false}
+	}
+
+	ns := namespace.GetMyNamespace()
+	cm, err := apiClient.Cl.CoreV1().ConfigMaps(ns).Get(ctx, csiConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.Debugf("CSI driver ConfigMap %s/%s not found", ns, csiConfigMapName)
+		} else {
+			log.Debugf("Failed to get CSI driver ConfigMap %s/%s: %v", ns, csiConfigMapName, err)
+		}
+		return CSIDriverStatus{Available: false}
+	}
+
+	ssiEnabled, _ := strconv.ParseBool(cm.Data[csiConfigKeySSIEnabled])
+
+	status := CSIDriverStatus{
+		Available:  true,
+		Version:    cm.Data[csiConfigKeyVersion],
+		SSIEnabled: ssiEnabled,
+	}
+
+	log.Debugf("CSI driver status: version=%s, ssi_enabled=%v (from %s/%s)",
+		status.Version, status.SSIEnabled, ns, csiConfigMapName)
+
+	return status
+}
+
+// InvalidateCSIConfigCache invalidates the CSI driver config cache.
+// This is useful for testing or when the CSI driver configuration changes.
+func InvalidateCSIConfigCache() {
+	csiConfigCacheMu.Lock()
+	csiConfigCacheTime = time.Time{}
+	csiConfigCacheMu.Unlock()
+}
+
+// SetCSIStatusFetcherForTest allows tests to override the CSI status fetcher.
+// It returns a cleanup function that restores the original fetcher.
+func SetCSIStatusFetcherForTest(fetcher func(ctx context.Context) CSIDriverStatus) func() {
+	csiConfigCacheMu.Lock()
+	originalFetcher := csiStatusFetcher
+	csiStatusFetcher = fetcher
+	csiConfigCacheTime = time.Time{} // Invalidate cache
+	csiConfigCacheMu.Unlock()
+
+	return func() {
+		csiConfigCacheMu.Lock()
+		csiStatusFetcher = originalFetcher
+		csiConfigCacheTime = time.Time{} // Invalidate cache
+		csiConfigCacheMu.Unlock()
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
@@ -8,6 +8,8 @@
 package libraryinjection
 
 import (
+	"context"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation/annotation"
@@ -32,18 +34,21 @@ const (
 // ProviderFactory holds the default injection mode and creates providers on demand.
 type ProviderFactory struct {
 	defaultMode InjectionMode
+	csiEnabled  bool
 }
 
 // NewProviderFactory creates a new provider factory with the specified default mode.
-func NewProviderFactory(defaultMode InjectionMode) *ProviderFactory {
+func NewProviderFactory(defaultMode InjectionMode, csiEnabled bool) *ProviderFactory {
 	return &ProviderFactory{
 		defaultMode: defaultMode,
+		csiEnabled:  csiEnabled,
 	}
 }
 
 // GetProviderForPod returns the appropriate injection provider for a pod.
 // It checks for the injection mode annotation on the pod and returns the corresponding provider.
 // If no annotation is present or the value is invalid, it returns the default provider.
+// For CSI mode, it verifies that the CSI driver is available and SSI-enabled before using it.
 func (f *ProviderFactory) GetProviderForPod(pod *corev1.Pod, cfg LibraryInjectionConfig) LibraryInjectionProvider {
 	mode := f.defaultMode
 
@@ -58,6 +63,26 @@ func (f *ProviderFactory) GetProviderForPod(pod *corev1.Pod, cfg LibraryInjectio
 	case InjectionModeAuto, InjectionModeInitContainer:
 		return NewInitContainerProvider(cfg)
 	case InjectionModeCSI:
+		if !f.isCSIAvailable() {
+			log.Warnf("CSI injection mode requested for pod %s/%s but CSI driver is not available, falling back to init_container",
+				pod.Namespace, pod.Name)
+			return NewInitContainerProvider(cfg)
+		}
 		return NewCSIProvider(cfg)
 	}
+}
+
+func (f *ProviderFactory) isCSIAvailable() bool {
+	// Check if CSI is enabled in the configuration
+	if !f.csiEnabled {
+		return false
+	}
+
+	// Check the CSI driver configMap to see if it is available and SSI-enabled
+	csiStatus := GetCSIDriverStatus(context.TODO())
+	if !csiStatus.Available {
+		return false
+	}
+
+	return csiStatus.SSIEnabled
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
@@ -8,6 +8,7 @@
 package libraryinjection_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,59 +21,85 @@ import (
 )
 
 func TestGetProviderForPod(t *testing.T) {
+	// Mock the CSI driver as available and SSI-enabled for tests that expect CSIProvider
+	cleanup := libraryinjection.SetCSIStatusFetcherForTest(func(_ context.Context) libraryinjection.CSIDriverStatus {
+		return libraryinjection.CSIDriverStatus{
+			Available:  true,
+			Version:    "1.0.0",
+			SSIEnabled: true,
+		}
+	})
+	defer cleanup()
+
 	tests := []struct {
 		name             string
 		defaultMode      libraryinjection.InjectionMode
+		csiEnabled       bool
 		annotationValue  *string // nil = no annotation
 		expectedProvider string
 	}{
 		{
 			name:             "no annotation uses default init_container",
 			defaultMode:      libraryinjection.InjectionModeInitContainer,
+			csiEnabled:       true,
 			annotationValue:  nil,
 			expectedProvider: "InitContainerProvider",
 		},
 		{
 			name:             "no annotation uses default csi",
 			defaultMode:      libraryinjection.InjectionModeCSI,
+			csiEnabled:       true,
 			annotationValue:  nil,
 			expectedProvider: "CSIProvider",
 		},
 		{
 			name:             "no annotation uses default auto (init_container)",
 			defaultMode:      libraryinjection.InjectionModeAuto,
+			csiEnabled:       true,
 			annotationValue:  nil,
 			expectedProvider: "InitContainerProvider",
 		},
 		{
 			name:             "annotation overrides default: init_container -> csi",
 			defaultMode:      libraryinjection.InjectionModeInitContainer,
+			csiEnabled:       true,
 			annotationValue:  ptr.To("csi"),
 			expectedProvider: "CSIProvider",
 		},
 		{
 			name:             "annotation overrides default: csi -> init_container",
 			defaultMode:      libraryinjection.InjectionModeCSI,
+			csiEnabled:       true,
 			annotationValue:  ptr.To("init_container"),
 			expectedProvider: "InitContainerProvider",
 		},
 		{
 			name:             "annotation auto uses init_container",
 			defaultMode:      libraryinjection.InjectionModeInitContainer,
+			csiEnabled:       true,
 			annotationValue:  ptr.To("auto"),
 			expectedProvider: "InitContainerProvider",
 		},
 		{
 			name:             "unknown mode falls back to auto (init_container)",
 			defaultMode:      libraryinjection.InjectionModeCSI,
+			csiEnabled:       true,
 			annotationValue:  ptr.To("unknown_mode"),
 			expectedProvider: "InitContainerProvider",
 		},
 		{
 			name:             "empty annotation uses default",
 			defaultMode:      libraryinjection.InjectionModeCSI,
+			csiEnabled:       true,
 			annotationValue:  ptr.To(""),
 			expectedProvider: "CSIProvider",
+		},
+		{
+			name:             "csi disabled in config falls back to init_container",
+			defaultMode:      libraryinjection.InjectionModeCSI,
+			csiEnabled:       false,
+			annotationValue:  nil,
+			expectedProvider: "InitContainerProvider",
 		},
 	}
 
@@ -91,7 +118,73 @@ func TestGetProviderForPod(t *testing.T) {
 				}
 			}
 
-			factory := libraryinjection.NewProviderFactory(tt.defaultMode)
+			factory := libraryinjection.NewProviderFactory(tt.defaultMode, tt.csiEnabled)
+			provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
+
+			switch tt.expectedProvider {
+			case "CSIProvider":
+				_, ok := provider.(*libraryinjection.CSIProvider)
+				assert.True(t, ok, "expected CSIProvider")
+			case "InitContainerProvider":
+				_, ok := provider.(*libraryinjection.InitContainerProvider)
+				assert.True(t, ok, "expected InitContainerProvider")
+			}
+		})
+	}
+}
+
+func TestGetProviderForPod_CSIFallback(t *testing.T) {
+	tests := []struct {
+		name             string
+		csiStatus        libraryinjection.CSIDriverStatus
+		expectedProvider string
+	}{
+		{
+			name: "CSI driver not available falls back to init_container",
+			csiStatus: libraryinjection.CSIDriverStatus{
+				Available:  false,
+				SSIEnabled: false,
+			},
+			expectedProvider: "InitContainerProvider",
+		},
+		{
+			name: "CSI driver available but SSI not enabled falls back to init_container",
+			csiStatus: libraryinjection.CSIDriverStatus{
+				Available:  true,
+				Version:    "1.0.0",
+				SSIEnabled: false,
+			},
+			expectedProvider: "InitContainerProvider",
+		},
+		{
+			name: "CSI driver available and SSI enabled uses CSI",
+			csiStatus: libraryinjection.CSIDriverStatus{
+				Available:  true,
+				Version:    "1.0.0",
+				SSIEnabled: true,
+			},
+			expectedProvider: "CSIProvider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup := libraryinjection.SetCSIStatusFetcherForTest(func(_ context.Context) libraryinjection.CSIDriverStatus {
+				return tt.csiStatus
+			})
+			defer cleanup()
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					Annotations: map[string]string{
+						annotation.InjectionMode: "csi",
+					},
+				},
+			}
+
+			factory := libraryinjection.NewProviderFactory(libraryinjection.InjectionModeCSI, true) // CSI enabled in config
 			provider := factory.GetProviderForPod(pod, libraryinjection.LibraryInjectionConfig{})
 
 			switch tt.expectedProvider {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/mutator.go
@@ -29,7 +29,7 @@ import (
 // Returns an error if the injection fails.
 func InjectAPMLibraries(pod *corev1.Pod, cfg LibraryInjectionConfig) error {
 	// Select the provider based on the injection mode (annotation or default)
-	factory := NewProviderFactory(InjectionMode(cfg.InjectionMode))
+	factory := NewProviderFactory(InjectionMode(cfg.InjectionMode), cfg.CSIEnabled)
 	provider := factory.GetProviderForPod(pod, cfg)
 
 	// Inject the APM injector

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/provider.go
@@ -74,6 +74,10 @@ type LibraryInjectionConfig struct {
 	// Possible values: "auto" (default), "init_container" and "csi".
 	InjectionMode string
 
+	// CSIEnabled indicates if CSI injection is enabled in the cluster agent configuration.
+	// When false, CSI mode requests will fall back to init_container mode.
+	CSIEnabled bool
+
 	// DefaultResourceRequirements are the default resource requirements for init containers.
 	// If empty, the provider will compute requirements based on the pod's existing resources.
 	DefaultResourceRequirements map[corev1.ResourceName]resource.Quantity

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -103,6 +103,7 @@ func (m *mutatorCore) apmInjectionMutator(config extractedPodLibInfo, autoDetect
 
 		return libraryinjection.InjectAPMLibraries(pod, libraryinjection.LibraryInjectionConfig{
 			InjectionMode:               m.config.Instrumentation.InjectionMode,
+			CSIEnabled:                  m.config.csiEnabled,
 			DefaultResourceRequirements: m.config.defaultResourceRequirements,
 			InitSecurityContext:         m.config.initSecurityContext,
 			ContainerFilter:             m.config.containerFilter,


### PR DESCRIPTION
### What does this PR do?

Adds CSI driver availability check before using CSI injection mode. The cluster-agent now verifies that:
1. CSI is enabled in the configuration (`csi.enabled`)
2. The CSI driver is deployed (ConfigMap `datadog-csi-driver-config` exists)
3. SSI is enabled in the CSI driver (`ssi_enabled=true`)

If any check fails, the injection falls back to init containers.

### Motivation

Prevent injection failures when CSI mode is requested but the CSI driver is not available or not properly configured.

### Describe how you validated your changes


### Additional Notes

- The CSI driver ConfigMap is expected to be in the same namespace as the cluster-agent
- Results are cached for 30 seconds to reduce API server load
