### PR TITLE
autoscaling: rework trigger rollout logic to allow self-healing in case of low recommendations

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/pod.go
@@ -140,8 +140,7 @@ func (p *MinimalPod) DeepCopyObject() runtime.Object {
 		out.Spec.Volumes = make([]MinimalVolume, len(p.Spec.Volumes))
 		for i := range p.Spec.Volumes {
 			if p.Spec.Volumes[i].PersistentVolumeClaim != nil {
-				out.Spec.Volumes[i].PersistentVolumeClaim =
-					p.Spec.Volumes[i].PersistentVolumeClaim.DeepCopy()
+				out.Spec.Volumes[i].PersistentVolumeClaim = p.Spec.Volumes[i].PersistentVolumeClaim.DeepCopy()
 			}
 		}
 	}
@@ -308,6 +307,12 @@ func (p minimalPodParser) Parse(obj interface{}) workloadmeta.Entity {
 		}
 		if memoryReq, found := container.Resources.Requests[corev1.ResourceMemory]; found {
 			c.Resources.MemoryRequest = kubeutil.FormatMemoryRequests(memoryReq)
+		}
+		if cpuLimit, found := container.Resources.Limits[corev1.ResourceCPU]; found {
+			c.Resources.CPULimit = kubeutil.FormatCPURequests(cpuLimit)
+		}
+		if memoryLimit, found := container.Resources.Limits[corev1.ResourceMemory]; found {
+			c.Resources.MemoryLimit = kubeutil.FormatMemoryRequests(memoryLimit)
 		}
 		containersList = append(containersList, c)
 	}

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod.go
@@ -89,6 +89,12 @@ func (p podParser) Parse(obj interface{}) workloadmeta.Entity {
 		if memoryReq, found := container.Resources.Requests[corev1.ResourceMemory]; found {
 			c.Resources.MemoryRequest = kubernetes.FormatMemoryRequests(memoryReq)
 		}
+		if cpuLimit, found := container.Resources.Limits[corev1.ResourceCPU]; found {
+			c.Resources.CPULimit = kubernetes.FormatCPURequests(cpuLimit)
+		}
+		if memoryLimit, found := container.Resources.Limits[corev1.ResourceMemory]; found {
+			c.Resources.MemoryLimit = kubernetes.FormatMemoryRequests(memoryLimit)
+		}
 		containersList = append(containersList, c)
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -35,31 +35,30 @@ import (
 )
 
 const (
+	// rolloutCheckRequeueDelay is the delay between rollout status checks
 	rolloutCheckRequeueDelay = 2 * time.Minute
-
-	// controllerRevisionHashLabel is the label used by Kubernetes to track pod template revisions
-	// for StatefulSets and DaemonSets. This is managed by Kubernetes itself and changes whenever
-	// any part of the pod template changes.
-	controllerRevisionHashLabel = "controller-revision-hash"
+	// minDelayBetweenRollouts is the minimum time between bypass rollout triggers to prevent thrashing
+	minDelayBetweenRollouts = 10 * time.Minute
 )
 
 // verticalController is responsible for updating targetRef objects with the vertical recommendations
 type verticalController struct {
-	clock         clock.Clock
-	eventRecorder record.EventRecorder
-	dynamicClient dynamic.Interface
-	podWatcher    PodWatcher
+	clock           clock.Clock
+	eventRecorder   record.EventRecorder
+	dynamicClient   dynamic.Interface
+	podWatcher      PodWatcher
+	progressTracker *rolloutProgressTracker
 }
 
 // newVerticalController creates a new *verticalController
 func newVerticalController(clock clock.Clock, eventRecorder record.EventRecorder, cl dynamic.Interface, pw PodWatcher) *verticalController {
-	res := &verticalController{
-		clock:         clock,
-		eventRecorder: eventRecorder,
-		dynamicClient: cl,
-		podWatcher:    pw,
+	return &verticalController{
+		clock:           clock,
+		eventRecorder:   eventRecorder,
+		dynamicClient:   cl,
+		podWatcher:      pw,
+		progressTracker: newRolloutProgressTracker(),
 	}
-	return res
 }
 
 func (u *verticalController) sync(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, autoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, target NamespacedPodOwner) (autoscaling.ProcessResult, error) {
@@ -98,7 +97,8 @@ func (u *verticalController) sync(ctx context.Context, podAutoscaler *datadoghq.
 	}
 
 	// Update scaled replicas status
-	autoscalerInternal.SetScaledReplicas(podsPerRecommendationID[recommendationID])
+	podsOnRecommendation := podsPerRecommendationID[recommendationID]
+	autoscalerInternal.SetScaledReplicas(podsOnRecommendation)
 
 	// Check if we're allowed to rollout, we don't care about the source in this case, so passing most favorable source: manual
 	updateStrategy, reason := getVerticalPatchingStrategy(autoscalerInternal)
@@ -107,57 +107,17 @@ func (u *verticalController) sync(ctx context.Context, podAutoscaler *datadoghq.
 		return autoscaling.NoRequeue, nil
 	}
 
-	// Check if last action was done in the `rolloutCheckRequeueDelay` window
-	if autoscalerInternal.VerticalLastAction() != nil && autoscalerInternal.VerticalLastAction().Time.Add(rolloutCheckRequeueDelay).After(u.clock.Now()) {
-		log.Debugf("Last action was done less than %s ago for autoscaler: %s, skipping", rolloutCheckRequeueDelay.String(), autoscalerInternal.ID())
-		return autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, nil
-	}
-
 	switch targetGVK.Kind {
 	case k8sutil.DeploymentKind:
-		return u.syncDeploymentKind(ctx, podAutoscaler, autoscalerInternal, updateStrategy, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
+		return u.syncDeploymentKind(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
 	case k8sutil.RolloutKind:
-		return u.syncRolloutKind(ctx, podAutoscaler, autoscalerInternal, updateStrategy, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
+		return u.syncRolloutKind(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
 	case k8sutil.StatefulSetKind:
-		return u.syncStatefulSetKind(ctx, podAutoscaler, autoscalerInternal, updateStrategy, target, targetGVK, recommendationID, pods, podsPerRecommendationID)
+		return u.syncStatefulSetKind(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, pods, podsPerRecommendationID)
 	default:
 		autoscalerInternal.UpdateFromVerticalAction(nil, fmt.Errorf("automatic rollout not available for target Kind: %s. Applying to existing PODs require manual trigger", targetGVK.Kind))
 		return autoscaling.NoRequeue, nil
 	}
-}
-
-// isRecommendationRolloutComplete checks if the current recommendation is entirely rolled out.
-// Returns true if all pods have the given recommendation ID.
-func isRecommendationRolloutComplete(recommendationID string, pods []*workloadmeta.KubernetesPod, podsPerRecommendationID map[string]int32) bool {
-	// currently basic check with 100% match expected.
-	// TODO: Refine the logic and add backoff for stuck PODs.
-	return podsPerRecommendationID[recommendationID] == int32(len(pods))
-}
-
-// isStatefulSetRolloutInProgress checks if a StatefulSet rollout is currently in progress
-// by examining the controller-revision-hash labels on pods. If pods have different revision
-// hashes, it indicates that Kubernetes is in the process of rolling out a new pod template.
-// This detects ANY ongoing rollout, not just ones triggered by us.
-func isStatefulSetRolloutInProgress(pods []*workloadmeta.KubernetesPod) bool {
-	if len(pods) <= 1 {
-		return false
-	}
-
-	var firstRevision string
-	for _, pod := range pods {
-		revision := pod.Labels[controllerRevisionHashLabel]
-		if revision == "" {
-			// Pod doesn't have the label yet, might be initializing
-			continue
-		}
-		if firstRevision == "" {
-			firstRevision = revision
-		} else if revision != firstRevision {
-			// Pods have different revisions - rollout in progress
-			return true
-		}
-	}
-	return false
 }
 
 // triggerRollout patches the target workload's pod template to trigger a rollout.
@@ -219,7 +179,6 @@ func (u *verticalController) syncDeploymentKind(
 	ctx context.Context,
 	podAutoscaler *datadoghq.DatadogPodAutoscaler,
 	autoscalerInternal *model.PodAutoscalerInternal,
-	_ datadoghqcommon.DatadogPodAutoscalerUpdateStrategy,
 	target NamespacedPodOwner,
 	targetGVK schema.GroupVersionKind,
 	recommendationID string,
@@ -227,29 +186,28 @@ func (u *verticalController) syncDeploymentKind(
 	podsPerRecommendationID map[string]int32,
 	podsPerDirectOwner map[string]int32,
 ) (autoscaling.ProcessResult, error) {
-	// Check if we need to rollout
-	if isRecommendationRolloutComplete(recommendationID, pods, podsPerRecommendationID) {
-		autoscalerInternal.UpdateFromVerticalAction(nil, nil)
-		return autoscaling.NoRequeue, nil
-	}
+	// For Deployments/Rollouts, multiple direct owners (ReplicaSets) indicate an ongoing rollout
+	rolloutInProgress := len(podsPerDirectOwner) > 1
 
-	// Check if a rollout is already ongoing.
-	// For Deployments/Rollouts, multiple direct owners (ReplicaSets) indicate an ongoing rollout.
-	// TODO: Refine the logic and add backoff for stuck PODs.
-	if len(podsPerDirectOwner) > 1 {
-		log.Debugf("Rollout already ongoing for autoscaler: %s, gvk: %s, name: %s", autoscalerInternal.ID(), targetGVK.String(), autoscalerInternal.Spec().TargetRef.Name)
-		return autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, nil
-	}
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		autoscalerInternal.VerticalLastAction(),
+		rolloutInProgress,
+		autoscalerInternal.ScalingValues().Vertical,
+		u.clock.Now(),
+		minDelayBetweenRollouts,
+		autoscalerInternal.ID(),
+	)
 
-	// Normally we should check updateStrategy here, we currently only support one way, so not required for now.
-	return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
+	return u.handleRolloutDecision(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, podsPerRecommendationID, decision)
 }
 
 func (u *verticalController) syncRolloutKind(
 	ctx context.Context,
 	podAutoscaler *datadoghq.DatadogPodAutoscaler,
 	autoscalerInternal *model.PodAutoscalerInternal,
-	updateStrategy datadoghqcommon.DatadogPodAutoscalerUpdateStrategy,
 	target NamespacedPodOwner,
 	targetGVK schema.GroupVersionKind,
 	recommendationID string,
@@ -259,68 +217,67 @@ func (u *verticalController) syncRolloutKind(
 ) (autoscaling.ProcessResult, error) {
 	// Argo Rollouts use the same pod template structure as Deployments,
 	// so we can reuse the same rollout logic
-	return u.syncDeploymentKind(ctx, podAutoscaler, autoscalerInternal, updateStrategy, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
+	return u.syncDeploymentKind(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, pods, podsPerRecommendationID, podsPerDirectOwner)
 }
 
 func (u *verticalController) syncStatefulSetKind(
 	ctx context.Context,
 	podAutoscaler *datadoghq.DatadogPodAutoscaler,
 	autoscalerInternal *model.PodAutoscalerInternal,
-	_ datadoghqcommon.DatadogPodAutoscalerUpdateStrategy,
 	target NamespacedPodOwner,
 	targetGVK schema.GroupVersionKind,
 	recommendationID string,
 	pods []*workloadmeta.KubernetesPod,
 	podsPerRecommendationID map[string]int32,
 ) (autoscaling.ProcessResult, error) {
-	// Check if we need to rollout
-	if isRecommendationRolloutComplete(recommendationID, pods, podsPerRecommendationID) {
-		autoscalerInternal.UpdateFromVerticalAction(nil, nil)
-		return autoscaling.NoRequeue, nil
-	}
+	// For StatefulSets, different controller-revision-hash labels indicate an ongoing rollout
+	rolloutInProgress := isStatefulSetRolloutInProgress(pods)
 
-	// Detect ongoing rollouts
-	if isStatefulSetRolloutInProgress(pods) {
-		log.Debugf("StatefulSet rollout in progress for autoscaler: %s, gvk: %s, name: %s (pods have different controller-revision-hash)",
-			autoscalerInternal.ID(), targetGVK.String(), autoscalerInternal.Spec().TargetRef.Name)
-		return autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, nil
-	}
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		autoscalerInternal.VerticalLastAction(),
+		rolloutInProgress,
+		autoscalerInternal.ScalingValues().Vertical,
+		u.clock.Now(),
+		minDelayBetweenRollouts,
+		autoscalerInternal.ID(),
+	)
 
-	// Normally we should check updateStrategy here, we currently only support one way, so not required for now.
-	return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
+	return u.handleRolloutDecision(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, podsPerRecommendationID, decision)
 }
 
-// getVerticalPatchingStrategy applied policies to determine effective patching strategy.
-// Return (strategy, reason). Reason is only returned when chosen strategy disables vertical patching.
-func getVerticalPatchingStrategy(autoscalerInternal *model.PodAutoscalerInternal) (datadoghqcommon.DatadogPodAutoscalerUpdateStrategy, string) {
-	// If we don't have spec, we cannot take decisions, should not happen.
-	if autoscalerInternal.Spec() == nil {
-		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "pod autoscaling hasn't been initialized yet"
-	}
-
-	// If we don't have a ScalingValue, we cannot take decisions, should not happen.
-	if autoscalerInternal.ScalingValues().Vertical == nil {
-		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "no scaling values available"
-	}
-
-	// By default, policy is to allow all
-	if autoscalerInternal.Spec().ApplyPolicy == nil {
-		return datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy, ""
-	}
-
-	// We do have policies, checking if they allow this source
-	if !model.ApplyModeAllowSource(autoscalerInternal.Spec().ApplyPolicy.Mode, autoscalerInternal.ScalingValues().Vertical.Source) {
-		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, fmt.Sprintf("vertical scaling disabled due to applyMode: %s not allowing recommendations from source: %s", autoscalerInternal.Spec().ApplyPolicy.Mode, autoscalerInternal.ScalingValues().Vertical.Source)
-	}
-
-	if autoscalerInternal.Spec().ApplyPolicy.Update != nil {
-		if autoscalerInternal.Spec().ApplyPolicy.Update.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy {
-			return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "vertical scaling disabled due to update strategy set to disabled"
+// handleRolloutDecision processes the rollout decision and takes appropriate action.
+// This is shared logic used by all workload types.
+func (u *verticalController) handleRolloutDecision(
+	ctx context.Context,
+	podAutoscaler *datadoghq.DatadogPodAutoscaler,
+	autoscalerInternal *model.PodAutoscalerInternal,
+	target NamespacedPodOwner,
+	targetGVK schema.GroupVersionKind,
+	recommendationID string,
+	podsPerRecommendationID map[string]int32,
+	decision rolloutDecision,
+) (autoscaling.ProcessResult, error) {
+	switch decision {
+	case rolloutDecisionComplete:
+		u.progressTracker.Clear(autoscalerInternal.ID())
+		autoscalerInternal.UpdateFromVerticalAction(nil, nil)
+		return autoscaling.NoRequeue, nil
+	case rolloutDecisionWait:
+		// Check if the rollout is stalled (no pod movement for too long)
+		isStalled := u.progressTracker.Update(autoscalerInternal.ID(), recommendationID, podsPerRecommendationID[recommendationID], u.clock.Now())
+		if isStalled {
+			log.Infof("Rollout stalled for autoscaler %s (no pod movement for %s), re-triggering rollout", autoscalerInternal.ID(), rolloutStallTimeout)
+			return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
 		}
-
-		return autoscalerInternal.Spec().ApplyPolicy.Update.Strategy, ""
+		return autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, nil
+	case rolloutDecisionTrigger:
+		return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
 	}
 
-	// No update strategy defined, defaulting to auto
-	return datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy, ""
+	// This should never happen if all rolloutDecision values are handled above
+	log.Errorf("Unknown rollout decision %d for autoscaler %s", decision, autoscalerInternal.ID())
+	return autoscaling.NoRequeue, nil
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -1,0 +1,253 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package workload
+
+import (
+	"fmt"
+	"time"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// controllerRevisionHashLabel is the label used by Kubernetes to track pod template revisions
+	// for StatefulSets and DaemonSets. This is managed by Kubernetes itself and changes whenever
+	// any part of the pod template changes.
+	controllerRevisionHashLabel = "controller-revision-hash"
+)
+
+// getVerticalPatchingStrategy applied policies to determine effective patching strategy.
+// Return (strategy, reason). Reason is only returned when chosen strategy disables vertical patching.
+func getVerticalPatchingStrategy(autoscalerInternal *model.PodAutoscalerInternal) (datadoghqcommon.DatadogPodAutoscalerUpdateStrategy, string) {
+	// If we don't have spec, we cannot take decisions, should not happen.
+	if autoscalerInternal.Spec() == nil {
+		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "pod autoscaling hasn't been initialized yet"
+	}
+
+	// If we don't have a ScalingValue, we cannot take decisions, should not happen.
+	if autoscalerInternal.ScalingValues().Vertical == nil {
+		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "no scaling values available"
+	}
+
+	// By default, policy is to allow all
+	if autoscalerInternal.Spec().ApplyPolicy == nil {
+		return datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy, ""
+	}
+
+	// We do have policies, checking if they allow this source
+	if !model.ApplyModeAllowSource(autoscalerInternal.Spec().ApplyPolicy.Mode, autoscalerInternal.ScalingValues().Vertical.Source) {
+		return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, fmt.Sprintf("vertical scaling disabled due to applyMode: %s not allowing recommendations from source: %s", autoscalerInternal.Spec().ApplyPolicy.Mode, autoscalerInternal.ScalingValues().Vertical.Source)
+	}
+
+	if autoscalerInternal.Spec().ApplyPolicy.Update != nil {
+		if autoscalerInternal.Spec().ApplyPolicy.Update.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy {
+			return datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy, "vertical scaling disabled due to update strategy set to disabled"
+		}
+
+		return autoscalerInternal.Spec().ApplyPolicy.Update.Strategy, ""
+	}
+
+	// No update strategy defined, defaulting to auto
+	return datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy, ""
+}
+
+// isRecommendationRolloutComplete checks if the current recommendation is entirely rolled out.
+// Returns true if all pods have the given recommendation ID.
+func isRecommendationRolloutComplete(recommendationID string, pods []*workloadmeta.KubernetesPod, podsPerRecommendationID map[string]int32) bool {
+	// currently basic check with 100% match expected.
+	// TODO: Refine the logic and add backoff for stuck PODs.
+	return podsPerRecommendationID[recommendationID] == int32(len(pods))
+}
+
+// isStatefulSetRolloutInProgress checks if a StatefulSet rollout is currently in progress
+// by examining the controller-revision-hash labels on pods. If pods have different revision
+// hashes, it indicates that Kubernetes is in the process of rolling out a new pod template.
+// This detects ANY ongoing rollout, not just ones triggered by us.
+func isStatefulSetRolloutInProgress(pods []*workloadmeta.KubernetesPod) bool {
+	if len(pods) <= 1 {
+		return false
+	}
+
+	var firstRevision string
+	for _, pod := range pods {
+		revision := pod.Labels[controllerRevisionHashLabel]
+		if revision == "" {
+			// Pod doesn't have the label yet, might be initializing
+			continue
+		}
+		if firstRevision == "" {
+			firstRevision = revision
+		} else if revision != firstRevision {
+			// Pods have different revisions - rollout in progress
+			return true
+		}
+	}
+	return false
+}
+
+// rolloutDecision represents the decision on whether to trigger a rollout
+type rolloutDecision int
+
+const (
+	// rolloutDecisionComplete indicates the rollout is complete (all pods have current recommendation)
+	rolloutDecisionComplete rolloutDecision = iota
+	// rolloutDecisionWait indicates we should wait (either already triggered or ongoing rollout without bypass)
+	rolloutDecisionWait
+	// rolloutDecisionTrigger indicates we should trigger a new rollout
+	rolloutDecisionTrigger
+)
+
+// shouldTriggerRollout determines whether a rollout should be triggered based on current state.
+// This function encapsulates the common decision logic used by all workload types:
+// 1. If all pods have the current recommendation, rollout is complete
+// 2. If we already triggered for this recommendation, wait for completion
+// 3. If there's an ongoing rollout:
+//   - Check if bypass is allowed (new recommendation increases limits)
+//   - Check rate limiting for bypass
+//
+// 4. Otherwise, trigger the rollout
+func shouldTriggerRollout(
+	recommendationID string,
+	pods []*workloadmeta.KubernetesPod,
+	podsPerRecommendationID map[string]int32,
+	lastAction *datadoghqcommon.DatadogPodAutoscalerVerticalAction,
+	rolloutInProgress bool,
+	recommendation *model.VerticalScalingValues,
+	currentTime time.Time,
+	minDelayBetweenRollouts time.Duration,
+	autoscalerID string,
+) rolloutDecision {
+	// Step 1: Check if rollout is complete for current recommendation
+	if isRecommendationRolloutComplete(recommendationID, pods, podsPerRecommendationID) {
+		return rolloutDecisionComplete
+	}
+
+	// Step 2: Check if we already triggered a rollout for THIS recommendation
+	if lastAction != nil && lastAction.Version == recommendationID {
+		log.Debugf("Rollout already triggered for recommendation %s on autoscaler %s, waiting for completion",
+			recommendationID, autoscalerID)
+		return rolloutDecisionWait
+	}
+
+	// Step 3: This is a NEW recommendation (different from what we last triggered)
+	// Check if there's an ongoing rollout from a previous recommendation
+	if rolloutInProgress {
+		// Check if the new recommendation increases limits - if so, we may bypass the rollout check
+		// to help recover from stuck rollouts caused by insufficient resources.
+		if hasLimitIncrease(recommendation, pods, recommendationID) {
+			// Apply rate limiting to prevent rollout thrashing from rapid new recommendations
+			if lastAction != nil && lastAction.Time.Add(minDelayBetweenRollouts).After(currentTime) {
+				log.Debugf("Rollout in progress for autoscaler: %s with new recommendation increasing limits, "+
+					"but last action was less than %s ago, waiting", autoscalerID, minDelayBetweenRollouts)
+				return rolloutDecisionWait
+			}
+			log.Infof("Rollout in progress for autoscaler: %s, but new recommendation increases limits - bypassing check to help recovery",
+				autoscalerID)
+			// Fall through to trigger rollout
+		} else {
+			log.Debugf("Rollout already ongoing for autoscaler: %s, waiting for completion before applying new recommendation",
+				autoscalerID)
+			return rolloutDecisionWait
+		}
+	}
+
+	// Step 4: No ongoing rollout (or bypassing due to limit increase) - trigger rollout
+	return rolloutDecisionTrigger
+}
+
+// hasLimitIncrease checks if the new recommendation increases any limit compared to existing patched pods.
+// It only compares against pods that have an OLD RecommendationIDAnnotation set (i.e., pods that were
+// previously patched but don't have the current recommendation). This is used to bypass the
+// rollout-in-progress check when a new recommendation would increase limits, which could help fix
+// a stuck rollout caused by insufficient resources.
+// Returns true if ANY container has a limit increase for CPU or Memory.
+// A limit is considered "increased" if:
+// - The new limit is higher than the current limit
+// - The pod has a limit but the recommendation removes it (no limit = unlimited)
+//
+// Performance: Uses early exit - returns as soon as any pod with lower limits is found.
+// Only processes pods with old recommendations (not already on current recommendation).
+func hasLimitIncrease(
+	recommendation *model.VerticalScalingValues,
+	pods []*workloadmeta.KubernetesPod,
+	currentRecommendationID string,
+) bool {
+	if recommendation == nil || len(recommendation.ContainerResources) == 0 {
+		return false
+	}
+
+	// recommendationLimits holds pre-computed limits from a recommendation for efficient comparison
+	type recommendationLimits struct {
+		cpuLimit    float64 // Percentage (100 = 1 core), 0 if not set
+		memoryLimit uint64  // Bytes, 0 if not set
+		hasCPU      bool    // true if recommendation specifies a CPU limit
+		hasMemory   bool    // true if recommendation specifies a memory limit
+	}
+
+	// Pre-compute recommendation limits once
+	// We store ALL containers from the recommendation, even those without limits,
+	// so we can detect when a limit is being removed (pod has limit, reco doesn't)
+	recoLimits := make(map[string]recommendationLimits, len(recommendation.ContainerResources))
+	for _, recoContainer := range recommendation.ContainerResources {
+		limits := recommendationLimits{}
+		if cpuLimit := recoContainer.Limits.Cpu(); cpuLimit != nil && !cpuLimit.IsZero() {
+			limits.cpuLimit = cpuLimit.AsApproximateFloat64() * 100 // Convert to percentage
+			limits.hasCPU = true
+		}
+		if memLimit := recoContainer.Limits.Memory(); memLimit != nil && !memLimit.IsZero() {
+			limits.memoryLimit = uint64(memLimit.Value())
+			limits.hasMemory = true
+		}
+		recoLimits[recoContainer.Name] = limits
+	}
+
+	// Check each pod - early exit as soon as we find any limit increase
+	for _, pod := range pods {
+		podRecoID := pod.Annotations[model.RecommendationIDAnnotation]
+		// Skip pods without recommendation annotation (never patched)
+		// Skip pods already on current recommendation (already have new limits)
+		if podRecoID == "" || podRecoID == currentRecommendationID {
+			continue
+		}
+
+		// Check each container in this pod
+		for _, container := range pod.Containers {
+			reco, ok := recoLimits[container.Name]
+			if !ok {
+				continue
+			}
+
+			// Case 1: Recommendation has higher CPU limit than pod
+			if reco.hasCPU && container.Resources.CPULimit != nil && reco.cpuLimit > *container.Resources.CPULimit {
+				return true
+			}
+
+			// Case 2: Recommendation removes CPU limit (pod has limit, reco doesn't)
+			// No limit = unlimited, which is greater than any finite limit
+			if !reco.hasCPU && container.Resources.CPULimit != nil {
+				return true
+			}
+
+			// Case 3: Recommendation has higher Memory limit than pod
+			if reco.hasMemory && container.Resources.MemoryLimit != nil && reco.memoryLimit > *container.Resources.MemoryLimit {
+				return true
+			}
+
+			// Case 4: Recommendation removes Memory limit (pod has limit, reco doesn't)
+			if !reco.hasMemory && container.Resources.MemoryLimit != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
@@ -1,0 +1,593 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package workload
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+)
+
+func TestHasLimitIncrease_CPUIncrease(t *testing.T) {
+	// Pod with current CPU limit of 500m (50% in workloadmeta format)
+	cpuLimit := float64(50)
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit: &cpuLimit,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation with higher CPU limit (800m)
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
+			},
+		},
+	}
+
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_MemoryIncrease(t *testing.T) {
+	// Pod with current memory limit of 512Mi
+	memLimit := uint64(512 * 1024 * 1024)
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						MemoryLimit: &memLimit,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation with higher memory limit (1Gi)
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"memory": resource.MustParse("1Gi")},
+			},
+		},
+	}
+
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_NoIncrease(t *testing.T) {
+	// Pod with current CPU limit of 1000m (100%)
+	cpuLimit := float64(100)
+	memLimit := uint64(1024 * 1024 * 1024) // 1Gi
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit:    &cpuLimit,
+						MemoryLimit: &memLimit,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation with lower limits
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("500m"), "memory": resource.MustParse("512Mi")},
+			},
+		},
+	}
+
+	assert.False(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_NoPatchedPods(t *testing.T) {
+	// Pods without RecommendationIDAnnotation should be ignored
+	cpuLimit := float64(50)
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Namespace:   "default",
+				Annotations: map[string]string{}, // No RecommendationIDAnnotation
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit: &cpuLimit,
+					},
+				},
+			},
+		},
+	}
+
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
+			},
+		},
+	}
+
+	// Should return false since there are no patched pods to compare with
+	assert.False(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_SkipsPodsWithCurrentRecommendation(t *testing.T) {
+	// Pod-1 has old recommendation with low limit - should be checked
+	// Pod-2 has current recommendation - should be skipped
+	cpuLimit1 := float64(50)  // 500m
+	cpuLimit2 := float64(100) // 1000m
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit: &cpuLimit1,
+					},
+				},
+			},
+		},
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-2",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "new-rec-456", // Already on current recommendation
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit: &cpuLimit2,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation with 700m - higher than pod-1's 500m limit
+	// Pod-2 is skipped because it already has current recommendation
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("700m")},
+			},
+		},
+	}
+
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_AllPodsOnCurrentRecommendation(t *testing.T) {
+	// All pods already have current recommendation - should return false
+	cpuLimit := float64(50) // 500m
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "current-rec",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit: &cpuLimit,
+					},
+				},
+			},
+		},
+	}
+
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
+			},
+		},
+	}
+
+	// Should return false since all pods are already on current recommendation
+	assert.False(t, hasLimitIncrease(recommendation, pods, "current-rec"))
+}
+
+func TestHasLimitIncrease_LimitRemovedIsIncrease(t *testing.T) {
+	// Pod has a limit, but recommendation removes it (no limit = unlimited)
+	// This should be treated as an increase
+	cpuLimit := float64(50) // 500m
+	memLimit := uint64(512 * 1024 * 1024)
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit:    &cpuLimit,
+						MemoryLimit: &memLimit,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation with only requests, no limits
+	// This means limits are being removed (unlimited)
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:     "container-1",
+				Requests: corev1.ResourceList{"cpu": resource.MustParse("250m"), "memory": resource.MustParse("256Mi")},
+				// No Limits specified - this removes the limit
+			},
+		},
+	}
+
+	// Should return true since removing a limit is effectively increasing it to unlimited
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+func TestHasLimitIncrease_OnlyCPULimitRemoved(t *testing.T) {
+	// Pod has CPU limit, recommendation removes only CPU limit but keeps memory limit
+	cpuLimit := float64(50) // 500m
+	memLimit := uint64(512 * 1024 * 1024)
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Annotations: map[string]string{
+					model.RecommendationIDAnnotation: "old-rec-123",
+				},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name: "container-1",
+					Resources: workloadmeta.ContainerResources{
+						CPULimit:    &cpuLimit,
+						MemoryLimit: &memLimit,
+					},
+				},
+			},
+		},
+	}
+
+	// Recommendation keeps memory limit but removes CPU limit
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"memory": resource.MustParse("512Mi")}, // Only memory, no CPU limit
+			},
+		},
+	}
+
+	// Should return true since CPU limit is being removed
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+}
+
+// Tests for shouldTriggerRollout
+
+func TestShouldTriggerRollout_Complete(t *testing.T) {
+	recommendationID := "rec-123"
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: recommendationID},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{recommendationID: 1}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		nil,   // no last action
+		false, // no rollout in progress
+		nil,   // no recommendation needed for complete check
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionComplete, decision)
+}
+
+func TestShouldTriggerRollout_AlreadyTriggered(t *testing.T) {
+	recommendationID := "rec-123"
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
+
+	// Last action was for THIS recommendation
+	lastAction := &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
+		Time:    metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+		Version: recommendationID,
+	}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		lastAction,
+		false, // no rollout in progress
+		nil,
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionWait, decision)
+}
+
+func TestShouldTriggerRollout_NewRecommendationNoRollout(t *testing.T) {
+	recommendationID := "rec-new"
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
+
+	// Last action was for a DIFFERENT recommendation
+	lastAction := &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
+		Time:    metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+		Version: "old-rec",
+	}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		lastAction,
+		false, // no rollout in progress
+		nil,
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionTrigger, decision)
+}
+
+func TestShouldTriggerRollout_OngoingRolloutNoBypass(t *testing.T) {
+	recommendationID := "rec-new"
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
+
+	// No limit increase (empty recommendation)
+	recommendation := &model.VerticalScalingValues{}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		nil,
+		true, // rollout in progress
+		recommendation,
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionWait, decision)
+}
+
+func TestShouldTriggerRollout_BypassAllowed(t *testing.T) {
+	recommendationID := "rec-new"
+	cpuLimit := float64(25) // 250m
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name:      "container-1",
+					Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit},
+				},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
+
+	// Recommendation with higher CPU limit
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("500m")},
+			},
+		},
+	}
+
+	// Last action was 10 minutes ago (outside rate limit)
+	lastAction := &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
+		Time:    metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+		Version: "old-rec",
+	}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		lastAction,
+		true, // rollout in progress
+		recommendation,
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionTrigger, decision)
+}
+
+func TestShouldTriggerRollout_BypassRateLimited(t *testing.T) {
+	recommendationID := "rec-new"
+	cpuLimit := float64(25) // 250m
+	currentTime := time.Now()
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{
+					Name:      "container-1",
+					Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit},
+				},
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
+
+	// Recommendation with higher CPU limit
+	recommendation := &model.VerticalScalingValues{
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:   "container-1",
+				Limits: corev1.ResourceList{"cpu": resource.MustParse("500m")},
+			},
+		},
+	}
+
+	// Last action was 2 minutes ago (within rate limit of 5 mins)
+	lastAction := &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
+		Time:    metav1.NewTime(currentTime.Add(-2 * time.Minute)),
+		Version: "old-rec",
+	}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		lastAction,
+		true, // rollout in progress
+		recommendation,
+		currentTime,
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionWait, decision)
+}
+
+func TestShouldTriggerRollout_FirstTriggerNoLastAction(t *testing.T) {
+	recommendationID := "rec-new"
+	pods := []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        "pod-1",
+				Annotations: map[string]string{}, // no recommendation annotation
+			},
+		},
+	}
+	podsPerRecommendationID := map[string]int32{"": 1, recommendationID: 0}
+
+	decision := shouldTriggerRollout(
+		recommendationID,
+		pods,
+		podsPerRecommendationID,
+		nil,   // no last action (first time)
+		false, // no rollout in progress
+		nil,
+		time.Now(),
+		5*time.Minute,
+		"test-autoscaler",
+	)
+
+	assert.Equal(t, rolloutDecisionTrigger, decision)
+}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_progress.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_progress.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package workload
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// rolloutStallTimeout is the duration after which a rollout is considered stalled if no pods have moved
+	// TODO: We should probably read the Rollout strategy to know what's the acceptable limit.
+	rolloutStallTimeout = 60 * time.Minute
+)
+
+// rolloutProgressEntry tracks the progress of a rollout for stall detection
+type rolloutProgressEntry struct {
+	recommendationID string
+	podCount         int32
+	lastMovementTime time.Time
+}
+
+// rolloutProgressTracker tracks rollout progress per autoscaler for stall detection.
+// It monitors pod counts to detect when a rollout has stalled (no pod movement for too long).
+type rolloutProgressTracker struct {
+	mu      sync.Mutex
+	entries map[string]rolloutProgressEntry
+}
+
+// newRolloutProgressTracker creates a new rolloutProgressTracker
+func newRolloutProgressTracker() *rolloutProgressTracker {
+	return &rolloutProgressTracker{
+		entries: make(map[string]rolloutProgressEntry),
+	}
+}
+
+// Update updates the progress for an autoscaler and returns whether the rollout is stalled.
+// A rollout is considered stalled if the pod count hasn't increased for rolloutStallTimeout.
+// This should be called during sync when pod counts are fetched.
+func (r *rolloutProgressTracker) Update(autoscalerID, recommendationID string, podCount int32, currentTime time.Time) (stalled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	entry, exists := r.entries[autoscalerID]
+	if !exists || entry.recommendationID != recommendationID {
+		// First time tracking this recommendation or new recommendation
+		r.entries[autoscalerID] = rolloutProgressEntry{
+			recommendationID: recommendationID,
+			podCount:         podCount,
+			lastMovementTime: currentTime,
+		}
+		return false
+	}
+
+	// Check if there's been progress (pod count increased)
+	if podCount > entry.podCount {
+		entry.podCount = podCount
+		entry.lastMovementTime = currentTime
+		r.entries[autoscalerID] = entry
+		return false
+	}
+
+	// Check if we've been waiting too long without progress
+	return currentTime.Sub(entry.lastMovementTime) >= rolloutStallTimeout
+}
+
+// Clear removes the progress entry for an autoscaler when rollout is complete
+func (r *rolloutProgressTracker) Clear(autoscalerID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.entries, autoscalerID)
+}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_progress_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_progress_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && test
+
+package workload
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgressTrackerUpdateFirstCall(t *testing.T) {
+	tr := newRolloutProgressTracker()
+	assert.False(t, tr.Update("id", "r1", 1, time.Now()))
+	assert.Equal(t, int32(1), tr.entries["id"].podCount)
+}
+
+func TestProgressTrackerUpdateWithProgress(t *testing.T) {
+	now := time.Now()
+	tr := newRolloutProgressTracker()
+	tr.Update("id", "r1", 1, now)
+	assert.False(t, tr.Update("id", "r1", 2, now.Add(61*time.Minute)))
+	assert.Equal(t, int32(2), tr.entries["id"].podCount)
+}
+
+func TestProgressTrackerUpdateNoProgress(t *testing.T) {
+	now := time.Now()
+	tr := newRolloutProgressTracker()
+	tr.Update("id", "r1", 1, now)
+	assert.True(t, tr.Update("id", "r1", 1, now.Add(61*time.Minute)))
+}
+
+func TestProgressTrackerUpdateDifferentRecommendation(t *testing.T) {
+	now := time.Now()
+	tr := newRolloutProgressTracker()
+	tr.Update("id", "old", 2, now)
+	assert.False(t, tr.Update("id", "new", 0, now.Add(61*time.Minute)))
+	assert.Equal(t, "new", tr.entries["id"].recommendationID)
+}
+
+func TestProgressTrackerClear(t *testing.T) {
+	tr := newRolloutProgressTracker()
+	tr.Update("id", "r1", 1, time.Now())
+	tr.Clear("id")
+	assert.Empty(t, tr.entries)
+}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,1087 +40,459 @@ import (
 type verticalControllerFixture struct {
 	t             *testing.T
 	clock         *clock.FakeClock
-	recorder      *record.FakeRecorder
 	dynamicClient *dynamicfake.FakeDynamicClient
-	podWatcher    *fakePodWatcher
 	controller    *verticalController
 }
 
 func newVerticalControllerFixture(t *testing.T, testTime time.Time) *verticalControllerFixture {
 	fakeClock := clock.NewFakeClock(testTime)
-	recorder := record.NewFakeRecorder(100)
-	scheme := runtime.NewScheme()
-	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme)
-	podWatcher := &fakePodWatcher{}
-
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 	return &verticalControllerFixture{
 		t:             t,
 		clock:         fakeClock,
-		recorder:      recorder,
 		dynamicClient: dynamicClient,
-		podWatcher:    podWatcher,
 		controller: &verticalController{
-			clock:         fakeClock,
-			eventRecorder: recorder,
-			dynamicClient: dynamicClient,
+			clock:           fakeClock,
+			eventRecorder:   record.NewFakeRecorder(100),
+			dynamicClient:   dynamicClient,
+			progressTracker: newRolloutProgressTracker(),
 		},
 	}
 }
 
