### PR TITLE
Remove configRetrieveFromPath helper

### DIFF
--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1184,43 +1184,8 @@ use_proxy_for_cloud_metadata: true
 	assert.Equal(t, err.Error(), "index out of range 5 >= 2")
 }
 
-// configRetrieveFromPath gets a setting from the config, handling URLs correctly
-// viper would do this by looking for "known" keys and reconstructing the url piece by piece
-// This method should only be needed by tests
-// In nodetreemodel, settings like additional_endpoints are leaf values
-// We should be able to simplify this implementation once ntm is in use everywhere
-func configRetrieveFromPath(cfg pkgconfigmodel.Config, settingPath string) (interface{}, error) {
-	parts := strings.Split(settingPath, ".")
-
-	if ncfg, ok := cfg.(nodetreemodel.NodeTreeConfig); ok {
-		for i := range parts {
-			if i == 0 {
-				continue
-			}
-			partial := strings.Join(parts[0:i], ".")
-			node, err := ncfg.GetNode(partial)
-			if err != nil {
-				return nil, err
-			}
-			if node.IsLeafNode() {
-				// if we find a leaf, can't get a child of it
-				leafValue := node.Get()
-				if leafMap, isMap := leafValue.(map[string]interface{}); isMap {
-					remain := strings.Join(parts[i:], ".")
-					return leafMap[remain], nil
-				}
-			}
-		}
-	}
-
-	return cfg.Get(settingPath), nil
-}
-
 func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
-
 	config := newTestConf(t)
-	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
-	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1237,20 +1202,21 @@ func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
 	err = configAssignAtPath(config, []string{"process_config", "additional_endpoints", "https://url2.eu", "0"}, "modified")
 	assert.NoError(t, err)
 
-	var expected interface{} = `different`
-	res, err := configRetrieveFromPath(config, "secret_backend_command")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
+	require.Equal(t, "different", config.Get("secret_backend_command"))
 
-	expected = []interface{}([]interface{}{"first", "changed"})
-	res, err = configRetrieveFromPath(config, "additional_endpoints.https://url1.com")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
-
-	expected = []interface{}([]interface{}{"modified"})
-	res, err = configRetrieveFromPath(config, "process_config.additional_endpoints.https://url2.eu")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
+	assert.Equal(t,
+		map[string]interface{}(
+			map[string]interface{}{
+				"https://url1.com": []interface{}{"first", "changed"},
+				"https://url2.eu":  []interface{}{"third"},
+			}),
+		config.Get("additional_endpoints"))
+	assert.Equal(t,
+		map[string]interface{}(
+			map[string]interface{}{
+				"https://url1.com": []interface{}{"fourth", "fifth"},
+				"https://url2.eu":  []interface{}{"modified"}}),
+		config.Get("process_config.additional_endpoints"))
 }
 
 var testSimpleConf = []byte(`process_config:


### PR DESCRIPTION
### What does this PR do?

The helper is not required, replacing with `Get`.