### PR TITLE
Run SMP tests only on PRs containing changes that can impact agent artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -330,6 +330,30 @@ variables:
     - .gitlab/deploy/container_build/fakeintake.yml
     - .gitlab/deploy/dev_container_deploy/fakeintake.yml
 
+# Paths that impact the final build artifacts (rpm, deb, docker images, etc.)
+# Used to conditionally skip expensive tests like SMP when only non-artifact files change
+# like documentation, CI config, e2e tests.
+.artifacts_build_impacting_paths: &artifacts_build_impacting_paths
+  paths:
+    # agent source code
+    - go.mod
+    - go.sum
+    - cmd/**/*
+    - comp/**/*
+    - internal/**/*
+    - pkg/**/*
+    - rtloader/**/*
+    # Build system
+    - tasks/**/*.py
+    - deps/**/*
+    - omnibus/**/*
+    - .bazelrc
+    - .bazelversion
+    - bazel/**/*
+    - BUILD.bazel
+    - MODULE.bazel
+    - release.json
+
 .if_coverage_pipeline: &if_coverage_pipeline
   if: $E2E_COVERAGE_PIPELINE == "true"
 
@@ -476,6 +500,12 @@ workflow:
   - !reference [.except_main_release_or_mq]
   - <<: *if_tagged_commit
     when: never
+
+.on_dev_branches_with_artifact_changes:
+  - !reference [.on_dev_branches]
+  - changes:
+      <<: *artifacts_build_impacting_paths
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -180,7 +180,11 @@ single_machine_performance-full-amd64-a7:
   stage: container_build
   rules:
     - !reference [.except_mergequeue]
-    - when: on_success
+    # Always publish SMP images on main (needed for baseline comparisons)
+    - !reference [.on_main]
+    # On dev branches, only publish when artifact-impacting files change.
+    # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
+    - !reference [.on_dev_branches_with_artifact_changes]
   needs:
     - docker_build_agent7_full
   variables:

--- a/.gitlab/test/functional_test/regression_detector.yml
+++ b/.gitlab/test/functional_test/regression_detector.yml
@@ -3,8 +3,9 @@ single_machine_performance-regression_detector-merge_base_check:
   timeout: 10m
   rules:
     - !reference [.except_coverage_pipeline]
-    - !reference [.on_dev_branches]
-    - when: on_success
+     # Only run SMP on dev branches when artifact-impacting files change.
+     # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
+    - !reference [.on_dev_branches_with_artifact_changes]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64
   tags: ["arch:amd64", "specific:true"]
   artifacts:
@@ -78,8 +79,9 @@ single_machine_performance-regression_detector-merge_base_check:
   tags: ["arch:amd64", "specific:true"]
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a duplicate, specialized artifact that is not useful to run through SMP on every PR
-    - !reference [.on_dev_branches]
-    - when: on_success
+     # Only run SMP on dev branches when artifact-impacting files change.
+     # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
+    - !reference [.on_dev_branches_with_artifact_changes]
   artifacts:
     expire_in: 1 weeks
     paths:
@@ -347,8 +349,9 @@ single-machine-performance-regression_detector-pr-comment:
   stage: functional_test
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a duplicate, specialized artifact that is not useful to run through SMP on every PR
-    - !reference [.on_dev_branches]
-    - when: always
+     # Only run SMP on dev branches when artifact-impacting files change.
+     # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
+    - !reference [.on_dev_branches_with_artifact_changes]
   image:
     name: "486234852809.dkr.ecr.us-east-1.amazonaws.com/pr-commenter:3-jammy"
     entrypoint: [""] # disable entrypoint script for the pr-commenter image


### PR DESCRIPTION
### What does this PR do?

Skip the execution of SMP tests on pull requests that don’t touch the agent.

### Motivation

SMP tests are expensive. So, we could save time and money by not running them on PRs that don’t touch what SMP tests.

### Describe how you validated your changes

Let the CI run.

### Additional Notes

GitLab unfortunately misses a “negative matching” feature to exclude PRs that touch only `*_test.go` files.
https://docs.gitlab.com/ci/yaml/#ruleschanges