### PR TITLE
Fix syntax error in `Create RC PR` workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -80,9 +80,8 @@ jobs:
           fi
 
       - name: Create RC PR
-        if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_QUALIFICATION == 'false') }}
+        if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_QUALIFICATION == 'false' }}
         env:
           SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: dda inv -- -e release.create-rc -r "6.53.x" --patch-version
-


### PR DESCRIPTION
### What does this PR do?
Fix syntax error in `Create RC PR` workflow (see #45359).

### Motivation
<img width="817" height="66" alt="image" src="https://github.com/user-attachments/assets/110f4926-7bf8-45a5-8543-52a4e1a1fba6" />

```
Invalid workflow file: .github/workflows/create_rc_pr.yml#L1
(Line: 83, Col: 13): Unexpected symbol: ')'. Located at position 85 within expression: steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_QUALIFICATION == 'false')
```
(https://github.com/DataDog/datadog-agent/actions/runs/21259698247)