### PR TITLE
[Backport 7.76.x] process: Avoid panic with no WLM processes in real-time mode

### DIFF
--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -119,6 +119,11 @@ func (r *RTContainerCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResu
 func (r *RTContainerCheck) Cleanup() {}
 
 func convertAndChunkContainers(containers []*model.Container, chunks int) [][]*model.ContainerStat {
+	// Callers should already ensure this, but check just in case
+	if chunks == 0 {
+		log.Tracef("No chunks requested, returning nil slice")
+		return nil
+	}
 	perChunk := (len(containers) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)
 	chunk := make([]*model.ContainerStat, 0, perChunk)

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -252,6 +252,10 @@ func (p *ProcessCheck) run(groupID int32, collectRealTime bool) (RunResult, erro
 	if err != nil {
 		return nil, err
 	}
+	if len(procs) == 0 {
+		log.Tracef("No processes found")
+		return CombinedRunResult{}, nil
+	}
 
 	// stores lastPIDs to be used by RTProcess
 	p.lastPIDs = p.lastPIDs[:0]

--- a/pkg/process/checks/process_test.go
+++ b/pkg/process/checks/process_test.go
@@ -280,6 +280,36 @@ func TestProcessCheckChunking(t *testing.T) {
 	}
 }
 
+func TestProcessCheckEmpty(t *testing.T) {
+	processCheck, probe, wmeta := processCheckWithMocks(t)
+
+	mockProcesses(processCheck.WLMProcessCollectionEnabled(), probe, wmeta, nil, nil)
+
+	// The first run returns nothing because processes must be observed on two consecutive runs
+	first, err := processCheck.run(0, false)
+	require.NoError(t, err)
+	assert.Equal(t, CombinedRunResult{}, first)
+
+	actual, err := processCheck.run(0, false)
+	require.NoError(t, err)
+	assert.Equal(t, CombinedRunResult{}, actual)
+}
+
+func TestProcessCheckEmptyWithRealtime(t *testing.T) {
+	processCheck, probe, wmeta := processCheckWithMocks(t)
+
+	mockProcesses(processCheck.WLMProcessCollectionEnabled(), probe, wmeta, nil, nil)
+
+	// The first run returns nothing because processes must be observed on two consecutive runs
+	first, err := processCheck.run(0, true)
+	require.NoError(t, err)
+	assert.Equal(t, CombinedRunResult{}, first)
+
+	actual, err := processCheck.run(0, true)
+	require.NoError(t, err)
+	assert.Equal(t, CombinedRunResult{}, actual)
+}
+
 func TestProcessCheckWithRealtime(t *testing.T) {
 	processCheck, probe, wmeta := processCheckWithMocks(t)
 	proc1 := makeProcess(1, "git clone google.com")


### PR DESCRIPTION
Backport 02c52f60ce166c854e5efa3e295e6c36ff0ad46b from #45376.

 ___

### What does this PR do?

If processesByPID() doesn't return any processes, the process check panics
in real-time mode with the below splat.  This situation happen in practice when 
process collection is disabled but discovery is enabled, in which it can take a
minimum of one minute before Process entities appear in workloadmeta.

Note that it can also happen even with process collection enabled (discovery
doesn't matter) if the first collection in `collectProcesses()` is delayed by 15-20
seconds (the exact time depends on the system), although this case has thus far
only been triggered by inserting artificial delays.

(Note that the missing handling of empty procs was not a problem earlier before
the use of workloadmeta since `processesByPID()` used to read `/proc` directly
and presumably never returned an empty list.)

Fix it by explicitly handling the empty process list case.  Also add a
defensive check just before the point where the divide-by-zero currently
happens.

```
 panic: runtime error: integer divide by zero

 goroutine 568 [running]:
 pkg/process/checks.convertAndChunkContainers({0x400286aa00, 0x6, 0x8}, 0x0)
         pkg/process/checks/container_rt.go:122 +0x2f8
 pkg/process/checks.(*ProcessCheck).run(0x4001561908, 0x581972ba, 0x1)
         pkg/process/checks/process.go:333 +0xd2c
 pkg/process/checks.(*ProcessCheck).Run(0x4001561908, 0x4001573be0, 0x4001764e68)
         pkg/process/checks/process.go:403 +0x17c
 pkg/process/runner.(*CheckRunner).runCheckWithRealTime(0x40015f1380, {0x55fe2b0, 0x4001561908}, 0x4001764e68)
         pkg/process/runner/runner.go:187 +0xbc
 pkg/process/runner.(*CheckRunner).runnerForCheck.func2({0x1, 0x1, 0x0})
         pkg/process/runner/runner.go:364 +0x70
 pkg/process/checks.(*runnerWithRealTime).run(0x4000ae2eb0)
         pkg/process/checks/runner.go:73 +0x40c
 pkg/process/runner.(*CheckRunner).Run.func1()
         pkg/process/runner/runner.go:301 +0x78
 created by pkg/process/runner.(*CheckRunner).Run in goroutine 333
         pkg/process/runner/runner.go:299 +0x8a0
```

### Motivation

https://app.datadoghq.com/incidents/48383

### Describe how you validated your changes

Regression tests added.  These panic without the fix.