### PR TITLE
[CONS-8004] Fix static pod UID mismatch when kubelet_use_api_server is enabled

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -124,7 +124,7 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 			if pkgconfigsetup.Datadog().GetBool("kubelet_use_api_server") {
 				podData, err = p.store.GetKubernetesPodByName(podStats.PodRef.Name, podStats.PodRef.Namespace)
 				if err != nil || podData == nil {
-					log.Debugf("Couldn't get pod data from workloadmeta store for pod %s/%s (uid=%s), error = %v",
+					log.Infof("Couldn't get pod data from workloadmeta store for pod %s/%s (uid=%s), error = %v",
 						podStats.PodRef.Namespace, podStats.PodRef.Name, podStats.PodRef.UID, err)
 					continue
 				}

--- a/pkg/collector/corechecks/containers/kubelet/testdata/summary_static_pod.json
+++ b/pkg/collector/corechecks/containers/kubelet/testdata/summary_static_pod.json
@@ -1,0 +1,39 @@
+{
+    "node": {
+        "nodeName": "test-node",
+        "fs": {
+            "usedBytes": 1000000,
+            "capacityBytes": 10000000
+        },
+        "systemContainers": []
+    },
+    "pods": [
+        {
+            "podRef": {
+                "name": "kube-apiserver-test-node",
+                "namespace": "kube-system",
+                "uid": "9b3c1a2d4e5f67890123456789abcdef"
+            },
+            "startTime": "2023-09-06T04:58:47Z",
+            "containers": [
+                {
+                    "name": "kube-apiserver",
+                    "startTime": "2023-09-06T04:59:07Z",
+                    "cpu": {
+                        "time": "2023-09-06T05:07:16Z",
+                        "usageNanoCores": 1000000,
+                        "usageCoreNanoSeconds": 5000000000
+                    },
+                    "memory": {
+                        "time": "2023-09-06T05:07:16Z",
+                        "usageBytes": 100000000,
+                        "workingSetBytes": 90000000
+                    }
+                }
+            ],
+            "ephemeral-storage": {
+                "usedBytes": 12345
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### What does this PR do?
Fixes warning spam "Couldn't get pod data from workloadmeta store" for static pods when `kubelet_use_api_server` is enabled.

Note: this is an edge case as it is not enabled by default and only affects static pods.                                                                       

### Motivation                                                                                                                                          
When `kubelet_use_api_server` is set to true, customers see repeated warning messages every 20 seconds for static pods (e.g., kube-proxy on GKE, etcd, kube-apiserver, kube-controller-manager,  kube-scheduler):                                                                                                                                                                                
                                                                                                                                                                                                  
```
  Couldn't get pod data from workloadmeta store, error = "9aac5b5c8815def09a2ef9e37b89da55" not found                                                                                             
  Couldn't get pod data from workloadmeta store, error = "55b4bbe24dac3803a7379f9ae169d6ba" not found  
```
  #### Root Cause                                                                                                                                                                                      
                                                                                                                                                                                                  
  Static pods have two different UIDs:                                                                                                                                                            
  - Canonical UID: Standard UUID format (e.g., 732ee13c-3ee3-4ad9-9d33-ed4846c8eef4) - used by the API server                                                                                     
  - Mirror hash UID: 32-character hash (e.g., 9aac5b5c8815def09a2ef9e37b89da55) - used by kubelet for mirror pods                                                                                 
                                                                                                                                                                                                  
  When kubelet_use_api_server=true:                                                                                                                                                               
  - workloadmeta fetches pod data from the API server, storing pods by canonical UID                                                                                                              
  - /stats/summary endpoint always comes from kubelet, which uses mirror hash UID for static pods                                                                                                 
                                                                                                                                                                                                  
  This UID mismatch causes the lookup to fail for static pods.                 

This fix is:
When the initial static pod UID lookup fails and `kubelet_use_api_server` is enabled + raw hash id is found, fall back to lookup by pod name and namespace. This succeeds because the pod name/namespace are consistent across both sources. **The canonical UID** from the successful lookup is then used for subsequent tagger operations because tagger indexed by canonical UID from wmeta                                                                                                                  
                                                                                
### Describe how you validated your changes
                                                                                                                                                                                                  
  Environment                                                                                                                                                                                     
                                                                                                                                                                                                  
  - Cluster: Minikube with kubelet_use_api_server: true                                                                                                                                           
  - Static pods: etcd, kube-apiserver, kube-controller-manager, kube-scheduler                                                                                                                    
                                                                                                                                                                                                  
  UID Mismatch Pattern:
                         
<img width="777" height="149" alt="Screenshot 2026-01-23 at 2 01 19 AM" src="https://github.com/user-attachments/assets/96725f23-cc35-4049-9425-bc368bfe5ca3" />
                                                                                                                                                  
  Before Fix                                                                                                                                                                                                                                                                                                                                                                
```
 2026-01-23 06:34:10 UTC | CORE | INFO | (pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go:116 in Provide) | Couldn't get pod data from workloadmeta store, error =      
  "***c2c28" not found                                                                                                                                                                            
  2026-01-23 06:34:10 UTC | CORE | INFO | (pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go:116 in Provide) | Couldn't get pod data from workloadmeta store, error =      
  "***9da55" not found                                                                                                                                                                            
  2026-01-23 06:34:10 UTC | CORE | INFO | (pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go:116 in Provide) | Couldn't get pod data from workloadmeta store, error =      
  "***2da00" not found                                                                                                                                                                            
  2026-01-23 06:34:10 UTC | CORE | INFO | (pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go:116 in Provide) | Couldn't get pod data from workloadmeta store, error =      
  "***9d6ba" not found    
```                                                                                   
  - 4 error messages every 20 seconds (one per static pod)                                                                                                                                        
  - Warning spam in logs                                                                                                                                                                          
                                                                                                                                                                                                  
  After fix, no more error messages. 
  
  Unit test added
### Additional Notes
