### PR TITLE
[CWS] add a queue size limit bypassing the retry mechanism

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -26,6 +26,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.retention", "6s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
+	cfg.BindEnvAndSetDefault("runtime_security_config.event_retry_queue_threshold", 30)
 	cfg.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 100)
 	cfg.BindEnvAndSetDefault("runtime_security_config.internal_monitoring.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -189,6 +189,8 @@ type RuntimeSecurityConfig struct {
 	EventServerRate int
 	// EventServerRetention defines an event retention period so that some fields can be resolved
 	EventServerRetention time.Duration
+	// EventRetryQueueThreshold defines the maximum size of the event queue after which we force sending events even if not resolved
+	EventRetryQueueThreshold int
 	// FIMEnabled determines whether fim rules will be loaded
 	FIMEnabled bool
 	// SelfTestEnabled defines if the self tests should be executed at startup or not
@@ -509,11 +511,12 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		WindowsWriteEventRateLimiterMaxAllowed: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.windows_write_event_rate_limiter_max_allowed"),
 		WindowsWriteEventRateLimiterPeriod:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.windows_write_event_rate_limiter_period"),
 
-		SocketPath:           pkgconfigsetup.SystemProbe().GetString("runtime_security_config.socket"),
-		CmdSocketPath:        pkgconfigsetup.SystemProbe().GetString("runtime_security_config.cmd_socket"),
-		EventServerBurst:     pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.burst"),
-		EventServerRate:      pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.rate"),
-		EventServerRetention: pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.event_server.retention"),
+		SocketPath:               pkgconfigsetup.SystemProbe().GetString("runtime_security_config.socket"),
+		CmdSocketPath:            pkgconfigsetup.SystemProbe().GetString("runtime_security_config.cmd_socket"),
+		EventServerBurst:         pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.burst"),
+		EventServerRate:          pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_server.rate"),
+		EventServerRetention:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.event_server.retention"),
+		EventRetryQueueThreshold: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.event_retry_queue_threshold"),
 
 		SelfTestEnabled:                 pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.self_test.enabled"),
 		SelfTestSendReport:              pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.self_test.send_report"),

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -62,6 +62,8 @@ const (
 	maxRetryForMsgWithSSHContext = 62
 	maxRetryForRegularMsgs       = 5
 	retryDelay                   = time.Second
+	// size of the queue after which we force sending events even if not resolved
+	queueLimit = 15
 )
 
 type pendingMsg struct {
@@ -249,25 +251,33 @@ func (a *APIServer) enqueue(msg *pendingMsg) {
 	a.queueLock.Unlock()
 }
 
-func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg) bool) {
+func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg, retry bool) bool) {
 	a.queueLock.Lock()
 	defer a.queueLock.Unlock()
 
+	queueSize := len(a.queue)
+
 	a.queue = slicesDeleteUntilFalse(a.queue, func(msg *pendingMsg) bool {
-		if msg.sendAfter.After(now) {
+		seclog.Tracef("dequeueing message, queue size: %d", queueSize)
+
+		// apply the delay only if the queue is not full
+		if queueSize < queueLimit && msg.sendAfter.After(now) {
 			return false
 		}
 
-		if cb(msg) {
+		if cb(msg, queueSize < queueLimit) {
+			queueSize--
 			return true
 		}
 
 		msgMaxRetry := msg.getMaxRetry()
 		if msg.retry >= msgMaxRetry {
-			seclog.Errorf("failed to sent event, max retry reached: %d", msg.retry)
+			seclog.Errorf("max retry reached: %dn, sending event anyway", msg.retry)
+
+			queueSize--
 			return true
 		}
-		seclog.Tracef("failed to sent event, retry %d/%d", msg.retry, msgMaxRetry)
+		seclog.Warnf("failed to sent event, retry %d/%d, queue size: %d", msg.retry, msgMaxRetry, len(a.queue))
 
 		msg.sendAfter = now.Add(retryDelay)
 		msg.retry++
@@ -336,8 +346,12 @@ func (a *APIServer) start(ctx context.Context) {
 	for {
 		select {
 		case now := <-ticker.C:
-			a.dequeue(now, func(msg *pendingMsg) bool {
-				if msg.extTagsCb != nil {
+			a.dequeue(now, func(msg *pendingMsg, isRetryAllowed bool) bool {
+				if !isRetryAllowed {
+					seclog.Warnf("queue limit reached: %d, sending event anyway", len(a.queue))
+				}
+
+				if msg.extTagsCb != nil && isRetryAllowed {
 					tags, retryable := msg.extTagsCb()
 					if len(tags) == 0 && retryable && msg.retry < msg.getMaxRetry() {
 						return false
@@ -352,7 +366,7 @@ func (a *APIServer) start(ctx context.Context) {
 				}
 
 				// not fully resolved, retry
-				if !msg.isResolved() && msg.retry < msg.getMaxRetry() {
+				if !msg.isResolved() && isRetryAllowed && msg.retry < msg.getMaxRetry() {
 					return false
 				}
 


### PR DESCRIPTION
### What does this PR do?

Add  event queue size limit. If the queue size is higher than the limit, the retry mechanism in disabled. This avoid having event not being resolved creating too much pending event in the queue.

### Motivation

### Describe how you validated your changes

### Additional Notes
