### PR TITLE
extend quality gates inventory with permission related fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -733,7 +733,6 @@
 /tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
 /tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes
 /tasks/unit_tests/experimental_gates_tests.py @DataDog/agent-build
-/tasks/unit_tests/experimental_gates_tests.py @DataDog/agent-build
 /tasks/unit_tests/static_quality_gates_tests.py @DataDog/agent-build
 /tasks/unit_tests/static_quality_gates_reporter_tests.py @DataDog/agent-build
 /tasks/installer.py                     @DataDog/fleet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -732,6 +732,10 @@
 /tasks/unit_tests/components_tests.py   @DataDog/agent-runtimes
 /tasks/unit_tests/omnibus_tests.py      @DataDog/agent-build
 /tasks/unit_tests/testdata/components_src/ @DataDog/agent-runtimes
+/tasks/unit_tests/experimental_gates_tests.py @DataDog/agent-build
+/tasks/unit_tests/experimental_gates_tests.py @DataDog/agent-build
+/tasks/unit_tests/static_quality_gates_tests.py @DataDog/agent-build
+/tasks/unit_tests/static_quality_gates_reporter_tests.py @DataDog/agent-build
 /tasks/installer.py                     @DataDog/fleet
 /tasks/full_host_profiler.py            @DataDog/opentelemetry-agent @DataDog/profiling-full-host
 /test/                                  @DataDog/agent-devx

--- a/tasks/unit_tests/experimental_gates_tests.py
+++ b/tasks/unit_tests/experimental_gates_tests.py
@@ -367,6 +367,32 @@ class TestInPlacePackageMeasurer(unittest.TestCase):
         self.assertNotIn('is_symlink', result)
         self.assertNotIn('symlink_target', result)
 
+    def test_serialize_file_info_regular_file_with_permissions(self):
+        """Test serializing regular file with permissions info."""
+        from tasks.static_quality_gates.experimental_gates import ReportBuilder
+
+        file_info = FileInfo(relative_path="opt/agent/bin/agent", size_bytes=321, chmod=123, owner=0, group=0)
+        result = ReportBuilder()._serialize_file_info(file_info)
+
+        self.assertEqual(result['relative_path'], "opt/agent/bin/agent")
+        self.assertEqual(result['chmod'], 123)
+        self.assertEqual(result['owner'], 0)
+        self.assertEqual(result['group'], 0)
+
+    def test_serialize_file_info_regular_file_without_permissions(self):
+        """Test serializing regular file without permissions info provided."""
+        from tasks.static_quality_gates.experimental_gates import ReportBuilder
+
+        file_info = FileInfo("opt/agent/bin/agent", 2048)
+        result = ReportBuilder()._serialize_file_info(file_info)
+
+        self.assertEqual(result['relative_path'], "opt/agent/bin/agent")
+
+        # Should NOT have symlink fields
+        self.assertNotIn('chmod', result)
+        self.assertNotIn('owner', result)
+        self.assertNotIn('group', result)
+
     def test_serialize_file_info_regular_file_without_checksum(self):
         """Test serializing regular file without checksum."""
         from tasks.static_quality_gates.experimental_gates import ReportBuilder

--- a/tasks/unit_tests/experimental_gates_tests.py
+++ b/tasks/unit_tests/experimental_gates_tests.py
@@ -29,11 +29,14 @@ class TestFileInfo(unittest.TestCase):
 
     def test_file_info_creation_valid(self):
         """Test creating a valid FileInfo instance."""
-        file_info = FileInfo(relative_path="opt/datadog-agent/bin/agent", size_bytes=12345, checksum="sha256:abc123")
+        file_info = FileInfo(
+            relative_path="opt/datadog-agent/bin/agent", size_bytes=12345, checksum="sha256:abc123", chmod=0o644
+        )
 
         self.assertEqual(file_info.relative_path, "opt/datadog-agent/bin/agent")
         self.assertEqual(file_info.size_bytes, 12345)
         self.assertEqual(file_info.checksum, "sha256:abc123")
+        self.assertEqual(file_info.chmod, 0o644)
 
     def test_file_info_creation_minimal(self):
         """Test creating FileInfo with minimal required fields."""
@@ -42,6 +45,7 @@ class TestFileInfo(unittest.TestCase):
         self.assertEqual(file_info.relative_path, "etc/config.yaml")
         self.assertEqual(file_info.size_bytes, 1024)
         self.assertIsNone(file_info.checksum)
+        self.assertIsNone(file_info.chmod)
 
     def test_file_info_validation_empty_path(self):
         """Test FileInfo validation with empty relative_path."""


### PR DESCRIPTION
### What does this PR do?

Add permissions (chmod/owner/group) info to our file inventory

### Motivation

[ABLD-331](https://datadoghq.atlassian.net/browse/ABLD-331)
We will use these information to perform additional checks on our packages

### Describe how you validated your changes

Local tests for docker & deb, double checking with the CI

### Additional Notes


[ABLD-331]: https://datadoghq.atlassian.net/browse/ABLD-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