### PR TITLE
Fix ebpf tests not initializing the config

### DIFF
--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 )
 
 func TestBuildModeConstants(t *testing.T) {
 	TestBuildMode(t, Prebuilt, "", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)
@@ -30,6 +32,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, Prebuilt, GetBuildMode())
 	})
 	TestBuildMode(t, RuntimeCompiled, "", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.True(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)
@@ -41,6 +44,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, RuntimeCompiled, GetBuildMode())
 	})
 	TestBuildMode(t, CORE, "", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.True(t, cfg.EnableCORE)
@@ -52,6 +56,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, CORE, GetBuildMode())
 	})
 	TestBuildMode(t, Fentry, "", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.True(t, cfg.EnableCORE)
@@ -63,6 +68,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.Equal(t, Fentry, GetBuildMode())
 	})
 	TestBuildMode(t, Ebpfless, "", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := ebpf.NewConfig()
 		assert.False(t, cfg.EnableRuntimeCompiler)
 		assert.False(t, cfg.EnableCORE)


### PR DESCRIPTION
### What does this PR do?

`ebpftest` package was not initializing the config nor the mock for their testing. This breaks test with the new NTM config implementation.
