### PR TITLE
feat(e2e): Create a qa_agent_linux to start tests earlier

### DIFF
--- a/.gitlab/deploy/dev_container_deploy/e2e.yml
+++ b/.gitlab/deploy/dev_container_deploy/e2e.yml
@@ -48,6 +48,38 @@ qa_agent_jmx:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-winltsc2022-amd64
     IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-jmx
 
+# Linux-only variants for e2e tests that don't require Windows images.
+# These unblock container-based tests ~20 minutes earlier by not waiting for Windows builds.
+qa_agent_linux:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_agent7
+    - docker_build_agent7_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux
+
+qa_agent_linux_jmx:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_agent7_jmx
+    - docker_build_agent7_jmx_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
+    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux-jmx
+
 qa_agent_fips_jmx:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy

--- a/.gitlab/deploy/dev_container_deploy/e2e.yml
+++ b/.gitlab/deploy/dev_container_deploy/e2e.yml
@@ -48,38 +48,6 @@ qa_agent_jmx:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-winltsc2022-amd64
     IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-jmx
 
-# Linux-only variants for e2e tests that don't require Windows images.
-# These unblock container-based tests ~20 minutes earlier by not waiting for Windows builds.
-qa_agent_linux:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.except_disable_e2e_tests]
-    - when: on_success
-  needs:
-    - docker_build_agent7
-    - docker_build_agent7_arm64
-  variables:
-    IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux
-
-qa_agent_linux_jmx:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.except_mergequeue]
-    - !reference [.except_disable_e2e_tests]
-    - when: on_success
-  needs:
-    - docker_build_agent7_jmx
-    - docker_build_agent7_jmx_arm64
-  variables:
-    IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux-jmx
-
 qa_agent_fips_jmx:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
@@ -95,6 +63,68 @@ qa_agent_fips_jmx:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-winltsc2022-servercore-amd64
     IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-jmx
+
+# Linux-only variants for e2e tests that don't require Windows images.
+# These unblock container-based tests ~20 minutes earlier by not waiting for Windows builds.
+qa_agent_linux:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_agent7
+    - docker_build_agent7_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux
+
+qa_agent_fips_linux:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_fips_agent7
+    - docker_build_fips_agent7_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-arm64
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-linux
+
+qa_agent_linux_jmx:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_agent7_jmx
+    - docker_build_agent7_jmx_arm64
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-linux-jmx
+
+qa_agent_fips_linux_jmx:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.except_mergequeue]
+    - !reference [.except_disable_e2e_tests]
+    - when: on_success
+  needs:
+    - docker_build_fips_agent7_jmx
+    - docker_build_fips_agent7_arm64_jmx
+  variables:
+    IMG_REGISTRIES: agent-qa
+    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-arm64
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-linux-jmx
 
 qa_agent_full:
   extends: .docker_publish_job_definition

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -87,7 +87,7 @@
     PRE_BUILT_BINARIES_FLAG: "--use-prebuilt-binaries"
     MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
     REMOTE_STACK_CLEANING: "true"
-    E2E_AGENT_IMAGE_CONFIG: "" # Extra config for agent image selection, e.g., "-c ddagent:linuxOnly=true"
+    WINDOWS_AGENT_FLAG: "" # Set to "--windows-agent" for jobs that need Windows-compatible images
   script:
     - export IS_DEV_BRANCH="$(dda inv -- -e pipeline.is-dev-branch)"
     - DYNAMIC_TESTS_BREAKGLASS=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DYNAMIC_TESTS_BREAKGLASS value) || exit $?; export DYNAMIC_TESTS_BREAKGLASS
@@ -95,7 +95,7 @@
       if [ "$DYNAMIC_TESTS_BREAKGLASS" == "true" ] || [ "$IS_DEV_BRANCH" == "false" ] || [ "$RUN_E2E_TESTS" == "on" ]; then
         export DYNAMIC_TESTS_FLAG=""
       fi
-    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) ${E2E_AGENT_IMAGE_CONFIG} --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) ${WINDOWS_AGENT_FLAG} --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
@@ -226,7 +226,7 @@ go_e2e_test_binaries:
     - qa_dca
     - qa_dogstatsd
   variables:
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-containers-ecs:
   extends: .new_e2e_template_needs_container_deploy
