### PR TITLE
[CSPM] add `compliance_config.run_in_system_probe` config flag

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -138,6 +138,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return status.NewInformationProvider(runtimeAgent.StatusProvider()), runtimeAgent, nil
 				}),
 				fx.Provide(func(stopper startstop.Stopper, log log.Component, config config.Component, statsdClient ddgostatsd.ClientInterface, sysprobeconfig sysprobeconfig.Component, wmeta workloadmeta.Component, filterStore workloadfilter.Component, compression logscompression.Component, hostname hostnameinterface.Component) (status.InformationProvider, *compliance.Agent, error) {
+					// Check if compliance should run in system-probe instead
+					if config.GetBool("compliance_config.run_in_system_probe") {
+						log.Info("compliance_config.run_in_system_probe is enabled, compliance will run in system-probe")
+						return status.NewInformationProvider(nil), nil, nil
+					}
+
 					hostnameDetected, err := hostname.Get(context.TODO())
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
@@ -267,7 +273,12 @@ func RunAgent(log log.Component, config config.Component, secrets secrets.Compon
 	}
 
 	// Check if we have at least one component to start based on config
-	if !config.GetBool("compliance_config.enabled") && !config.GetBool("runtime_security_config.enabled") {
+	// Check if security-agent should run compliance
+	complianceEnabled := config.GetBool("compliance_config.enabled")
+	complianceRunInSystemProbe := config.GetBool("compliance_config.run_in_system_probe")
+	securityAgentShouldRunCompliance := complianceEnabled && !complianceRunInSystemProbe
+
+	if !securityAgentShouldRunCompliance && !config.GetBool("runtime_security_config.enabled") {
 		log.Infof("All security-agent components are deactivated, exiting")
 
 		// A sleep is necessary so that sysV doesn't think the agent has failed

--- a/cmd/system-probe/modules/compliance.go
+++ b/cmd/system-probe/modules/compliance.go
@@ -50,7 +50,10 @@ func newComplianceModule(_ *sysconfigtypes.Config, deps module.FactoryDependenci
 
 	var complianceAgent *compliance.Agent
 
-	if deps.CoreConfig.GetBool("compliance_config.enabled") {
+	enabled := deps.CoreConfig.GetBool("compliance_config.enabled")
+	runInSystemProbe := deps.CoreConfig.GetBool("compliance_config.run_in_system_probe")
+
+	if enabled && runInSystemProbe {
 		hostnameDetected, err := deps.Hostname.Get(context.Background())
 		if err != nil {
 			return nil, err

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1145,6 +1145,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
+	config.BindEnvAndSetDefault("compliance_config.run_in_system_probe", false)
 	config.BindEnvAndSetDefault("compliance_config.xccdf.enabled", false) // deprecated, use host_benchmarks instead
 	config.BindEnvAndSetDefault("compliance_config.host_benchmarks.enabled", true)
 	config.BindEnvAndSetDefault("compliance_config.database_benchmarks.enabled", false)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new config flag, `compliance_config.run_in_system_probe` that instructs the compliance (CSPM) code to run in the system-probe.
Until now we were running the CSPM code in the container created by the orchestrator (the datadog operator) for example and taking advantage that it would only enable CSPM in the security agent OR the system-probe.

One issue with this is that if you run the agent in a single docker container, passing the `DD_COMPLIANCE_CONFIG_ENABLE=true` env to the whole container, both the security agent and the system-probe would see the flag and run CSPM twice, in both agents.

While this is not a critical issue from a feature point of view, it's kind unneeded.

To fix this issue, this PR is introducing a new config flag `compliance_config.run_in_system_probe` to tell both agents where you want to run CSPM. Currently the default is to keep running it in the security agent, and turning the flag on will instruct the security agent to not run CSPM, and the system-probe to actually run it.

### Motivation

### Describe how you validated your changes

### Additional Notes
