### PR TITLE
fix: avoid flushing stats without container tags

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -435,6 +435,8 @@ func (a *Agent) Process(p *api.Payload) {
 			log.Debugf("Failed getting container tags for ID %s: %v", p.TracerPayload.ContainerID, err)
 		} else {
 			p.ContainerTags = cTags
+			// Populate statsInput.ContainerTags so agent-computed stats include container tags
+			statsInput.ContainerTags = cTags
 		}
 	}
 
@@ -609,6 +611,8 @@ func (a *Agent) ProcessV1(p *api.PayloadV1) {
 			log.Debugf("Failed getting container tags for ID %s: %v", p.TracerPayload.ContainerID(), err)
 		} else {
 			p.ContainerTags = cTags
+			// Populate statsInput.ContainerTags so agent-computed stats include container tags
+			statsInput.ContainerTags = cTags
 		}
 	}
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -4374,7 +4374,7 @@ func TestAgentWriteTagsBufferedChunksV1(t *testing.T) {
 func TestAgentComputedStatsContainerTags(t *testing.T) {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
-	
+
 	// Mock container tags function that returns tags for a given container ID
 	expectedTags := []string{"datacenter:us-east-1", "env:prod", "image:nginx:latest"}
 	cfg.ContainerTags = func(cid string) ([]string, error) {
@@ -4422,7 +4422,7 @@ func TestAgentComputedStatsContainerTags(t *testing.T) {
 func TestAgentComputedStatsNoContainerID(t *testing.T) {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
-	
+
 	// ContainerTags function should be called even with empty container ID
 	// It should return nil/empty for empty container IDs
 	cfg.ContainerTags = func(cid string) ([]string, error) {
@@ -4469,8 +4469,8 @@ func TestAgentComputedStatsNoContainerID(t *testing.T) {
 func TestClientComputedStatsNoContainerTagsNeeded(t *testing.T) {
 	cfg := config.New()
 	cfg.Endpoints[0].APIKey = "test"
-	
-	cfg.ContainerTags = func(cid string) ([]string, error) {
+
+	cfg.ContainerTags = func(_ string) ([]string, error) {
 		return []string{"datacenter:us-east-1"}, nil
 	}
 


### PR DESCRIPTION
### What does this PR do?

Populates `statsInput.ContainerTags` after retrieving container tags in `pkg/trace/agent/agent.go`.

### Motivation

The `datacenter` tag (and other container tags) were missing from trace metrics when the Datadog Agent computed stats from traces received at the `/v0.4/traces` endpoint.

The bug existed in the agent all along, but became visible when `dd-trace-go` v2.6.x changed its stats computation behavior:

- **v2.5.x**: More likely to compute stats client-side (working path)
- **v2.6.x**: Changed conditions for client-side stats, causing more reliance on agent-side stats (broken path)

The key difference is in the `canComputeStats()` function logic:

#### v2.5.x Logic (Working)

```go
func (c *config) canComputeStats() bool {
    return c.agent.Stats && (c.HasFeature("discovery") || c.statsComputationEnabled)
}

func (c *config) canDropP0s() bool {
    return c.canComputeStats() && c.agent.DropP0s
}
```

#### v2.6.x Logic (Broken)

```go
func (c *config) canComputeStats() bool {
    return c.agent.Stats && c.agent.DropP0s && (c.internalConfig.HasFeature("discovery") || c.internalConfig.StatsComputationEnabled())
}

func (c *config) canDropP0s() bool {
    return c.canComputeStats()
}
```

#### The Critical Change

v2.6.x added c.agent.DropP0s as a required condition for `canComputeStats()`.
This means:
- v2.5.x: Could compute stats even if `client_drop_p0s` was false (agent didn't advertise it)
- v2.6.x: requires `client_drop_p0s=true` to compute stats

#### What Could be Happening in Production

1. The agent might not advertising `client_drop_p0s: true` (or could be advertising it as `false`)
2. With v2.5.x:
    1. `canComputeStats()` returns `true` (didn't check `DropP0s`)
    2. Tracer computed stats client-side
    3. Sent stats to `/v0.6/stats` with container headers
    4. Agent enriched stats with container tags (working path) ✅
3. With v2.6.x:
    1. `canComputeStats()` returns `false` (because `c.agent.DropP0s` was `false`)
    2. Tracer did not compute stats client-side
    3. Sent only traces to `/v0.4/traces` with container headers
    4. Agent computed stats but forgot to populate `ContainerTags` (broken path) ❌

In other words, `c.agent.DropP0s` determines whether client-side stats computation happens:

- `DropP0s=true` AND `Stats=true ` → `canDropP0s() = true`
  - ✅ Tracer computes stats client-side
  - ✅ Sends stats to /v0.6/stats (with container headers)
  - ✅ Still sends traces to /v0.4/traces (but may drop P0 spans)
- `DropP0s=false` OR `Stats=false` → `canDropP0s() = false`
  - ❌ Tracer does not compute stats
  - ❌ Does not send to /v0.6/stats
  - ✅ Only sends traces to /v0.4/traces (agent computes stats)
  - 🐛 This exposes the agent bug

The agent bug was always present but only manifested when agent-side stats computation was used.

### Describe how you validated your changes

- ✅ New tests pass
- ✅ Existing tests pass
- ✅ No linter errors
- ✅ Fix is minimal and targeted

### Additional Notes
