### PR TITLE
Fix panic in aggregator test

### DIFF
--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -223,6 +223,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 			return serie.Name == "dist.metric"
 		})
 
+		require.NotEqualf(-1, metric, "dist.metric not found in %+v", s.sketches)
 		tags := strings.Split(s.sketches[metric].Tags.Join(","), ",")
 		require.ElementsMatch(expected, tags)
 	}

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -217,6 +217,9 @@ func TestUpdateTagFilterList(t *testing.T) {
 			Tags:      []string{"tag1:one", "tag2:two", "tag3:three", "tag4:four"},
 		})
 
+		require.Eventually(func() bool {
+			return len(demux.statsd.workers[0].samplesChan) == 0
+		}, time.Second, time.Millisecond)
 		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
 
 		metric := slices.IndexFunc(s.sketches, func(serie *metrics.SketchSeries) bool {
@@ -314,6 +317,9 @@ func TestUpdateMetricFilterList(t *testing.T) {
 			Name: "original.blocked", Value: 42, Mtype: metrics.HistogramType, Timestamp: ts,
 		})
 
+		require.Eventually(func() bool {
+			return len(demux.statsd.workers[0].samplesChan) == 0
+		}, time.Second, time.Millisecond)
 		demux.ForceFlushToSerializer(time.Unix(int64(ts+30), 0), true)
 
 		// We should always contain the average of the histogram.


### PR DESCRIPTION
### What does this PR do?
Fix a panic in aggregator test and fail cleanly instead.

### Motivation
I think on panic we don't retry failed tests, which means we don't have the nice flaky test management.
Also a panic makes the error very unclear.

### Describe how you validated your changes
CI

### Additional Notes
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1372692674#L1056