### PR TITLE
Fix source for nested keys in `configstream` component

### DIFF
--- a/comp/core/configstream/impl/configstream.go
+++ b/comp/core/configstream/impl/configstream.go
@@ -243,7 +243,7 @@ func (cs *configStream) createConfigSnapshot() (*pb.ConfigEvent, uint64, error) 
 
 		pbValue, err := structpb.NewValue(sanitizedValue)
 		if err != nil {
-			cs.log.Warnf("Failed to convert setting '%s' to structpb.Value: %v", key, err)
+			cs.log.Errorf("Failed to convert setting '%s' to structpb.Value: %v", key, err)
 			continue
 		}
 

--- a/comp/core/configstream/impl/configstream.go
+++ b/comp/core/configstream/impl/configstream.go
@@ -227,27 +227,30 @@ func (cs *configStream) handleConfigUpdate(event *pb.ConfigEvent) {
 }
 
 func (cs *configStream) createConfigSnapshot() (*pb.ConfigEvent, uint64, error) {
-	allSettings, sequenceID := cs.config.AllSettingsWithSequenceID()
+	allSettings, sequenceID := cs.config.AllFlattenedSettingsWithSequenceID()
 
-	// Sanitize all settings to ensure compatibility with structpb.NewValue
-	sanitizedSettings, err := sanitizeValue(allSettings)
-	if err != nil {
-		cs.log.Errorf("Failed to sanitize config settings while creating snapshot: %v", err)
-		return nil, 0, err
-	}
-
-	intermediateMap := sanitizedSettings.(map[string]interface{})
-	settings := make([]*pb.ConfigSetting, 0, len(intermediateMap))
-	for setting, value := range intermediateMap {
-		pbValue, err := structpb.NewValue(value)
-		if err != nil {
-			cs.log.Errorf("Failed to convert setting '%s' to structpb.Value: %v", setting, err)
+	settings := make([]*pb.ConfigSetting, 0, len(allSettings))
+	for key, value := range allSettings {
+		if value == nil {
 			continue
 		}
-		source := cs.config.GetSource(setting).String()
+
+		sanitizedValue, err := sanitizeValue(value)
+		if err != nil {
+			cs.log.Errorf("Failed to sanitize setting '%s': %v", key, err)
+			continue
+		}
+
+		pbValue, err := structpb.NewValue(sanitizedValue)
+		if err != nil {
+			cs.log.Warnf("Failed to convert setting '%s' to structpb.Value: %v", key, err)
+			continue
+		}
+
+		source := cs.config.GetSource(key).String()
 		settings = append(settings, &pb.ConfigSetting{
 			Source: source,
-			Key:    setting,
+			Key:    key,
 			Value:  pbValue,
 		})
 	}

--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -222,7 +222,7 @@ func TestConfigStream(t *testing.T) {
 
 		// Set nested config values with different sources
 		configComp.Set("logs_config.auto_multi_line_detection", false, model.SourceFile)
-		configComp.Set("logs_config.use_compression", true, model.SourceEnvVar)
+		configComp.Set("logs_config.use_compression", true, model.SourceAgentRuntime)
 
 		eventsCh, unsubscribe := provides.Comp.Subscribe(&pb.ConfigStreamRequest{Name: "test-client-nested"})
 		defer unsubscribe()
@@ -252,8 +252,8 @@ func TestConfigStream(t *testing.T) {
 
 		require.Contains(t, settingsMap, "logs_config.use_compression",
 			"snapshot should contain flattened key logs_config.use_compression")
-		require.Equal(t, model.SourceEnvVar.String(), settingsMap["logs_config.use_compression"],
-			"logs_config.use_compression should have source 'environment'")
+		require.Equal(t, model.SourceAgentRuntime.String(), settingsMap["logs_config.use_compression"],
+			"logs_config.use_compression should have source 'agent-runtime'")
 
 		// Parent keys should not exist as settings (they are containers, not leaf values)
 		require.NotContains(t, settingsMap, "logs_config",

--- a/comp/core/configstream/impl/configstream_test.go
+++ b/comp/core/configstream/impl/configstream_test.go
@@ -216,4 +216,47 @@ func TestConfigStream(t *testing.T) {
 			t.Fatal("timed out waiting for channel to close")
 		}
 	})
+
+	t.Run("snapshot contains correct sources for nested keys", func(t *testing.T) {
+		provides, configComp := buildComponent(t)
+
+		// Set nested config values with different sources
+		configComp.Set("logs_config.auto_multi_line_detection", false, model.SourceFile)
+		configComp.Set("logs_config.use_compression", true, model.SourceEnvVar)
+
+		eventsCh, unsubscribe := provides.Comp.Subscribe(&pb.ConfigStreamRequest{Name: "test-client-nested"})
+		defer unsubscribe()
+
+		// Get the snapshot
+		var event *pb.ConfigEvent
+		select {
+		case event = <-eventsCh:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for initial snapshot")
+		}
+		require.NotNil(t, event)
+		snapshot, isSnapshot := event.GetEvent().(*pb.ConfigEvent_Snapshot)
+		require.True(t, isSnapshot, "first event must be a snapshot")
+
+		// Build a map of key -> source from the snapshot
+		settingsMap := make(map[string]string)
+		for _, setting := range snapshot.Snapshot.Settings {
+			settingsMap[setting.Key] = setting.Source
+		}
+
+		// Verify flattened keys have their correct individual sources
+		require.Contains(t, settingsMap, "logs_config.auto_multi_line_detection",
+			"snapshot should contain flattened key logs_config.auto_multi_line_detection")
+		require.Equal(t, model.SourceFile.String(), settingsMap["logs_config.auto_multi_line_detection"],
+			"logs_config.auto_multi_line_detection should have source 'file'")
+
+		require.Contains(t, settingsMap, "logs_config.use_compression",
+			"snapshot should contain flattened key logs_config.use_compression")
+		require.Equal(t, model.SourceEnvVar.String(), settingsMap["logs_config.use_compression"],
+			"logs_config.use_compression should have source 'environment'")
+
+		// Parent keys should not exist as settings (they are containers, not leaf values)
+		require.NotContains(t, settingsMap, "logs_config",
+			"snapshot should NOT contain the parent key 'logs_config' as a setting")
+	})
 }

--- a/pkg/config/create/read_config_file_fuzz_test.go
+++ b/pkg/config/create/read_config_file_fuzz_test.go
@@ -150,7 +150,7 @@ other: value`) // Null value (YAML parses as nil)
 			structure.UnmarshalKey(cfg, "c", &result)
 
 			// Test settings retrieval with sequence ID
-			_, _ = cfg.AllSettingsWithSequenceID()
+			_, _ = cfg.AllFlattenedSettingsWithSequenceID()
 		}
 	})
 }

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -163,7 +163,10 @@ type Reader interface {
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string
-	AllSettingsWithSequenceID() (map[string]interface{}, uint64)
+	// AllFlattenedSettingsWithSequenceID returns all settings as a flattened map (e.g., "logs_config.enabled"
+	// instead of nested {"logs_config": {"enabled": ...}}) along with the current sequence ID.
+	// This provides atomic access to flattened keys, values, and sequence ID under a single lock.
+	AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64)
 
 	// SetTestOnlyDynamicSchema is used by tests to disable validation of the config schema
 	// This lets tests use the config is more flexible ways (can add to the schema at any point,

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -700,12 +700,9 @@ func (c *ntmConfig) HasSection(key string) bool {
 	return false
 }
 
-// AllKeysLowercased returns all keys, including unknown keys and those without default values
-// Unlike AllSettings, this returns keys defined by SetKnown or BindEnv
-func (c *ntmConfig) AllKeysLowercased() []string {
-	c.RLock()
-	defer c.RUnlock()
-
+// collectFlattenedKeys returns all flattened keys without acquiring a lock.
+// Must be called while holding at least a read lock.
+func (c *ntmConfig) collectFlattenedKeys() []string {
 	// collect keys from known set
 	allKeys := map[string]struct{}{}
 	for k, isLeaf := range c.knownKeys {
@@ -718,7 +715,16 @@ func (c *ntmConfig) AllKeysLowercased() []string {
 		allKeys[k] = struct{}{}
 	}
 
-	keylist := slices.Collect(maps.Keys(allKeys))
+	return slices.Collect(maps.Keys(allKeys))
+}
+
+// AllKeysLowercased returns all keys, including unknown keys and those without default values
+// Unlike AllSettings, this returns keys defined by SetKnown or BindEnv
+func (c *ntmConfig) AllKeysLowercased() []string {
+	c.RLock()
+	defer c.RUnlock()
+
+	keylist := c.collectFlattenedKeys()
 	sort.Strings(keylist)
 	return keylist
 }
@@ -923,13 +929,21 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 	}
 }
 
-// AllSettingsWithSequenceID returns the settings and the sequence ID.
-func (c *ntmConfig) AllSettingsWithSequenceID() (map[string]interface{}, uint64) {
+// AllFlattenedSettingsWithSequenceID returns all settings as a flattened map along with the sequence ID.
+// Keys are flattened (e.g., "logs_config.enabled" instead of nested {"logs_config": {"enabled": ...}}).
+// This provides atomic access to flattened keys, values, and sequence ID under a single lock.
+func (c *ntmConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64) {
 	c.maybeRebuild()
 
 	c.RLock()
 	defer c.RUnlock()
-	return c.root.dumpSettings(true), c.sequenceID
+
+	keys := c.collectFlattenedKeys()
+	settings := make(map[string]interface{}, len(keys))
+	for _, key := range keys {
+		settings[key] = c.getNodeValue(key)
+	}
+	return settings, c.sequenceID
 }
 
 // AddConfigPath adds another config for the given path

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -465,12 +465,12 @@ func (t *teeConfig) AllSettingsBySource() map[model.Source]interface{} {
 
 }
 
-// AllSettingsWithSequenceID returns the settings and the sequence ID.
-func (t *teeConfig) AllSettingsWithSequenceID() (map[string]interface{}, uint64) {
-	base, baseSequenceID := t.baseline.AllSettingsWithSequenceID()
-	compare, compareSequenceID := t.compare.AllSettingsWithSequenceID()
-	t.compareResult("", "AllSettingsWithSequenceID (settings)", base, compare)
-	t.compareResult("", "AllSettingsWithSequenceID (sequenceID)", baseSequenceID, compareSequenceID)
+// AllFlattenedSettingsWithSequenceID returns all settings as a flattened map along with the sequence ID.
+func (t *teeConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64) {
+	base, baseSequenceID := t.baseline.AllFlattenedSettingsWithSequenceID()
+	compare, compareSequenceID := t.compare.AllFlattenedSettingsWithSequenceID()
+	t.compareResult("", "AllFlattenedSettingsWithSequenceID (settings)", base, compare)
+	t.compareResult("", "AllFlattenedSettingsWithSequenceID (sequenceID)", baseSequenceID, compareSequenceID)
 	return base, baseSequenceID
 }
 


### PR DESCRIPTION
### What does this PR do?

Previously, nested keys were being sent via the `configstream` with the same source as the top level key.

This pr changes `AllSettingsWithSequenceID` -> `AllFlattenedSettingsWithSequenceID` 

Instead of sending the top level key for keys that are nested, we now send the flattened key since they may have a different source.

Ex:
Old
```
pb.ConfigSetting{
	Source: "default",
	Key:    "logs_config",
	Value:  {"enabled": true, "url": "datadoghq.com"},
}
```
New
```
[
pb.ConfigSetting{
	Source: "file",
	Key:    "logs_config.enabled",
	Value:  true,
},
pb.ConfigSetting{
	Source: "env var",
	Key:    "logs_config.url",
	Value: "datadoghq.com",
}]
```

### Motivation

### Describe how you validated your changes
1. Existing unit tests + new unit test
2. Running the agent + ADP[(pr)](https://github.com/DataDog/saluki/pull/1125) with the config stream enabled and seeing that ADP's config command still outputs nested settings.
### Additional Notes
Previous bug shouldn't have had an impact anywhere as we do not do anything with `Source` in ADP.