-func TestSyncDeploymentKind_AllPodsUpdated(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
+type verticalTestArgs struct {
+	targetKind       string
+	targetName       string
+	recommendationID string
 
-	autoscalerNamespace := "default"
-	autoscalerName := "test-deployment-autoscaler"
-	deploymentName := "test-deployment"
-	replicaSetName := "test-deployment-abc123"
-	recommendationID := "rec-123"
+	pods                    []*workloadmeta.KubernetesPod
+	podsPerRecommendationID map[string]int32
+	podsPerDirectOwner      map[string]int32 // For Deployments only
 
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.DeploymentKind,
+	lastAction    *datadoghqcommon.DatadogPodAutoscalerVerticalAction
+	scalingValues *model.VerticalScalingValues
+
+	// Control flags
+	createTarget bool
+	patchError   bool
+
+	// Expectations
+	expectPatch         bool
+	expectError         bool
+	expectActionSet     bool
+	expectActionCleared bool
+}
+
+func (f *verticalControllerFixture) runSync(args verticalTestArgs) {
+	f.t.Helper()
+	ns := "default"
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: args.targetKind}
+	resourceName := strings.ToLower(args.targetKind) + "s"
+
+	if args.createTarget {
+		f.createTarget(ns, args.targetName, args.targetKind)
 	}
 
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
+	// Setup patch reactor
+	patchCalled := false
+	if args.patchError || args.expectPatch {
+		var patchErr error
+		if args.patchError {
+			patchErr = assert.AnError
+		}
+		f.controller.dynamicClient.(*dynamicfake.FakeDynamicClient).PrependReactor(
+			"patch", resourceName, func(action k8stesting.Action) (bool, runtime.Object, error) {
+				patchCalled = true
+				if patchErr != nil {
+					return true, nil, patchErr
+				}
+				pa := action.(k8stesting.PatchAction)
+				return true, &unstructured.Unstructured{Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       args.targetKind,
+					"metadata":   map[string]interface{}{"name": pa.GetName(), "namespace": pa.GetNamespace()},
+				}}, nil
+			})
+	}
+
+	// Build autoscaler internal
+	pai := &model.FakePodAutoscalerInternal{
+		Namespace:          ns,
+		Name:               args.targetName + "-autoscaler",
+		TargetGVK:          gvk,
+		CurrentReplicas:    pointer.Ptr[int32](3),
+		VerticalLastAction: args.lastAction,
 		Spec: &datadoghq.DatadogPodAutoscalerSpec{
 			TargetRef: v2.CrossVersionObjectReference{
-				Name:       deploymentName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
-		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// All pods have the recommendation ID - rollout complete
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-2",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-3",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
+				Name:       args.targetName,
+				Kind:       gvk.Kind,
+				APIVersion: "apps/v1",
 			},
 		},
 	}
