### PR TITLE
SanitizeAPIKey at AgentRuntime layer

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2852,10 +2852,15 @@ func envVarAreSetAndNotEqual(lhsName string, rhsName string) bool {
 
 // sanitizeAPIKeyConfig strips newlines and other control characters from a given key.
 func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
-	if !config.IsKnown(key) || !config.IsSet(key) {
+	if !config.IsKnown(key) || !config.IsConfigured(key) {
 		return
 	}
-	config.Set(key, strings.TrimSpace(config.GetString(key)), config.GetSource(key))
+	original := config.GetString(key)
+	trimmed := strings.TrimSpace(original)
+	if original == trimmed {
+		return
+	}
+	config.Set(key, trimmed, pkgconfigmodel.SourceAgentRuntime)
 }
 
 // sanitizeExternalMetricsProviderChunkSize ensures the value of `external_metrics_provider.chunk_size` is within an acceptable range


### PR DESCRIPTION
### What does this PR do?

When calling `sanitizeAPIKeyConfig`, set the sanitized key at the `AgentRuntime` layer, instead of the source layer. This works better with Nodetreemodel, which prohibits saving to the env var layer.

### Motivation

Forward compatibility with nodetreemodel.

### Describe how you validated your changes

Ran with `DD_API_KEY` set to my api key. The unit tests cover that existing functionality still work.

### Additional Notes
