### PR TITLE
[CWS] Fixes in SSH User Session Tracking

### DIFF
--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -294,6 +294,7 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 			return probe.NewSSHUserSessionPatcher(
 				userSessionCtx,
 				ebpfProbe.Resolvers.UserSessionsResolver,
+				ev.ProcessContext.UserSession.SSHDPid,
 			)
 		}
 	}

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -31,7 +31,7 @@ func TestProcessArgsFlags(t *testing.T) {
 	}
 
 	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&utils.Scrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
+		&utils.Scrubber{}, nil, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{
@@ -94,7 +94,7 @@ func TestProcessArgsOptions(t *testing.T) {
 	}
 
 	resolver, _ := process.NewEBPFResolver(&manager.Manager{}, &config.Config{}, &statsd.NoOpClient{},
-		&utils.Scrubber{}, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
+		&utils.Scrubber{}, nil, nil, nil, nil, nil, nil, nil, process.NewResolverOpts())
 
 	e := model.Event{
 		Exec: model.ExecEvent{

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1639,10 +1639,10 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 			p.Resolvers.ProcessResolver.UpdateProcessContexts(pce, cacheEntry.GetCGroupContext(), cacheEntry.GetContainerContext())
 		}
 	case model.ExecEventType:
-		p.HandleSSHUserSession(event)
+		p.HandleSSHUserSessionFromEvent(event)
 
 	case model.ForkEventType:
-		p.HandleSSHUserSession(event)
+		p.HandleSSHUserSessionFromEvent(event)
 	}
 	return true
 }

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -11,80 +11,22 @@ package probe
 import (
 	"errors"
 	"fmt"
-	"math/rand/v2"
-	"net"
 	"strconv"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
 )
 
 const maxRetryForMsgWithSSHContext = 15
 
