### PR TITLE
ci(review): Remove references to the agent-e2e-testing team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -144,7 +144,7 @@
 /.gitlab/deploy/deploy_packages/windows.yml                    @DataDog/agent-delivery @DataDog/windows-products
 /.gitlab/distribute/winget.yml                     @DataDog/agent-delivery @DataDog/windows-products
 /.gitlab/deploy/deploy_packages/cluster_agent_cloudfoundry.yml @DataDog/agent-integrations @DataDog/agent-devx
-/.gitlab/deploy/deploy_packages/e2e.yml                        @DataDog/agent-devx @DataDog/agent-e2e-testing @DataDog/fleet
+/.gitlab/deploy/deploy_packages/e2e.yml                        @DataDog/agent-devx  @DataDog/fleet
 
 /.gitlab/.pre/deps_build/                                 @DataDog/ebpf-platform @DataDog/agent-build @DataDog/windows-products
 
@@ -153,8 +153,8 @@
 /.gitlab/.pre/common/                                     @DataDog/agent-devx
 
 /.gitlab/test/e2e/e2e.yml                                 @DataDog/container-integrations @DataDog/agent-devx @DataDog/fleet
-/.gitlab/deploy/container_build/fakeintake.yml              @DataDog/agent-e2e-testing @DataDog/agent-devx
-/.gitlab/build/binary_build/fakeintake.yml                 @DataDog/agent-e2e-testing @DataDog/agent-devx
+/.gitlab/deploy/container_build/fakeintake.yml               @DataDog/agent-devx
+/.gitlab/build/binary_build/fakeintake.yml                  @DataDog/agent-devx
 
 /.gitlab/test/functional_test/oracle.yml                  @DataDog/agent-devx @DataDog/database-monitoring
 
@@ -171,7 +171,7 @@
 
 /.gitlab/deploy/dev_container_deploy/                       @DataDog/container-integrations @DataDog/agent-delivery
 /.gitlab/deploy/dev_container_deploy/fakeintake.yml         @DataDog/agent-devx
-/.gitlab/deploy/dev_container_deploy/e2e.yml                @DataDog/agent-devx @DataDog/agent-e2e-testing
+/.gitlab/deploy/dev_container_deploy/e2e.yml                @DataDog/agent-devx 
 /.gitlab/deploy/dev_container_deploy/docker_windows.yml     @DataDog/agent-delivery @DataDog/windows-products
 
 /.gitlab/deploy/container_scan/container_scan.yml           @DataDog/container-integrations @DataDog/agent-delivery
@@ -701,7 +701,7 @@
 /tasks/cluster_agent_cloudfoundry.py    @DataDog/agent-integrations
 /tasks/devcontainer.py                  @DataDog/agent-devx @DataDog/container-platform
 /tasks/skaffold.py                      @DataDog/agent-devx @DataDog/container-platform
-/tasks/new_e2e_tests.py                 @DataDog/agent-e2e-testing @DataDog/agent-devx
+/tasks/new_e2e_tests.py                  @DataDog/agent-devx
 /tasks/process_agent.py                 @DataDog/container-experiences
 /tasks/privateactionrunner.py           @DataDog/action-platform
 /tasks/system_probe.py                  @DataDog/ebpf-platform
@@ -741,12 +741,12 @@
 /test/integration/                      @DataDog/serverless-azure-gcp
 /test/integration/docker/               @DataDog/opentelemetry-agent
 /test/e2e-framework/testing/testcommon/check            @DataDog/agent-runtimes
-/test/fakeintake/                             @DataDog/agent-e2e-testing @DataDog/agent-devx
+/test/fakeintake/                              @DataDog/agent-devx
 /test/fakeintake/aggregator/ndmAggregator.go @DataDog/ndm-core
 /test/fakeintake/aggregator/ndmAggregator_test.go @DataDog/ndm-core
 /test/fakeintake/aggregator/ndmflowAggregator.go @DataDog/ndm-integrations
 /test/fakeintake/aggregator/ndmflowAggregator_test.go @DataDog/ndm-integrations
-/test/new-e2e/                                @DataDog/agent-e2e-testing @DataDog/agent-devx
+/test/new-e2e/                                 @DataDog/agent-devx
 /test/new-e2e/test-infra-definition           @DataDog/agent-devx
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/system-probe/config/vmconfig-security-agent.json @DataDog/ebpf-platform @DataDog/agent-security

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -33,7 +33,6 @@
 '@datadog/windows-products': WINA
 '@datadog/opentelemetry': OTAGENT
 '@datadog/opentelemetry-agent': OTAGENT
-'@datadog/agent-e2e-testing': ADXT
 '@datadog/sdlc-security': SINT
 '@datadog/single-machine-performance': SMP
 '@datadog/agent-integrations': AI

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -12,7 +12,6 @@
 '@datadog/agent-delivery': '#agent-delivery-ops'
 '@datadog/agent-devx': '#agent-devx-ops'
 '@datadog/agent-discovery': '#agent-discovery'
-'@datadog/agent-e2e-testing': '#agent-devx-ops'
 '@datadog/agent-integrations': '#agent-integrations'
 '@datadog/agent-log-pipelines': '#agent-log-pipelines'
 '@datadog/agent-metric-pipelines': '#agent-metric-pipelines'

--- a/tasks/libs/pipeline/github_slack_review_map.yaml
+++ b/tasks/libs/pipeline/github_slack_review_map.yaml
@@ -13,7 +13,6 @@
 '@datadog/agent-delivery': '#agent-delivery-reviews'
 '@datadog/agent-devx': '#agent-devx-reviews'
 '@datadog/agent-discovery': '#agent-discovery'
-'@datadog/agent-e2e-testing': '#agent-devx-reviews'
 '@datadog/agent-health': '#agent-health'
 '@datadog/agent-integrations': '#agent-integrations-reviews'
 '@datadog/agent-log-pipelines': '#agent-log-pipelines'

--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -14,7 +14,6 @@ NON_RELEASING_TEAMS = {
     'apm-core-reliability-and-performance',
     'debugger',
     'asm-go',
-    'agent-e2e-testing',
     'serverless',
     'agent-platform',
     'agent-release-management',


### PR DESCRIPTION
### What does this PR do?
Remove the references to the `agent-e2e-testing` team

### Motivation
The taskforce on e2e testing is over, and having ownership on this team creates double notifications in case of code review

### Describe how you validated your changes
Deleted code for configuration, no specific test

### Additional Notes
