### PR TITLE
[CWS] add config flag to control ssh user session resolution

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -134,6 +134,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.kernel_compilation_flags", []string{})
 
 	// CWS - UserSessions
+	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.ssh.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
 
 	// CWS -eBPF Less

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -376,6 +376,8 @@ type RuntimeSecurityConfig struct {
 
 	// UserSessionsCacheSize defines the size of the User Sessions cache size
 	UserSessionsCacheSize int
+	// SSHUserSessionsEnabled defines if SSH user session features should be enabled
+	SSHUserSessionsEnabled bool
 
 	// EBPFLessEnabled enables the ebpfless probe
 	EBPFLessEnabled bool
@@ -631,7 +633,8 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		EnforcementDisarmerExecutablePeriod:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.enforcement.disarmer.executable.period"),
 
 		// User Sessions
-		UserSessionsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
+		SSHUserSessionsEnabled: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.user_sessions.ssh.enabled"),
+		UserSessionsCacheSize:  pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.user_sessions.cache_size"),
 
 		// ebpf less
 		EBPFLessEnabled: IsEBPFLessModeEnabled(),

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -276,6 +276,11 @@ type sshSessionPatcher = *probe.SSHUserSessionPatcher
 
 // createSSHSessionPatcher creates an SSH session patcher for Linux
 func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher {
+	// Early return if SSH user sessions are disabled
+	if !p.Config.RuntimeSecurity.SSHUserSessionsEnabled {
+		return nil
+	}
+
 	// Check if SSH session exists
 	if ev.ProcessContext.UserSession.SSHSessionID != 0 {
 		// Access the EBPFProbe to get the UserSessionsResolver

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -37,6 +37,11 @@ func getEnvVar(envp []string, key string) string {
 
 // HandleSSHUserSession handles the ssh user session
 func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
+	// Early return if SSH user sessions are disabled
+	if !p.config.RuntimeSecurity.SSHUserSessionsEnabled {
+		return
+	}
+
 	// First, we check if this event is link to an existing ssh session from his parent
 	ppid := event.ProcessContext.Process.PPid
 	parent := p.Resolvers.ProcessResolver.Resolve(ppid, ppid, 0, false, nil)

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -187,7 +187,7 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		return nil, err
 	}
 
-	userSessionsResolver, err := usersessions.NewResolver(config.RuntimeSecurity.UserSessionsCacheSize)
+	userSessionsResolver, err := usersessions.NewResolver(config.RuntimeSecurity.UserSessionsCacheSize, config.RuntimeSecurity.SSHUserSessionsEnabled)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

This PR adds a new config flag to control the enablement of the SSH user session feature. The k8s user session feature doesn't really need a config flag because it requires some payload from the outside (from cws-instrumentation especially) so disabling it can be done by disabling this outside code.

When SSH user sessions are disabled, we don't start the SSH resolver, and we don't create the patcher.

### Motivation

### Describe how you validated your changes

### Additional Notes
