### PR TITLE
Fix CI rule to trigger fleet e2e tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -868,6 +868,7 @@ workflow:
         - omnibus/config/**/*
         - pkg/fleet/**/*
         - cmd/installer/**/*
+        - test/new-e2e/tests/fleet/**/*
         - test/new-e2e/tests/installer/**/*
         - tasks/installer.py
       compare_to: $COMPARE_TO_BRANCH


### PR DESCRIPTION
### What does this PR do?
Add `test/new-e2e/tests/fleet/**/*` to the `.on_installer_or_e2e_changes` rule paths (consistent with `pkg/fleet/**/*`).

### Motivation
`new-e2e-fleet-config` and `new-e2e-fleet-upgrade` did not trigger when files in `test/new-e2e/tests/fleet/` were modified.

When fleet test helper packages (`agent/`, `fleetbackend/`) and the config smoke test (`config_test.go`) were extracted from installer tests in #42607, the CI rule `.on_installer_or_e2e_changes` was not updated to include the new path.

This caused #44488 which modified `test/new-e2e/tests/fleet/agent/agent.go` to skip running fleet tests, resulting in failures that weren't caught until after merge to `main`, leading to #45200.

### Describe how you validated your changes
- the pattern matches other similar rules (e.g., `.on_apm_or_e2e_changes` includes `test/new-e2e/tests/apm/**/*`),
- this is also consistent with `.on_installer_or_e2e_changes` already including `pkg/fleet/**/*`.