### PR TITLE
Fix RST validation to detect unresolved references and title issues

### DIFF
--- a/tasks/libs/linter/releasenotes.py
+++ b/tasks/libs/linter/releasenotes.py
@@ -175,19 +175,26 @@ def validate_rst(text: str) -> list[RSTLintError]:
 
     # Lazy import docutils to avoid import errors when not installed
     try:
-        from docutils.core import publish_doctree  # type: ignore[import-untyped]
-        from docutils.nodes import system_message  # type: ignore[import-untyped]
+        from io import StringIO
+
+        from docutils.core import publish_parts  # type: ignore[import-untyped]
+        from docutils.utils import Reporter  # type: ignore[import-untyped]
     except ImportError:
         # docutils not installed, skip RST validation but keep Markdown detection
         return errors
 
-    # Then validate with docutils
+    # Capture docutils warnings/errors via warning_stream
+    # Using publish_parts with full processing to detect unresolved references
+    warning_stream = StringIO()
+
     try:
-        doctree = publish_doctree(
+        publish_parts(
             text,
+            writer_name='html',
             settings_overrides={
-                'report_level': 5,  # Suppress console output (we collect messages from doctree)
-                'halt_level': 5,  # Never halt, collect all errors
+                'report_level': Reporter.INFO_LEVEL,  # Capture INFO and above (for title underline issues)
+                'halt_level': Reporter.SEVERE_LEVEL + 1,  # Never halt, collect all errors
+                'warning_stream': warning_stream,
             },
         )
     except Exception as e:
@@ -195,23 +202,22 @@ def validate_rst(text: str) -> list[RSTLintError]:
         errors.append(RSTLintError(line=None, level='error', message=str(e)))
         return errors
 
-    level_map = {1: 'info', 2: 'warning', 3: 'error', 4: 'severe'}
-
-    for msg in doctree.traverse(system_message):
-        line = msg.get('line')
-        level = level_map.get(msg['level'], 'warning')
-        # Only report warnings and above
-        if msg['level'] >= 2:
-            message_text = msg.astext()
-            # Clean up the message - remove redundant path info and <string>: prefix
-            message_text = message_text.split('\n')[0] if '\n' in message_text else message_text
-            # Remove docutils source prefix like "<string>:15: (WARNING/2) "
-            if message_text.startswith('<string>:'):
-                # Extract just the description part after the level indicator
-                match = re.match(r'<string>:\d+: \([A-Z]+/\d+\) (.+)', message_text)
-                if match:
-                    message_text = match.group(1)
-            errors.append(RSTLintError(line=line, level=level, message=message_text))
+    # Parse the warning stream for errors
+    # Format: <string>:LINE: (LEVEL/NUM) Message
+    warning_output = warning_stream.getvalue()
+    if warning_output:
+        level_map = {'INFO': 'info', 'WARNING': 'warning', 'ERROR': 'error', 'SEVERE': 'severe'}
+        for line in warning_output.strip().split('\n'):
+            if not line:
+                continue
+            # Parse docutils warning format: <string>:LINE: (LEVEL/NUM) Message
+            match = re.match(r'<string>:(\d+): \(([A-Z]+)/\d+\) (.+)', line)
+            if match:
+                line_num = int(match.group(1))
+                level_str = match.group(2)
+                message = match.group(3)
+                level = level_map.get(level_str, 'warning')
+                errors.append(RSTLintError(line=line_num, level=level, message=message))
 
     return errors
 


### PR DESCRIPTION
## Summary

- Fix `validate_rst` function to properly detect RST errors that were previously missed
- Switch from `publish_doctree` to `publish_parts` with full HTML writer processing to detect unresolved references
- Lower report level to capture INFO-level messages like title underline warnings

## Problem

The `validate_rst` function in the release notes linter was not detecting certain RST errors:

1. **Unknown/unresolved target references** (e.g., `` `config`_ `` pointing to a non-existent target)
2. **Title underline mismatches** (underline too short for the title)

Root causes:
- `publish_doctree` only parses the RST without full document processing, so unresolved references were never detected
- Messages with level 1 (INFO) were filtered out by the `level >= 2` check, missing title underline warnings from docutils

## Changes

- Use `publish_parts` with `writer_name='html'` instead of `publish_doctree` for complete document processing
- Set `report_level` to `Reporter.INFO_LEVEL` to capture title underline issues
- Capture errors via `warning_stream` instead of traversing the doctree for `system_message` nodes

## Test plan

- [x] All 54 unit tests pass in `tasks/unit_tests/releasenotes_linter_tests.py`
- [x] The 3 previously skipped tests (requiring docutils) now pass:
  - `test_unknown_target_reference`
  - `test_title_underline_mismatch`
  - `test_error_contains_line_number`

🤖 Generated with [Claude Code](https://claude.com/claude-code)