### PR TITLE
[ABLD-339] Remove DMG notarization from PR pipelines

### DIFF
--- a/.gitlab/build/package_build/build_agent_dmg.sh
+++ b/.gitlab/build/package_build/build_agent_dmg.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-if [ "$SIGN" = true ]; then
+if [ "${SIGN:-false}" = true ]; then
     echo "Signing enabled"
 else
     echo "Signing disabled"
@@ -24,7 +24,7 @@ if [ -n "$INTEGRATIONS_CORE_REF" ]; then
 fi
 
 # --- Setup signing ---
-if [ "$SIGN" = true ]; then
+if [ "${SIGN:-false}" = true ]; then
     # Add certificates to temporary keychain
     echo "Setting up signing secrets"
 
@@ -84,7 +84,7 @@ echo Launching omnibus build
 rm -rf "$INSTALL_DIR" "$CONFIG_DIR"
 mkdir -p "$INSTALL_DIR" "$CONFIG_DIR"
 rm -rf "$OMNIBUS_DIR" && mkdir -p "$OMNIBUS_DIR"
-if [ "$SIGN" = "true" ]; then
+if [ "${SIGN:-false}" = true ]; then
     # Unlock the keychain to get access to the signing certificates
     security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
     dda inv -- -e omnibus.build --hardened-runtime --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
@@ -123,7 +123,7 @@ fi
 echo Built packages using omnibus
 
 # --- Notarization ---
-if [ "$SIGN" = true ]; then
+if [ "${SIGN:-false}" = true ]; then
     printf "\033[0Ksection_start:%s:notarization\r\033[0KDoing notarization\n" "$(date +%s)"
     unset LATEST_DMG
 
@@ -176,7 +176,7 @@ if [ "$SIGN" = true ]; then
     printf "\033[0Ksection_end:%s:notarization\r\033[0K\n" "$(date +%s)"
 fi
 
-if [ "$SIGN" = true ]; then
+if [ "${SIGN:-false}" = true ]; then
     echo Built signed package
 else
     echo Built unsigned package

--- a/.gitlab/build/package_build/dmg.yml
+++ b/.gitlab/build/package_build/dmg.yml
@@ -26,9 +26,14 @@
   stage: package_build
   needs: ["go_mod_tidy_check"]
   rules:
+     - if: $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
+       variables:
+         SIGN: true  # for `main` and release branches
+     - if: $CI_COMMIT_BRANCH =~ /notarization/
+       variables:
+         SIGN: true  # for branches with "notarization" in their name - should we need to tune it
      - !reference [.on_macos_files_change]
      - !reference [.on_packaging_change]
-     - !reference [.on_main_or_release_branch]
      - !reference [.on_all_builds]
      - !reference [.manual]
   artifacts:
@@ -40,7 +45,6 @@
     CI_IDENTITIES_GITLAB_ID_TOKEN:
       aud: ci-identities
   variables:
-    SIGN: true
     KEYCHAIN_NAME: "build.keychain"
     INTEGRATION_WHEELS_CACHE_BUCKET: dd-agent-omnibus
     INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD: true
@@ -59,7 +63,7 @@
   after_script:
     # Destroy the keychain used to sign packages
     - |
-      if [ "$SIGN" = true ]; then
+      if [ "${SIGN:-false}" = true ]; then
         security delete-keychain "build.keychain" || true
       fi
     - sudo umount /Volumes/Agent || true


### PR DESCRIPTION
### What does this PR do?
Makes DMG notarization conditional based on branch:
- enabled on `main` and release branches (e.g., `7.76.x`),
- enabled for branches with `notarization` in their name, should we need to tune signing and/or notarization snippets,
- disabled otherwise (automated PRs and dev branch builds).

### Motivation
DMG notarization was enabled for all builds (since #33519 and probably before), but:
- notarization may take up to 15 minutes,
- it requires Apple Developer credentials,
- PR builds don't really need notarization (testing only),
- 8 commits to the DMG build script were about mitigating notarization issues,
- multiple production incidents: #incident-40404, #incident-47785, etc.

### Describe how you validated your changes
Changes will be validated in CI:
- PR builds should skip notarization (faster, no failures),
- `main`/release builds should still notarize (production requirement),
- `manual` builds default to notarizing (can override with `SIGN=false` through GitLab API call).

### Additional Notes
The solution leverages GitLab CI's rule evaluation order (first match wins), in particular branch conditions checked first: `main`/release branch => `SIGN=true`.

Script now uses `${SIGN:-false}` for explicit defaulting and eventual `set -u` compatibility.