### PR TITLE
[CWS] fix config mock lifecycle around module tester

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -78,9 +78,18 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		RuntimeEnabled: cfg.RuntimeEnabled,
 		FIMEnabled:     cfg.FIMEnabled,
 	}
-	crtelemetry, err := telemetry.NewContainersRunningTelemetry(crtelemcfg, evm.StatsdClient, wmeta, filterStore)
-	if err != nil {
-		return nil, err
+
+	var (
+		crtelemetry *telemetry.ContainersRunningTelemetry
+		err         error
+	)
+
+	// filterStore can be nil, especially in the case of functional tests
+	if filterStore != nil {
+		crtelemetry, err = telemetry.NewContainersRunningTelemetry(crtelemcfg, evm.StatsdClient, wmeta, filterStore)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var selfTester *selftests.SelfTester

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
-	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/impl"
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
@@ -804,8 +803,6 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 
 	ipcComp := ipcmock.New(t)
 
-	mockFilterStore := workloadfilterfxmock.SetupMockFilter(t)
-
 	testMod.eventMonitor, err = eventmonitor.NewEventMonitor(emconfig, secconfig, "functional_tests_host", emopts)
 	if err != nil {
 		return nil, err
@@ -817,7 +814,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 		msgSender := newFakeMsgSender(testMod)
 
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, mockFilterStore, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod, MsgSender: msgSender}, compression, ipcComp)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
-	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/impl"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
@@ -169,8 +168,6 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 
 	ipcComp := ipcmock.New(t)
 
-	mockFilterStore := workloadfilterfxmock.SetupMockFilter(t)
-
 	testMod.eventMonitor, err = eventmonitor.NewEventMonitor(emconfig, secconfig, "functional_tests_host", emopts)
 	if err != nil {
 		return nil, err
@@ -180,7 +177,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	var ruleSetloadedErr *multierror.Error
 	if !opts.staticOpts.disableRuntimeSecurity {
 		compression := logscompression.NewComponent()
-		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, mockFilterStore, module.Opts{EventSender: testMod}, compression, ipcComp)
+		cws, err := module.NewCWSConsumer(testMod.eventMonitor, secconfig.RuntimeSecurity, nil, nil, module.Opts{EventSender: testMod}, compression, ipcComp)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create module: %w", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Calling `workloadfilterfxmock.SetupMockFilter` associates a config mock with the current `*testing.T`. The issue is that we store that in the CWS module that we re-use across tests, meaning that we end up re-using a `*testing.T` from the wrong test, making a mess with the config and dependent components like the logger.

This PR fixes this by removing the workloadfilter mock creation altogether, and just skipping the containers running metric in functional tests.

### Motivation

### Describe how you validated your changes

### Additional Notes
