### PR TITLE
refactor(ssi): extract AutoProvider from factory for library injection

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/auto.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package libraryinjection
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AutoProvider implements LibraryInjectionProvider.
+// It will be capable of determining the best provider based on the pod and runtime environment.
+type AutoProvider struct {
+	realProvider LibraryInjectionProvider
+}
+
+// NewAutoProvider creates a new AutoProvider.
+func NewAutoProvider(cfg LibraryInjectionConfig) *AutoProvider {
+	return &AutoProvider{
+		realProvider: NewInitContainerProvider(cfg),
+	}
+}
+
+// InjectInjector mutates the pod to add the APM injector.
+func (p *AutoProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConfig) MutationResult {
+	return p.realProvider.InjectInjector(pod, cfg)
+}
+
+// InjectLibrary mutates the pod to add a language-specific tracing library.
+func (p *AutoProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig) MutationResult {
+	return p.realProvider.InjectLibrary(pod, cfg)
+}
+
+// Verify that AutoProvider implements LibraryInjectionProvider.
+var _ LibraryInjectionProvider = (*AutoProvider)(nil)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory.go
@@ -55,7 +55,9 @@ func (f *ProviderFactory) GetProviderForPod(pod *corev1.Pod, cfg LibraryInjectio
 	default:
 		log.Warnf("Unknown injection mode %q for pod %s/%s, using 'auto'", mode, pod.Namespace, pod.Name)
 		fallthrough
-	case InjectionModeAuto, InjectionModeInitContainer:
+	case InjectionModeAuto:
+		return NewAutoProvider(cfg)
+	case InjectionModeInitContainer:
 		return NewInitContainerProvider(cfg)
 	case InjectionModeCSI:
 		return NewCSIProvider(cfg)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/factory_test.go
@@ -39,10 +39,10 @@ func TestGetProviderForPod(t *testing.T) {
 			expectedProvider: "CSIProvider",
 		},
 		{
-			name:             "no annotation uses default auto (init_container)",
+			name:             "no annotation uses default auto",
 			defaultMode:      libraryinjection.InjectionModeAuto,
 			annotationValue:  nil,
-			expectedProvider: "InitContainerProvider",
+			expectedProvider: "AutoProvider",
 		},
 		{
 			name:             "annotation overrides default: init_container -> csi",
@@ -57,16 +57,16 @@ func TestGetProviderForPod(t *testing.T) {
 			expectedProvider: "InitContainerProvider",
 		},
 		{
-			name:             "annotation auto uses init_container",
+			name:             "annotation auto uses AutoProvider",
 			defaultMode:      libraryinjection.InjectionModeInitContainer,
 			annotationValue:  ptr.To("auto"),
-			expectedProvider: "InitContainerProvider",
+			expectedProvider: "AutoProvider",
 		},
 		{
-			name:             "unknown mode falls back to auto (init_container)",
+			name:             "unknown mode falls back to auto",
 			defaultMode:      libraryinjection.InjectionModeCSI,
 			annotationValue:  ptr.To("unknown_mode"),
-			expectedProvider: "InitContainerProvider",
+			expectedProvider: "AutoProvider",
 		},
 		{
 			name:             "empty annotation uses default",
@@ -101,6 +101,9 @@ func TestGetProviderForPod(t *testing.T) {
 			case "InitContainerProvider":
 				_, ok := provider.(*libraryinjection.InitContainerProvider)
 				assert.True(t, ok, "expected InitContainerProvider")
+			case "AutoProvider":
+				_, ok := provider.(*libraryinjection.AutoProvider)
+				assert.True(t, ok, "expected AutoProvider")
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Extract `AutoProvider` into its own file (`auto.go`) to separate the "auto" mode logic from the factory.

### Motivation

Prepare the structure to later select the best injection provider based on pod/runtime characteristics (e.g., CSI availability).

### Describe how you validated your changes

Unit tests pass.

### Additional Notes

Currently `AutoProvider` wraps `InitContainerProvider`. No functional change.