-
-	podsPerRecomendationID := map[string]int32{
-		recommendationID: 3,
+	if args.scalingValues != nil {
+		pai.ScalingValues = model.ScalingValues{Vertical: args.scalingValues}
 	}
 
-	// All pods owned by the same ReplicaSet
-	podsPerDirectOwner := map[string]int32{
-		replicaSetName: 3,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.DeploymentKind,
-		Name:      deploymentName,
-	}
-
-	autoscalerInternal := fakePai.Build()
+	autoscalerInternal := pai.Build()
 	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: pai.Name, Namespace: ns},
+	}
+	target := NamespacedPodOwner{Namespace: ns, Kind: args.targetKind, Name: args.targetName}
+
+	// Execute sync based on target kind
+	var result autoscaling.ProcessResult
+	var err error
+	switch args.targetKind {
+	case kubernetes.DeploymentKind:
+		result, err = f.controller.syncDeploymentKind(
+			context.Background(), fakeAutoscaler, &autoscalerInternal, target, gvk,
+			args.recommendationID, args.pods, args.podsPerRecommendationID, args.podsPerDirectOwner,
+		)
+	case kubernetes.StatefulSetKind:
+		result, err = f.controller.syncStatefulSetKind(
+			context.Background(), fakeAutoscaler, &autoscalerInternal, target, gvk,
+			args.recommendationID, args.pods, args.podsPerRecommendationID,
+		)
 	}
 
