### PR TITLE
[AGTMETRICS-393] fix nil pointer deref in `AgentSecure::RefreshRemoteAgent` RPC

### DIFF
--- a/comp/api/grpcserver/impl-agent/server.go
+++ b/comp/api/grpcserver/impl-agent/server.go
@@ -234,6 +234,10 @@ func (s *serverSecure) RegisterRemoteAgent(_ context.Context, in *pb.RegisterRem
 }
 
 func (s *serverSecure) RefreshRemoteAgent(_ context.Context, in *pb.RefreshRemoteAgentRequest) (*pb.RefreshRemoteAgentResponse, error) {
+	if s.remoteAgentRegistry == nil {
+		return nil, status.Error(codes.Unimplemented, "remote agent registry not enabled")
+	}
+
 	found := s.remoteAgentRegistry.RefreshRemoteAgent(in.SessionId)
 	if !found {
 		return nil, status.Error(codes.NotFound, "no remote agent found with session ID")


### PR DESCRIPTION
### What does this PR do?

Exactly what it says in the title: fixes a nil pointer dereference bug.

### Motivation

I noticed this when testing ADP due to an issue on the ADP side where we would try to call the `RefreshRemoteAgent` RPC even when we had failed to correctly register ourselves in the first place.

### Describe how you validated your changes

Built and ran the Agent with RAR disabled, and ensured that calling the RPC did not trigger a nil pointer dereference.

### Additional Notes
