### PR TITLE
fix(backport): Use a matrix

### DIFF
--- a/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
+++ b/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
@@ -41,8 +41,7 @@ def cmd(
             app.display_warning("Expecting a pull request event or --pr-number argument.")
             return
 
-    # target_branch can be either "backport/7.75.x" or just "7.75.x"
-    base = target_branch.removeprefix("backport/")
+    base = target_branch
 
     # Merge commit SHA (the commit created on base branch)
     merge_commit_sha = original_pr.get("merge_commit_sha")

--- a/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
+++ b/.dda/extend/commands/gh/cherry_pick_pr/__init__.py
@@ -21,30 +21,28 @@ if TYPE_CHECKING:
     features=["github"],
 )
 @click.option("--pr-number", type=int)
-@click.option("--target-branch", type=str)
+@click.option("--target-branch", type=str, required=True)
 @pass_app
 def cmd(
     app: Application,
+    target_branch: str,
     pr_number: int | None = None,
-    target_branch: str | None = None,
 ) -> None:
     """
     Cherry-pick a merged PR changes to another branch.
     """
-    # Use pr_number and target_branch if provided, otherwise use the event
-    if pr_number and target_branch:
+    # Get the PR either from --pr-number or from the event
+    if pr_number:
         original_pr = get_pr_by_number(pr_number)
-        base = target_branch
     else:
         event = get_event()
         original_pr = event.get("pull_request")
         if not original_pr:
-            app.display_warning("Expecting a pull request event or --pr-number and --target-branch arguments.")
+            app.display_warning("Expecting a pull request event or --pr-number argument.")
             return
-        base = find_backport_target(original_pr.get("labels", []))
-        if not base:
-            app.display_warning("No backport/<target> label found. Skipping backport.")
-            return
+
+    # target_branch can be either "backport/7.75.x" or just "7.75.x"
+    base = target_branch.removeprefix("backport/")
 
     # Merge commit SHA (the commit created on base branch)
     merge_commit_sha = original_pr.get("merge_commit_sha")
@@ -131,19 +129,6 @@ def get_event() -> dict:
     event_path = os.environ["GITHUB_EVENT_PATH"]
     with open(event_path, encoding="utf-8") as f:
         return json.load(f)
-
-
-def find_backport_target(labels: list[dict]) -> str | None:
-    """
-    Look for a label of the form 'backport/<target>' and return <target>'.
-    """
-    for lbl in labels:
-        name = lbl.get("name")
-        if not name:
-            continue
-        if name.startswith("backport/"):
-            return name.split("/", 1)[1]
-    return None
 
 
 def get_non_backport_labels(labels: list[dict]) -> list[str]:

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -44,6 +44,13 @@ jobs:
       contents: write # This is required for pushing the backport branch
       pull-requests: write # This is required for creating the backport PR
     steps:
+      - name: Compute target branch
+        id: target
+        run: |
+          target="${{ matrix.target }}"
+          target_branch="${target/backport\//}"
+          echo "target_branch=$target_branch" >> $GITHUB_OUTPUT
+
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:
@@ -64,7 +71,7 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
             GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: dda gh cherry-pick-pr --target-branch "${{ matrix.target }}"
+        run: dda gh cherry-pick-pr --target-branch "${{ steps.target.outputs.target_branch }}"
 
       - name: Reset cherry-pick
         if: steps.cherry-pick.outputs.base != ''

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -6,18 +6,39 @@ on:
       - labeled
 
 jobs:
-  backport:
-    name: Backport PR
+  get-backport-targets:
+    name: Get backport targets
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.merged
-      && (
-        github.event.action == 'closed'
-        || (
-          github.event.action == 'labeled'
-          && contains(github.event.label.name, 'backport')
-        )
-      )
+    if: github.event.pull_request.merged
+    outputs:
+      targets: ${{ steps.get-targets.outputs.targets }}
+    steps:
+      - name: Get backport targets
+        id: get-targets
+        run: |
+          # For 'labeled' event, use just the added label
+          # For 'closed' event, use all backport labels
+          if [[ "${{ github.event.action }}" == "labeled" ]]; then
+            if [[ "${{ github.event.label.name }}" == backport/* ]]; then
+              echo "targets=[\"${{ github.event.label.name }}\"]" >> $GITHUB_OUTPUT
+            else
+              echo "targets=[]" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Extract all backport/* labels as JSON array
+            targets=$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -c '[.[] | select(startswith("backport/"))]')
+            echo "targets=$targets" >> $GITHUB_OUTPUT
+          fi
+
+  backport:
+    name: Backport PR to ${{ matrix.target }}
+    needs: get-backport-targets
+    if: needs.get-backport-targets.outputs.targets != '[]' && needs.get-backport-targets.outputs.targets != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.get-backport-targets.outputs.targets) }}
     permissions:
       id-token: write # This is required for getting the required OIDC token from GitHub
       contents: write # This is required for pushing the backport branch
@@ -32,7 +53,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # needed to get the full history of the PR
-  
+
       - name: Install dda
         uses: ./.github/actions/install-dda
         with:
@@ -43,12 +64,12 @@ jobs:
         env:
             GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
             GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: dda gh cherry-pick-pr
+        run: dda gh cherry-pick-pr --target-branch "${{ matrix.target }}"
 
       - name: Reset cherry-pick
         if: steps.cherry-pick.outputs.base != ''
         run: git reset HEAD~1
-  
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         if: steps.cherry-pick.outputs.base != ''
@@ -60,15 +81,15 @@ jobs:
           title: "[Backport ${{steps.cherry-pick.outputs.base}}]  ${{steps.cherry-pick.outputs.original_title}}"
           body: |
             Backport ${{steps.cherry-pick.outputs.merge_commit_sha}} from #${{steps.cherry-pick.outputs.original_pr_number}}.
-            
+
              ___
-  
+
             ${{ steps.cherry-pick.outputs.original_body }}
-  
+
           labels: ${{ steps.cherry-pick.outputs.original_labels }},backport,bot
           commit-message: |
             ${{ steps.cherry-pick.outputs.message }}
-            
+
             ___
-  
+
             Co-authored-by: ${{ steps.cherry-pick.outputs.author }}


### PR DESCRIPTION
### What does this PR do?
Update the backport workflow to use a matrix run. The list of targets is deduced by:
- the current label name in case of `labeled` action.
- all the `backport/*` labels in case of `closed` action. 

### Motivation
We need to consider all the `backport/*` labels provided to the workflow. With current implementation only the first one was retrieved by `find_backport_target`, so led [this PR](https://github.com/DataDog/datadog-agent/pull/45376) to always create backport [on the same target](https://github.com/DataDog/datadog-agent/actions/runs/21353009992/job/61453868843?pr=45376#step:3:25)

### Describe how you validated your changes
No test :/

### Additional Notes
