### PR TITLE
[PROF-13359] Infer configuration from agent

### DIFF
--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -110,14 +110,11 @@ The component is configured via an OpenTelemetry Collector YAML file. See [`dist
 
 ### Configuration Inference
 
-It's possible to let the host profiler infer some configuration information from the agent in certain conditions:
-1. Use Bundled Mode
-2. Remove `receivers.hostprofiler.symbol_uploader.symbol_endpoints` to enable endpoint inference
-3. Remove `exporters.otlphttp` to infer otlphttp configuration
+Configuration inference is enabled by default in bundled mode when symbol_endpoints and otlphttp exporters are not explicitly configured.
 
 The host profiler searches for the following nodes in the core agent's configuration file:
 - **`apm_config`**:
-    - **`profiling_dd_url`**: URL from which the site is extracted (takes priority)"
+    - **`profiling_dd_url`**: URL from which the site is extracted (takes priority)
     - **`profiling_additional_endpoints`**: additional endpoints with a url to extract `site` and `n` number of api keys
 - **`site`**: secondary site (if `profiling_dd_url` isn't configured) for symbol endpoints and otlphttp's `profiles_endpoint`
 - **`api_key`**: main api key for `site`

--- a/cmd/host-profiler/README.md
+++ b/cmd/host-profiler/README.md
@@ -108,6 +108,21 @@ The component is configured via an OpenTelemetry Collector YAML file. See [`dist
 - **`exporters.otlphttp`**: Datadog profiling intake endpoint configuration
 - **`extensions.ddprofiling`**: Datadog profiling extension (Agent mode only)
 
+### Configuration Inference
+
+It's possible to let the host profiler infer some configuration information from the agent in certain conditions:
+1. Use Bundled Mode
+2. Remove `receivers.hostprofiler.symbol_uploader.symbol_endpoints` to enable endpoint inference
+3. Remove `exporters.otlphttp` to infer otlphttp configuration
+
+The host profiler searches for the following nodes in the core agent's configuration file:
+- **`apm_config`**:
+    - **`profiling_dd_url`**: URL from which the site is extracted (takes priority)"
+    - **`profiling_additional_endpoints`**: additional endpoints with a url to extract `site` and `n` number of api keys
+- **`site`**: secondary site (if `profiling_dd_url` isn't configured) for symbol endpoints and otlphttp's `profiles_endpoint`
+- **`api_key`**: main api key for `site`
+
+This inference will create as many symbol endpoints and otlphttp exporters as there are site+key combinations.
 
 ## CLI Flags
 

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -9,10 +9,6 @@ receivers:
   hostprofiler:
     symbol_uploader:
       enabled: true
-      symbol_endpoints:
-        - site: ${env:DD_SITE}
-          api_key: ${env:DD_API_KEY}
-
 processors:
 # infraattributes/default is automatically removed when the Agent Core is not available
   infraattributes/default:
@@ -35,9 +31,8 @@ processors:
 
 exporters:
   debug: {}
-  otlphttp:
+  otlphttp/metrics:
     metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     headers:
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
@@ -49,9 +44,9 @@ service:
       # infraattributes/default is automatically removed when the Agent Core is not available
       # resourcedetection is automatically removed when the Agent Core is available
       processors: [infraattributes/default, resourcedetection]
-      exporters: [otlphttp, debug]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       # infraattributes/default is automatically removed when the Agent Core is not available
       processors: [cumulativetodelta, infraattributes/default]
-      exporters: [otlphttp]
+      exporters: [otlphttp/metrics]

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -9,6 +9,10 @@ receivers:
   hostprofiler:
     symbol_uploader:
       enabled: true
+      symbol_endpoints:
+        - site: ${env:DD_SITE}
+          api_key: ${env:DD_API_KEY}
+          app_key: ${env:DD_APP_KEY}
 processors:
 # infraattributes/default is automatically removed when the Agent Core is not available
   infraattributes/default:
@@ -31,8 +35,9 @@ processors:
 
 exporters:
   debug: {}
-  otlphttp/metrics:
+  otlphttp:
     metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     headers:
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
@@ -44,9 +49,9 @@ service:
       # infraattributes/default is automatically removed when the Agent Core is not available
       # resourcedetection is automatically removed when the Agent Core is available
       processors: [infraattributes/default, resourcedetection]
-      exporters: [debug]
+      exporters: [otlphttp, debug]
     metrics:
       receivers: [otlp]
       # infraattributes/default is automatically removed when the Agent Core is not available
       processors: [cumulativetodelta, infraattributes/default]
-      exporters: [otlphttp/metrics]
+      exporters: [otlphttp]

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -9,10 +9,6 @@ receivers:
   hostprofiler:
     symbol_uploader:
       enabled: true
-      symbol_endpoints:
-        - site: ${env:DD_SITE}
-          api_key: ${env:DD_API_KEY}
-          app_key: ${env:DD_APP_KEY}
 processors:
 # infraattributes/default is automatically removed when the Agent Core is not available
   infraattributes/default:
@@ -35,9 +31,8 @@ processors:
 
 exporters:
   debug: {}
-  otlphttp:
+  otlphttp/metrics:
     metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     headers:
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
@@ -49,9 +44,9 @@ service:
       # infraattributes/default is automatically removed when the Agent Core is not available
       # resourcedetection is automatically removed when the Agent Core is available
       processors: [infraattributes/default, resourcedetection]
-      exporters: [otlphttp, debug]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       # infraattributes/default is automatically removed when the Agent Core is not available
       processors: [cumulativetodelta, infraattributes/default]
-      exporters: [otlphttp]
+      exporters: [otlphttp/metrics]

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -31,7 +31,7 @@ type mockConfig struct {
 func newMockConfig() *mockConfig {
 	return &mockConfig{
 		values: map[string]interface{}{
-			"dd_site": "datadoghq.com",
+			"site": "datadoghq.com",
 			"api_key": "test_api_key_123",
 		},
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -31,7 +31,7 @@ type mockConfig struct {
 func newMockConfig() *mockConfig {
 	return &mockConfig{
 		values: map[string]interface{}{
-			"site": "datadoghq.com",
+			"site":    "datadoghq.com",
 			"api_key": "test_api_key_123",
 		},
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -79,7 +79,7 @@ func newConfigManager(config config.Component) configManager {
 			apiKeys: keys,
 		})
 	}
-	log.Infof("Main site infered from core configuration is %s", usedSite)
+	log.Infof("Main site inferred from core configuration is %s", usedSite)
 
 	// Add main endpoint if we have a valid site
 	if usedSite == "" {

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -198,7 +198,12 @@ func (c *converterWithAgent) fixReceiversPipeline(conf confMap, receiverNames []
 		return receiverNames, nil
 	}
 
-	if err := Set(conf, pathPrefixReceivers+defaultHostProfilerName+"::symbol_uploader::enabled", false); err != nil {
+	if err := Set(conf, pathPrefixReceivers+defaultHostProfilerName+"::symbol_uploader::enabled", true); err != nil {
+		return nil, err
+	}
+
+	defaultHostProfiler, _ := Get[confMap](conf, pathPrefixReceivers+defaultHostProfilerName)
+	if err := c.inferHostProfilerEndpointConfig(defaultHostProfiler); err != nil {
 		return nil, err
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -54,7 +54,7 @@ func extractSite(s string) string {
 
 func newConfigManager(config config.Component) configManager {
 	profilingDDURL := config.GetString("apm_config.profiling_dd_url")
-	ddSite := config.GetString("dd_site")
+	ddSite := config.GetString("site")
 	ddURL := config.GetString("dd_url")
 	apiKey := config.GetString(fieldAPIKey)
 

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -245,9 +245,9 @@ func (c *converterWithAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporter
 		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
 			hasOtlpHTTP = true
 
-			headers, err := Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
-			if err != nil {
-				return err
+			headers, ok := Get[confMap](conf, pathPrefixExporters+name+"::headers")
+			if !ok {
+				return fmt.Errorf("exporter %s is not configured", name)
 			}
 
 			if !ensureKeyStringValue(headers, fieldDDAPIKey) {

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -11,11 +11,93 @@ package converters
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"slices"
+	"strings"
 
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.opentelemetry.io/collector/confmap"
+	"golang.org/x/net/publicsuffix"
 )
+
+type endpoint struct {
+	site    string
+	url     string
+	apiKeys []string
+}
+
+type configManager struct {
+	endpoints []endpoint
+	config    config.Component
+}
+
+func extractSite(s string) string {
+	u, err := url.Parse(s)
+	if err != nil {
+		log.Debugf("Failed to parse URL %s: %v", s, err)
+		return ""
+	}
+
+	hostname := strings.Trim(u.Hostname(), ".")
+	if hostname == "" {
+		return ""
+	}
+	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(hostname)
+	if err != nil {
+		log.Debugf("Failed to extract apex domain from %s: %v", hostname, err)
+		return hostname
+	}
+
+	return apexDomain
+}
+
+func newConfigManager(config config.Component) configManager {
+	profilingDDURL := config.GetString("apm_config.profiling_dd_url")
+	ddSite := config.GetString("dd_site")
+	ddURL := config.GetString("dd_url")
+	apiKey := config.GetString(fieldAPIKey)
+
+	var usedURL string
+	if ddSite == "" {
+		if profilingDDURL != "" {
+			ddSite = extractSite(profilingDDURL)
+			usedURL = profilingDDURL
+		} else {
+			ddSite = extractSite(ddURL)
+			usedURL = ddURL
+		}
+	}
+
+	profilingAdditionalEndpoints := config.GetStringMapStringSlice("apm_config.profiling_additional_endpoints")
+	var endpoints []endpoint
+	for endpointURL, keys := range profilingAdditionalEndpoints {
+		site := extractSite(endpointURL)
+		if site == "" {
+			log.Warnf("Could not extract site from URL %s, skipping endpoint", endpointURL)
+			continue
+		}
+		endpoints = append(endpoints, endpoint{
+			site:    site,
+			url:     endpointURL,
+			apiKeys: keys,
+		})
+	}
+	log.Infof("Global dd_site is %s", ddSite)
+
+	// Add main endpoint if we have a valid site
+	if ddSite == "" {
+		log.Warn("Could not determine dd_site from configuration, no default endpoint will be configured")
+	} else {
+		endpoints = append(endpoints, endpoint{site: ddSite, url: usedURL, apiKeys: []string{apiKey}})
+	}
+
+	if len(endpoints) == 0 {
+		log.Warn("No valid endpoints in core agent configured for inference")
+	}
+
+	return configManager{config: config, endpoints: endpoints}
+}
 
 // converterWithAgent ensures sane configuration that satisfies the following conditions:
 //   - At least one infraattributes processor declared and used with `allow_hostname_override: true`
@@ -25,10 +107,12 @@ import (
 //   - Check if used otlphttpexporter has dd-api-key as string, if not string convert it, if not at all notify user
 //   - If hostprofiler::symbol_uploader::enabled == true, convert api_key/app_key to strings in each endpoint
 //   - If no hostprofiler is used & configured, add minimal one with symbol_uploader: false
-type converterWithAgent struct{}
+type converterWithAgent struct {
+	configManager configManager
+}
 
-func newConverterWithAgent(_ confmap.ConverterSettings) confmap.Converter {
-	return &converterWithAgent{}
+func newConverterWithAgent(_ confmap.ConverterSettings, config config.Component) confmap.Converter {
+	return &converterWithAgent{configManager: newConfigManager(config)}
 }
 
 // Convert implements the confmap.Converter interface for converterWithAgent.
@@ -55,9 +139,8 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 		return err
 	}
 
-	// If there's no otlphttpexporter configured. We can't infer necessary configurations as it needs URLs and API keys
-	// so if nothing is found, notify user
-	if err := ensureOtlpHTTPExporterConfig(confStringMap, exporterNames); err != nil {
+	// See if there is any otlpHTTP exporter configured, if not, infer as many exporters as possible
+	if err := c.ensureOtlpHTTPExporterConfig(confStringMap, exporterNames); err != nil {
 		return err
 	}
 
@@ -71,7 +154,7 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 
 	// Ensures at least one hostprofiler is used & configured
 	// If not, create a minimal component with symbol uploading disabled
-	newReceiverNames, err := fixReceiversPipeline(confStringMap, receiverNames, func(v ...any) { log.Warn(v...) })
+	newReceiverNames, err := c.fixReceiversPipeline(confStringMap, receiverNames)
 	if err != nil {
 		return err
 	}
@@ -84,6 +167,150 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 	}
 
 	*conf = *confmap.NewFromStringMap(confStringMap)
+	return nil
+}
+
+// fixReceiversPipeline ensures at least one hostprofiler receiver is configured in the pipeline
+// If none exists, it adds a minimal hostprofiler receiver with symbol_uploader disabled
+func (c *converterWithAgent) fixReceiversPipeline(conf confMap, receiverNames []any) ([]any, error) {
+	// Check if hostprofiler is in the pipeline
+	hasHostProfiler := false
+	for _, nameAny := range receiverNames {
+		name, ok := nameAny.(string)
+		if !ok {
+			return nil, fmt.Errorf("receiver name must be a string, got %T", nameAny)
+		}
+
+		if !isComponentType(name, componentTypeHostProfiler) {
+			continue
+		}
+
+		hasHostProfiler = true
+
+		if hostProfilerConfig, ok := Get[confMap](conf, pathPrefixReceivers+name); ok {
+			if err := c.checkHostProfilerReceiverConfig(hostProfilerConfig); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if hasHostProfiler {
+		return receiverNames, nil
+	}
+
+	if err := Set(conf, pathPrefixReceivers+defaultHostProfilerName+"::symbol_uploader::enabled", false); err != nil {
+		return nil, err
+	}
+
+	return append(receiverNames, defaultHostProfilerName), nil
+}
+
+// checkHostProfilerReceiverConfig validates and normalizes hostprofiler receiver configuration
+// It ensures that if symbol_uploader is enabled, symbol_endpoints is properly configured
+// and all api_key/app_key values are strings
+func (c *converterWithAgent) checkHostProfilerReceiverConfig(hostProfiler confMap) error {
+	if isEnabled, ok := Get[bool](hostProfiler, pathSymbolUploaderEnabled); !ok || !isEnabled {
+		return nil
+	}
+
+	endpoints, ok := Get[[]any](hostProfiler, pathSymbolEndpoints)
+
+	// If symbol_endpoints is missing, wrong type, or empty, infer from agent config
+	if !ok || len(endpoints) == 0 {
+		log.Info("Symbol uploader enabled but endpoints not configured, inferring from agent config")
+		if err := c.inferHostProfilerEndpointConfig(hostProfiler); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// We have valid endpoints, just ensure keys are strings
+	for _, epAny := range endpoints {
+		if ep, ok := epAny.(confMap); ok {
+			ensureKeyStringValue(ep, fieldAPIKey)
+			ensureKeyStringValue(ep, fieldAppKey)
+		}
+	}
+	return nil
+}
+
+func (c *converterWithAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
+	hasOtlpHTTP := false
+	for _, nameAny := range exporterNames {
+		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
+			hasOtlpHTTP = true
+
+			headers, err := Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
+			if err != nil {
+				return err
+			}
+
+			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
+				// should we try to infer those keys as well? we might have a key for the given site
+				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
+			}
+		}
+	}
+
+	if !hasOtlpHTTP {
+		log.Info("No otlphttp exporter configured, inferring from agent config")
+		if err := c.inferOtlpHTTPConfig(conf); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *converterWithAgent) inferHostProfilerEndpointConfig(hostProfiler confMap) error {
+	var symbolEndpoints []any
+	for _, endpoint := range c.configManager.endpoints {
+		for _, key := range endpoint.apiKeys {
+			symbolEndpoints = append(symbolEndpoints, confMap{
+				"site":      endpoint.site,
+				fieldAPIKey: key,
+			})
+		}
+	}
+
+	if err := Set(hostProfiler, "symbol_uploader::symbol_endpoints", symbolEndpoints); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *converterWithAgent) inferOtlpHTTPConfig(conf confMap) error {
+	const (
+		profilesEndpointFormat = "https://intake.profile.%s/v1development/profiles"
+		metricsEndpointFormat  = "https://otlp.%s/v1/metrics"
+		otlpHTTPNameFormat     = "otlphttp/%s_%d"
+	)
+
+	createOtlpHTTPFromEndpoint := func(site, key string) confMap {
+		return confMap{
+			"profiles_endpoint": fmt.Sprintf(profilesEndpointFormat, site),
+			"metrics_endpoint":  fmt.Sprintf(metricsEndpointFormat, site),
+			"headers": confMap{
+				fieldDDAPIKey: key,
+			},
+		}
+	}
+
+	const profilesExportersPath = "service::pipelines::profiles::exporters"
+	profilesExporters, _ := Get[[]any](conf, profilesExportersPath)
+	for _, endpoint := range c.configManager.endpoints {
+		for i, key := range endpoint.apiKeys {
+			exporterName := fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, i)
+			if err := Set(conf, pathPrefixExporters+exporterName, createOtlpHTTPFromEndpoint(endpoint.site, key)); err != nil {
+				return err
+			}
+			profilesExporters = append(profilesExporters, exporterName)
+		}
+	}
+
+	if err := Set(conf, profilesExportersPath, profilesExporters); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -81,7 +81,7 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 
 	// If there's no otlphttpexporter configured. We can't infer necessary configurations as it needs URLs and API keys
 	// so if nothing is found, notify user
-	if err := ensureOtlpHTTPExporterConfig(confStringMap, exporterNames); err != nil {
+	if err := c.ensureOtlpHTTPExporterConfig(confStringMap, exporterNames); err != nil {
 		return err
 	}
 
@@ -95,7 +95,7 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 
 	// Ensures at least one hostprofiler is used & configured
 	// If not, create a minimal component with symbol uploading disabled
-	newReceiverNames, err := fixReceiversPipeline(confStringMap, receiverNames, standaloneLogger.Warn)
+	newReceiverNames, err := c.fixReceiversPipeline(confStringMap, receiverNames)
 	if err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (c *converterWithoutAgent) fixProcessorsPipeline(conf confMap, processorNam
 
 		// Track if we have resourcedetection
 		if isComponentType(name, componentTypeResourceDetection) {
-			if resourceDetectionConfig, ok := Get[confMap](conf, "processors::"+name); ok {
+			if resourceDetectionConfig, ok := Get[confMap](conf, pathPrefixProcessors+name); ok {
 				if err := c.ensureResourceDetectionConfig(resourceDetectionConfig); err != nil {
 					return nil, err
 				}
@@ -246,6 +246,95 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 		if err := Set(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// fixReceiversPipeline ensures at least one hostprofiler receiver is configured in the pipeline
+// If none exists, it adds a minimal hostprofiler receiver with symbol_uploader disabled
+func (c *converterWithoutAgent) fixReceiversPipeline(conf confMap, receiverNames []any) ([]any, error) {
+	// Check if hostprofiler is in the pipeline
+	hasHostProfiler := false
+	for _, nameAny := range receiverNames {
+		name, ok := nameAny.(string)
+		if !ok {
+			return nil, fmt.Errorf("receiver name must be a string, got %T", nameAny)
+		}
+
+		if !isComponentType(name, componentTypeHostProfiler) {
+			continue
+		}
+
+		hasHostProfiler = true
+
+		if hostProfilerConfig, ok := Get[confMap](conf, pathPrefixReceivers+name); ok {
+			if err := c.checkHostProfilerReceiverConfig(hostProfilerConfig); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if hasHostProfiler {
+		return receiverNames, nil
+	}
+
+	// Ensure default config exists if hostprofiler receiver is not configured
+	if err := Set(conf, pathPrefixReceivers+defaultHostProfilerName+"::"+pathSymbolUploaderEnabled, false); err != nil {
+		return nil, err
+	}
+
+	standaloneLogger.Warn("Added minimal hostprofiler receiver to user configuration")
+	return append(receiverNames, defaultHostProfilerName), nil
+}
+
+// checkHostProfilerReceiverConfig validates and normalizes hostprofiler receiver configuration
+// It ensures that if symbol_uploader is enabled, symbol_endpoints is properly configured
+// and all api_key/app_key values are strings
+func (c *converterWithoutAgent) checkHostProfilerReceiverConfig(hostProfiler confMap) error {
+	if isEnabled, ok := Get[bool](hostProfiler, pathSymbolUploaderEnabled); !ok || !isEnabled {
+		return nil
+	}
+
+	endpoints, ok := Get[[]any](hostProfiler, pathSymbolEndpoints)
+
+	if !ok {
+		return errors.New("symbol_endpoints must be a list")
+	}
+
+	if len(endpoints) == 0 {
+		return errors.New("symbol_endpoints cannot be empty when symbol_uploader is enabled")
+	}
+
+	for _, epAny := range endpoints {
+		if ep, ok := epAny.(confMap); ok {
+			ensureKeyStringValue(ep, fieldAPIKey)
+			ensureKeyStringValue(ep, fieldAppKey)
+		}
+	}
+	return nil
+}
+
+func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
+	// for each otlphttpexporter used, check if necessary api key is present
+	hasOtlpHTTP := false
+	for _, nameAny := range exporterNames {
+		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
+			hasOtlpHTTP = true
+
+			headers, err := Ensure[confMap](conf, pathPrefixExporters+name+"::headers")
+			if err != nil {
+				return err
+			}
+
+			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
+				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
+			}
+		}
+	}
+
+	if !hasOtlpHTTP {
+		return errors.New("no otlphttp exporter configured in profiles pipeline")
 	}
 
 	return nil

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -10,7 +10,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
     otlp: {}
 service:
     pipelines:

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
     otlp: {}
 service:
     pipelines:

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -10,7 +10,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
@@ -1,0 +1,22 @@
+exporters:
+  otlphttp/datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp/datadoghq.com_0
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
@@ -10,7 +10,10 @@ processors:
 receivers:
   hostprofiler:
     symbol_uploader:
-      enabled: false
+      enabled: true
+      symbol_endpoints:
+      - api_key: test_api_key_123
+        site: datadoghq.com
 service:
   pipelines:
     profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -9,7 +9,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
@@ -1,0 +1,26 @@
+exporters:
+  debug: {}
+  logging: {}
+  otlphttp/datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - logging
+      - debug
+      - otlphttp/datadoghq.com_0
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
@@ -12,7 +12,10 @@ processors:
 receivers:
   hostprofiler:
     symbol_uploader:
-      enabled: false
+      enabled: true
+      symbol_endpoints:
+      - api_key: test_api_key_123
+        site: datadoghq.com
 service:
   pipelines:
     profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -10,7 +10,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -12,7 +12,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -9,7 +9,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -9,7 +9,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
     otlp:
         protocols:
             grpc:

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -11,7 +11,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -8,7 +8,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -9,7 +9,10 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: false
+            enabled: true
+            symbol_endpoints:
+            - api_key: test_api_key_123
+              site: datadoghq.com
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/in.yaml
@@ -2,7 +2,11 @@ receivers:
   hostprofiler:
     symbol_uploader:
       enabled: true
-      symbol_endpoints: not-a-list
+      symbol_endpoints:
+      - site: datadoghq.eu
+        api_key: custom-api-key-eu
+      - site: datadoghq.com
+        api_key: custom-api-key-us
 service:
   pipelines:
     profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
@@ -1,0 +1,25 @@
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-api-key
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: custom-api-key-eu
+        site: datadoghq.eu
+      - api_key: custom-api-key-us
+        site: datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
@@ -1,0 +1,23 @@
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-api-key
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: test_api_key_123
+        site: datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -9,6 +9,7 @@
 package collectorimpl
 
 import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
 	hostname "github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -49,6 +50,7 @@ type extraFactoriesWithAgentCore struct {
 	ipcComp    ipc.Component
 	traceAgent traceagent.Component
 	log        log.Component
+	config     config.Component
 }
 
 var _ ExtraFactories = (*extraFactoriesWithAgentCore)(nil)
@@ -59,6 +61,7 @@ func NewExtraFactoriesWithAgentCore(
 	hostname hostname.Component, ipcComp ipc.Component,
 	traceAgent traceagent.Component,
 	log log.Component,
+	config config.Component,
 ) ExtraFactories {
 	return extraFactoriesWithAgentCore{
 		tagger:     tagger,
@@ -66,6 +69,7 @@ func NewExtraFactoriesWithAgentCore(
 		ipcComp:    ipcComp,
 		traceAgent: traceAgent,
 		log:        log,
+		config:     config,
 	}
 }
 
@@ -84,7 +88,7 @@ func (e extraFactoriesWithAgentCore) GetProcessors() []processor.Factory {
 
 func (e extraFactoriesWithAgentCore) GetConverters() []confmap.ConverterFactory {
 	return []confmap.ConverterFactory{
-		converters.NewFactoryWithAgent(),
+		converters.NewFactoryWithAgent(e.config),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Implements automatic inference of API keys and OTLP endpoints from agent configuration for the host profiler when running with the agent core. When `otlphttp` exporters or symbol uploader endpoints are missing, the converter now extracts them from agent config.

#### Site determination precedence
1. `apm_config.profiling_dd_url` (extract site from URL)
2. `site` (if explicitly set)

#### Endpoint inference
  - All endpoints from `apm_config.profiling_additional_endpoints` with their respective API keys
  - Main endpoint using determined site and `api_key`

Each inferred endpoint is used as both a symbol uploader endpoint and a `otlphttp` exporter endpoint.

### Motivation
Facilitates onboarding and eases configuration needed for deployment.

### Describe how you validated your changes
Added test case verifying explicit configuration is preserved (not overwritten by inference)

### Additional Notes