-	result, err := f.controller.syncDeploymentKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-		podsPerDirectOwner,
-	)
+	// Verify expectations
+	if args.expectError {
+		assert.Error(f.t, err)
+	} else {
+		assert.NoError(f.t, err)
+	}
+	assert.Equal(f.t, args.expectPatch, patchCalled, "patch call mismatch")
 
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	// Vertical action should be cleared (nil, nil) on success
-	assert.Nil(t, autoscalerInternal.VerticalLastAction())
-	assert.Nil(t, autoscalerInternal.VerticalLastActionError())
+	if args.expectActionSet {
+		assert.NotNil(f.t, autoscalerInternal.VerticalLastAction())
+		assert.Equal(f.t, args.recommendationID, autoscalerInternal.VerticalLastAction().Version)
+	}
+	if args.expectActionCleared {
+		assert.Nil(f.t, autoscalerInternal.VerticalLastAction())
+	}
+
+	_ = result // Result is validated implicitly via expectError/expectPatch
 }
 
-func TestSyncDeploymentKind_RolloutInProgress(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-deployment-autoscaler"
-	deploymentName := "test-deployment"
-	oldReplicaSetName := "test-deployment-old123"
-	newReplicaSetName := "test-deployment-new456"
-	recommendationID := "rec-123"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.DeploymentKind,
-	}
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       deploymentName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
+func (f *verticalControllerFixture) createTarget(ns, name, kind string) {
+	var obj *unstructured.Unstructured
+	var gvr schema.GroupVersionResource
+	switch kind {
+	case kubernetes.DeploymentKind:
+		obj, _ = autoscaling.ToUnstructured(&appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Ptr(int32(3)),
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
 			},
-		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// Pods from two different ReplicaSets - rollout in progress
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-old-1",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
+		})
+		gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	case kubernetes.StatefulSetKind:
+		obj, _ = autoscaling.ToUnstructured(&appsv1.StatefulSet{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: pointer.Ptr(int32(3)),
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}},
 			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: oldReplicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-new-1",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: newReplicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-new-2",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: newReplicaSetName},
