### PR TITLE
[CWS] remove hostname fetching logic from rule filter model

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -523,7 +523,7 @@ func start(log log.Component,
 		go func() {
 			defer wg.Done()
 
-			if err := runCompliance(mainCtx, demultiplexer, wmeta, filterStore, apiCl, compression, ipc, le.IsLeader); err != nil {
+			if err := runCompliance(mainCtx, demultiplexer, wmeta, filterStore, apiCl, compression, le.IsLeader); err != nil {
 				pkglog.Errorf("Error while running compliance agent: %v", err)
 			}
 		}()

--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -13,7 +13,6 @@ import (
 
 	"k8s.io/client-go/dynamic"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
@@ -27,9 +26,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 )
 
-func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, filterStore workloadfilter.Component, apiCl *apiserver.APIClient, compression logscompression.Component, ipc ipc.Component, isLeader func() bool) error {
+func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, filterStore workloadfilter.Component, apiCl *apiserver.APIClient, compression logscompression.Component, isLeader func() bool) error {
 	stopper := startstop.NewSerialStopper()
-	if err := startCompliance(ctx, senderManager, wmeta, filterStore, stopper, apiCl, isLeader, compression, ipc); err != nil {
+	if err := startCompliance(ctx, senderManager, wmeta, filterStore, stopper, apiCl, isLeader, compression); err != nil {
 		return err
 	}
 
@@ -39,7 +38,7 @@ func runCompliance(ctx context.Context, senderManager sender.SenderManager, wmet
 	return nil
 }
 
-func startCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, filterStore workloadfilter.Component, stopper startstop.Stopper, apiCl *apiserver.APIClient, isLeader func() bool, compression logscompression.Component, ipc ipc.Component) error {
+func startCompliance(ctx context.Context, senderManager sender.SenderManager, wmeta workloadmeta.Component, filterStore workloadfilter.Component, stopper startstop.Stopper, apiCl *apiserver.APIClient, isLeader func() bool, compression logscompression.Component) error {
 	endpoints, destinationsCtx, err := seccommon.NewLogContextCompliance()
 	if err != nil {
 		log.Error(err)
@@ -63,7 +62,7 @@ func startCompliance(ctx context.Context, senderManager sender.SenderManager, wm
 	reflectorStore := compliance.NewReflectorStore(apiCl.Cl)
 	reflectorStore.Run(ctx.Done())
 
-	agent := compliance.NewAgent(statsdClient, wmeta, ipc, filterStore, compliance.AgentOptions{
+	agent := compliance.NewAgent(statsdClient, wmeta, filterStore, hname, compliance.AgentOptions{
 		ConfigDir:     configDir,
 		Reporter:      reporter,
 		CheckInterval: checkInterval,

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -137,7 +137,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					// TODO - components: Do not remove runtimeAgent ref until "github.com/DataDog/datadog-agent/pkg/security/agent" is a component so they're not GCed
 					return status.NewInformationProvider(runtimeAgent.StatusProvider()), runtimeAgent, nil
 				}),
-				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, filterStore workloadfilter.Component, compression logscompression.Component, ipc ipc.Component, hostname hostnameinterface.Component) (status.InformationProvider, *compliance.Agent, error) {
+				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, filterStore workloadfilter.Component, compression logscompression.Component, hostname hostnameinterface.Component) (status.InformationProvider, *compliance.Agent, error) {
 					hostnameDetected, err := hostname.Get(context.TODO())
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
@@ -149,7 +149,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 
 					// start compliance security agent
-					complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient, wmeta, filterStore, compression, ipc, sysProbeClient)
+					complianceAgent, err := compliance.StartCompliance(log, config, hostnameDetected, stopper, statsdClient, wmeta, filterStore, compression, sysProbeClient)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -59,7 +59,7 @@ func newComplianceModule(_ *sysconfigtypes.Config, deps module.FactoryDependenci
 		sysProbeClient := &compliance.LocalSysProbeClient{}
 
 		// start compliance agent
-		complianceAgent, err = compliance.StartCompliance(deps.Log, deps.CoreConfig, hostnameDetected, stopper, deps.Statsd, deps.WMeta, deps.FilterStore, deps.Compression, deps.Ipc, sysProbeClient)
+		complianceAgent, err = compliance.StartCompliance(deps.Log, deps.CoreConfig, hostnameDetected, stopper, deps.Statsd, deps.WMeta, deps.FilterStore, deps.Compression, sysProbeClient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compliance/agent.go
+++ b/pkg/compliance/agent.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/shirou/gopsutil/v4/process"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/compliance/aptconfig"
@@ -115,7 +114,7 @@ type Agent struct {
 	telemetrySender telemetry.SimpleTelemetrySender
 	wmeta           workloadmeta.Component
 	filterStore     workloadfilter.Component
-	ipc             ipc.Component
+	hostname        string
 	opts            AgentOptions
 
 	telemetry  *telemetry.ContainersTelemetry
@@ -139,7 +138,7 @@ var seclRuleFilterError error
 // MakeDefaultRuleFilter implements the default filtering of benchmarks' rules. It
 // will exclude rules based on the evaluation context / environment running
 // the benchmark.
-func MakeDefaultRuleFilter(ipc ipc.Component) RuleFilter {
+func MakeDefaultRuleFilter(hostname string) RuleFilter {
 	isK8s := env.IsKubernetes()
 	xccdfEnabled := xccdfEnabled()
 
@@ -158,7 +157,7 @@ func MakeDefaultRuleFilter(ipc ipc.Component) RuleFilter {
 		}
 		if len(r.Filters) > 0 {
 			initSECRulerFilter.Do(func() {
-				seclRuleFilterValue, seclRuleFilterError = newSECLRuleFilter(ipc)
+				seclRuleFilterValue, seclRuleFilterError = newSECLRuleFilter(hostname)
 			})
 			if seclRuleFilterError != nil {
 				log.Errorf("failed to apply rule filters: %s", seclRuleFilterError)
@@ -179,7 +178,7 @@ func MakeDefaultRuleFilter(ipc ipc.Component) RuleFilter {
 }
 
 // NewAgent returns a new compliance agent.
-func NewAgent(telemetrySender telemetry.SimpleTelemetrySender, wmeta workloadmeta.Component, ipc ipc.Component, filterStore workloadfilter.Component, opts AgentOptions) *Agent {
+func NewAgent(telemetrySender telemetry.SimpleTelemetrySender, wmeta workloadmeta.Component, filterStore workloadfilter.Component, hostname string, opts AgentOptions) *Agent {
 	if opts.ConfigDir == "" {
 		panic("compliance: missing agent configuration directory")
 	}
@@ -195,7 +194,7 @@ func NewAgent(telemetrySender telemetry.SimpleTelemetrySender, wmeta workloadmet
 	if opts.CheckIntervalLowPriority <= 0 {
 		opts.CheckIntervalLowPriority = defaultCheckIntervalLowPriority
 	}
-	defaultRuleFilter := MakeDefaultRuleFilter(ipc)
+	defaultRuleFilter := MakeDefaultRuleFilter(hostname)
 	if ruleFilter := opts.RuleFilter; ruleFilter != nil {
 		opts.RuleFilter = func(r *Rule) bool { return defaultRuleFilter(r) && ruleFilter(r) }
 	} else {
@@ -205,7 +204,7 @@ func NewAgent(telemetrySender telemetry.SimpleTelemetrySender, wmeta workloadmet
 		telemetrySender: telemetrySender,
 		wmeta:           wmeta,
 		filterStore:     filterStore,
-		ipc:             ipc,
+		hostname:        hostname,
 		opts:            opts,
 		statuses:        make(map[string]*CheckStatus),
 	}
@@ -424,7 +423,7 @@ func (a *Agent) runKubernetesConfigurationsExport(ctx context.Context) {
 }
 
 func (a *Agent) runAptConfigurationExport(ctx context.Context) {
-	seclRuleFilter, err := newSECLRuleFilter(a.ipc)
+	seclRuleFilter, err := newSECLRuleFilter(a.hostname)
 	if err != nil {
 		log.Errorf("failed to run apt configuration export: %v", err)
 		return

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -115,7 +115,7 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 	} else if checkArgs.Framework != "" {
 		benchDir, benchGlob = configDir, checkArgs.Framework+".yaml"
 	} else {
-		ruleFilter = compliance.MakeDefaultRuleFilter(ipc)
+		ruleFilter = compliance.MakeDefaultRuleFilter(hname)
 		benchDir, benchGlob = configDir, "*.yaml"
 	}
 

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -16,7 +16,6 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -38,7 +37,6 @@ func StartCompliance(log log.Component,
 	wmeta workloadmeta.Component,
 	filterStore workloadfilter.Component,
 	compression compression.Component,
-	ipc ipc.Component,
 	sysProbeClient SysProbeClient,
 ) (*Agent, error) {
 

--- a/pkg/compliance/compliance.go
+++ b/pkg/compliance/compliance.go
@@ -78,7 +78,7 @@ func StartCompliance(log log.Component,
 	reporter := NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
 	telemetrySender := telemetry.NewSimpleTelemetrySenderFromStatsd(statsdClient)
 
-	agent := NewAgent(telemetrySender, wmeta, ipc, filterStore, AgentOptions{
+	agent := NewAgent(telemetrySender, wmeta, filterStore, hostname, AgentOptions{
 		ResolverOptions:               resolverOptions,
 		ConfigDir:                     configDir,
 		Reporter:                      reporter,

--- a/pkg/compliance/rulefilter.go
+++ b/pkg/compliance/rulefilter.go
@@ -11,7 +11,6 @@ package compliance
 import (
 	"fmt"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules/filter"
 )
@@ -22,9 +21,9 @@ type seclRuleFilter struct {
 }
 
 // newSECLRuleFilter returns a new agent version based rule filter
-func newSECLRuleFilter(ipc ipc.Component) (*seclRuleFilter, error) {
+func newSECLRuleFilter(hostname string) (*seclRuleFilter, error) {
 	cfg := filtermodel.RuleFilterEventConfig{}
-	model, err := filtermodel.NewRuleFilterModel(cfg, ipc)
+	model, err := filtermodel.NewRuleFilterModel(cfg, hostname)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create default SECL rule filter: %w", err)
 	}

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -143,7 +143,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		listeners = append(listeners, selfTester)
 	}
 
-	c.ruleEngine, err = rulesmodule.NewRuleEngine(evm, cfg, evm.Probe, c.rateLimiter, c.apiServer, c, c.statsdClient, ipc, listeners...)
+	c.ruleEngine, err = rulesmodule.NewRuleEngine(evm, cfg, evm.Probe, c.rateLimiter, c.apiServer, c, c.statsdClient, hostname, ipc, listeners...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -69,6 +69,7 @@ type RuleEngine struct {
 	pid              uint32
 	wg               sync.WaitGroup
 	ipc              ipc.Component
+	hostname         string
 
 	// userspace filtering metrics (avoid statsd calls in event hot path)
 	noMatchCounters []atomic.Uint64
@@ -82,7 +83,7 @@ type APIServer interface {
 }
 
 // NewRuleEngine returns a new rule engine
-func NewRuleEngine(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurityConfig, probe *probe.Probe, rateLimiter *events.RateLimiter, apiServer APIServer, sender events.EventSender, statsdClient statsd.ClientInterface, ipc ipc.Component, rulesetListeners ...rules.RuleSetListener) (*RuleEngine, error) {
+func NewRuleEngine(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurityConfig, probe *probe.Probe, rateLimiter *events.RateLimiter, apiServer APIServer, sender events.EventSender, statsdClient statsd.ClientInterface, hostname string, ipc ipc.Component, rulesetListeners ...rules.RuleSetListener) (*RuleEngine, error) {
 	engine := &RuleEngine{
 		probe:            probe,
 		config:           config,
@@ -96,6 +97,7 @@ func NewRuleEngine(evm *eventmonitor.EventMonitor, config *config.RuntimeSecurit
 		statsdClient:     statsdClient,
 		rulesetListeners: rulesetListeners,
 		pid:              utils.Getpid(),
+		hostname:         hostname,
 		ipc:              ipc,
 	}
 
@@ -168,7 +170,7 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}) erro
 		COREEnabled: e.probe.Config.Probe.EnableCORE,
 		Origin:      e.probe.Origin(),
 	}
-	ruleFilterModel, err := filtermodel.NewRuleFilterModel(rfmCfg, e.ipc)
+	ruleFilterModel, err := filtermodel.NewRuleFilterModel(rfmCfg, e.hostname)
 	if err != nil {
 		return fmt.Errorf("failed to create rule filter: %w", err)
 	}

--- a/pkg/security/rules/filtermodel/rule_filters_model.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model.go
@@ -9,9 +9,7 @@ package filtermodel
 import (
 	"reflect"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
 )
 
 // RuleFilterEventConfig holds the config used by the rule filter event
@@ -67,12 +65,4 @@ func (m *RuleFilterModel) ValidateRule(_ *eval.Rule) error {
 // GetFieldRestrictions returns the field event type restrictions
 func (m *RuleFilterModel) GetFieldRestrictions(_ eval.Field) []eval.EventType {
 	return nil
-}
-
-func getHostname(ipcComp ipc.Component) string {
-	hostname, err := hostnameutils.GetHostname(ipcComp)
-	if err != nil || hostname == "" {
-		hostname = "unknown"
-	}
-	return hostname
 }

--- a/pkg/security/rules/filtermodel/rule_filters_model_other.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_other.go
@@ -12,35 +12,34 @@ import (
 	"os"
 	"runtime"
 
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
 // RuleFilterEvent represents a rule filtering event
 type RuleFilterEvent struct {
-	cfg RuleFilterEventConfig
-	ipc ipc.Component
+	cfg      RuleFilterEventConfig
+	hostname string
 }
 
 // RuleFilterModel represents a rule fitlering model
 type RuleFilterModel struct {
-	cfg RuleFilterEventConfig
-	ipc ipc.Component
+	cfg      RuleFilterEventConfig
+	hostname string
 }
 
 // NewRuleFilterModel returns a new rule filtering model
-func NewRuleFilterModel(cfg RuleFilterEventConfig, ipc ipc.Component) (*RuleFilterModel, error) {
+func NewRuleFilterModel(cfg RuleFilterEventConfig, hostname string) (*RuleFilterModel, error) {
 	return &RuleFilterModel{
-		cfg: cfg,
-		ipc: ipc,
+		cfg:      cfg,
+		hostname: hostname,
 	}, nil
 }
 
 // NewEvent returns a new rule filtering event
 func (m *RuleFilterModel) NewEvent() eval.Event {
 	return &RuleFilterEvent{
-		cfg: m.cfg,
-		ipc: m.ipc,
+		cfg:      m.cfg,
+		hostname: m.hostname,
 	}
 }
 
@@ -83,7 +82,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID, _ in
 		}, nil
 	case "hostname":
 		return &eval.StringEvaluator{
-			Value: getHostname(m.ipc),
+			Value: m.hostname,
 			Field: field,
 		}, nil
 	}
@@ -112,7 +111,7 @@ func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "origin":
 		return e.cfg.Origin, nil
 	case "hostname":
-		return getHostname(e.ipc), nil
+		return e.hostname, nil
 	}
 
 	return nil, &eval.ErrFieldNotFound{Field: field}

--- a/pkg/security/rules/filtermodel/rule_filters_model_test.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_test.go
@@ -25,7 +25,7 @@ func TestSECLRuleFilter(t *testing.T) {
 		Code:         kernel.Kernel5_9,
 	}
 
-	m := NewRuleFilterModelWithKernelVersion(RuleFilterEventConfig{}, kv)
+	m := NewRuleFilterModelWithKernelVersion(RuleFilterEventConfig{}, kv, "functional_tests_host")
 	seclRuleFilter := rules.NewSECLRuleFilter(m)
 
 	t.Run("true", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Follow up to https://github.com/DataDog/datadog-agent/pull/45326 and https://github.com/DataDog/datadog-agent/pull/45366 removing more usage of `ipc.Component` and replacing it by passing and using the hostname directly.

This PR is focused on the rule filter model, and updates the calling code in both CSPM code and CWS code.

### Motivation

### Describe how you validated your changes

### Additional Notes
