### PR TITLE
[ABLD-317] Fix Go stdlib build command and make it fail-fast

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -100,12 +100,7 @@ def build_standard_lib(
     """
     args["go_build_tags"] = " ".join(build_tags)
 
-    ctx.run(
-        cmd.format(**args),
-        env=env,
-        out_stream=test_profiler,
-        warn=True,
-    )
+    ctx.run(cmd.format(**args), env=env, out_stream=test_profiler)  # with `warn=True`, errors went unnoticed
 
 
 def test_flavor(
@@ -328,7 +323,7 @@ def test(
     # build flags are used both for building the stdlib and to run the tests
     gobuild_flags = '-mod={go_mod} -tags "{go_build_tags}" -gcflags="{gcflags}" -ldflags="{ldflags}" {build_cpus} {race_opt} {trimpath_opt}'
 
-    stdlib_build_cmd = f'go build {verbose} {gobuild_flags} std cmd'
+    stdlib_build_cmd = f'go build {{verbose}} {gobuild_flags} std cmd'
     rerun_coverage_fix = '--raw-command {cov_test_path}' if coverage else ""
     gotestsum_flags = (
         '{junit_file_flag} {json_flag} --format {gotestsum_format} {rerun_fails} --packages="{packages}" '


### PR DESCRIPTION
### What does this PR do?
1. fix a bug in the Go stdlib build command where a Python boolean (`False`) was being interpolated directly into the command string instead of using a placeholder for later formatting,
2. apply the [fail-fast](https://en.wikipedia.org/wiki/Fail-fast_system) principle to prevent it from happening again.

### Motivation
While having a look at the progress of a [CI job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1372087787), I noticed strange error messages that appeared to be ignored:
```sh
go build False -mod=readonly -tags "..." ...
package False is not in std (/usr/local/go/src/False)
malformed import path "-mod=readonly": leading dash
[...]
```

The error was silently ignored due to `warn=True` in `build_standard_lib`, which means one would notice such issues purely by chance.

The problem was that, since #44976, a Python f-string (`f'go build {verbose} ...'`) was interpolated prematurely.

Overall, this defeated the purpose of the stdlib pre-compilation step:
```
# To avoid a perfomance overhead when running tests, we pre-compile the standard library and cache it.
# We must use the same build flags as the one we are using when compiling tests to not invalidate the cache.
```

### Describe how you validated your changes
Removing `warn=True` so build failures are no longer silenced ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1372241366)).