### PR TITLE
[Backport 7.76.x] fix(incident-48489): Allow failure of new-e2e-installer-ansible (#45482)

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
@@ -107,6 +108,10 @@ func TestPackages(t *testing.T) {
 			suite := test.t(flavor, flavor.Architecture, method)
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
+				// incident-48489
+				if method == InstallMethodAnsible {
+					flake.Mark(t)
+				}
 				opts := []awshost.ProvisionerOption{
 					awshost.WithRunOptions(
 						ec2.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),


### PR DESCRIPTION
### What does this PR do?
Allows failure on failing E2E job leveraging Ansible Galaxy (which is [down](https://forum.ansible.com/t/galaxy-ansible-com-currently-down-500-errors/45170))

### Motivation

### Describe how you validated your changes

### Additional Notes

(cherry picked from commit b6b0bd4d676c8e0feb9e3882d8723ac68836e62c)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
