### PR TITLE
Fix rollback purge bug during remote update experiment

### DIFF
--- a/releasenotes/notes/fix-fleet-msi-rollback-purge-23fbc8ac04dcf6ad.yaml
+++ b/releasenotes/notes/fix-fleet-msi-rollback-purge-23fbc8ac04dcf6ad.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug introduced in 7.73.0 that can cause a remote Agent update through Fleet Automation to fail to restore the previous version if the MSI fails and
+    the ``C:\Windows\SystemTemp\datadog-installer\rollback\InstallOciPackages.json`` file is present.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
@@ -120,13 +120,14 @@ namespace Datadog.CustomActions
 
         private ActionResult InstallPackages()
         {
-            if (!ShouldInstall())
-            {
-                _session.Log("Skipping install as FLEET_INSTALL is set to 1");
-                return ActionResult.Success;
-            }
             try
             {
+                if (!ShouldInstall())
+                {
+                    _session.Log("Skipping install as FLEET_INSTALL is set to 1");
+                    return ActionResult.Success;
+                }
+
                 _session.Log("Running datadog-installer setup");
 
                 // add purge command to the rollback data store


### PR DESCRIPTION
### What does this PR do?
Fix a bug where purge could mistakenly run when the MSI rolls back during a remote update experiment

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2318
If purge runs during rollback, the experiment fails to roll back to the stable agent version

fix for failures in https://github.com/DataDog/datadog-agent/pull/45394

### Describe how you validated your changes
Cherry-pick PR on https://github.com/DataDog/datadog-agent/pull/45394 should fix the E2E test failures there. This was not caught earlier because we were late on bumping the "last stable" version. 

### Additional Notes
Bug occurs when MSI rolls back after the InstallOciPackages action runs AND the rollback file is present from a previous install, it's created in `C:\Windows\SystemTemp` so if the previous Agent version was installed very recently it's probably still there.

Will have a follow up PR to update the rollback data store to ensure these files are deleted at an appropriate time, which will prevent this issue from being reintroduced.