### PR TITLE
[EBPF-1016] attacher: enable process sync on event stream tests

### DIFF
--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -934,7 +934,15 @@ func testUprobeAttacherInner(t *testing.T, attacherFunc func(useEventStream bool
 		},
 	}
 
-	RunTestAttacher(t, LibraryAndMainAttacherTestConfigName, attacher, target, config)
+	// The process event stream can lose events sometimes and causes flaky tests. We
+	// use the configuration with sync enabled in that case to avoid them. The netlink
+	// set of tests will still cover the part without sync enabled.
+	attacherConfigName := LibraryAndMainAttacherTestConfigName
+	if useEventStream {
+		attacherConfigName = LibraryAndMainAttacherWithSyncTestConfigName
+	}
+
+	RunTestAttacher(t, attacherConfigName, attacher, target, config)
 }
 
 func TestUprobeAttacher(t *testing.T) {

--- a/pkg/ebpf/uprobes/testutil_attacher_runner.go
+++ b/pkg/ebpf/uprobes/testutil_attacher_runner.go
@@ -106,7 +106,8 @@ type AttacherTestConfigName string
 
 const (
 	// LibraryAndMainAttacherTestConfigName is the name of the test configuration for the attacher that attaches to a libssl library and the main executable
-	LibraryAndMainAttacherTestConfigName AttacherTestConfigName = "library-and-main"
+	LibraryAndMainAttacherTestConfigName         AttacherTestConfigName = "library-and-main"
+	LibraryAndMainAttacherWithSyncTestConfigName AttacherTestConfigName = "library-and-main-with-sync"
 )
 
 // AttacherTestConfigs is a map of attacher test config names to attacher configs.
@@ -470,6 +471,16 @@ func loadAttacherTestConfigs() {
 		ExcludeTargets:        ExcludeInternal | ExcludeSelf,
 		EnableDetailedLogging: true,
 		SharedLibsLibsets:     []sharedlibraries.Libset{sharedlibraries.LibsetCrypto},
+	}
+
+	// Same config, but with scan enabled in case we're using the event stream, which can lose events sometimes.
+	AttacherTestConfigs[LibraryAndMainAttacherWithSyncTestConfigName] = AttacherConfig{
+		Rules:                          AttacherTestConfigs[LibraryAndMainAttacherTestConfigName].Rules,
+		ExcludeTargets:                 AttacherTestConfigs[LibraryAndMainAttacherTestConfigName].ExcludeTargets,
+		EnableDetailedLogging:          AttacherTestConfigs[LibraryAndMainAttacherTestConfigName].EnableDetailedLogging,
+		SharedLibsLibsets:              AttacherTestConfigs[LibraryAndMainAttacherTestConfigName].SharedLibsLibsets,
+		ScanProcessesInterval:          500 * time.Millisecond,
+		EnablePeriodicScanNewProcesses: true,
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Enables process sync in the tests for the uprobe attacher when using the process event data stream.

### Motivation

Eliminate flakes in this test due to the attacher missing process exit events.

### Describe how you validated your changes

Existing unit tests, will monitor these flakes.

### Additional Notes
