### PR TITLE
sd-agent: act as a loader for system-probe in s6 and systemd

### DIFF
--- a/Dockerfiles/agent/s6-services/sysprobe/run
+++ b/Dockerfiles/agent/s6-services/sysprobe/run
@@ -1,11 +1,17 @@
 #!/usr/bin/execlineb -P
 
-# Check if the system-probe exists before running it
+# Check if the system-probe and sd-agent exist before running
 ifelse -n
     { s6-test -x "/opt/datadog-agent/embedded/bin/system-probe" }
     {
         foreground { /initlog.sh "system-probe not bundled, disabling" }
         foreground { /bin/s6-svc -d /var/run/s6/services/sysprobe/ }
     }
-    foreground { /initlog.sh "starting system-probe" }
-    system-probe run --config=/etc/datadog-agent/system-probe.yaml
+    ifelse -n
+        { s6-test -x "/opt/datadog-agent/embedded/bin/sd-agent" }
+        {
+            foreground { /initlog.sh "sd-agent not bundled, disabling" }
+            foreground { /bin/s6-svc -d /var/run/s6/services/sysprobe/ }
+        }
+        foreground { /initlog.sh "starting system-probe with sd-agent" }
+        /opt/datadog-agent/embedded/bin/sd-agent -- /opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml

--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-sysprobe.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-sysprobe.service.tmpl
@@ -28,7 +28,7 @@ Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
 {{- if not .Stable}}
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 {{- end}}
-ExecStart={{.InstallDir}}/embedded/bin/system-probe run --config={{.EtcDir}}/system-probe.yaml --pid={{.InstallDir}}/run/system-probe.pid
+ExecStart={{.InstallDir}}/embedded/bin/sd-agent -- {{.InstallDir}}/embedded/bin/system-probe run --config={{.EtcDir}}/system-probe.yaml --pid={{.InstallDir}}/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
@@ -15,7 +15,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
-ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+ExecStart=/opt/datadog-agent/embedded/bin/sd-agent -- /opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe.service
@@ -14,7 +14,7 @@ PIDFile=/opt/datadog-agent/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
-ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+ExecStart=/opt/datadog-agent/embedded/bin/sd-agent -- /opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
@@ -15,7 +15,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
-ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+ExecStart=/opt/datadog-agent/embedded/bin/sd-agent -- /opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe.service
@@ -14,7 +14,7 @@ PIDFile=/opt/datadog-agent/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
-ExecStart=/opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
+ExecStart=/opt/datadog-agent/embedded/bin/sd-agent -- /opt/datadog-agent/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
@@ -15,7 +15,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
+ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/sd-agent -- /opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe.service
@@ -14,7 +14,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
-ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
+ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/sd-agent -- /opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
@@ -15,7 +15,7 @@ Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
+ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/sd-agent -- /opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent-exp/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe.service
@@ -14,7 +14,7 @@ PIDFile=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 Restart=on-failure
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
-ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
+ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/sd-agent -- /opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 StartLimitInterval=10
 StartLimitBurst=5
 

--- a/releasenotes/notes/sd-agent-wrap-system-probe-88325f5daadb5bf9.yaml
+++ b/releasenotes/notes/sd-agent-wrap-system-probe-88325f5daadb5bf9.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The resource discovery agent (``sd-agent``) now wraps ``system-probe``,
+    acting as a loader for it. ``sd-agent`` will automatically fallback to
+    ``system-probe`` when one of the following is true:
+    - ``discovery.enabled` is set to false
+    - ``discovery.useSdAgent`` is set to false (the default).
+    - Any other non-discovery feature of system-probe is enabled.

--- a/releasenotes/notes/sd-agent-wrap-system-probe-88325f5daadb5bf9.yaml
+++ b/releasenotes/notes/sd-agent-wrap-system-probe-88325f5daadb5bf9.yaml
@@ -6,4 +6,4 @@ enhancements:
     ``system-probe`` when one of the following is true:
     - ``discovery.enabled` is set to false
     - ``discovery.useSdAgent`` is set to false (the default).
-    - Any other non-discovery feature of system-probe is enabled.
+    - Any other non-discovery feature of ``system-probe`` is enabled.


### PR DESCRIPTION
### What does this PR do?

This PR makes the systemd services and the s6 run scripts start sd-agent first instead of system-probe. If any system-probe feature is required, or if system-probe's config (`discovery.useSdAgent: false`) enforces it, sd-agent will fallback to system-probe.

### Motivation

Make sd-agent act as a system-probe loader, allowing for discovery features to run without system-probe, or fallback to system-probe if need be.

### Describe how you validated your changes

Change covered by e2e-tests in #45381 + manual testing in LXC containers and with docker-compose.

### Additional Notes
