### PR TITLE
Get caller frame once in json logger

### DIFF
--- a/pkg/util/log/setup/log_format.go
+++ b/pkg/util/log/setup/log_format.go
@@ -66,11 +66,12 @@ func jsonFormatter(loggerName LoggerName, cfg pkgconfigmodel.Reader) func(ctx co
 	return func(_ context.Context, r slog.Record) string {
 		date := dateFmt(r.Time)
 		level := formatters.UppercaseLevel(r.Level)
-		shortFilePath := formatters.ShortFilePath(formatters.Frame(r))
-		line := formatters.Frame(r).Line
-		funcShort := formatters.ShortFunction(formatters.Frame(r))
 		extraContext := formatters.ExtraJSONContext(r)
 
-		return fmt.Sprintf(`{"agent":"%s","time":"%s","level":"%s","file":"%s","line":"%d","func":"%s","msg":%s%s}`+"\n", strings.ToLower(string(loggerName)), date, level, shortFilePath, line, funcShort, formatters.Quote(r.Message), extraContext)
+		frame := formatters.Frame(r)
+		shortFilePath := formatters.ShortFilePath(frame)
+		funcShort := formatters.ShortFunction(frame)
+
+		return fmt.Sprintf(`{"agent":"%s","time":"%s","level":"%s","file":"%s","line":"%d","func":"%s","msg":%s%s}`+"\n", strings.ToLower(string(loggerName)), date, level, shortFilePath, frame.Line, funcShort, formatters.Quote(r.Message), extraContext)
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Only get the caller's frame once in the json logger.

### Motivation
Performance, code simplification.

### Describe how you validated your changes
CI

### Additional Notes
Also aligned the code to be closer to the `commonFormatter` just above (moved some lines around).