@@ -380,7 +380,7 @@ new-e2e-fips-compliance-test:
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7-fips
-    - qa_agent_fips
+    - qa_agent_fips_linux
   rules:
     - !reference [.on_arun_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
@@ -407,6 +407,7 @@ new-e2e-windows-fips-compliance-test:
   variables:
     TARGETS: ./tests/fips-compliance
     TEAM: windows-products
+    WINDOWS_AGENT_FLAG: "--windows-agent"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "TestWindowsVM$"
@@ -567,7 +568,7 @@ new-e2e-amp:
     TARGETS: ./tests/agent-metric-pipelines
     TEAM: agent-metric-pipelines
     ON_NIGHTLY_FIPS: "true"
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-alp:
   extends: .new_e2e_template
@@ -586,7 +587,7 @@ new-e2e-alp:
   variables:
     TARGETS: ./tests/agent-log-pipelines
     TEAM: agent-log-pipelines
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
   # Temporary for #incident-44744
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
@@ -608,7 +609,7 @@ new-e2e-cws:
     TEAM: csm-threats-agent
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestAgentSuiteEC2
@@ -666,7 +667,7 @@ new-e2e-process-ecs:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-process:
   extends: .new_e2e_template
@@ -685,7 +686,7 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
+    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-orchestrator-ecs:
   extends: .new_e2e_template_needs_container_deploy_linux
@@ -969,7 +970,6 @@ new-e2e-otel-eks:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent_linux
     - qa_agent_full
     - qa_ot_agent_standalone
     - new-e2e-otel-eks-init
@@ -989,7 +989,6 @@ new-e2e-otel:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent_linux
     - qa_agent_full
     - qa_ot_agent_standalone
   variables:
@@ -1132,6 +1131,8 @@ generate-flakes-finder-pipeline:
     - qa_agent
     - qa_agent_fips
     - qa_agent_fips_jmx
+    - qa_agent_fips_linux
+    - qa_agent_fips_linux_jmx
     - qa_agent_full
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64", "specific:true"]
@@ -1191,6 +1192,8 @@ generate-fips-e2e-pipeline:
     - qa_agent_full
     - qa_agent_fips
     - qa_agent_fips_jmx
+    - qa_agent_fips_linux
+    - qa_agent_fips_linux_jmx
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64", "specific:true"]
   script:

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -207,6 +207,15 @@ go_e2e_test_binaries:
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
 
+.new_e2e_template_needs_container_deploy_linux:
+  extends: .new_e2e_template
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - qa_agent_linux
+    - qa_agent_linux_jmx
+    - qa_dca
+    - qa_dogstatsd
+
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template
   needs:
@@ -229,7 +238,7 @@ new-e2e-containers-ecs:
 
 new-e2e-containers:
   extends:
-    - .new_e2e_template_needs_container_deploy
+    - .new_e2e_template_needs_container_deploy_linux
   # TODO once images are deployed to ECR for dev branches, update
   #.on_main_or_rc_and_no_skip_e2e adding on_dev_branch_manual rules
   # and move rules to template
@@ -257,7 +266,7 @@ new-e2e-containers:
 
 new-e2e-containers-k8s-latest:
   extends:
-    - .new_e2e_template_needs_container_deploy
+    - .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_container_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
@@ -475,7 +484,7 @@ new-e2e-npm-docker:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent
+    - qa_agent_linux
   variables:
     TARGETS: ./tests/npm
     TEAM: cloud-network-monitoring
@@ -512,7 +521,7 @@ new-e2e-npm-eks:
   needs:
     - !reference [.needs_new_e2e_template]
     - new-e2e-npm-eks-init
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   variables:
     TARGETS: ./tests/npm
@@ -530,7 +539,7 @@ new-e2e-npm:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   variables:
     TARGETS: ./tests/npm
@@ -577,7 +586,6 @@ new-e2e-alp:
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
-
 new-e2e-cws:
   extends: .new_e2e_template
   rules:
@@ -609,7 +617,7 @@ new-e2e-cws:
 
 
 new-e2e-sbom:
-  extends: .new_e2e_template_needs_container_deploy
+  extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_sbom_or_e2e_changes]
     - !reference [.manual]