-			},
-		},
+		})
+		gvr = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
 	}
-
-	podsPerRecomendationID := map[string]int32{
-		"old-rec":        1,
-		recommendationID: 2,
-	}
-
-	// Pods from two different ReplicaSets - indicates rollout in progress
-	podsPerDirectOwner := map[string]int32{
-		oldReplicaSetName: 1,
-		newReplicaSetName: 2,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.DeploymentKind,
-		Name:      deploymentName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	result, err := f.controller.syncDeploymentKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-		podsPerDirectOwner,
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, result)
+	_, _ = f.controller.dynamicClient.Resource(gvr).Namespace(ns).Create(context.Background(), obj, metav1.CreateOptions{})
 }
 
-func TestSyncDeploymentKind_TriggerRollout(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-deployment-autoscaler"
-	deploymentName := "test-deployment"
-	replicaSetName := "test-deployment-abc123"
-	recommendationID := "rec-123"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.DeploymentKind,
+// Pod builders
+func pod(name, recID, ownerKind, owner string) *workloadmeta.KubernetesPod {
+	return &workloadmeta.KubernetesPod{
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: name, Namespace: "default",
+			Annotations: map[string]string{model.RecommendationIDAnnotation: recID},
+		},
+		Owners: []workloadmeta.KubernetesPodOwner{{Kind: ownerKind, Name: owner, ID: owner}},
 	}
+}
 
