### PR TITLE
[ACTP] add artitificial delay to rc service startup to avoid timestamp collisions

### DIFF
--- a/comp/remote-config/rcservice/rcserviceimpl/rcservice.go
+++ b/comp/remote-config/rcservice/rcserviceimpl/rcservice.go
@@ -127,6 +127,9 @@ func newRemoteConfigService(deps dependencies) (rcservice.Component, error) {
 	deps.Lc.Append(fx.Hook{OnStart: func(_ context.Context) error {
 		configService.Start()
 		deps.Logger.Info("remote config service started")
+		// Sleep for 2 seconds to avoid timestamp collision issues where rapid consecutive
+		// refresh calls within the same second cause TUF to see updates as identical versions
+		time.Sleep(2 * time.Second)
 		return nil
 	}})
 	deps.Lc.Append(fx.Hook{OnStop: func(_ context.Context) error {


### PR DESCRIPTION
### What does this PR do?

Introduce a startup delay in RC service

### Motivation

This is something we discovered last year but supposedly was fixed in this [PR](https://github.com/DataDog/datadog-agent/pull/34844)
Unfortunately it doesn't seem to be working when starting the PAR in agent as we see an almost systematic 50s startup latency before getting the first RC configuration.
In the regular PAR this got worked around by introducing a 2s sleep between starting the rc service and starting the rc client. But with the PAR in the agent we don't manage the lifecycle of rcClient / rcService.

### Describe how you validated your changes

Started the agent and restarted the PAR process several times and the delay before getting new configuration seems consistently be < 100ms instead of systematic 50s + (although the entire startup is probably longer)

### Additional Notes

There are probably better solutions than this one so having this PR more for discussions  / having a reproducer