@@ -627,7 +635,7 @@ new-e2e-discovery:
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
-    - qa_agent
+    - qa_agent_linux
   rules:
     - !reference [.on_discovery_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
@@ -672,7 +680,7 @@ new-e2e-process:
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-orchestrator-ecs:
-  extends: .new_e2e_template_needs_container_deploy
+  extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_orchestrator_or_e2e_changes]
     - !reference [.manual]
@@ -684,7 +692,7 @@ new-e2e-orchestrator-ecs:
   timeout: 55m
 
 new-e2e-orchestrator:
-  extends: .new_e2e_template_needs_container_deploy
+  extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_orchestrator_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
@@ -703,7 +711,7 @@ new-e2e-apm:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - qa_agent
+    - qa_agent_linux
     - agent_deb-x64-a7
   variables:
     TARGETS: ./tests/apm
@@ -834,7 +842,7 @@ new-e2e-ndm-netflow:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - qa_agent
+    - qa_agent_linux
   variables:
     TARGETS: ./tests/ndm/netflow
     TEAM: ndm-integrations
@@ -849,7 +857,7 @@ new-e2e-ndm-snmp:
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
-    - qa_agent
+    - qa_agent_linux
   variables:
     TARGETS: ./tests/ndm/snmp
     TEAM: ndm-core
@@ -953,7 +961,7 @@ new-e2e-otel-eks:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent
+    - qa_agent_linux
     - qa_agent_full
     - qa_ot_agent_standalone
     - new-e2e-otel-eks-init
@@ -973,7 +981,7 @@ new-e2e-otel:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent
+    - qa_agent_linux
     - qa_agent_full
     - qa_ot_agent_standalone
   variables:
@@ -990,7 +998,7 @@ new-e2e-ssi:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_dca
-    - qa_agent
+    - qa_agent_linux
     - qa_agent_full
   variables:
     TARGETS: ./tests/ssi
@@ -1037,7 +1045,7 @@ new-e2e-cspm:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   variables:
     TARGETS: ./tests/cspm
@@ -1046,7 +1054,7 @@ new-e2e-cspm:
   timeout: 35m
 
 new-e2e-gpu:
-  extends: .new_e2e_template_needs_container_deploy
+  extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_gpu_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
@@ -1057,7 +1065,7 @@ new-e2e-gpu:
     E2E_PULUMI_LOG_LEVEL: 10 # incident-33572
     ON_NIGHTLY_FIPS: "true"
   needs: # list of required jobs. By default gitlab waits for any previous jobs.
-    - !reference [.new_e2e_template_needs_container_deploy, needs]
+    - !reference [.new_e2e_template_needs_container_deploy_linux, needs]
     - agent_deb-x64-a7 # agent 7 debian package
   parallel:
     matrix:

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -87,7 +87,6 @@
     PRE_BUILT_BINARIES_FLAG: "--use-prebuilt-binaries"
     MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
     REMOTE_STACK_CLEANING: "true"
-    WINDOWS_AGENT_FLAG: "" # Set to "--windows-agent" for jobs that need Windows-compatible images
   script:
     - export IS_DEV_BRANCH="$(dda inv -- -e pipeline.is-dev-branch)"
     - DYNAMIC_TESTS_BREAKGLASS=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DYNAMIC_TESTS_BREAKGLASS value) || exit $?; export DYNAMIC_TESTS_BREAKGLASS
@@ -95,7 +94,7 @@
       if [ "$DYNAMIC_TESTS_BREAKGLASS" == "true" ] || [ "$IS_DEV_BRANCH" == "false" ] || [ "$RUN_E2E_TESTS" == "on" ]; then
         export DYNAMIC_TESTS_FLAG=""
       fi
-    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) ${WINDOWS_AGENT_FLAG} --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
@@ -225,8 +224,6 @@ go_e2e_test_binaries:
     - qa_agent_jmx
     - qa_dca
     - qa_dogstatsd
-  variables:
-    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-containers-ecs:
   extends: .new_e2e_template_needs_container_deploy
@@ -407,7 +404,6 @@ new-e2e-windows-fips-compliance-test:
   variables:
     TARGETS: ./tests/fips-compliance
     TEAM: windows-products
