### PR TITLE
fix(ask_review): Prevent `None` name in case of bot PR

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -59,7 +59,7 @@ def ask_reviews(_, pr_id, team_slugs):
     last_event = events[-1]
     actor = last_event.actor.name or last_event.actor.login
     if "[bot]" in actor:
-        actor = pr.user.name
+        actor = pr.user.name or pr.user.login
     for channel, reviewers in channels.items():
         stop_updating = ""
         if (pr.user.login == "renovate[bot]" or pr.user.login == "mend[bot]") and pr.title.startswith(


### PR DESCRIPTION
### What does this PR do
Use also the login to prevent having `None` as actor when a bot has no name

### Motivation
Prevent this
<img width="752" height="126" alt="image" src="https://github.com/user-attachments/assets/5fa55279-6969-403e-9e1b-28cee293a142" />

### Describe how you validated your changes
Manual test on the PR data

### Additional Notes