-	// Create a fake Deployment in the dynamic client
-	deployment, err := autoscaling.ToUnstructured(&appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
+func podWithRev(name, recID, ownerKind, owner, rev string) *workloadmeta.KubernetesPod {
+	p := pod(name, recID, ownerKind, owner)
+	p.Labels = map[string]string{controllerRevisionHashLabel: rev}
+	return p
+}
+
+func podWithLimit(name, recID, ownerKind, owner string, cpu float64) *workloadmeta.KubernetesPod {
+	p := pod(name, recID, ownerKind, owner)
+	p.Containers = []workloadmeta.OrchestratorContainer{{Name: "c1", Resources: workloadmeta.ContainerResources{CPULimit: &cpu}}}
+	return p
+}
+
+func podWithRevLimit(name, recID, ownerKind, owner, rev string, cpu float64) *workloadmeta.KubernetesPod {
+	p := podWithRev(name, recID, ownerKind, owner, rev)
+	p.Containers = []workloadmeta.OrchestratorContainer{{Name: "c1", Resources: workloadmeta.ContainerResources{CPULimit: &cpu}}}
+	return p
+}
+
+func scalingVal(recID string, cpuLimit string) *model.VerticalScalingValues {
+	return &model.VerticalScalingValues{
+		ResourcesHash: recID,
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{Name: "c1", Limits: corev1.ResourceList{"cpu": resource.MustParse(cpuLimit)}},
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      deploymentName,
-			Namespace: autoscalerNamespace,
+	}
+}
+
+func lastAction(t time.Time, version string) *datadoghqcommon.DatadogPodAutoscalerVerticalAction {
+	return &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
+		Time: metav1.NewTime(t), Version: version, Type: datadoghqcommon.DatadogPodAutoscalerRolloutTriggeredVerticalActionType,
+	}
+}
+
+// Deployment tests
+
+func TestDeploymentSyncAllPodsUpdated(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			pod("p1", "r1", kubernetes.ReplicaSetKind, "rs1"),
+			pod("p2", "r1", kubernetes.ReplicaSetKind, "rs1"),
 		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: pointer.Ptr(int32(3)),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-		},
+		podsPerRecommendationID: map[string]int32{"r1": 2},
+		podsPerDirectOwner:      map[string]int32{"rs1": 2},
+		expectActionCleared:     true,
 	})
-	assert.NoError(t, err)
-
-	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
-	_, err = f.dynamicClient.Resource(gvr).Namespace(autoscalerNamespace).Create(context.Background(), deployment, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       deploymentName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
-		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// No pods have the new recommendation ID - need to trigger rollout
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-2",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-3",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		"old-rec":        3,
-		recommendationID: 0,
-	}
-
-	// All pods from the same ReplicaSet - no rollout in progress
-	podsPerDirectOwner := map[string]int32{
-		replicaSetName: 3,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.DeploymentKind,
-		Name:      deploymentName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	result, err := f.controller.syncDeploymentKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-		podsPerDirectOwner,
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, result)
-
-	// Verify vertical action was recorded
-	assert.NotNil(t, autoscalerInternal.VerticalLastAction())
-	assert.Equal(t, recommendationID, autoscalerInternal.VerticalLastAction().Version)
-	assert.Equal(t, datadoghqcommon.DatadogPodAutoscalerRolloutTriggeredVerticalActionType, autoscalerInternal.VerticalLastAction().Type)
-
-	// Verify the Deployment was patched
-	updatedDeployment, err := f.dynamicClient.Resource(gvr).Namespace(autoscalerNamespace).Get(context.Background(), deploymentName, metav1.GetOptions{})
-	assert.NoError(t, err)
-
-	annotations, found, err := unstructured.NestedStringMap(updatedDeployment.Object, "spec", "template", "metadata", "annotations")
-	assert.NoError(t, err)
-	assert.True(t, found)
-	assert.Equal(t, recommendationID, annotations[model.RecommendationIDAnnotation])
-	assert.NotEmpty(t, annotations[model.RolloutTimestampAnnotation])
 }
 