-    WINDOWS_AGENT_FLAG: "--windows-agent"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "TestWindowsVM$"
@@ -556,9 +552,9 @@ new-e2e-amp:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
-    - qa_agent
-    - qa_agent_jmx
-    - qa_agent_fips_jmx
+    - qa_agent_linux
+    - qa_agent_linux_jmx
+    - qa_agent_fips_linux_jmx
     - qa_dca
   rules:
     - !reference [.on_amp_or_e2e_changes]
@@ -568,7 +564,6 @@ new-e2e-amp:
     TARGETS: ./tests/agent-metric-pipelines
     TEAM: agent-metric-pipelines
     ON_NIGHTLY_FIPS: "true"
-    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-alp:
   extends: .new_e2e_template
@@ -576,9 +571,9 @@ new-e2e-alp:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
-    - qa_agent
-    - qa_agent_jmx
-    - qa_agent_fips_jmx
+    - qa_agent_linux
+    - qa_agent_linux_jmx
+    - qa_agent_fips_linux_jmx
     - qa_dca
   rules:
     - !reference [.on_alp_or_e2e_changes]
@@ -587,7 +582,6 @@ new-e2e-alp:
   variables:
     TARGETS: ./tests/agent-log-pipelines
     TEAM: agent-log-pipelines
-    WINDOWS_AGENT_FLAG: "--windows-agent"
   # Temporary for #incident-44744
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
@@ -602,14 +596,13 @@ new-e2e-cws:
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
     - qa_cws_instrumentation
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
-    WINDOWS_AGENT_FLAG: "--windows-agent"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestAgentSuiteEC2
@@ -657,7 +650,7 @@ new-e2e-process-ecs:
   needs:
     - !reference [.needs_new_e2e_template]
     - windows_msi_and_bosh_zip_x64-a7
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   rules:
     - !reference [.on_process_or_e2e_changes]
@@ -667,7 +660,6 @@ new-e2e-process-ecs:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-process:
   extends: .new_e2e_template
@@ -675,7 +667,7 @@ new-e2e-process:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
-    - qa_agent
+    - qa_agent_linux
     - qa_dca
   rules:
     - !reference [.on_process_or_e2e_changes]
@@ -686,7 +678,6 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
-    WINDOWS_AGENT_FLAG: "--windows-agent"
 
 new-e2e-orchestrator-ecs:
   extends: .new_e2e_template_needs_container_deploy_linux

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -87,6 +87,7 @@
     PRE_BUILT_BINARIES_FLAG: "--use-prebuilt-binaries"
     MAX_RETRIES_FLAG: "" # Empty by default, can be set to `--max-retries=3` for example to retry failed tests
     REMOTE_STACK_CLEANING: "true"
+    E2E_AGENT_IMAGE_CONFIG: "" # Extra config for agent image selection, e.g., "-c ddagent:linuxOnly=true"
   script:
     - export IS_DEV_BRANCH="$(dda inv -- -e pipeline.is-dev-branch)"
     - DYNAMIC_TESTS_BREAKGLASS=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $DYNAMIC_TESTS_BREAKGLASS value) || exit $?; export DYNAMIC_TESTS_BREAKGLASS
@@ -94,7 +95,7 @@
       if [ "$DYNAMIC_TESTS_BREAKGLASS" == "true" ] || [ "$IS_DEV_BRANCH" == "false" ] || [ "$RUN_E2E_TESTS" == "on" ]; then
         export DYNAMIC_TESTS_FLAG=""
       fi
-    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - dda inv -- -e new-e2e-tests.run $DYNAMIC_TESTS_FLAG $PRE_BUILT_BINARIES_FLAG $MAX_RETRIES_FLAG --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --result-json $E2E_RESULT_JSON --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) ${E2E_AGENT_IMAGE_CONFIG} --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - CODECOV_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $CODECOV token) || exit $?; export CODECOV_TOKEN
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
@@ -224,6 +225,8 @@ go_e2e_test_binaries:
     - qa_agent_jmx
     - qa_dca
     - qa_dogstatsd
+  variables:
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
 
 new-e2e-containers-ecs:
   extends: .new_e2e_template_needs_container_deploy
