### PR TITLE
[CWS] remove `sshSessionParsed` struct and use `lru.Cache` directly

### DIFF
--- a/pkg/security/probe/ssh_user_session.go
+++ b/pkg/security/probe/ssh_user_session.go
@@ -110,9 +110,7 @@ func (p *SSHUserSessionPatcher) IsResolved() error {
 		Port: strconv.Itoa(p.userSessionCtx.SSHClientPort),
 	}
 
-	p.resolver.SSHSessionParsed.Mu.Lock()
-	_, ok := p.resolver.SSHSessionParsed.Lru.Get(key)
-	p.resolver.SSHSessionParsed.Mu.Unlock()
+	_, ok := p.resolver.GetSSHSession(key)
 
 	if !ok {
 		return fmt.Errorf("ssh session not found in LRU for %s:%d",
@@ -136,9 +134,7 @@ func (p *SSHUserSessionPatcher) PatchEvent(ev *serializers.EventSerializer) {
 		IP:   p.userSessionCtx.SSHClientIP,
 		Port: strconv.Itoa(p.userSessionCtx.SSHClientPort),
 	}
-	p.resolver.SSHSessionParsed.Mu.Lock()
-	value, ok := p.resolver.SSHSessionParsed.Lru.Get(key)
-	p.resolver.SSHSessionParsed.Mu.Unlock()
+	value, ok := p.resolver.GetSSHSession(key)
 
 	if ok {
 		ev.ProcessContextSerializer.UserSession.SSHAuthMethod = model.SSHAuthMethodToString(usersession.AuthType(value.AuthenticationMethod))

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cilium/ebpf"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -82,11 +83,6 @@ type SSHSessionValue struct {
 	PublicKey            string
 }
 
-type sshSessionParsed struct {
-	Mu  sync.Mutex
-	Lru *simplelru.LRU[SSHSessionKey, SSHSessionValue]
-}
-
 // Resolver is used to resolve the user sessions context
 type Resolver struct {
 	sync.RWMutex
@@ -95,7 +91,7 @@ type Resolver struct {
 	userSessionsMap *ebpf.Map
 
 	sshLogReader     *incrementalFileReader
-	SSHSessionParsed sshSessionParsed
+	sshSessionParsed *lru.Cache[SSHSessionKey, SSHSessionValue]
 }
 
 // NewResolver returns a new instance of Resolver
@@ -181,6 +177,14 @@ func (r *Resolver) ResolveK8SUserSession(id uint64) *model.K8SSessionContext {
 	return ctx
 }
 
+// GetSSHSession retrieves SSH session information from the cache
+func (r *Resolver) GetSSHSession(key SSHSessionKey) (SSHSessionValue, bool) {
+	if r.sshSessionParsed == nil {
+		return SSHSessionValue{}, false
+	}
+	return r.sshSessionParsed.Get(key)
+}
+
 // Init opens the file and sets the initial offset
 func (ifr *incrementalFileReader) Init(f *os.File) error {
 	if ifr.f != nil {
@@ -220,7 +224,7 @@ func (r *Resolver) startReading() {
 				return
 			case <-ticker.C:
 				r.sshLogReader.mu.Lock()
-				err := r.sshLogReader.resolveFromLogFile(&r.SSHSessionParsed)
+				err := r.sshLogReader.resolveFromLogFile(r.sshSessionParsed)
 				if err != nil {
 					seclog.Errorf("failed to read ssh log lines: %v", err)
 				}
@@ -233,7 +237,7 @@ func (r *Resolver) startReading() {
 
 // parseSSHLogLine parse the ssh log line
 // Does not return any error and just automatically updates the LRU when a new session is found
-func parseSSHLogLine(line string, sshSessionParsed *sshSessionParsed) {
+func parseSSHLogLine(line string, sshSessionParsed *lru.Cache[SSHSessionKey, SSHSessionValue]) {
 	type SSHLogLine struct {
 		Date      string
 		Hostname  string
@@ -321,16 +325,13 @@ func parseSSHLogLine(line string, sshSessionParsed *sshSessionParsed) {
 			AuthenticationMethod: int(authType),
 			PublicKey:            publicKey,
 		}
-		sshSessionParsed.Mu.Lock()
-
-		sshSessionParsed.Lru.Add(key, value)
-		sshSessionParsed.Mu.Unlock()
+		sshSessionParsed.Add(key, value)
 	}
 }
 
 // resolveFromLogFile read all the lines that have been added since the last call without reopening the file.
 // Return new lines, the byte offsets at the end of each line, and an error.
-func (ifr *incrementalFileReader) resolveFromLogFile(sshSessionParsed *sshSessionParsed) error {
+func (ifr *incrementalFileReader) resolveFromLogFile(sshSessionParsed *lru.Cache[SSHSessionKey, SSHSessionValue]) error {
 	if err := ifr.reloadIfRotated(); err != nil {
 		return err
 	}
@@ -428,7 +429,7 @@ func (r *Resolver) StartSSHUserSessionResolver() error {
 	var err error
 
 	// Initialize the SSH session LRU cache (needed in all cases)
-	r.SSHSessionParsed.Lru, err = simplelru.NewLRU[SSHSessionKey, SSHSessionValue](100, nil)
+	r.sshSessionParsed, err = lru.New[SSHSessionKey, SSHSessionValue](100)
 	if err != nil {
 		seclog.Errorf("couldn't create SSH Session LRU cache: %v", err)
 		return err

--- a/pkg/security/resolvers/usersessions/resolver_linux_test.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux_test.go
@@ -11,7 +11,7 @@ package usersessions
 import (
 	"testing"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
@@ -73,12 +73,8 @@ func Test_parseSSHLogLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lru, err := simplelru.NewLRU[SSHSessionKey, SSHSessionValue](100, nil)
+			sshSessionParsed, err := lru.New[SSHSessionKey, SSHSessionValue](100)
 			assert.NoError(t, err)
-
-			sshSessionParsed := &sshSessionParsed{
-				Lru: lru,
-			}
 
 			parseSSHLogLine(tt.logLine, sshSessionParsed)
 
@@ -88,7 +84,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 					Port: tt.expectedPort,
 				}
 
-				value, found := sshSessionParsed.Lru.Get(key)
+				value, found := sshSessionParsed.Get(key)
 				assert.True(t, found, "SSH Session must be in LRU")
 
 				if found {
@@ -96,7 +92,7 @@ func Test_parseSSHLogLine(t *testing.T) {
 					assert.Equal(t, tt.expectedPublicKey, value.PublicKey, "Public key must match")
 				}
 			} else {
-				assert.Equal(t, 0, sshSessionParsed.Lru.Len(), "LRU must be empty")
+				assert.Equal(t, 0, sshSessionParsed.Len(), "LRU must be empty")
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

Simple cleanup of ssh user session resolver avoiding exposing the internals of the resolver, while also avoiding re-implementing `lru.Cache` (which is really just a simplelru with a mutex under the hood)

### Motivation

### Describe how you validated your changes

### Additional Notes