-func TestSyncDeploymentKind_PatchError(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-deployment-autoscaler"
-	deploymentName := "nonexistent-deployment"
-	replicaSetName := "nonexistent-deployment-abc123"
-	recommendationID := "rec-123"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.DeploymentKind,
-	}
-
-	// Don't create the Deployment in the dynamic client - patch will fail
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       deploymentName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
+func TestDeploymentSyncRolloutInProgress(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			pod("p1", "old", kubernetes.ReplicaSetKind, "rs1"),
+			pod("p2", "r1", kubernetes.ReplicaSetKind, "rs2"),
 		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: autoscalerNamespace,
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.ReplicaSetKind, Name: replicaSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		recommendationID: 0,
-	}
-
-	podsPerDirectOwner := map[string]int32{
-		replicaSetName: 1,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.DeploymentKind,
-		Name:      deploymentName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	// Add a reactor that returns an error for patch operations
-	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, assert.AnError
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 1},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1, "rs2": 1},
 	})
-
-	result, err := f.controller.syncDeploymentKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-		podsPerDirectOwner,
-	)
-
-	assert.Error(t, err)
-	assert.Equal(t, autoscaling.Requeue, result)
-	assert.NotNil(t, autoscalerInternal.VerticalLastActionError())
 }
 
-func TestSyncStatefulSetKind_AllPodsUpdated(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-statefulset-autoscaler"
-	statefulSetName := "test-statefulset"
-	recommendationID := "rec-123"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.StatefulSetKind,
-	}
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       statefulSetName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
+func TestDeploymentSyncTriggerRollout(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		createTarget:     true,
+		pods: []*workloadmeta.KubernetesPod{
+			pod("p1", "old", kubernetes.ReplicaSetKind, "rs1"),
 		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// All pods have the recommendation ID - rollout complete
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-0",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-1",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-2",
-				Namespace: autoscalerNamespace,
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		recommendationID: 3,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.StatefulSetKind,
-		Name:      statefulSetName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	result, err := f.controller.syncStatefulSetKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	// Vertical action should be cleared (nil, nil) on success
-	assert.Nil(t, autoscalerInternal.VerticalLastAction())
-	assert.Nil(t, autoscalerInternal.VerticalLastActionError())
-}
-
-func TestSyncStatefulSetKind_RolloutInProgress(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-statefulset-autoscaler"
-	statefulSetName := "test-statefulset"
-	recommendationID := "rec-123"
-	oldRevision := "test-statefulset-rev1"
-	newRevision := "test-statefulset-rev2"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.StatefulSetKind,
-	}
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       statefulSetName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
-		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// Pods have different controller-revision-hash labels - rollout in progress
-	// StatefulSets update pods in reverse ordinal order, so pod-2 is updated first
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-0",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: oldRevision,
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-1",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: oldRevision,
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-2",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: newRevision, // Updated pod
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: recommendationID,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		"old-rec":        2,
-		recommendationID: 1, // Partial update
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.StatefulSetKind,
-		Name:      statefulSetName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	result, err := f.controller.syncStatefulSetKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, result)
-}
-
-func TestSyncStatefulSetKind_TriggerRollout(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-statefulset-autoscaler"
-	statefulSetName := "test-statefulset"
-	recommendationID := "rec-123"
-	currentRevision := "test-statefulset-rev1"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.StatefulSetKind,
-	}
-
-	// Create a fake StatefulSet in the dynamic client
-	statefulSet, err := autoscaling.ToUnstructured(&appsv1.StatefulSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "StatefulSet",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      statefulSetName,
-			Namespace: autoscalerNamespace,
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas: pointer.Ptr(int32(3)),
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{},
-				},
-			},
-		},
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 0},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1},
+		expectPatch:             true,
+		expectActionSet:         true,
 	})
-	assert.NoError(t, err)
-
-	gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
-	_, err = f.dynamicClient.Resource(gvr).Namespace(autoscalerNamespace).Create(context.Background(), statefulSet, metav1.CreateOptions{})
-	assert.NoError(t, err)
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       statefulSetName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
-		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// No pods have the new recommendation ID - need to trigger rollout
-	// All pods have the same controller-revision-hash - no rollout in progress
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-0",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: currentRevision,
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-1",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: currentRevision,
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-2",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: currentRevision,
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec",
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		"old-rec":        3,
-		recommendationID: 0, // No pods have the new recommendation
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.StatefulSetKind,
-		Name:      statefulSetName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	result, err := f.controller.syncStatefulSetKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, result)
-
-	// Verify vertical action was recorded
-	assert.NotNil(t, autoscalerInternal.VerticalLastAction())
-	assert.Equal(t, recommendationID, autoscalerInternal.VerticalLastAction().Version)
-	assert.Equal(t, datadoghqcommon.DatadogPodAutoscalerRolloutTriggeredVerticalActionType, autoscalerInternal.VerticalLastAction().Type)
-
-	// Verify the StatefulSet was patched
-	updatedSts, err := f.dynamicClient.Resource(gvr).Namespace(autoscalerNamespace).Get(context.Background(), statefulSetName, metav1.GetOptions{})
-	assert.NoError(t, err)
-
-	annotations, found, err := unstructured.NestedStringMap(updatedSts.Object, "spec", "template", "metadata", "annotations")
-	assert.NoError(t, err)
-	assert.True(t, found)
-	assert.Equal(t, recommendationID, annotations[model.RecommendationIDAnnotation])
-	assert.NotEmpty(t, annotations[model.RolloutTimestampAnnotation])
 }
 
-func TestSyncStatefulSetKind_PatchError(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-statefulset-autoscaler"
-	statefulSetName := "nonexistent-statefulset"
-	recommendationID := "rec-123"
-	currentRevision := "nonexistent-statefulset-rev1"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.StatefulSetKind,
-	}
-
-	// Don't create the StatefulSet in the dynamic client - patch will fail
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       statefulSetName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
+func TestDeploymentSyncPatchError(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			pod("p1", "", kubernetes.ReplicaSetKind, "rs1"),
 		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
-
-	// All pods have the same controller-revision-hash - no rollout in progress
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-0",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: currentRevision,
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
-		},
-	}
-
-	podsPerRecomendationID := map[string]int32{
-		recommendationID: 0,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.StatefulSetKind,
-		Name:      statefulSetName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
-		},
-	}
-
-	// Add a reactor that returns an error for patch operations
-	f.dynamicClient.PrependReactor("patch", "statefulsets", func(_ k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, assert.AnError
+		podsPerRecommendationID: map[string]int32{"r1": 0},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1},
+		patchError:              true,
+		expectPatch:             true,
+		expectError:             true,
 	})
-
-	result, err := f.controller.syncStatefulSetKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-	)
-
-	assert.Error(t, err)
-	assert.Equal(t, autoscaling.Requeue, result)
-	assert.NotNil(t, autoscalerInternal.VerticalLastActionError())
 }
 
-// TestSyncStatefulSetKind_ExternalRolloutInProgress tests that we correctly detect
-// rollouts triggered by external changes (e.g., image updates) by checking
-// controller-revision-hash labels, even when all pods have the same recommendation ID.
-func TestSyncStatefulSetKind_ExternalRolloutInProgress(t *testing.T) {
-	testTime := time.Now()
-	f := newVerticalControllerFixture(t, testTime)
-
-	autoscalerNamespace := "default"
-	autoscalerName := "test-statefulset-autoscaler"
-	statefulSetName := "test-statefulset"
-	recommendationID := "rec-123"
-	oldRevision := "test-statefulset-rev1"
-	newRevision := "test-statefulset-rev2"
-
-	expectedGVK := schema.GroupVersionKind{
-		Group:   "apps",
-		Version: "v1",
-		Kind:    kubernetes.StatefulSetKind,
-	}
-
-	fakePai := &model.FakePodAutoscalerInternal{
-		Namespace: autoscalerNamespace,
-		Name:      autoscalerName,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{
-				Name:       statefulSetName,
-				Kind:       expectedGVK.Kind,
-				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
-			},
+func TestDeploymentSyncAlreadyTriggeredWaits(t *testing.T) {
+	now := time.Now()
+	f := newVerticalControllerFixture(t, now)
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			pod("p1", "old", kubernetes.ReplicaSetKind, "rs1"),
+			pod("p2", "r1", kubernetes.ReplicaSetKind, "rs2"),
 		},
-		TargetGVK:       expectedGVK,
-		CurrentReplicas: pointer.Ptr[int32](3),
-	}
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 1},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1, "rs2": 1},
+		lastAction:              lastAction(now.Add(-time.Minute), "r1"),
+	})
+}
 