@@ -564,6 +567,7 @@ new-e2e-amp:
     TARGETS: ./tests/agent-metric-pipelines
     TEAM: agent-metric-pipelines
     ON_NIGHTLY_FIPS: "true"
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
 
 new-e2e-alp:
   extends: .new_e2e_template
@@ -582,6 +586,7 @@ new-e2e-alp:
   variables:
     TARGETS: ./tests/agent-log-pipelines
     TEAM: agent-log-pipelines
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
   # Temporary for #incident-44744
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
@@ -603,6 +608,7 @@ new-e2e-cws:
     TEAM: csm-threats-agent
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestAgentSuiteEC2
@@ -660,6 +666,7 @@ new-e2e-process-ecs:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
 
 new-e2e-process:
   extends: .new_e2e_template
@@ -678,6 +685,7 @@ new-e2e-process:
     TARGETS: ./tests/process
     TEAM: container-experiences
     ON_NIGHTLY_FIPS: "true"
+    E2E_AGENT_IMAGE_CONFIG: "-c ddagent:linuxOnly=false"
 
 new-e2e-orchestrator-ecs:
   extends: .new_e2e_template_needs_container_deploy_linux

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -235,7 +235,6 @@ def build_binaries(
         "max_retries": "Maximum number of retries for failed tests, default 3",
         "impacted": "Only run tests that are impacted by the changes (only available in CI for now)",
         "keep_stack": "Keep the stack after running the test, you are responsible for destroying the stack later.",
-        "windows_agent": "Use Windows-compatible agent images (multi-arch with Windows support)",
     },
 )
 def run(
@@ -270,7 +269,6 @@ def run(
     max_retries=0,
     osdescriptors="",
     module_name="test/new-e2e",
-    windows_agent=False,
 ):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
@@ -350,9 +348,6 @@ def run(
 
     if cluster_agent_image:
         parsed_params["ddagent:clusterAgentFullImagePath"] = cluster_agent_image
-
-    if windows_agent:
-        parsed_params["ddagent:linuxOnly"] = "false"
 
     if parsed_params:
         env_vars["E2E_STACK_PARAMS"] = json.dumps(parsed_params)

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -235,6 +235,7 @@ def build_binaries(
         "max_retries": "Maximum number of retries for failed tests, default 3",
         "impacted": "Only run tests that are impacted by the changes (only available in CI for now)",
         "keep_stack": "Keep the stack after running the test, you are responsible for destroying the stack later.",
+        "windows_agent": "Use Windows-compatible agent images (multi-arch with Windows support)",
     },
 )
 def run(
@@ -269,6 +270,7 @@ def run(
     max_retries=0,
     osdescriptors="",
     module_name="test/new-e2e",
+    windows_agent=False,
 ):
     """
     Run E2E Tests based on test-infra-definitions infrastructure provisioning.
@@ -348,6 +350,9 @@ def run(
 
     if cluster_agent_image:
         parsed_params["ddagent:clusterAgentFullImagePath"] = cluster_agent_image
+
+    if windows_agent:
+        parsed_params["ddagent:linuxOnly"] = "false"
 
     if parsed_params:
         env_vars["E2E_STACK_PARAMS"] = json.dumps(parsed_params)

--- a/test/e2e-framework/common/config/environment.go
+++ b/test/e2e-framework/common/config/environment.go
@@ -72,6 +72,7 @@ const (
 	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
 	DDAgentJMX                           = "jmx"
 	DDAgentFIPS                          = "fips"
+	DDAgentLinuxOnly                     = "linuxOnly"
 	DDAgentConfigPathParamName           = "configPath"
 	DDAgentHelmConfig                    = "helmConfig"
 
@@ -126,6 +127,7 @@ type Env interface {
 	AgentDeploy() bool
 	AgentVersion() string
 	AgentFIPS() bool
+	AgentLinuxOnly() bool
 	AgentLocalPackage() string
 	AgentLocalChartPath() string
 	PipelineID() string
@@ -500,6 +502,10 @@ func (e *CommonEnvironment) GetIntWithDefault(config *sdkconfig.Config, paramNam
 
 func (e *CommonEnvironment) AgentFIPS() bool {
 	return e.GetBoolWithDefault(e.AgentConfig, DDAgentFIPS, false)
+}
+
+func (e *CommonEnvironment) AgentLinuxOnly() bool {
+	return e.GetBoolWithDefault(e.AgentConfig, DDAgentLinuxOnly, true)
 }
 
 func (e *CommonEnvironment) AgentJMX() bool {

--- a/test/e2e-framework/components/datadog/agent/docker.go
+++ b/test/e2e-framework/components/datadog/agent/docker.go
@@ -56,7 +56,7 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 		comp.FIPSEnabled = pulumi.Bool(e.AgentFIPS() || params.FIPS).ToBoolOutput()
 		fullImagePath := params.FullImagePath
 		if fullImagePath == "" {
-			fullImagePath = dockerAgentFullImagePath(e, params.Repository, params.ImageTag, false, params.FIPS, params.JMX)
+			fullImagePath = dockerAgentFullImagePath(e, params.Repository, params.ImageTag, false, params.FIPS, params.JMX, params.WindowsImage)
 		}
 
 		// Check FullImagePath exists in internal registry

--- a/test/e2e-framework/components/datadog/agent/docker_image.go
+++ b/test/e2e-framework/components/datadog/agent/docker_image.go
@@ -25,6 +25,7 @@ const (
 	jmxSuffix                        = "-jmx"
 	otelSuffix                       = "-7-full"
 	fipsSuffix                       = "-fips"
+	linuxOnlySuffix                  = "-linux"
 )
 
 func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, otel bool, fips bool, jmx bool) string {
@@ -36,6 +37,7 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 	useOtel := otel
 	useFIPS := fips || e.AgentFIPS()
 	useJMX := jmx
+	useLinuxOnly := e.AgentLinuxOnly()
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" && imageTag == "" {
@@ -45,12 +47,20 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 			panic("Unsupported: no image with FIPS, JMX and OTel exists yet")
 		case useOtel && useFIPS:
 			panic("Unsupported: no image with FIPS and OTel exists yet")
+		case useLinuxOnly && useFIPS:
+			panic("Unsupported: no image with FIPS and Linux-only exists yet")
+		case useLinuxOnly && useOtel:
+			panic("Unsupported: no image with OTel and Linux-only exists yet")
 		case useOtel && useJMX:
 			tag += otelSuffix
 		case useFIPS && useJMX:
 			tag += fipsSuffix + jmxSuffix
 		case useFIPS:
 			tag += fipsSuffix
+		case useLinuxOnly && useJMX:
+			tag += linuxOnlySuffix + jmxSuffix
+		case useLinuxOnly:
+			tag += linuxOnlySuffix
 		case useJMX:
 			tag += jmxSuffix
 		case useOtel:

--- a/test/e2e-framework/components/datadog/agent/docker_image.go
+++ b/test/e2e-framework/components/datadog/agent/docker_image.go
@@ -28,7 +28,7 @@ const (
 	linuxOnlySuffix                  = "-linux"
 )
 
-func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, otel bool, fips bool, jmx bool) string {
+func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, otel bool, fips bool, jmx bool, windowsImage bool) string {
 	// return agent image path if defined
 	if e.AgentFullImagePath() != "" {
 		return e.AgentFullImagePath()
@@ -37,7 +37,7 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 	useOtel := otel
 	useFIPS := fips || e.AgentFIPS()
 	useJMX := jmx
-	useLinuxOnly := e.AgentLinuxOnly()
+	useLinuxOnly := e.AgentLinuxOnly() && !windowsImage
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" && imageTag == "" {
@@ -47,11 +47,12 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 			panic("Unsupported: no image with FIPS, JMX and OTel exists yet")
 		case useOtel && useFIPS:
 			panic("Unsupported: no image with FIPS and OTel exists yet")
+		case useLinuxOnly && useFIPS && useJMX:
+			tag += fipsSuffix + linuxOnlySuffix + jmxSuffix
 		case useLinuxOnly && useFIPS:
-			panic("Unsupported: no image with FIPS and Linux-only exists yet")
-		case useLinuxOnly && useOtel:
-			panic("Unsupported: no image with OTel and Linux-only exists yet")
-		case useOtel && useJMX:
+			tag += fipsSuffix + linuxOnlySuffix
+		case useOtel:
+			// OTel images (-7-full) are already Linux-only and have jmx
 			tag += otelSuffix
 		case useFIPS && useJMX:
 			tag += fipsSuffix + jmxSuffix
@@ -63,8 +64,6 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 			tag += linuxOnlySuffix
 		case useJMX:
 			tag += jmxSuffix
-		case useOtel:
-			tag += otelSuffix
 		}
 
 		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/agent-qa", e.InternalRegistry()), tag)

--- a/test/e2e-framework/components/datadog/agent/ecs.go
+++ b/test/e2e-framework/components/datadog/agent/ecs.go
@@ -83,7 +83,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 		Cpu:       pulumi.IntPtr(200),
 		Memory:    pulumi.IntPtr(512),
 		Name:      pulumi.String("datadog-agent"),
-		Image:     pulumi.String(dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false)),
+		Image:     pulumi.String(dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false, false)),
 		Essential: pulumi.BoolPtr(true),
 		LinuxParameters: ecs.TaskDefinitionLinuxParametersArgs{
 			Capabilities: ecs.TaskDefinitionKernelCapabilitiesArgs{

--- a/test/e2e-framework/components/datadog/agent/ecsFargate.go
+++ b/test/e2e-framework/components/datadog/agent/ecsFargate.go
@@ -16,7 +16,7 @@ import (
 
 func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *fakeintake.Fakeintake, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) (*ecs.TaskDefinitionContainerDefinitionArgs, *ecs.TaskDefinitionContainerDefinitionArgs) {
 	if image == "" {
-		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false)
+		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false, false)
 	}
 
 	// Init container copies files to a writeable volume
@@ -144,7 +144,7 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/tutorial-deploy-fluentbit-on-windows.html
 func ECSFargateWindowsContainerDefinition(e config.Env, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *fakeintake.Fakeintake) *ecs.TaskDefinitionContainerDefinitionArgs {
 	if image == "" {
-		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false)
+		image = dockerAgentFullImagePath(e, "public.ecr.aws/datadog/agent", "", false, false, false, true)
 	}
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:       pulumi.IntPtr(0),

--- a/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
+++ b/test/e2e-framework/components/datadog/agent/helm/kubernetes_agent.go
@@ -46,6 +46,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			GKEAutopilot:                   params.GKEAutopilot,
 			FIPS:                           params.FIPS,
 			JMX:                            params.JMX,
+			WindowsImage:                   params.WindowsImage,
 		}, pulumiResourceOptions...)
 		if err != nil {
 			return err

--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -69,6 +69,8 @@ type HelmInstallationArgs struct {
 	FIPS bool
 	// JMX is used to deploy the agent with the JMX agent image
 	JMX bool
+	// WindowsImage is used to use Windows-compatible image (multi-arch with Windows)
+	WindowsImage bool
 }
 
 type HelmComponent struct {
@@ -147,7 +149,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	}
 
 	// Compute some values
-	agentImagePath := dockerAgentFullImagePath(e, "", "", args.OTelAgent, args.FIPS, args.JMX)
+	agentImagePath := dockerAgentFullImagePath(e, "", "", args.OTelAgent, args.FIPS, args.JMX, args.WindowsImage)
 	if args.AgentFullImagePath != "" {
 		agentImagePath = args.AgentFullImagePath
 	}

--- a/test/e2e-framework/components/datadog/dockeragentparams/params.go
+++ b/test/e2e-framework/components/datadog/dockeragentparams/params.go
@@ -47,6 +47,8 @@ type Params struct {
 	Repository string
 	// JMX is true if the JMX image is needed
 	JMX bool
+	// WindowsImage is true if Windows-compatible image is needed
+	WindowsImage bool
 	// AgentServiceEnvironment is a map of environment variables to set in the docker compose agent service's environment.
 	AgentServiceEnvironment pulumi.Map
 	// ExtraComposeManifests is a list of extra docker compose manifests to add beside the agent service.
@@ -65,6 +67,7 @@ func NewParams(e config.Env, options ...Option) (*Params, error) {
 	version := &Params{
 		AgentServiceEnvironment: pulumi.Map{},
 		EnvironmentVariables:    pulumi.StringMap{},
+		WindowsImage:            !e.AgentLinuxOnly(),
 	}
 
 	for k, v := range e.AgentExtraEnvVars() {
@@ -100,6 +103,14 @@ func WithJMX() func(*Params) error {
 func WithFIPS() func(*Params) error {
 	return func(p *Params) error {
 		p.FIPS = true
+		return nil
+	}
+}
+
+// WithWindowsImage makes the image Windows-compatible (multi-arch with Windows)
+func WithWindowsImage() func(*Params) error {
+	return func(p *Params) error {
+		p.WindowsImage = true
 		return nil
 	}
 }

--- a/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
+++ b/test/e2e-framework/components/datadog/kubernetesagentparams/params.go
@@ -77,6 +77,8 @@ type Params struct {
 	FIPS bool
 	// JMX is a flag to deploy the agent with JMX agent image.
 	JMX bool
+	// WindowsImage is a flag to use Windows-compatible image (multi-arch with Windows).
+	WindowsImage bool
 }
 
 type Option = func(*Params) error
@@ -86,6 +88,7 @@ func NewParams(env config.Env, options ...Option) (*Params, error) {
 		Namespace:     defaultAgentNamespace,
 		HelmRepoURL:   DatadogHelmRepo,
 		HelmChartPath: "datadog",
+		WindowsImage:  !env.AgentLinuxOnly(),
 	}
 
 	if env.AgentLocalChartPath() != "" {
@@ -256,6 +259,13 @@ func WithFIPS() func(*Params) error {
 func WithJMX() func(*Params) error {
 	return func(p *Params) error {
 		p.JMX = true
+		return nil
+	}
+}
+
+func WithWindowsImage() func(*Params) error {
+	return func(p *Params) error {
+		p.WindowsImage = true
 		return nil
 	}
 }

--- a/test/new-e2e/examples/eks_test.go
+++ b/test/new-e2e/examples/eks_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	scenarioeks "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/eks"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
@@ -37,6 +38,9 @@ func TestMyEKSSuite(t *testing.T) {
 					scenarioeks.WithWindowsNodeGroup(),
 					scenarioeks.WithBottlerocketNodeGroup(),
 					scenarioeks.WithLinuxARMNodeGroup(),
+				),
+				scenarioeks.WithAgentOptions(
+					kubernetesagentparams.WithWindowsImage(),
 				),
 			),
 		)))

--- a/test/new-e2e/tests/containers/eks_test.go
+++ b/test/new-e2e/tests/containers/eks_test.go
@@ -36,7 +36,10 @@ func TestEKSSuite(t *testing.T) {
 			sceneks.WithFakeIntakeOptions(
 				fakeintake.WithRetentionPeriod("31m"),
 			),
-			sceneks.WithAgentOptions(kubernetesagentparams.WithDualShipping()),
+			sceneks.WithAgentOptions(
+				kubernetesagentparams.WithDualShipping(),
+				kubernetesagentparams.WithWindowsImage(),
+			),
 			sceneks.WithDeployArgoRollout(),
 		),
 	)))

--- a/test/new-e2e/tests/sbom/eks_test.go
+++ b/test/new-e2e/tests/sbom/eks_test.go
@@ -35,6 +35,7 @@ func TestSBOMEKSSuite(t *testing.T) {
 				sceneks.WithAgentOptions(
 					kubernetesagentparams.WithDualShipping(),
 					kubernetesagentparams.WithHelmValues(helmValues),
+					kubernetesagentparams.WithWindowsImage(),
 				),
 				sceneks.WithDeployArgoRollout(),
 			),


### PR DESCRIPTION
### What does this PR do?
- Create new images for tests without windows
- Update the dependency of tests not needing windows to depend on this new image.

### Motivation
Start tests earlier. As windows chain is really slower than the rest, the concerned tests should start ~several min earlier

We can see here the tests requiring the windows image start way after other e2e tests
<img width="1557" height="522" alt="image" src="https://github.com/user-attachments/assets/c7dcea70-6bc1-423e-85f8-fb1a81aa4788" />
mostly because the image was available after
<img width="1372" height="358" alt="image" src="https://github.com/user-attachments/assets/519c9b69-18af-4eec-a18f-76d5f1763f96" />

https://datadoghq.atlassian.net/browse/ACIX-1241

### Describe how you validated your changes
Check CI execution on a full pipeline

### Additional Notes
