### PR TITLE
bazel: install sd-agent

### DIFF
--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -10,6 +10,7 @@ pkg_filegroup(
     ] + select({
         "@platforms//os:linux": [
             "//deps/compile_policy:bin_files",
+            "//pkg/discovery/module/rust:sd-agent_pkg",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -433,7 +433,7 @@ func TestRustBinary(t *testing.T) {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 
-	binaryPath := filepath.Join(curDir, "rust", "sd-agent")
+	binaryPath := filepath.Join(curDir, "rust", "embedded", "bin", "sd-agent")
 
 	require.FileExists(t, binaryPath, "Rust binary should be built")
 

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -133,6 +133,8 @@ pkg_files(
     attributes = pkg_attributes(
         mode = "0755",
     ),
+    prefix = "embedded/bin",
+    visibility = ["//packages/install_dir:__pkg__"],
 )
 
 pkg_install(


### PR DESCRIPTION
### What does this PR do?

This PR makes Bazel include `sd-agent` in agent packages. It installs it alongside `system-probe` e.g `/opt/datadog-agent/embedded/bin/sd-agent`.

### Motivation

Shipping sd-agent!

### Describe how you validated your changes

### Additional Notes
