### PR TITLE
[CWS] Handle pod pause/sandbox container tags

### DIFF
--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -77,6 +77,8 @@ const (
 	KubernetesCapabilities EntityIDPrefix = "kubernetes_capabilities"
 	// KubernetesPodUID is the prefix `kubernetes_pod_uid`
 	KubernetesPodUID EntityIDPrefix = "kubernetes_pod_uid"
+	// KubernetesPodSandbox is the prefix `kubernetes_pod_sandbox` for sandbox/pause containers
+	KubernetesPodSandbox EntityIDPrefix = "kubernetes_pod_sandbox"
 	// Process is the prefix `process`
 	Process EntityIDPrefix = "process"
 	// InternalID is the prefix `internal`
@@ -99,6 +101,7 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		KubernetesDeployment:   {},
 		KubernetesMetadata:     {},
 		KubernetesPodUID:       {},
+		KubernetesPodSandbox:   {},
 		Process:                {},
 		InternalID:             {},
 		GPU:                    {},

--- a/comp/core/tagger/types/filter_builder_test.go
+++ b/comp/core/tagger/types/filter_builder_test.go
@@ -57,6 +57,7 @@ func TestFilterBuilderOps(t *testing.T) {
 					ECSTask:                {},
 					KubernetesMetadata:     {},
 					KubernetesPodUID:       {},
+					KubernetesPodSandbox:   {},
 					Process:                {},
 					InternalID:             {},
 					GPU:                    {},

--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -163,6 +163,13 @@ func buildWorkloadMetaContainer(namespace string, container containerd.Container
 		return workloadmeta.Container{}, err
 	}
 
+	// Check if this is a sandbox/pause container
+	isSandbox, err := containerdClient.IsSandbox(namespace, container)
+	if err != nil {
+		log.Debugf("cannot determine if container %s is a sandbox: %v", container.ID(), err)
+	}
+	workloadContainer.IsSandbox = isSandbox
+
 	return workloadContainer, nil
 }
 

--- a/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/container_builder_test.go
@@ -242,6 +242,9 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		MockTaskPids: func(string, containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
+		MockIsSandbox: func(string, containerd.Container) (bool, error) {
+			return false, nil
+		},
 	}
 
 	// Create a workload meta global store containing image metadata

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -390,15 +390,16 @@ func (c *collector) extractContainerFromEvent(ctx context.Context, containerdEve
 }
 
 // ignoreContainer returns whether a containerd event should be ignored.
-// The ignored events are the ones that refer to a "pause" container.
 func (c *collector) ignoreContainer(namespace string, container containerd.Container) (bool, error) {
 	isSandbox, err := c.containerdClient.IsSandbox(namespace, container)
 	if err != nil {
 		return false, err
 	}
 
+	// Sandbox containers are collected to support CWS tag resolution
+	// They will be filtered at the tagger level if needed
 	if isSandbox {
-		return true, nil
+		return false, nil
 	}
 
 	info, err := c.containerdClient.Info(namespace, container)

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd_test.go
@@ -51,7 +51,7 @@ func TestIgnoreContainer(t *testing.T) {
 			imgName:        "k8s.gcr.io/pause",
 			container:      &container,
 			isSandbox:      true,
-			expectsIgnored: true,
+			expectsIgnored: false,
 		},
 		{
 			name:           "non-pause container that exists",

--- a/comp/core/workloadmeta/collectors/internal/containerd/event_builder_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/event_builder_test.go
@@ -347,5 +347,8 @@ func containerdClient(container containerd.Container) fake.MockedContainerdClien
 		MockTaskPids: func(string, containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
+		MockIsSandbox: func(string, containerd.Container) (bool, error) {
+			return false, nil
+		},
 	}
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -657,6 +657,8 @@ type Container struct {
 	// Linux only.
 	CgroupPath   string
 	RestartCount int
+	// IsSandbox indicates if this container is a sandbox/pause container (Kubernetes pod infrastructure container)
+	IsSandbox bool
 }
 
 // GetID implements Entity#GetID.

--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -311,6 +311,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                 "variables": {
                     "$ref": "#/$defs/Variables",
                     "description": "Variables values"
+                },
+                "is_sandbox": {
+                    "type": "boolean",
+                    "description": "Indicates if the container is a sandbox/pause container"
                 }
             },
             "additionalProperties": false,
@@ -2928,6 +2932,10 @@ Workload Protection events for Linux systems have the following JSON schema:
         "variables": {
             "$ref": "#/$defs/Variables",
             "description": "Variables values"
+        },
+        "is_sandbox": {
+            "type": "boolean",
+            "description": "Indicates if the container is a sandbox/pause container"
         }
     },
     "additionalProperties": false,
@@ -2942,6 +2950,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `id` | Container ID |
 | `created_at` | Creation time of the container |
 | `variables` | Variables values |
+| `is_sandbox` | Indicates if the container is a sandbox/pause container |
 
 | References |
 | ---------- |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -300,6 +300,10 @@
         "variables": {
           "$ref": "#/$defs/Variables",
           "description": "Variables values"
+        },
+        "is_sandbox": {
+          "type": "boolean",
+          "description": "Indicates if the container is a sandbox/pause container"
         }
       },
       "additionalProperties": false,

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -207,6 +207,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`process.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.ancestors.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -317,6 +318,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`process.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -408,6 +410,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`process.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.parent.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -800,6 +803,7 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`exec.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`exec.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exec.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`exec.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exec.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exec.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -927,6 +931,7 @@ A process was terminated
 | [`exit.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`exit.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`exit.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exit.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`exit.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exit.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exit.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -1390,6 +1395,7 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`ptrace.tracee.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`ptrace.tracee.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.ancestors.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`ptrace.tracee.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -1500,6 +1506,7 @@ A ptrace command was executed
 | [`ptrace.tracee.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`ptrace.tracee.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`ptrace.tracee.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`ptrace.tracee.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -1591,6 +1598,7 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`ptrace.tracee.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`ptrace.tracee.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`ptrace.tracee.parent.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`ptrace.tracee.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`ptrace.tracee.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`ptrace.tracee.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -1890,6 +1898,7 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`setrlimit.target.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`setrlimit.target.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.ancestors.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`setrlimit.target.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -2000,6 +2009,7 @@ A setrlimit command was executed
 | [`setrlimit.target.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`setrlimit.target.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`setrlimit.target.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`setrlimit.target.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -2091,6 +2101,7 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`setrlimit.target.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`setrlimit.target.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`setrlimit.target.parent.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`setrlimit.target.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`setrlimit.target.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`setrlimit.target.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -2295,6 +2306,7 @@ A signal was sent
 | [`signal.target.ancestors.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`signal.target.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`signal.target.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.ancestors.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`signal.target.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.ancestors.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -2405,6 +2417,7 @@ A signal was sent
 | [`signal.target.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`signal.target.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`signal.target.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`signal.target.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -2496,6 +2509,7 @@ A signal was sent
 | [`signal.target.parent.comm`](#common-process-comm-doc) | Comm attribute of the process |
 | [`signal.target.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`signal.target.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`signal.target.parent.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`signal.target.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`signal.target.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`signal.target.parent.egid`](#common-credentials-egid-doc) | Effective GID of the process |
@@ -3224,6 +3238,15 @@ Definition: Whether the IP address belongs to a public network
 
 `*.is_public` has 9 possible prefixes:
 `accept.addr` `bind.addr` `connect.addr` `network.destination` `network.source` `network_flow_monitor.flows.destination` `network_flow_monitor.flows.source` `packet.destination` `packet.source`
+
+
+### `*.is_sandbox` {#common-containercontext-is_sandbox-doc}
+Type: bool
+
+Definition: indicates if this is a sandbox/pause container
+
+`*.is_sandbox` has 14 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container` `ptrace.tracee.ancestors.container` `ptrace.tracee.container` `ptrace.tracee.parent.container` `setrlimit.target.ancestors.container` `setrlimit.target.container` `setrlimit.target.parent.container` `signal.target.ancestors.container` `signal.target.container` `signal.target.parent.container`
 
 
 ### `*.is_thread` {#common-process-is_thread-doc}

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -143,6 +143,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "process.ancestors.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "process.ancestors.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -693,6 +698,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "process.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "process.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -1146,6 +1156,11 @@
           "name": "process.parent.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.parent.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "process.parent.container.tags",
@@ -2776,6 +2791,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "exec.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "exec.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -3383,6 +3403,11 @@
           "name": "exit.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exit.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "exit.container.tags",
@@ -5378,6 +5403,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -5928,6 +5958,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "ptrace.tracee.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "ptrace.tracee.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -6381,6 +6416,11 @@
           "name": "ptrace.tracee.parent.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "ptrace.tracee.parent.container.tags",
@@ -7722,6 +7762,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -8272,6 +8317,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "setrlimit.target.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "setrlimit.target.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -8725,6 +8775,11 @@
           "name": "setrlimit.target.parent.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "setrlimit.target.parent.container.tags",
@@ -9643,6 +9698,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "signal.target.ancestors.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "signal.target.ancestors.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -10193,6 +10253,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "signal.target.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "signal.target.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -10646,6 +10711,11 @@
           "name": "signal.target.parent.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "signal.target.parent.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "signal.target.parent.container.tags",
@@ -13158,6 +13228,31 @@
         "network_flow_monitor.flows.source",
         "packet.destination",
         "packet.source"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.is_sandbox",
+      "link": "common-containercontext-is_sandbox-doc",
+      "type": "bool",
+      "definition": "indicates if this is a sandbox/pause container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container",
+        "ptrace.tracee.ancestors.container",
+        "ptrace.tracee.container",
+        "ptrace.tracee.parent.container",
+        "setrlimit.target.ancestors.container",
+        "setrlimit.target.container",
+        "setrlimit.target.parent.container",
+        "signal.target.ancestors.container",
+        "signal.target.container",
+        "signal.target.parent.container"
       ],
       "constants": "",
       "constants_link": "",

--- a/docs/cloud-workload-security/secl_windows.json
+++ b/docs/cloud-workload-security/secl_windows.json
@@ -58,6 +58,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "process.ancestors.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "process.ancestors.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -143,6 +148,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "process.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "process.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -201,6 +211,11 @@
           "name": "process.parent.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "process.parent.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "process.parent.container.tags",
@@ -537,6 +552,11 @@
           "property_doc_link": "common-containercontext-id-doc"
         },
         {
+          "name": "exec.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
+        },
+        {
           "name": "exec.container.tags",
           "definition": "Tags of the container",
           "property_doc_link": "common-containercontext-tags-doc"
@@ -634,6 +654,11 @@
           "name": "exit.container.id",
           "definition": "ID of the container",
           "property_doc_link": "common-containercontext-id-doc"
+        },
+        {
+          "name": "exit.container.is_sandbox",
+          "definition": "indicates if this is a sandbox/pause container",
+          "property_doc_link": "common-containercontext-is_sandbox-doc"
         },
         {
           "name": "exit.container.tags",
@@ -1102,6 +1127,22 @@
       "link": "common-containercontext-id-doc",
       "type": "string",
       "definition": "ID of the container",
+      "prefixes": [
+        "exec.container",
+        "exit.container",
+        "process.ancestors.container",
+        "process.container",
+        "process.parent.container"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.is_sandbox",
+      "link": "common-containercontext-is_sandbox-doc",
+      "type": "bool",
+      "definition": "indicates if this is a sandbox/pause container",
       "prefixes": [
         "exec.container",
         "exit.container",

--- a/docs/cloud-workload-security/windows_expressions.md
+++ b/docs/cloud-workload-security/windows_expressions.md
@@ -74,6 +74,7 @@ List of the available variables:
 | [`process.ancestors.cmdline`](#common-process-cmdline-doc) | Command line of the process |
 | [`process.ancestors.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.ancestors.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.ancestors.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.ancestors.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.ancestors.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.ancestors.envp`](#common-process-envp-doc) | Environment variables of the process |
@@ -91,6 +92,7 @@ List of the available variables:
 | [`process.cmdline`](#common-process-cmdline-doc) | Command line of the process |
 | [`process.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.envp`](#common-process-envp-doc) | Environment variables of the process |
@@ -103,6 +105,7 @@ List of the available variables:
 | [`process.parent.cmdline`](#common-process-cmdline-doc) | Command line of the process |
 | [`process.parent.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`process.parent.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`process.parent.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`process.parent.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`process.parent.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`process.parent.envp`](#common-process-envp-doc) | Environment variables of the process |
@@ -201,6 +204,7 @@ A process was executed or forked
 | [`exec.cmdline`](#common-process-cmdline-doc) | Command line of the process |
 | [`exec.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`exec.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exec.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`exec.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exec.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exec.envp`](#common-process-envp-doc) | Environment variables of the process |
@@ -226,6 +230,7 @@ A process was terminated
 | [`exit.code`](#exit-code-doc) | Exit code of the process or number of the signal that caused the process to terminate |
 | [`exit.container.created_at`](#common-containercontext-created_at-doc) | Timestamp of the creation of the container |
 | [`exit.container.id`](#common-containercontext-id-doc) | ID of the container |
+| [`exit.container.is_sandbox`](#common-containercontext-is_sandbox-doc) | indicates if this is a sandbox/pause container |
 | [`exit.container.tags`](#common-containercontext-tags-doc) | Tags of the container |
 | [`exit.created_at`](#common-process-created_at-doc) | Timestamp of the creation of the process |
 | [`exit.envp`](#common-process-envp-doc) | Environment variables of the process |
@@ -419,6 +424,15 @@ Type: string
 Definition: ID of the container
 
 `*.id` has 5 possible prefixes:
+`exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container`
+
+
+### `*.is_sandbox` {#common-containercontext-is_sandbox-doc}
+Type: bool
+
+Definition: indicates if this is a sandbox/pause container
+
+`*.is_sandbox` has 5 possible prefixes:
 `exec.container` `exit.container` `process.ancestors.container` `process.container` `process.parent.container`
 
 

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -301,6 +301,9 @@ var (
 	// MetricCGroupResolverActiveContainerWorkloads is the name of the metric used to report the count of active cgroups corresponding to a container kept in memory
 	// Tags: -
 	MetricCGroupResolverActiveContainerWorkloads = newRuntimeMetric(".cgroup_resolver.active_containers")
+	// MetricCGroupResolverSandboxContainers is the name of the metric used to report the count of sandbox/pause containers
+	// Tags: -
+	MetricCGroupResolverSandboxContainers = newRuntimeMetric(".cgroup_resolver.sandbox_containers")
 	// MetricCGroupResolverActiveHostWorkloads is the name of the metric used to report the count of active cgroups not corresponding to a container kept in memory
 	// Tags: -
 	MetricCGroupResolverActiveHostWorkloads = newRuntimeMetric(".cgroup_resolver.active_non_containers")

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -362,6 +362,7 @@ func (a *APIServer) start(ctx context.Context) {
 				if a.containerFilter != nil {
 					containerName, imageName, podNamespace := utils.GetContainerFilterTags(msg.tags)
 					if a.containerFilter.IsExcluded(nil, containerName, imageName, podNamespace) {
+						seclog.Debugf("Event for rule `%s` excluded by container filter: container_name=%s, image_name=%s, pod_namespace=%s", msg.ruleID, containerName, imageName, podNamespace)
 						// similar return value as if we had sent the message
 						return true
 					}

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -116,7 +116,7 @@ func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.H
 	evt.Container.ID = string(msg.ContainerContext.ID)
 
 	if tagger != nil {
-		tags, err := tags.GetTagsOfContainer(tagger, containerutils.ContainerID(msg.ContainerContext.ID))
+		_, tags, err := tags.GetTagsOfContainer(tagger, containerutils.ContainerID(msg.ContainerContext.ID))
 		if err != nil {
 			seclog.Errorf("Failed to get tags for container %s: %v", msg.ContainerContext.ID, err)
 		} else {

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	tagsresolver "github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -555,7 +556,9 @@ func (fh *EBPFFieldHandlers) ResolveContainerID(ev *model.Event, e *model.Contai
 // ResolveContainerTags resolves the container tags of the event
 func (fh *EBPFFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.ContainerContext) []string {
 	if len(e.Tags) == 0 && e.ContainerID != "" {
-		e.Tags = fh.resolvers.TagsResolver.Resolve(e.ContainerID)
+		workloadType, tags, _ := fh.resolvers.TagsResolver.ResolveWithErr(e.ContainerID)
+		e.Tags = tags
+		e.IsSandbox = workloadType == tagsresolver.WorkloadTypePodSandbox
 	}
 	return e.Tags
 }

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
+	tagsresolver "github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"golang.org/x/net/bpf"
 
@@ -193,7 +194,9 @@ func (fh *EBPFLessFieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *m
 // ResolveContainerTags resolves the container tags of the event
 func (fh *EBPFLessFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.ContainerContext) []string {
 	if len(e.Tags) == 0 && e.ContainerID != "" {
-		e.Tags = fh.resolvers.TagsResolver.Resolve(e.ContainerID)
+		workloadType, tags, _ := fh.resolvers.TagsResolver.ResolveWithErr(e.ContainerID)
+		e.Tags = tags
+		e.IsSandbox = workloadType == tagsresolver.WorkloadTypePodSandbox
 	}
 	return e.Tags
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -910,7 +910,7 @@ func (p *EBPFProbe) DispatchEvent(event *model.Event, notifyConsumers bool) {
 			imageTag = utils.GetTagValue("image_tag", event.ProcessContext.Process.ContainerContext.Tags)
 		} else if event.ProcessContext.Process.CGroup.IsResolved() {
 			workloadID = event.ProcessContext.Process.CGroup.CGroupID
-			tags, err := p.Resolvers.TagsResolver.ResolveWithErr(workloadID)
+			_, tags, err := p.Resolvers.TagsResolver.ResolveWithErr(workloadID)
 			if err != nil {
 				seclog.Errorf("failed to resolve tags for cgroup %s: %v", workloadID, err)
 				return

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -188,3 +188,21 @@ func (cgce *CacheEntry) CGroupContextEquals(other *CacheEntry) bool {
 
 	return cgce.cgroupContext.Equals(&other.cgroupContext)
 }
+
+// SetSandbox sets the sandbox flag and return true if it was not set before
+func (cgce *CacheEntry) SetSandbox() bool {
+	cgce.lock.Lock()
+	defer cgce.lock.Unlock()
+
+	prev := cgce.containerContext.IsSandbox
+	cgce.containerContext.IsSandbox = true
+	return !prev
+}
+
+// Sandbox returns whether the cache entry is a sandbox/pause container
+func (cgce *CacheEntry) Sandbox() bool {
+	cgce.lock.RLock()
+	defer cgce.lock.RUnlock()
+
+	return cgce.containerContext.Sandbox()
+}

--- a/pkg/security/resolvers/tags/resolver_test.go
+++ b/pkg/security/resolvers/tags/resolver_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package tags
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+)
+
+// MockTagger implements Tagger for testing
+type MockTagger struct {
+	// ContainerTags maps container ID to tags
+	ContainerTags map[string][]string
+	// SandboxTags maps sandbox container ID to tags
+	SandboxTags map[string][]string
+	// GlobalTagsValue holds the global tags
+	GlobalTagsValue []string
+	// Error to return on Tag calls
+	TagError error
+}
+
+func (m *MockTagger) Tag(entity types.EntityID, _ types.TagCardinality) ([]string, error) {
+	if m.TagError != nil {
+		return nil, m.TagError
+	}
+
+	prefix := entity.GetPrefix()
+	id := entity.GetID()
+
+	switch prefix {
+	case types.ContainerID:
+		if tags, ok := m.ContainerTags[id]; ok {
+			return tags, nil
+		}
+	case types.KubernetesPodSandbox:
+		if tags, ok := m.SandboxTags[id]; ok {
+			return tags, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (m *MockTagger) GlobalTags(_ types.TagCardinality) ([]string, error) {
+	return m.GlobalTagsValue, nil
+}
+
+func TestGetTagsOfContainer_RegularContainer(t *testing.T) {
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{
+			"container-123": {"env:prod", "service:web"},
+		},
+	}
+
+	workloadType, tags, err := GetTagsOfContainer(mockTagger, containerutils.ContainerID("container-123"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypeContainer, workloadType)
+	assert.Equal(t, []string{"env:prod", "service:web"}, tags)
+}
+
+func TestGetTagsOfContainer_SandboxContainer(t *testing.T) {
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{}, // No regular container tags
+		SandboxTags: map[string][]string{
+			"sandbox-456": {"kube_namespace:default", "kube_pod:demo-pod"},
+		},
+	}
+
+	workloadType, tags, err := GetTagsOfContainer(mockTagger, containerutils.ContainerID("sandbox-456"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypePodSandbox, workloadType)
+	assert.Equal(t, []string{"kube_namespace:default", "kube_pod:demo-pod"}, tags)
+}
+
+func TestGetTagsOfContainer_UnknownContainer(t *testing.T) {
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{},
+		SandboxTags:   map[string][]string{},
+	}
+
+	workloadType, tags, err := GetTagsOfContainer(mockTagger, containerutils.ContainerID("unknown-789"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypeUnknown, workloadType)
+	assert.Nil(t, tags)
+}
+
+func TestGetTagsOfContainer_NilTagger(t *testing.T) {
+	workloadType, tags, err := GetTagsOfContainer(nil, containerutils.ContainerID("container-123"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypeUnknown, workloadType)
+	assert.Nil(t, tags)
+}
+
+func TestGetTagsOfContainer_TaggerError(t *testing.T) {
+	mockTagger := &MockTagger{
+		TagError: errors.New("tagger unavailable"),
+	}
+
+	workloadType, tags, err := GetTagsOfContainer(mockTagger, containerutils.ContainerID("container-123"))
+
+	assert.Error(t, err)
+	assert.Equal(t, WorkloadTypeUnknown, workloadType)
+	assert.Nil(t, tags)
+}
+
+func TestGetTagsOfContainer_FallbackToSandboxWhenContainerTagsEmpty(t *testing.T) {
+	// This test verifies that when a container ID has no tags as a regular container,
+	// but has tags as a sandbox container, the sandbox tags are returned.
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{
+			"container-123": {}, // Empty tags for regular container
+		},
+		SandboxTags: map[string][]string{
+			"container-123": {"kube_namespace:kube-system", "kube_pod:coredns"},
+		},
+	}
+
+	workloadType, tags, err := GetTagsOfContainer(mockTagger, containerutils.ContainerID("container-123"))
+
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypePodSandbox, workloadType)
+	assert.Equal(t, []string{"kube_namespace:kube-system", "kube_pod:coredns"}, tags)
+}
+
+func TestDefaultResolver_Resolve(t *testing.T) {
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{
+			"container-abc": {"env:staging", "version:1.0"},
+		},
+	}
+
+	resolver := NewDefaultResolver(mockTagger)
+
+	tags := resolver.Resolve(containerutils.ContainerID("container-abc"))
+	assert.Equal(t, []string{"env:staging", "version:1.0"}, tags)
+}
+
+func TestDefaultResolver_ResolveWithErr(t *testing.T) {
+	mockTagger := &MockTagger{
+		SandboxTags: map[string][]string{
+			"pause-container": {"kube_namespace:test", "kube_pod:nginx"},
+		},
+	}
+
+	resolver := NewDefaultResolver(mockTagger)
+
+	workloadType, tags, err := resolver.ResolveWithErr(containerutils.ContainerID("pause-container"))
+	assert.NoError(t, err)
+	assert.Equal(t, WorkloadTypePodSandbox, workloadType)
+	assert.Equal(t, []string{"kube_namespace:test", "kube_pod:nginx"}, tags)
+}
+
+func TestDefaultResolver_ResolveWithErr_NilWorkloadID(t *testing.T) {
+	mockTagger := &MockTagger{}
+	resolver := NewDefaultResolver(mockTagger)
+
+	workloadType, tags, err := resolver.ResolveWithErr(nil)
+	assert.Error(t, err)
+	assert.Equal(t, WorkloadTypeUnknown, workloadType)
+	assert.Nil(t, tags)
+}
+
+func TestDefaultResolver_ResolveWithErr_EmptyContainerID(t *testing.T) {
+	mockTagger := &MockTagger{}
+	resolver := NewDefaultResolver(mockTagger)
+
+	workloadType, tags, err := resolver.ResolveWithErr(containerutils.ContainerID(""))
+	assert.Error(t, err)
+	assert.Equal(t, WorkloadTypeUnknown, workloadType)
+	assert.Nil(t, tags)
+}
+
+func TestDefaultResolver_GetValue(t *testing.T) {
+	mockTagger := &MockTagger{
+		ContainerTags: map[string][]string{
+			"container-xyz": {"env:production", "service:api", "version:2.0"},
+		},
+	}
+
+	resolver := NewDefaultResolver(mockTagger)
+
+	value := resolver.GetValue(containerutils.ContainerID("container-xyz"), "env")
+	assert.Equal(t, "production", value)
+
+	value = resolver.GetValue(containerutils.ContainerID("container-xyz"), "service")
+	assert.Equal(t, "api", value)
+
+	value = resolver.GetValue(containerutils.ContainerID("container-xyz"), "nonexistent")
+	assert.Equal(t, "", value)
+}

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -2245,6 +2245,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "exec.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -3718,6 +3729,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return string(ev.Exit.Process.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -8524,6 +8546,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.container.is_sandbox":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.ContainerContext.IsSandbox
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.ContainerContext.IsSandbox
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -11498,6 +11547,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "process.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -12706,6 +12766,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return string(ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return false
+				}
+				return ev.BaseEvent.ProcessContext.Parent.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -14831,6 +14905,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return string(current.ProcessContext.Process.ContainerContext.ContainerID)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.ancestors.container.is_sandbox":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.ContainerContext.IsSandbox
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.ContainerContext.IsSandbox
+				})
+				ctx.BoolCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -17811,6 +17912,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.PTrace.Tracee.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -19019,6 +19131,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return string(ev.PTrace.Tracee.Parent.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return false
+				}
+				return ev.PTrace.Tracee.Parent.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -22574,6 +22700,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.container.is_sandbox":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.ContainerContext.IsSandbox
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.ContainerContext.IsSandbox
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -25548,6 +25701,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Setrlimit.Target.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -26756,6 +26920,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return string(ev.Setrlimit.Target.Parent.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return false
+				}
+				return ev.Setrlimit.Target.Parent.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -29402,6 +29580,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return string(current.ProcessContext.Process.ContainerContext.ContainerID)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.ancestors.container.is_sandbox":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.ContainerContext.IsSandbox
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.ContainerContext.IsSandbox
+				})
+				ctx.BoolCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -32382,6 +32587,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Signal.Target.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -33590,6 +33806,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return string(ev.Signal.Target.Parent.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return false
+				}
+				return ev.Signal.Target.Parent.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -36543,6 +36773,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.comm",
 		"exec.container.created_at",
 		"exec.container.id",
+		"exec.container.is_sandbox",
 		"exec.container.tags",
 		"exec.created_at",
 		"exec.egid",
@@ -36663,6 +36894,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.comm",
 		"exit.container.created_at",
 		"exit.container.id",
+		"exit.container.is_sandbox",
 		"exit.container.tags",
 		"exit.created_at",
 		"exit.egid",
@@ -37038,6 +37270,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.comm",
 		"process.ancestors.container.created_at",
 		"process.ancestors.container.id",
+		"process.ancestors.container.is_sandbox",
 		"process.ancestors.container.tags",
 		"process.ancestors.created_at",
 		"process.ancestors.egid",
@@ -37148,6 +37381,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.comm",
 		"process.container.created_at",
 		"process.container.id",
+		"process.container.is_sandbox",
 		"process.container.tags",
 		"process.created_at",
 		"process.egid",
@@ -37239,6 +37473,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.comm",
 		"process.parent.container.created_at",
 		"process.parent.container.id",
+		"process.parent.container.is_sandbox",
 		"process.parent.container.tags",
 		"process.parent.created_at",
 		"process.parent.egid",
@@ -37368,6 +37603,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.comm",
 		"ptrace.tracee.ancestors.container.created_at",
 		"ptrace.tracee.ancestors.container.id",
+		"ptrace.tracee.ancestors.container.is_sandbox",
 		"ptrace.tracee.ancestors.container.tags",
 		"ptrace.tracee.ancestors.created_at",
 		"ptrace.tracee.ancestors.egid",
@@ -37478,6 +37714,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.comm",
 		"ptrace.tracee.container.created_at",
 		"ptrace.tracee.container.id",
+		"ptrace.tracee.container.is_sandbox",
 		"ptrace.tracee.container.tags",
 		"ptrace.tracee.created_at",
 		"ptrace.tracee.egid",
@@ -37569,6 +37806,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.comm",
 		"ptrace.tracee.parent.container.created_at",
 		"ptrace.tracee.parent.container.id",
+		"ptrace.tracee.parent.container.is_sandbox",
 		"ptrace.tracee.parent.container.tags",
 		"ptrace.tracee.parent.created_at",
 		"ptrace.tracee.parent.egid",
@@ -37826,6 +38064,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.comm",
 		"setrlimit.target.ancestors.container.created_at",
 		"setrlimit.target.ancestors.container.id",
+		"setrlimit.target.ancestors.container.is_sandbox",
 		"setrlimit.target.ancestors.container.tags",
 		"setrlimit.target.ancestors.created_at",
 		"setrlimit.target.ancestors.egid",
@@ -37936,6 +38175,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.comm",
 		"setrlimit.target.container.created_at",
 		"setrlimit.target.container.id",
+		"setrlimit.target.container.is_sandbox",
 		"setrlimit.target.container.tags",
 		"setrlimit.target.created_at",
 		"setrlimit.target.egid",
@@ -38027,6 +38267,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.comm",
 		"setrlimit.target.parent.container.created_at",
 		"setrlimit.target.parent.container.id",
+		"setrlimit.target.parent.container.is_sandbox",
 		"setrlimit.target.parent.container.tags",
 		"setrlimit.target.parent.created_at",
 		"setrlimit.target.parent.egid",
@@ -38203,6 +38444,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.comm",
 		"signal.target.ancestors.container.created_at",
 		"signal.target.ancestors.container.id",
+		"signal.target.ancestors.container.is_sandbox",
 		"signal.target.ancestors.container.tags",
 		"signal.target.ancestors.created_at",
 		"signal.target.ancestors.egid",
@@ -38313,6 +38555,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.comm",
 		"signal.target.container.created_at",
 		"signal.target.container.id",
+		"signal.target.container.is_sandbox",
 		"signal.target.container.tags",
 		"signal.target.created_at",
 		"signal.target.egid",
@@ -38404,6 +38647,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.comm",
 		"signal.target.parent.container.created_at",
 		"signal.target.parent.container.id",
+		"signal.target.parent.container.is_sandbox",
 		"signal.target.parent.container.tags",
 		"signal.target.parent.created_at",
 		"signal.target.parent.egid",
@@ -39014,6 +39258,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.container.id":
 		return "exec", reflect.String, "string", false, nil
+	case "exec.container.is_sandbox":
+		return "exec", reflect.Bool, "bool", false, nil
 	case "exec.container.tags":
 		return "exec", reflect.String, "string", true, nil
 	case "exec.created_at":
@@ -39254,6 +39500,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.container.id":
 		return "exit", reflect.String, "string", false, nil
+	case "exit.container.is_sandbox":
+		return "exit", reflect.Bool, "bool", false, nil
 	case "exit.container.tags":
 		return "exit", reflect.String, "string", true, nil
 	case "exit.created_at":
@@ -40004,6 +40252,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.ancestors.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.ancestors.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.ancestors.created_at":
@@ -40224,6 +40474,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.created_at":
@@ -40406,6 +40658,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.parent.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.parent.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.parent.created_at":
@@ -40664,6 +40918,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.ancestors.container.id":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.ancestors.container.is_sandbox":
+		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.ancestors.container.tags":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.ancestors.created_at":
@@ -40884,6 +41140,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.container.id":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.container.is_sandbox":
+		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.container.tags":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.created_at":
@@ -41066,6 +41324,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Int, "int", false, nil
 	case "ptrace.tracee.parent.container.id":
 		return "ptrace", reflect.String, "string", false, nil
+	case "ptrace.tracee.parent.container.is_sandbox":
+		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.parent.container.tags":
 		return "ptrace", reflect.String, "string", true, nil
 	case "ptrace.tracee.parent.created_at":
@@ -41580,6 +41840,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.ancestors.container.id":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.ancestors.container.is_sandbox":
+		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.ancestors.container.tags":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.ancestors.created_at":
@@ -41800,6 +42062,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.container.id":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.container.is_sandbox":
+		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.container.tags":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.created_at":
@@ -41982,6 +42246,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Int, "int", false, nil
 	case "setrlimit.target.parent.container.id":
 		return "setrlimit", reflect.String, "string", false, nil
+	case "setrlimit.target.parent.container.is_sandbox":
+		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.parent.container.tags":
 		return "setrlimit", reflect.String, "string", true, nil
 	case "setrlimit.target.parent.created_at":
@@ -42334,6 +42600,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.ancestors.container.id":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.ancestors.container.is_sandbox":
+		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.ancestors.container.tags":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.ancestors.created_at":
@@ -42554,6 +42822,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.container.id":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.container.is_sandbox":
+		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.container.tags":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.created_at":
@@ -42736,6 +43006,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Int, "int", false, nil
 	case "signal.target.parent.container.id":
 		return "signal", reflect.String, "string", false, nil
+	case "signal.target.parent.container.is_sandbox":
+		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.parent.container.tags":
 		return "signal", reflect.String, "string", true, nil
 	case "signal.target.parent.created_at":
@@ -43591,6 +43863,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Exec.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exec.container.is_sandbox":
+		return ev.setBoolFieldValue("exec.container.is_sandbox", &ev.Exec.Process.ContainerContext.IsSandbox, value)
 	case "exec.container.tags":
 		return ev.setStringArrayFieldValue("exec.container.tags", &ev.Exec.Process.ContainerContext.Tags, value)
 	case "exec.created_at":
@@ -43946,6 +44220,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Exit.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exit.container.is_sandbox":
+		return ev.setBoolFieldValue("exit.container.is_sandbox", &ev.Exit.Process.ContainerContext.IsSandbox, value)
 	case "exit.container.tags":
 		return ev.setStringArrayFieldValue("exit.container.tags", &ev.Exit.Process.ContainerContext.Tags, value)
 	case "exit.created_at":
@@ -44880,6 +45156,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.ancestors.container.is_sandbox":
+		return ev.setBoolFieldValue("process.ancestors.container.is_sandbox", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "process.ancestors.container.tags":
 		return ev.setStringArrayFieldValue("process.ancestors.container.tags", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.ancestors.created_at":
@@ -45215,6 +45493,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.container.is_sandbox":
+		return ev.setBoolFieldValue("process.container.is_sandbox", &ev.BaseEvent.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "process.container.tags":
 		return ev.setStringArrayFieldValue("process.container.tags", &ev.BaseEvent.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.created_at":
@@ -45507,6 +45787,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.parent.container.is_sandbox":
+		return ev.setBoolFieldValue("process.parent.container.is_sandbox", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.IsSandbox, value)
 	case "process.parent.container.tags":
 		return ev.setStringArrayFieldValue("process.parent.container.tags", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.Tags, value)
 	case "process.parent.created_at":
@@ -45993,6 +46275,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.ancestors.container.is_sandbox":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Ancestor == nil {
+			ev.PTrace.Tracee.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setBoolFieldValue("ptrace.tracee.ancestors.container.is_sandbox", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "ptrace.tracee.ancestors.container.tags":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -46934,6 +47224,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.PTrace.Tracee.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.container.is_sandbox":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		return ev.setBoolFieldValue("ptrace.tracee.container.is_sandbox", &ev.PTrace.Tracee.Process.ContainerContext.IsSandbox, value)
 	case "ptrace.tracee.container.tags":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -47553,6 +47848,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.PTrace.Tracee.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "ptrace.tracee.parent.container.is_sandbox":
+		if ev.PTrace.Tracee == nil {
+			ev.PTrace.Tracee = &ProcessContext{}
+		}
+		if ev.PTrace.Tracee.Parent == nil {
+			ev.PTrace.Tracee.Parent = &Process{}
+		}
+		return ev.setBoolFieldValue("ptrace.tracee.parent.container.is_sandbox", &ev.PTrace.Tracee.Parent.ContainerContext.IsSandbox, value)
 	case "ptrace.tracee.parent.container.tags":
 		if ev.PTrace.Tracee == nil {
 			ev.PTrace.Tracee = &ProcessContext{}
@@ -48895,6 +49198,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.ancestors.container.is_sandbox":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.ancestors.container.is_sandbox", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "setrlimit.target.ancestors.container.tags":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -49836,6 +50147,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Setrlimit.Target.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.container.is_sandbox":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.container.is_sandbox", &ev.Setrlimit.Target.Process.ContainerContext.IsSandbox, value)
 	case "setrlimit.target.container.tags":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -50455,6 +50771,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Setrlimit.Target.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "setrlimit.target.parent.container.is_sandbox":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.parent.container.is_sandbox", &ev.Setrlimit.Target.Parent.ContainerContext.IsSandbox, value)
 	case "setrlimit.target.parent.container.tags":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -51645,6 +51969,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.ancestors.container.is_sandbox":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setBoolFieldValue("signal.target.ancestors.container.is_sandbox", &ev.Signal.Target.Ancestor.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "signal.target.ancestors.container.tags":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52586,6 +52918,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Signal.Target.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.container.is_sandbox":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setBoolFieldValue("signal.target.container.is_sandbox", &ev.Signal.Target.Process.ContainerContext.IsSandbox, value)
 	case "signal.target.container.tags":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -53205,6 +53542,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Signal.Target.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "signal.target.parent.container.is_sandbox":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setBoolFieldValue("signal.target.parent.container.is_sandbox", &ev.Signal.Target.Parent.ContainerContext.IsSandbox, value)
 	case "signal.target.parent.container.tags":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -310,6 +310,7 @@ func deepCopyContainerContext(fieldToCopy ContainerContext) ContainerContext {
 	copied := ContainerContext{}
 	copied.ContainerID = fieldToCopy.ContainerID
 	copied.CreatedAt = fieldToCopy.CreatedAt
+	copied.IsSandbox = fieldToCopy.IsSandbox
 	copied.Releasable = deepCopyReleasablePtr(fieldToCopy.Releasable)
 	copied.Tags = deepCopystringArr(fieldToCopy.Tags)
 	return copied

--- a/pkg/security/secl/model/event_deep_copy_windows.go
+++ b/pkg/security/secl/model/event_deep_copy_windows.go
@@ -121,6 +121,7 @@ func deepCopyContainerContext(fieldToCopy ContainerContext) ContainerContext {
 	copied := ContainerContext{}
 	copied.ContainerID = fieldToCopy.ContainerID
 	copied.CreatedAt = fieldToCopy.CreatedAt
+	copied.IsSandbox = fieldToCopy.IsSandbox
 	copied.Releasable = deepCopyReleasablePtr(fieldToCopy.Releasable)
 	copied.Tags = deepCopystringArr(fieldToCopy.Tags)
 	return copied

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -97,8 +97,9 @@ func (r *Releasable) AppendReleaseCallback(callback func()) {
 type ContainerContext struct {
 	*Releasable
 	ContainerID containerutils.ContainerID `field:"id,opts:gen_getters"`                                        // SECLDoc[id] Definition:`ID of the container`
-	CreatedAt   uint64                     `field:"created_at,opts:gen_getters"`                                // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
+	CreatedAt   uint64                     `field:"created_at,opts:gen_getters"`                                // SECLDoc[created_at] Definition:`Timestamp of the creation of the container`
 	Tags        []string                   `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	IsSandbox   bool                       `field:"is_sandbox" json:"is_sandbox,omitempty"`                     // SECLDoc[is_sandbox] Definition: `indicates if this is a sandbox/pause container`
 }
 
 // Hash returns a unique key for the entity
@@ -116,6 +117,11 @@ func (c *ContainerContext) IsNull() bool {
 // ParentScope returns the parent entity scope
 func (c *ContainerContext) ParentScope() (eval.VariableScope, bool) {
 	return nil, false
+}
+
+// Sandbox returns true if the container is a sandbox/pause container
+func (c *ContainerContext) Sandbox() bool {
+	return c.IsSandbox
 }
 
 // SecurityProfileContext holds the security context of the profile

--- a/pkg/security/seclwin/model/accessors_win.go
+++ b/pkg/security/seclwin/model/accessors_win.go
@@ -589,6 +589,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "exec.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -788,6 +799,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return string(ev.Exit.Process.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1109,6 +1131,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return string(current.ProcessContext.Process.ContainerContext.ContainerID)
 				})
 				ctx.StringCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
+	case "process.ancestors.container.is_sandbox":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.ContainerContext.IsSandbox
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.ContainerContext.IsSandbox
+				})
+				ctx.BoolCache[field] = results
 				return results
 			},
 			Field:  field,
@@ -1516,6 +1565,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.ContainerContext.IsSandbox
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "process.container.tags":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -1658,6 +1718,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return ""
 				}
 				return string(ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.container.is_sandbox":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return false
+				}
+				return ev.BaseEvent.ProcessContext.Parent.ContainerContext.IsSandbox
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2349,6 +2423,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.cmdline",
 		"exec.container.created_at",
 		"exec.container.id",
+		"exec.container.is_sandbox",
 		"exec.container.tags",
 		"exec.created_at",
 		"exec.envp",
@@ -2367,6 +2442,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.code",
 		"exit.container.created_at",
 		"exit.container.id",
+		"exit.container.is_sandbox",
 		"exit.container.tags",
 		"exit.created_at",
 		"exit.envp",
@@ -2391,6 +2467,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.cmdline",
 		"process.ancestors.container.created_at",
 		"process.ancestors.container.id",
+		"process.ancestors.container.is_sandbox",
 		"process.ancestors.container.tags",
 		"process.ancestors.created_at",
 		"process.ancestors.envp",
@@ -2408,6 +2485,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.cmdline",
 		"process.container.created_at",
 		"process.container.id",
+		"process.container.is_sandbox",
 		"process.container.tags",
 		"process.created_at",
 		"process.envp",
@@ -2420,6 +2498,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.cmdline",
 		"process.parent.container.created_at",
 		"process.parent.container.id",
+		"process.parent.container.is_sandbox",
 		"process.parent.container.tags",
 		"process.parent.created_at",
 		"process.parent.envp",
@@ -2581,6 +2660,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Int, "int", false, nil
 	case "exec.container.id":
 		return "exec", reflect.String, "string", false, nil
+	case "exec.container.is_sandbox":
+		return "exec", reflect.Bool, "bool", false, nil
 	case "exec.container.tags":
 		return "exec", reflect.String, "string", true, nil
 	case "exec.created_at":
@@ -2617,6 +2698,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exit", reflect.Int, "int", false, nil
 	case "exit.container.id":
 		return "exit", reflect.String, "string", false, nil
+	case "exit.container.is_sandbox":
+		return "exit", reflect.Bool, "bool", false, nil
 	case "exit.container.tags":
 		return "exit", reflect.String, "string", true, nil
 	case "exit.created_at":
@@ -2665,6 +2748,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.ancestors.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.ancestors.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.ancestors.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.ancestors.created_at":
@@ -2699,6 +2784,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.created_at":
@@ -2723,6 +2810,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Int, "int", false, nil
 	case "process.parent.container.id":
 		return "", reflect.String, "string", false, nil
+	case "process.parent.container.is_sandbox":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.parent.container.tags":
 		return "", reflect.String, "string", true, nil
 	case "process.parent.created_at":
@@ -2937,6 +3026,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Exec.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exec.container.is_sandbox":
+		return ev.setBoolFieldValue("exec.container.is_sandbox", &ev.Exec.Process.ContainerContext.IsSandbox, value)
 	case "exec.container.tags":
 		return ev.setStringArrayFieldValue("exec.container.tags", &ev.Exec.Process.ContainerContext.Tags, value)
 	case "exec.created_at":
@@ -2978,6 +3069,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.Exit.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "exit.container.is_sandbox":
+		return ev.setBoolFieldValue("exit.container.is_sandbox", &ev.Exit.Process.ContainerContext.IsSandbox, value)
 	case "exit.container.tags":
 		return ev.setStringArrayFieldValue("exit.container.tags", &ev.Exit.Process.ContainerContext.Tags, value)
 	case "exit.created_at":
@@ -3031,6 +3124,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.ancestors.container.is_sandbox":
+		return ev.setBoolFieldValue("process.ancestors.container.is_sandbox", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "process.ancestors.container.tags":
 		return ev.setStringArrayFieldValue("process.ancestors.container.tags", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.ancestors.created_at":
@@ -3070,6 +3165,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Process.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.container.is_sandbox":
+		return ev.setBoolFieldValue("process.container.is_sandbox", &ev.BaseEvent.ProcessContext.Process.ContainerContext.IsSandbox, value)
 	case "process.container.tags":
 		return ev.setStringArrayFieldValue("process.container.tags", &ev.BaseEvent.ProcessContext.Process.ContainerContext.Tags, value)
 	case "process.created_at":
@@ -3099,6 +3196,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		ev.BaseEvent.ProcessContext.Parent.ContainerContext.ContainerID = containerutils.ContainerID(rv)
 		return nil
+	case "process.parent.container.is_sandbox":
+		return ev.setBoolFieldValue("process.parent.container.is_sandbox", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.IsSandbox, value)
 	case "process.parent.container.tags":
 		return ev.setStringArrayFieldValue("process.parent.container.tags", &ev.BaseEvent.ProcessContext.Parent.ContainerContext.Tags, value)
 	case "process.parent.created_at":

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -97,8 +97,9 @@ func (r *Releasable) AppendReleaseCallback(callback func()) {
 type ContainerContext struct {
 	*Releasable
 	ContainerID containerutils.ContainerID `field:"id,opts:gen_getters"`                                        // SECLDoc[id] Definition:`ID of the container`
-	CreatedAt   uint64                     `field:"created_at,opts:gen_getters"`                                // SECLDoc[created_at] Definition:`Timestamp of the creation of the container``
+	CreatedAt   uint64                     `field:"created_at,opts:gen_getters"`                                // SECLDoc[created_at] Definition:`Timestamp of the creation of the container`
 	Tags        []string                   `field:"tags,handler:ResolveContainerTags,opts:skip_ad,weight:9999"` // SECLDoc[tags] Definition:`Tags of the container`
+	IsSandbox   bool                       `field:"is_sandbox" json:"is_sandbox,omitempty"`                     // SECLDoc[is_sandbox] Definition: `indicates if this is a sandbox/pause container`
 }
 
 // Hash returns a unique key for the entity
@@ -116,6 +117,11 @@ func (c *ContainerContext) IsNull() bool {
 // ParentScope returns the parent entity scope
 func (c *ContainerContext) ParentScope() (eval.VariableScope, bool) {
 	return nil, false
+}
+
+// Sandbox returns true if the container is a sandbox/pause container
+func (c *ContainerContext) Sandbox() bool {
+	return c.IsSandbox
 }
 
 // SecurityProfileContext holds the security context of the profile

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -228,7 +228,7 @@ func (m *Manager) resolveTags(ad *dump.ActivityDump) error {
 	}
 
 	if workloadID != nil {
-		tags, err := m.resolvers.TagsResolver.ResolveWithErr(workloadID)
+		_, tags, err := m.resolvers.TagsResolver.ResolveWithErr(workloadID)
 		if err != nil {
 			return fmt.Errorf("failed to resolve %v: %w", workloadID, err)
 		}

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -708,14 +708,14 @@ func (m *Manager) GetNodesInProcessCache() map[activity_tree.ImageProcessKey]boo
 		var err error
 		var imageName, imageTag string
 		if id := cgce.GetContainerID(); id != "" {
-			cgceTags, err = tagsResolver.ResolveWithErr(id)
+			_, cgceTags, err = tagsResolver.ResolveWithErr(id)
 			if err != nil {
 				return false
 			}
 			imageName = utils.GetTagValue("image_name", cgceTags)
 			imageTag = utils.GetTagValue("image_tag", cgceTags)
 		} else if cgce.IsCGroupContextResolved() {
-			cgceTags, err = tagsResolver.ResolveWithErr(cgce.GetCGroupID())
+			_, cgceTags, err = tagsResolver.ResolveWithErr(cgce.GetCGroupID())
 			if err != nil {
 				return false
 			}

--- a/pkg/security/security_profile/secprofs.go
+++ b/pkg/security/security_profile/secprofs.go
@@ -80,7 +80,7 @@ func (m *Manager) LookupEventInProfiles(event *model.Event) {
 
 	// If no profile found and there's a cgroup ID, try cgroup-based lookup
 	if profile == nil && event.ProcessContext.Process.CGroup.CGroupID != "" {
-		tags, err := m.resolvers.TagsResolver.ResolveWithErr(event.ProcessContext.Process.CGroup.CGroupID)
+		_, tags, err := m.resolvers.TagsResolver.ResolveWithErr(event.ProcessContext.Process.CGroup.CGroupID)
 		if err != nil {
 			seclog.Errorf("failed to resolve tags for cgroup %s: %v", event.ProcessContext.Process.CGroup.CGroupID, err)
 			return
@@ -400,6 +400,7 @@ func (m *Manager) onWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 
 	containerName, imageName, podNamespace := utils.GetContainerFilterTags(workload.Tags)
 	if m.containerFilters != nil && m.containerFilters.IsExcluded(nil, containerName, imageName, podNamespace) {
+		seclog.Debugf("Workload excluded by container filter: container_name=%s, image_name=%s, pod_namespace=%s", containerName, imageName, podNamespace)
 		return
 	}
 

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -34,6 +34,8 @@ type ContainerContextSerializer struct {
 	CreatedAt *utils.EasyjsonTime `json:"created_at,omitempty"`
 	// Variables values
 	Variables Variables `json:"variables,omitempty"`
+	// Indicates if the container is a sandbox/pause container
+	IsSandbox bool `json:"is_sandbox,omitempty"`
 }
 
 // CGroupContextSerializer serializes a cgroup context to JSON

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -3078,6 +3078,12 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 			} else {
 				(out.Variables).UnmarshalEasyJSON(in)
 			}
+		case "is_sandbox":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsSandbox = bool(in.Bool())
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -3117,6 +3123,16 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 			out.RawString(prefix)
 		}
 		(in.Variables).MarshalEasyJSON(out)
+	}
+	if in.IsSandbox {
+		const prefix string = ",\"is_sandbox\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.Bool(bool(in.IsSandbox))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -996,6 +996,7 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			psSerializer.Container = &ContainerContextSerializer{
 				ID:        string(ps.ContainerContext.ContainerID),
 				CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.Unix(0, int64(e.ProcessContext.ContainerContext.CreatedAt))),
+				IsSandbox: ps.ContainerContext.IsSandbox,
 			}
 		}
 
@@ -1577,6 +1578,7 @@ func NewEventSerializer(event *model.Event, rule *rules.Rule, scrubber *utils.Sc
 			ID:        string(event.ProcessContext.ContainerContext.ContainerID),
 			CreatedAt: utils.NewEasyjsonTimeIfNotZero(time.Unix(0, int64(event.ProcessContext.ContainerContext.CreatedAt))),
 			Variables: newVariablesContext(event, rule, "container."),
+			IsSandbox: event.ProcessContext.ContainerContext.IsSandbox,
 		}
 	}
 

--- a/pkg/security/serializers/serializers_windows.go
+++ b/pkg/security/serializers/serializers_windows.go
@@ -165,7 +165,8 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 
 	if len(ps.ContainerContext.ContainerID) != 0 {
 		psSerializer.Container = &ContainerContextSerializer{
-			ID: string(ps.ContainerContext.ContainerID),
+			ID:        string(ps.ContainerContext.ContainerID),
+			IsSandbox: ps.ContainerContext.IsSandbox,
 		}
 	}
 	return psSerializer


### PR DESCRIPTION
### What does this PR do?

It adds a fallback when trying to resolve containerID tags: if no tags were found, we try the ID against kube POD ids (looking for pause/sandbox containers match)

PR modifications:
* it adds a WorkloadType to differenciate cgroup/containers/sandbox-containers
* it adds a new tagger entity for pause containers, which are now collected and not ignored anymore by workload meta (and retrievable with its new entity type)
* now pause containers are identifiable, but are still excluded by default container filter. to let them produce events or activity dumps, `runtime_security_config.exclude_pause_container` has to be set to false. NB: running containers metric would count sandbox containers only if the config is set to false too.
* `ContainerContext` now provide the `IsSandbox` field, which is exposed on a new secl field
* A new `.cgroup_resolver.sandbox_containers` metric has been added to differentiate nominal containers from sandbox ones

NB: modifications to tagger/workloadmeta were AI assisted

### Motivation

Even if we filter out those sandbox from being able to generate events/dumps, we still need to handle them. Beforehand we weren't able to resolve tags for those containers and thus unable easily to tell if it was an issue or not. Now -normally- :tm: the only way we won't have tags for a given container would be related to a remote tagger connection issue.

### Describe how you validated your changes

1. set `runtime_security_config.exclude_pause_container` to false
2. create an agent rule with `expression: exec.file.path == "/pause" && container.id != ""`
3. create a dumb pod with:
```
$ cat pod.json 
{
  "metadata": {
    "name": "demo-pod",
    "namespace": "default",
    "uid": "demo-pod-uid",
    "attempt": 1
  },
  "linux": {},
  "log_directory": "/tmp",
  "dns_config": {}
}
$ sudo crictl --runtime-endpoint unix:///run/containerd/containerd.sock runp pod.json
```
4. check it has been created with `sudo crictl pods`
5. start the agent and check that the agent workload meta retrieved the pod sandbox `sudo ./bin/agent/agent tagger-list`
6. start sysprobe and check that the rule triggered
7. check also that an activity dump is being collected for this sandbox:
````
 $ sudo ./bin/system-probe/system-probe runtime activity-dump list
[...]
	- name: activity-dump-YjPtWIZJER
	  start: 27 Jan 26 11:23 CET
	  timeout: 15m0s
	  container ID: 0625f010ac2b693de880d8238addd2403db315768f3c1375aa89da4468e04e72
	  cgroup ID: /k8s.io/0625f010ac2b693de880d8238addd2403db315768f3c1375aa89da4468e04e72
	  tags: image_name:registry.k8s.io/pause, short_image:pause, image_tag:3.10.1, image_id:sha256:cd073f4c5f6a8e9dc6f3125ba00cf60819cae95c1ec84a1f146ee4a9cf9e803f
	  differentiate args: false
	  activity_tree_stats:
	    approximate_size: 2048
	    process_nodes_count: 1
	    file_nodes_count: 2
	    dns_nodes_count: 0
	    socket_nodes_count: 0
	    capabilities_nodes_count: 0
	  storage:
		- file: /opt/datadog-agent/run/runtime-security/profiles/activity-dump-YjPtWIZJER.profile
		  format: profile
		  storage type: local_storage
		  compression: false
		- file: activity-dump-YjPtWIZJER.protobuf.gz
		  format: protobuf
		  storage type: remote_storage
		  compression: true
````
8. check that without the config the rule nor the dump got triggered/started


### Additional Notes
