### PR TITLE
e2e: run discovery tests with sd-agent

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -44,6 +44,16 @@ var agentProcessConfigStr string
 //go:embed testdata/config/agent_process_disabled_config.yaml
 var agentProcessDisabledConfigStr string
 
+//go:embed testdata/config/system_probe_config_fallback.yaml
+var systemProbeConfigFallbackStr string
+
+type discoveryMode string
+
+const (
+	discoveryModeSdAgent     discoveryMode = "sd-agent"
+	discoveryModeSystemProbe discoveryMode = "system-probe"
+)
+
 type linuxTestSuite struct {
 	e2e.BaseSuite[environments.Host]
 }
@@ -77,11 +87,33 @@ func (s *linuxTestSuite) SetupSuite() {
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithServiceDiscovery() {
-	s.testProcessCheckWithServiceDiscovery(agentProcessConfigStr, systemProbeConfigStr)
+	for _, mode := range []discoveryMode{discoveryModeSdAgent, discoveryModeSystemProbe} {
+		s.Run(string(mode), func() {
+			systemProbeConfig := s.getSystemProbeConfigForMode(mode)
+			s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig(agentProcessConfigStr),
+					agentparams.WithSystemProbeConfig(systemProbeConfig)),
+			)))
+			s.validateDiscoveryMode(mode)
+			s.testProcessCheckWithServiceDiscovery(agentProcessConfigStr, systemProbeConfig)
+		})
+	}
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithServiceDiscoveryProcessCollectionDisabled() {
-	s.testProcessCheckWithServiceDiscovery(agentProcessDisabledConfigStr, systemProbeConfigStr)
+	for _, mode := range []discoveryMode{discoveryModeSdAgent, discoveryModeSystemProbe} {
+		s.Run(string(mode), func() {
+			systemProbeConfig := s.getSystemProbeConfigForMode(mode)
+			s.UpdateEnv(awshost.Provisioner(awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig(agentProcessDisabledConfigStr),
+					agentparams.WithSystemProbeConfig(systemProbeConfig)),
+			)))
+			s.validateDiscoveryMode(mode)
+			s.testProcessCheckWithServiceDiscovery(agentProcessDisabledConfigStr, systemProbeConfig)
+		})
+	}
 }
 
 func (s *linuxTestSuite) TestProcessCheckWithServiceDiscoveryPrivilegedLogs() {
@@ -158,7 +190,7 @@ func (s *linuxTestSuite) dumpDebugInfo(t *testing.T) {
 	// This is very useful for debugging, but we probably don't want to decode
 	// and assert based on this in this E2E test since this is an internal
 	// interface between the agent and system-probe.
-	discoveredServices := s.Env().RemoteHost.MustExecute("sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/debug")
+	discoveredServices := s.Env().RemoteHost.MustExecute("sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/debug")
 	t.Log("system-probe services", discoveredServices)
 
 	workloadmetaStore := s.Env().RemoteHost.MustExecute("sudo datadog-agent workload-list --verbose")
@@ -517,6 +549,32 @@ func matchingTracerMetadata(expectedTracerMetadata []*agentmodel.TracerMetadata,
 
 	diff := cmp.Diff(expectedTracerMetadata, actualTracerMetadata, cmpopts.EquateEmpty(), ignoreID, sortByName)
 	return diff == ""
+}
+
+func (s *linuxTestSuite) getSystemProbeConfigForMode(mode discoveryMode) string {
+	switch mode {
+	case discoveryModeSdAgent:
+		return systemProbeConfigStr // Only discovery config
+	case discoveryModeSystemProbe:
+		return systemProbeConfigFallbackStr // Discovery + use_sd_agent: false (triggers fallback)
+	}
+	return systemProbeConfigStr
+}
+
+func (s *linuxTestSuite) validateDiscoveryMode(mode discoveryMode) {
+	ps := s.Env().RemoteHost.MustExecute("ps aux | grep -E '(system-probe|sd-agent)' | grep -v grep")
+	s.T().Logf("Process list:\n%s", ps)
+
+	// sd-agent execs into system-probe (process replacement), they don't run simultaneously
+	if mode == discoveryModeSdAgent {
+		// In sd-agent mode, sd-agent runs its own server (no exec)
+		require.Contains(s.T(), ps, "sd-agent", "sd-agent should be running in sd-agent mode")
+		s.T().Logf("Found sd-agent process (mode: %s)", mode)
+	} else if mode == discoveryModeSystemProbe {
+		// In system-probe mode, sd-agent exec'd into system-probe (replaced itself)
+		require.Contains(s.T(), ps, "system-probe", "system-probe should be running in system-probe mode")
+		s.T().Logf("Found system-probe process (mode: %s)", mode)
+	}
 }
 
 func (s *linuxTestSuite) provisionServer() {

--- a/test/new-e2e/tests/discovery/testdata/config/system_probe_config_fallback.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/system_probe_config_fallback.yaml
@@ -1,4 +1,4 @@
 log_level: 'debug'
 discovery:
   enabled: true
-  use_sd_agent: true
+  use_sd_agent: false

--- a/test/new-e2e/tests/discovery/testdata/config/system_probe_config_privileged_logs.yaml
+++ b/test/new-e2e/tests/discovery/testdata/config/system_probe_config_privileged_logs.yaml
@@ -1,5 +1,6 @@
 log_level: 'debug'
 discovery:
   enabled: true
+  use_sd_agent: true
 privileged_logs:
   enabled: true


### PR DESCRIPTION
### What does this PR do?

This PR makes discovery E2E tests run both against sd-agent and system-probe.

### Motivation

Ensure sd-agent passes the same tests as system-probe.

### Describe how you validated your changes

### Additional Notes