-// getEnvVar extracts a specific environment variable from a list of environment variables.
-// Each environment variable is in the format "KEY=VALUE".
-func getEnvVar(envp []string, key string) string {
-	prefix := key + "="
-	for _, env := range envp {
-		if after, ok := strings.CutPrefix(env, prefix); ok {
-			return after
-		}
+func (p *EBPFProbe) HandleSSHUserSessionFromEvent(event *model.Event) {
+	if p.config.RuntimeSecurity.SSHUserSessionsEnabled {
+		pc := event.ProcessContext
+		envp := p.fieldHandlers.ResolveProcessEnvp(nil, &pc.Process)
+		usersessions.HandleSSHUserSession(pc, envp)
 	}
-	return ""
-}
-
-// HandleSSHUserSession handles the ssh user session
-func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
-	// Early return if SSH user sessions are disabled
-	if !p.config.RuntimeSecurity.SSHUserSessionsEnabled {
-		return
-	}
-
-	// First, we check if this event is link to an existing ssh session from his parent
-	parent := event.ProcessContext.Parent
-
-	// If the parent is a sshd process, we consider it's a new ssh session
-	// A sshd process will always be sshd, except on Ubuntu 25 where they introduced sshd-session
-	if parent != nil && strings.HasPrefix(parent.Comm, "sshd") && !strings.HasPrefix(event.ProcessContext.Comm, "sshd") {
-		sshSessionID := rand.Uint64()
-		event.ProcessContext.UserSession.SSHSessionID = sshSessionID
-		// Try to extract the SSH client IP and port
-		envp := p.fieldHandlers.ResolveProcessEnvp(event, &event.ProcessContext.Process)
-		sshClientVar := getEnvVar(envp, "SSH_CLIENT")
-		parts := strings.Fields(sshClientVar)
-		if len(parts) >= 2 {
-			event.ProcessContext.UserSession.SSHClientIP = getIPfromEnv(parts[0])
-			if port, err := strconv.Atoi(parts[1]); err != nil {
-				seclog.Warnf("failed to parse SSH_CLIENT port from %q: %v", sshClientVar, err)
-			} else {
-				event.ProcessContext.UserSession.SSHClientPort = port
-			}
-		} else {
-			seclog.Tracef("SSH_CLIENT is not in the expected format: %q", sshClientVar)
-		}
-	}
-}
-
-func getIPfromEnv(ipStr string) net.IPNet {
-	ip := net.ParseIP(ipStr)
-	if ip != nil {
-		if ip.To4() != nil {
-			return net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(32, 32),
-			}
-		} else if ip.To16() != nil {
-			return net.IPNet{
-				IP:   ip,
-				Mask: net.CIDRMask(128, 128),
-			}
-		}
-	}
-	return net.IPNet{}
 }
 
 // SSHUserSessionPatcher defines a patcher for SSH user sessions

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -51,7 +51,6 @@ func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
 	if parent != nil && parent.Comm == "sshd" && event.ProcessContext.Comm != "sshd" {
 		sshSessionID := rand.Uint64()
 		event.ProcessContext.UserSession.SSHSessionID = sshSessionID
-		event.ProcessContext.UserSession.SessionType = int(usersession.UserSessionTypeSSH)
 		// Try to extract the SSH client IP and port
 		envp := p.fieldHandlers.ResolveProcessEnvp(event, &event.ProcessContext.Process)
 		sshClientVar := getEnvVar(envp, "SSH_CLIENT")

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -48,7 +48,8 @@ func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
 	parent := event.ProcessContext.Parent
 
 	// If the parent is a sshd process, we consider it's a new ssh session
-	if parent != nil && parent.Comm == "sshd" && event.ProcessContext.Comm != "sshd" {
+	// A sshd process will always be sshd, except on Ubuntu 25 where they introduced sshd-session
+	if parent != nil && strings.HasPrefix(parent.Comm, "sshd") && !strings.HasPrefix(event.ProcessContext.Comm, "sshd") {
 		sshSessionID := rand.Uint64()
 		event.ProcessContext.UserSession.SSHSessionID = sshSessionID
 		// Try to extract the SSH client IP and port

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -33,13 +33,15 @@ func (p *EBPFProbe) HandleSSHUserSessionFromEvent(event *model.Event) {
 type SSHUserSessionPatcher struct {
 	userSessionCtx *serializers.SSHSessionContextSerializer
 	resolver       *usersessions.Resolver
+	SSHDPid        uint32
 }
 
 // NewSSHUserSessionPatcher creates a new SSH user session patcher
-func NewSSHUserSessionPatcher(userSessionCtx *serializers.SSHSessionContextSerializer, resolver *usersessions.Resolver) *SSHUserSessionPatcher {
+func NewSSHUserSessionPatcher(userSessionCtx *serializers.SSHSessionContextSerializer, resolver *usersessions.Resolver, SSHDPid uint32) *SSHUserSessionPatcher {
 	return &SSHUserSessionPatcher{
 		userSessionCtx: userSessionCtx,
 		resolver:       resolver,
+		SSHDPid:        SSHDPid,
 	}
 }
 
@@ -54,8 +56,9 @@ func (p *SSHUserSessionPatcher) IsResolved() error {
 
 	// Check in LRU
 	key := usersessions.SSHSessionKey{
-		IP:   p.userSessionCtx.SSHClientIP,
-		Port: strconv.Itoa(p.userSessionCtx.SSHClientPort),
+		SSHDPid: strconv.FormatUint(uint64(p.SSHDPid), 10),
+		IP:      p.userSessionCtx.SSHClientIP,
+		Port:    strconv.Itoa(p.userSessionCtx.SSHClientPort),
 	}
 
 	_, ok := p.resolver.GetSSHSession(key)
@@ -84,8 +87,9 @@ func (p *SSHUserSessionPatcher) PatchEvent(ev *serializers.EventSerializer) {
 	}
 
 	key := usersessions.SSHSessionKey{
-		IP:   p.userSessionCtx.SSHClientIP,
-		Port: strconv.Itoa(p.userSessionCtx.SSHClientPort),
+		SSHDPid: strconv.FormatUint(uint64(p.SSHDPid), 10),
+		IP:      p.userSessionCtx.SSHClientIP,
+		Port:    strconv.Itoa(p.userSessionCtx.SSHClientPort),
 	}
 	value, ok := p.resolver.GetSSHSession(key)
 

--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -45,11 +45,10 @@ func (p *EBPFProbe) HandleSSHUserSession(event *model.Event) {
 	}
 
 	// First, we check if this event is link to an existing ssh session from his parent
-	ppid := event.ProcessContext.Process.PPid
-	parent := p.Resolvers.ProcessResolver.Resolve(ppid, ppid, 0, false, nil)
+	parent := event.ProcessContext.Parent
 
 	// If the parent is a sshd process, we consider it's a new ssh session
-	if parent != nil && parent.Comm == "sshd" {
+	if parent != nil && parent.Comm == "sshd" && event.ProcessContext.Comm != "sshd" {
 		sshSessionID := rand.Uint64()
 		event.ProcessContext.UserSession.SSHSessionID = sshSessionID
 		event.ProcessContext.UserSession.SessionType = int(usersession.UserSessionTypeSSH)

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -135,7 +135,7 @@ func newResolver() (*EBPFResolver, error) {
 		return nil, err
 	}
 
-	resolver, err := NewEBPFResolver(nil, &config.Config{}, &statsd.NoOpClient{}, nil, nil, nil, userGroupResolver, timeResolver, &path.NoOpResolver{}, nil, NewResolverOpts())
+	resolver, err := NewEBPFResolver(nil, &config.Config{}, &statsd.NoOpClient{}, nil, nil, nil, userGroupResolver, timeResolver, &path.NoOpResolver{}, nil, nil, NewResolverOpts())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -175,11 +175,6 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		}
 	}
 
-	processResolver, err := process.NewEBPFResolver(manager, config.Probe, statsdClient,
-		scrubber, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, envVarsResolver, processOpts)
-	if err != nil {
-		return nil, err
-	}
 	hashResolver, err := hash.NewResolver(config.RuntimeSecurity, statsdClient, cgroupsResolver)
 	if err != nil {
 		return nil, err
@@ -191,6 +186,12 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 	}
 
 	fileMetadataResolver, err := file.NewResolver(config.RuntimeSecurity, statsdClient, &file.Opt{CgroupResolver: cgroupsResolver})
+	if err != nil {
+		return nil, err
+	}
+
+	processResolver, err := process.NewEBPFResolver(manager, config.Probe, statsdClient,
+		scrubber, mountResolver, cgroupsResolver, userGroupResolver, timeResolver, pathResolver, envVarsResolver, userSessionsResolver, processOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -203,8 +203,8 @@ func (ifr *incrementalFileReader) Init(f *os.File) error {
 		seclog.Warnf("Fail to stat log file: %v", err)
 		return err
 	}
-
-	ifr.offset = st.Size()
+	// Start from the beginning
+	ifr.offset = 0
 
 	ifr.f = f
 	ifr.ino = inodeOf(st)

--- a/pkg/security/resolvers/usersessions/resolver_linux_test.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux_test.go
@@ -25,6 +25,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 		expectedPort       string
 		expectedAuthMethod int
 		expectedPublicKey  string
+		expectedSSHDPid    string
 		shouldAddToLRU     bool
 	}{
 		{
@@ -34,6 +35,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 			expectedPort:       "38835",
 			expectedAuthMethod: int(usersession.SSHAuthMethodPublicKey),
 			expectedPublicKey:  "J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			expectedSSHDPid:    "1234",
 			shouldAddToLRU:     true,
 		},
 		{
@@ -43,6 +45,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 			expectedPort:       "38835",
 			expectedAuthMethod: int(usersession.SSHAuthMethodPublicKey),
 			expectedPublicKey:  "J3I5W45pnQtan5u0m27HWzyqAMZfTbG+nRet/pzzylU",
+			expectedSSHDPid:    "5678",
 			shouldAddToLRU:     true,
 		},
 		{
@@ -52,6 +55,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 			expectedPort:       "12345",
 			expectedAuthMethod: int(usersession.SSHAuthMethodPassword),
 			expectedPublicKey:  "",
+			expectedSSHDPid:    "5678",
 			shouldAddToLRU:     true,
 		},
 		{
@@ -80,8 +84,9 @@ func Test_parseSSHLogLine(t *testing.T) {
 
 			if tt.shouldAddToLRU {
 				key := SSHSessionKey{
-					IP:   tt.expectedIP,
-					Port: tt.expectedPort,
+					SSHDPid: tt.expectedSSHDPid,
+					IP:      tt.expectedIP,
+					Port:    tt.expectedPort,
 				}
 
 				value, found := sshSessionParsed.Get(key)

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -433,6 +433,7 @@ func deepCopySSHSessionContext(fieldToCopy SSHSessionContext) SSHSessionContext 
 	copied.SSHAuthMethod = fieldToCopy.SSHAuthMethod
 	copied.SSHClientIP = fieldToCopy.SSHClientIP
 	copied.SSHClientPort = fieldToCopy.SSHClientPort
+	copied.SSHDPid = fieldToCopy.SSHDPid
 	copied.SSHPublicKey = fieldToCopy.SSHPublicKey
 	copied.SSHSessionID = fieldToCopy.SSHSessionID
 	return copied

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -389,6 +389,7 @@ type SSHSessionContext struct {
 	SSHClientIP   net.IPNet `field:"ssh_client_ip" json:"client_ip,omitempty"`       // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
 	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`   // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
 	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`     // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
+	SSHDPid       uint32    `field:"-" json:"-"`                                     // Internal field
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 )
 
 func (pc *ProcessCacheEntry) setAncestor(parent *ProcessCacheEntry) {
@@ -96,8 +95,8 @@ func (pc *ProcessCacheEntry) copyAUIDFrom(parent *ProcessCacheEntry) {
 }
 
 func (pc *ProcessCacheEntry) copySSHUserSessionFrom(parent *ProcessCacheEntry) {
-	if parent.UserSession.SSHSessionID != 0 && parent.UserSession.SessionType == int(usersession.UserSessionTypeSSH) {
-		pc.UserSession = parent.UserSession
+	if parent.ProcessContext.UserSession.SSHSessionID != 0 {
+		pc.UserSession.SSHSessionContext = parent.UserSession.SSHSessionContext
 	}
 }
 

--- a/pkg/security/secl/model/process_cache_entry_unix_test.go
+++ b/pkg/security/secl/model/process_cache_entry_unix_test.go
@@ -11,7 +11,6 @@ package model
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -141,8 +140,6 @@ func TestCopyProcessContextFromParent(t *testing.T) {
 	parent.MntNS = 1234
 	parent.NetNS = 5678
 	parent.UserSession = UserSessionContext{
-		ID:          "abc",
-		SessionType: int(usersession.UserSessionTypeSSH),
 		SSHSessionContext: SSHSessionContext{
 			SSHSessionID: 9876,
 		},
@@ -159,7 +156,7 @@ func TestCopyProcessContextFromParent(t *testing.T) {
 		assert.Equal(t, parent.ContainerContext, child.ContainerContext)
 		assert.Equal(t, parent.MntNS, child.MntNS)
 		assert.Equal(t, parent.NetNS, child.NetNS)
-		assert.Equal(t, parent.UserSession, child.UserSession)
+		assert.Equal(t, parent.UserSession.SSHSessionContext, child.UserSession.SSHSessionContext)
 		assert.Equal(t, parent.Credentials, child.Credentials)
 	})
 
@@ -171,7 +168,7 @@ func TestCopyProcessContextFromParent(t *testing.T) {
 		assert.Equal(t, parent.ContainerContext, child.ContainerContext)
 		assert.Equal(t, parent.MntNS, child.MntNS)
 		assert.Equal(t, parent.NetNS, child.NetNS)
-		assert.Equal(t, parent.UserSession, child.UserSession)
+		assert.Equal(t, parent.UserSession.SSHSessionContext, child.UserSession.SSHSessionContext)
 		assert.Equal(t, parent.Credentials, child.Credentials)
 	})
 
@@ -183,7 +180,7 @@ func TestCopyProcessContextFromParent(t *testing.T) {
 		assert.Equal(t, parent.ContainerContext, child.ContainerContext)
 		assert.Equal(t, parent.MntNS, child.MntNS)
 		assert.Equal(t, parent.NetNS, child.NetNS)
-		assert.Equal(t, parent.UserSession, child.UserSession)
+		assert.Equal(t, parent.UserSession.SSHSessionContext, child.UserSession.SSHSessionContext)
 		assert.Equal(t, parent.Credentials, child.Credentials)
 	})
 
@@ -195,7 +192,7 @@ func TestCopyProcessContextFromParent(t *testing.T) {
 		assert.Equal(t, parent.ContainerContext, child.ContainerContext)
 		assert.Equal(t, parent.MntNS, child.MntNS)
 		assert.Equal(t, parent.NetNS, child.NetNS)
-		assert.Equal(t, parent.UserSession, child.UserSession)
+		assert.Equal(t, parent.UserSession.SSHSessionContext, child.UserSession.SSHSessionContext)
 		assert.Equal(t, parent.Credentials, child.Credentials)
 	})
 }

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -389,6 +389,7 @@ type SSHSessionContext struct {
 	SSHClientIP   net.IPNet `field:"ssh_client_ip" json:"client_ip,omitempty"`       // SECLDoc[ssh_client_ip] Definition:`SSH client IP of the user that executed the process`
 	SSHAuthMethod int       `field:"ssh_auth_method" json:"auth_method,omitempty"`   // SECLDoc[ssh_auth_method] Definition:`SSH authentication method used by the user` Constants:`SSHAuthMethod`
 	SSHPublicKey  string    `field:"ssh_public_key" json:"public_key,omitempty"`     // SECLDoc[ssh_public_key] Definition:`SSH public key used for authentication (if applicable)`
+	SSHDPid       uint32    `field:"-" json:"-"`                                     // Internal field
 }
 
 // MatchedRule contains the identification of one rule that has match

--- a/pkg/security/tests/ssh_user_session_test.go
+++ b/pkg/security/tests/ssh_user_session_test.go
@@ -29,20 +29,17 @@ import (
 
 // testSSHUser représente un utilisateur de test pour SSH
 type testSSHUser struct {
-	Username string
-	HomeDir  string
-	KeyPath  string
+	Username          string
+	HomeDir           string
+	KeyPath           string
+	PubKeyFingerprint string // SHA256 fingerprint of the public key (base64 hash only, e.g. "J3I5W45pnQ...")
 }
 
-// createTestUser crée un utilisateur système temporaire pour les tests SSH
+// createTestUser creates a temporary system user for SSH tests
 func createTestUser() (*testSSHUser, error) {
 	username := fmt.Sprintf("ddtest_ssh_%d", time.Now().Unix())
 
-	// Create a user system with useradd
-	// -r : system user
-	// -m : create home directory
-	// -s : shell
-	// -K MAIL_DIR=/dev/null : deactivate mailbox
+	// 1. Create a system user with a home directory
 	cmd := exec.Command("sudo", "useradd", "-r", "-m", "-s", "/bin/bash", "-K", "MAIL_DIR=/dev/null", username)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("useradd failed: %v (out: %s)", err, string(out))
@@ -59,18 +56,17 @@ func createTestUser() (*testSSHUser, error) {
 	gid := u.Gid
 	sshDir := filepath.Join(homeDir, ".ssh")
 
-	// Create the .ssh directory with the correct permissions
+	// 2. Create ~/.ssh with mode 700
 	if err := exec.Command("sudo", "mkdir", "-p", sshDir).Run(); err != nil {
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
 		return nil, fmt.Errorf("mkdir .ssh: %w", err)
 	}
-
 	if err := exec.Command("sudo", "chmod", "700", sshDir).Run(); err != nil {
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
 		return nil, fmt.Errorf("chmod .ssh: %w", err)
 	}
 
-	// Generate an ed25519 key pair
+	// 3. Generate an ed25519 key pair in a temp directory
 	tmpDir, err := os.MkdirTemp("", "ssh_test_keys_*")
 	if err != nil {
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
@@ -87,7 +83,7 @@ func createTestUser() (*testSSHUser, error) {
 		return nil, fmt.Errorf("ssh-keygen: %v (out: %s)", err, string(out))
 	}
 
-	// Copy the public key to the authorized_keys file
+	// 4. Install the public key as authorized_keys (mode 600, correct owner)
 	authzPath := filepath.Join(sshDir, "authorized_keys")
 	cmd = exec.Command("sudo", "cp", pubPath, authzPath)
 	if err := cmd.Run(); err != nil {
@@ -95,23 +91,43 @@ func createTestUser() (*testSSHUser, error) {
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
 		return nil, fmt.Errorf("copy authorized_keys: %w", err)
 	}
-
-	// Définir les bonnes permissions et propriétaire
 	if err := exec.Command("sudo", "chmod", "600", authzPath).Run(); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
 		return nil, fmt.Errorf("chmod authorized_keys: %w", err)
 	}
-
 	if err := exec.Command("sudo", "chown", "-R", uid+":"+gid, sshDir).Run(); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		_ = exec.Command("sudo", "userdel", "-r", username).Run()
 		return nil, fmt.Errorf("chown .ssh: %w", err)
 	}
+
+	// 5. Extract the SHA256 fingerprint of the public key (base64 hash only)
+	//    ssh-keygen -lf outputs: "256 SHA256:<base64hash> comment (ED25519)"
+	fingerprintOut, err := exec.Command("ssh-keygen", "-lf", pubPath, "-E", "sha256").Output()
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("ssh-keygen fingerprint: %w", err)
+	}
+	fingerprintStr := strings.TrimSpace(string(fingerprintOut))
+	var pubKeyFingerprint string
+	for _, field := range strings.Fields(fingerprintStr) {
+		if strings.HasPrefix(field, "SHA256:") {
+			pubKeyFingerprint = strings.TrimPrefix(field, "SHA256:")
+			break
+		}
+	}
+	if pubKeyFingerprint == "" {
+		_ = os.RemoveAll(tmpDir)
+		_ = exec.Command("sudo", "userdel", "-r", username).Run()
+		return nil, fmt.Errorf("failed to extract SHA256 fingerprint from: %s", fingerprintStr)
+	}
 	return &testSSHUser{
-		Username: username,
-		HomeDir:  homeDir,
-		KeyPath:  keyPath,
+		Username:          username,
+		HomeDir:           homeDir,
+		KeyPath:           keyPath,
+		PubKeyFingerprint: pubKeyFingerprint,
 	}, nil
 }
 
@@ -153,20 +169,18 @@ func (u *testSSHUser) cleanup() error {
 
 // SSHUserSessionExpected contient les valeurs attendues pour vérifier une session SSH
 type SSHUserSessionExpected struct {
-	SessionType    *string  // If nil, only check if the field exists and is "ssh"
-	AuthMethod     *string  // If nil, only check if the field exists and is either "password" or "public_key" or "unknown"
-	ClientIP       *string  // If nil, only check it's local host
-	ClientPort     *float64 // If nil, only check if port > 0
-	SessionID      *string  // If nil, only check if ssh_session_id > 0
-	CheckPublicKey bool     // If true and AuthMethod == "public_key", checks if the public key is valid
+	SessionType       *string  // If nil, only check if the field exists and is "ssh"
+	AuthMethod        *string  // If nil, only check if the field exists and is either "password" or "public_key" or "unknown"
+	ClientIP          *string  // If nil, only check it's local host
+	ClientPort        *float64 // If nil, only check if port > 0
+	SessionID         *string  // If nil, only check if ssh_session_id > 0
+	ExpectedPublicKey *string  // If not nil and AuthMethod == "public_key", checks that the public key matches this value
 }
 
 // checkSSHUserSessionJSON check if all the fields in the JSON are valid for a SSH Session
 func checkSSHUserSessionJSON(testMod *testModule, t testing.TB, data []byte, expected *SSHUserSessionExpected) {
 	if expected == nil {
-		expected = &SSHUserSessionExpected{
-			CheckPublicKey: true,
-		}
+		expected = &SSHUserSessionExpected{}
 	}
 
 	jsonPathValidation(testMod, data, func(_ *testModule, jsonData interface{}) {
@@ -260,13 +274,15 @@ func checkSSHUserSessionJSON(testMod *testModule, t testing.TB, data []byte, exp
 			}
 		}
 
-		if expected.CheckPublicKey {
+		if expected.ExpectedPublicKey != nil {
 			if authMethod, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_auth_method`); err == nil {
 				if authMethodStr, ok := authMethod.(string); ok && authMethodStr == "public_key" {
 					if el, err := jsonpath.JsonPathLookup(jsonData, `$.process.user_session.ssh_public_key`); err != nil || el == nil {
 						t.Errorf("user_session.ssh_public_key not found for publickey auth: %v", err)
 					} else if pubKey, ok := el.(string); !ok || pubKey == "" {
 						t.Errorf("user_session.ssh_public_key is empty for publickey auth: %v", el)
+					} else if pubKey != *expected.ExpectedPublicKey {
+						t.Errorf("user_session.ssh_public_key mismatch: got %v, want %v", pubKey, *expected.ExpectedPublicKey)
 					}
 				}
 			}
@@ -449,7 +465,8 @@ func TestSSHUserSession(t *testing.T) {
 			// Check all the fields
 			expectedAuthType := "public_key"
 			expected := &SSHUserSessionExpected{
-				AuthMethod: &expectedAuthType,
+				AuthMethod:        &expectedAuthType,
+				ExpectedPublicKey: &testUser.PubKeyFingerprint,
 			}
 			checkSSHUserSessionJSON(test, t, msg.Data, expected)
 
@@ -541,7 +558,8 @@ func TestSSHUserSessionRotated(t *testing.T) {
 			// Check all the fields
 			expectedAuthType := "public_key"
 			expected := &SSHUserSessionExpected{
-				AuthMethod: &expectedAuthType,
+				AuthMethod:        &expectedAuthType,
+				ExpectedPublicKey: &testUser.PubKeyFingerprint,
 			}
 
 			checkSSHUserSessionJSON(test, t, msg.Data, expected)
@@ -599,7 +617,7 @@ func TestSSHUserSessionBlocking(t *testing.T) {
 
 	host := testUser.Username + "@localhost"
 
-	// 2) Start master in background: -M (master), -N (pas de commande), -f (fork background)
+	// 2) Start master in background: -M (master), -N (no command), -f (fork background)
 	masterArgs := append([]string{}, baseOpts...)
 	masterArgs = append(masterArgs,
 		"-o", "ControlMaster=yes",
@@ -656,10 +674,10 @@ func TestSSHUserSessionBlocking(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			// Check that the field is unknown since the connection is multiplexed and ws initialized before the resolver started
-			expectedAuthType := "unknown"
+			expectedAuthType := "public_key"
 			expected := &SSHUserSessionExpected{
-				AuthMethod: &expectedAuthType,
+				AuthMethod:        &expectedAuthType,
+				ExpectedPublicKey: &testUser.PubKeyFingerprint,
 			}
 			checkSSHUserSessionJSON(test, t, msg.Data, expected)
 			return nil
@@ -828,10 +846,10 @@ func TestSSHUserSessionSnapshot(t *testing.T) {
 			}
 			validateMessageSchema(t, string(msg.Data))
 
-			// Check that the field is unknown since the connection was started before the resolver
-			expectedAuthType := "unknown"
+			expectedAuthType := "public_key"
 			expected := &SSHUserSessionExpected{
-				AuthMethod: &expectedAuthType,
+				AuthMethod:        &expectedAuthType,
+				ExpectedPublicKey: &testUser.PubKeyFingerprint,
 			}
 			checkSSHUserSessionJSON(test, t, msg.Data, expected)
 			return nil


### PR DESCRIPTION
### What does this PR do?
**1) This PR fixes 3 bugs in the SSH User Session tracking.**

- Properly get the parent of a process. Previously, we based the resolution on the pid, which caused new sessions to be generated when execve was used.
- Do not overwrite the Session Type because it's now inferred from the entire User Session Context.
- Edit the heritage mechanism from the parent to the child so we only transfer the ssh context

**2) Track SSH Session from Snapshot** (required to refactor)
**3) Fixes the mechanism so it can work on Ubuntu 25.10**

### Motivation
