### PR TITLE
fix(tags): Increase hard-time limit on test

### DIFF
--- a/pkg/trace/containertags/buffer_test.go
+++ b/pkg/trace/containertags/buffer_test.go
@@ -253,7 +253,7 @@ func TestAsyncEnrichment_Buffered_HardLimit(t *testing.T) {
 	}
 
 	ctb := newContainerTagsBuffer(conf, &statsd.NoOpClient{})
-	ctb.hardTimeLimit = 1 * time.Nanosecond
+	ctb.hardTimeLimit = 100 * time.Millisecond
 	ctb.Start()
 
 	resultChan := make(chan []string, 1)


### PR DESCRIPTION

### What does this PR do?
Fix for https://datadoghq.atlassian.net/browse/APMSP-2515

The test had an extremely low hard limit, which could cause race conditions (the async goroutine finishing before the assertion was done).


### Motivation

### Describe how you validated your changes
unit tests

### Additional Notes