-	// Scenario: Someone updated the StatefulSet image (external change).
-	// All pods still have the OLD recommendation ID (inherited from template),
-	// but they have DIFFERENT controller-revision-hash labels because a rollout is in progress.
-	// Without checking controller-revision-hash, we would try to trigger another rollout
-	// which would interfere with the ongoing one.
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-0",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: oldRevision, // Old revision
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec", // Same recommendation
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
+func TestDeploymentSyncBypassOnLimitIncrease(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		createTarget:     true,
+		pods: []*workloadmeta.KubernetesPod{
+			podWithLimit("p1", "old", kubernetes.ReplicaSetKind, "rs1", 25),
+			podWithLimit("p2", "old", kubernetes.ReplicaSetKind, "rs2", 25),
 		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-1",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: oldRevision, // Old revision
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec", // Same recommendation
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
+		podsPerRecommendationID: map[string]int32{"old": 2, "r1": 0},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1, "rs2": 1},
+		scalingValues:           scalingVal("r1", "500m"),
+		expectPatch:             true,
+		expectActionSet:         true,
+	})
+}
+
+func TestDeploymentSyncBypassRateLimited(t *testing.T) {
+	now := time.Now()
+	f := newVerticalControllerFixture(t, now)
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.DeploymentKind,
+		targetName:       "d1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithLimit("p1", "old", kubernetes.ReplicaSetKind, "rs1", 25),
+			podWithLimit("p2", "old", kubernetes.ReplicaSetKind, "rs2", 25),
 		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      statefulSetName + "-2",
-				Namespace: autoscalerNamespace,
-				Labels: map[string]string{
-					controllerRevisionHashLabel: newRevision, // New revision - external rollout in progress!
-				},
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec", // Still has old recommendation
-				},
-			},
-			Owners: []workloadmeta.KubernetesPodOwner{
-				{Kind: kubernetes.StatefulSetKind, Name: statefulSetName},
-			},
+		podsPerRecommendationID: map[string]int32{"old": 2, "r1": 0},
+		podsPerDirectOwner:      map[string]int32{"rs1": 1, "rs2": 1},
+		lastAction:              lastAction(now.Add(-2*time.Minute), "old"),
+		scalingValues:           scalingVal("r1", "500m"),
+	})
+}
+
+// StatefulSet tests
+
+func TestStatefulSetSyncAllPodsUpdated(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			pod("s1-0", "r1", kubernetes.StatefulSetKind, "s1"),
+			pod("s1-1", "r1", kubernetes.StatefulSetKind, "s1"),
 		},
-	}
+		podsPerRecommendationID: map[string]int32{"r1": 2},
+		expectActionCleared:     true,
+	})
+}
 
-	// All pods have the OLD recommendation ID - without controller-revision-hash check,
-	// we would think we need to trigger a rollout
-	podsPerRecomendationID := map[string]int32{
-		"old-rec":        3,
-		recommendationID: 0,
-	}
-
-	target := NamespacedPodOwner{
-		Namespace: autoscalerNamespace,
-		Kind:      kubernetes.StatefulSetKind,
-		Name:      statefulSetName,
-	}
-
-	autoscalerInternal := fakePai.Build()
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      autoscalerName,
-			Namespace: autoscalerNamespace,
+func TestStatefulSetSyncRolloutInProgress(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRev("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1"),
+			podWithRev("s1-1", "r1", kubernetes.StatefulSetKind, "s1", "v2"),
 		},
-	}
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 1},
+	})
+}
 
-	result, err := f.controller.syncStatefulSetKind(
-		context.Background(),
-		fakeAutoscaler,
-		&autoscalerInternal,
-		datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
-		target,
-		expectedGVK,
-		recommendationID,
-		pods,
-		podsPerRecomendationID,
-	)
+func TestStatefulSetSyncTriggerRollout(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		createTarget:     true,
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRev("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1"),
+		},
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 0},
+		expectPatch:             true,
+		expectActionSet:         true,
+	})
+}
 
-	// Should detect external rollout in progress and NOT trigger our own rollout
-	assert.NoError(t, err)
-	assert.Equal(t, autoscaling.ProcessResult{Requeue: true, RequeueAfter: rolloutCheckRequeueDelay}, result)
-	// Vertical action should NOT be set since we didn't trigger a rollout
-	assert.Nil(t, autoscalerInternal.VerticalLastAction())
+func TestStatefulSetSyncPatchError(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRev("s1-0", "", kubernetes.StatefulSetKind, "s1", "v1"),
+		},
+		podsPerRecommendationID: map[string]int32{"r1": 0},
+		patchError:              true,
+		expectPatch:             true,
+		expectError:             true,
+	})
+}
+
+func TestStatefulSetSyncExternalRolloutInProgress(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRev("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1"),
+			podWithRev("s1-1", "old", kubernetes.StatefulSetKind, "s1", "v1"),
+			podWithRev("s1-2", "old", kubernetes.StatefulSetKind, "s1", "v2"),
+		},
+		podsPerRecommendationID: map[string]int32{"old": 3, "r1": 0},
+	})
+}
+
+func TestStatefulSetSyncBypassOnLimitIncrease(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		createTarget:     true,
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRevLimit("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1", 25),
+			podWithRevLimit("s1-1", "old", kubernetes.StatefulSetKind, "s1", "v2", 25),
+		},
+		podsPerRecommendationID: map[string]int32{"old": 2, "r1": 0},
+		scalingValues:           scalingVal("r1", "500m"),
+		expectPatch:             true,
+		expectActionSet:         true,
+	})
+}
+
+func TestStatefulSetSyncAlreadyTriggeredWaits(t *testing.T) {
+	now := time.Now()
+	f := newVerticalControllerFixture(t, now)
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRev("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1"),
+			podWithRev("s1-1", "r1", kubernetes.StatefulSetKind, "s1", "v2"),
+		},
+		podsPerRecommendationID: map[string]int32{"old": 1, "r1": 1},
+		lastAction:              lastAction(now.Add(-time.Minute), "r1"),
+	})
+}
+
+func TestStatefulSetSyncBypassRateLimited(t *testing.T) {
+	now := time.Now()
+	f := newVerticalControllerFixture(t, now)
+	f.runSync(verticalTestArgs{
+		targetKind:       kubernetes.StatefulSetKind,
+		targetName:       "s1",
+		recommendationID: "r1",
+		pods: []*workloadmeta.KubernetesPod{
+			podWithRevLimit("s1-0", "old", kubernetes.StatefulSetKind, "s1", "v1", 25),
+			podWithRevLimit("s1-1", "old", kubernetes.StatefulSetKind, "s1", "v2", 25),
+		},
+		podsPerRecommendationID: map[string]int32{"old": 2, "r1": 0},
+		lastAction:              lastAction(now.Add(-2*time.Minute), "old"),
+		scalingValues:           scalingVal("r1", "500m"),
+	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR reworks the trigger rollout logic to handle:
- Stuck deployments or missed Pods (will re-rollout after 1h)
- Will bypass the on-going rollout check for recommendations increasing limits (CPU or Memory)

That's to allow better self-healing when we recover after a too low recommendation.

### Motivation

Improve automatic recovery in case of incorrect vertical recommendations.

### Describe how you validated your changes

Create a `Deployment` with `maxUnavailable: 0, maxSurge: 1` and a readiness probe that takes 30s to complete.
Use a fixed amount of memory (stress-ng for instance).
Wait for DPA to make a recommendation.
Increase the memory usage. The Deployment rollout will be stuck due to OOM Kills.
DPA should make quickly a new recommendation to increase memory and trigger a rollout with these logs:

```
CLUSTER | INFO | (pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go:153 in shouldTriggerRollout) | Rollout in progress for autoscaler: default/stress-ng-autoscaler-2, but new recommendation increases limits - bypassing check to help recovery
CLUSTER | INFO | (pkg/clusteragent/autoscaling/workload/controller_vertical.go:165 in triggerRollout) | Successfully triggered rollout for autoscaler: default/stress-ng-autoscaler-2, gvk: apps/v1, Kind=Deployment, name: stress-ng-2
```

### Additional Notes
