### PR TITLE
chore(WorkloadFilter): Filter Builder Helper

### DIFF
--- a/comp/core/workloadfilter/baseimpl/base.go
+++ b/comp/core/workloadfilter/baseimpl/base.go
@@ -29,7 +29,7 @@ import (
 type FilterProgramFactory struct {
 	once    sync.Once
 	program program.FilterProgram
-	factory func(filterConfig *catalog.FilterConfig, logger logcomp.Component) program.FilterProgram
+	factory func(builder *catalog.ProgramBuilder) program.FilterProgram
 }
 
 // ProgramFactory is an interface for creating filter programs
@@ -44,6 +44,7 @@ type BaseFilterStore struct {
 	Log                 logcomp.Component
 	ProgramFactoryStore map[workloadfilter.ResourceType]map[string]*FilterProgramFactory
 	TelemetryStore      *telemetry.Store
+	Builder             *catalog.ProgramBuilder
 	// Pre-built filter configuration with all parsed values
 	selection    *filterSelection
 	FilterConfig *catalog.FilterConfig
@@ -58,35 +59,40 @@ func NewBaseFilterStore(cfg config.Component, logger logcomp.Component, telemetr
 		os.Exit(1)
 	}
 
+	telemetryStore := telemetry.NewStore(telemetryComp)
+	builder := catalog.NewProgramBuilder(filterConfig, logger, telemetryStore)
+
 	baseFilter := &BaseFilterStore{
 		Config:              cfg,
 		Log:                 logger,
 		ProgramFactoryStore: make(map[workloadfilter.ResourceType]map[string]*FilterProgramFactory),
 		selection:           newFilterSelection(cfg),
 		FilterConfig:        filterConfig,
-		TelemetryStore:      telemetry.NewStore(telemetryComp),
+		TelemetryStore:      telemetryStore,
+		Builder:             builder,
 	}
 
-	genericADProgram := catalog.AutodiscoveryAnnotations()
-	genericADMetricsProgram := catalog.AutodiscoveryMetricsAnnotations()
-	genericADLogsProgram := catalog.AutodiscoveryLogsAnnotations()
-	genericADProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return genericADProgram }
-	genericADMetricsProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram {
+	// Pre-compute shared annotation programs
+	genericADProgram := catalog.AutodiscoveryAnnotations(builder)
+	genericADMetricsProgram := catalog.AutodiscoveryMetricsAnnotations(builder)
+	genericADLogsProgram := catalog.AutodiscoveryLogsAnnotations(builder)
+	genericADProgramFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return genericADProgram }
+	genericADMetricsProgramFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram {
 		return genericADMetricsProgram
 	}
-	genericADLogsProgramFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return genericADLogsProgram }
+	genericADLogsProgramFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return genericADLogsProgram }
 
 	// Pre-compute legacy programs via `DD_CONTAINER_EXCLUDE*` that can be shared across entity types
-	legacyGlobalPrg := catalog.LegacyContainerGlobalProgram(filterConfig, logger)
-	legacyMetricsPrg := catalog.LegacyContainerMetricsProgram(filterConfig, logger)
-	legacyLogsPrg := catalog.LegacyContainerLogsProgram(filterConfig, logger)
-	legacyACIncludePrg := catalog.LegacyContainerACIncludeProgram(filterConfig, logger)
-	legacyACExcludePrg := catalog.LegacyContainerACExcludeProgram(filterConfig, logger)
-	legacyGlobalPrgFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return legacyGlobalPrg }
-	legacyMetricsPrgFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return legacyMetricsPrg }
-	legacyLogsPrgFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return legacyLogsPrg }
-	legacyACIncludePrgFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return legacyACIncludePrg }
-	legacyACExcludePrgFactory := func(_ *catalog.FilterConfig, _ logcomp.Component) program.FilterProgram { return legacyACExcludePrg }
+	legacyGlobalPrg := catalog.LegacyContainerGlobalProgram(builder)
+	legacyMetricsPrg := catalog.LegacyContainerMetricsProgram(builder)
+	legacyLogsPrg := catalog.LegacyContainerLogsProgram(builder)
+	legacyACIncludePrg := catalog.LegacyContainerACIncludeProgram(builder)
+	legacyACExcludePrg := catalog.LegacyContainerACExcludeProgram(builder)
+	legacyGlobalPrgFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return legacyGlobalPrg }
+	legacyMetricsPrgFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return legacyMetricsPrg }
+	legacyLogsPrgFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return legacyLogsPrg }
+	legacyACIncludePrgFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return legacyACIncludePrg }
+	legacyACExcludePrgFactory := func(_ *catalog.ProgramBuilder) program.FilterProgram { return legacyACExcludePrg }
 
 	// Container Filters
 	baseFilter.RegisterFactory(workloadfilter.ContainerLegacyMetrics, legacyMetricsPrgFactory)
@@ -128,7 +134,7 @@ func NewBaseFilterStore(cfg config.Component, logger logcomp.Component, telemetr
 }
 
 // RegisterFactory registers a factory function for a given resource type and program ID
-func (f *BaseFilterStore) RegisterFactory(id workloadfilter.FilterIdentifier, factory func(filterConfig *catalog.FilterConfig, logger logcomp.Component) program.FilterProgram) {
+func (f *BaseFilterStore) RegisterFactory(id workloadfilter.FilterIdentifier, factory func(builder *catalog.ProgramBuilder) program.FilterProgram) {
 	resourceType := id.TargetResource()
 	programID := id.GetFilterName()
 	if f.ProgramFactoryStore[resourceType] == nil {
@@ -156,7 +162,7 @@ func (f *BaseFilterStore) GetProgram(resourceType workloadfilter.ResourceType, p
 	}
 
 	factory.once.Do(func() {
-		factory.program = factory.factory(f.FilterConfig, f.Log)
+		factory.program = factory.factory(f.Builder)
 	})
 
 	return factory.program

--- a/comp/core/workloadfilter/catalog/builder.go
+++ b/comp/core/workloadfilter/catalog/builder.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package catalog contains the implementation of the filtering catalogs.
+package catalog
+
+import (
+	"regexp"
+	"strings"
+
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+// ProgramBuilder provides methods for creating filter programs with shared dependencies
+type ProgramBuilder struct {
+	config         *FilterConfig
+	logger         log.Component
+	telemetryStore *telemetry.Store
+}
+
+// NewProgramBuilder creates a new ProgramBuilder with the given dependencies
+func NewProgramBuilder(config *FilterConfig, logger log.Component, telemetryStore *telemetry.Store) *ProgramBuilder {
+	return &ProgramBuilder{
+		config:         config,
+		logger:         logger,
+		telemetryStore: telemetryStore,
+	}
+}
+
+// CreateCELProgram creates a CEL-based filter program (uses build-tagged createCELProgram helper)
+func (b *ProgramBuilder) CreateCELProgram(id workloadfilter.FilterIdentifier, product workloadfilter.Product) program.FilterProgram {
+	name := id.GetFilterName()
+	resourceType := id.TargetResource()
+	rule := b.config.GetCELRulesForProduct(product, resourceType)
+	return createCELProgram(name, rule, resourceType, b.telemetryStore, b.logger)
+}
+
+// CreateLegacyProgram creates a legacy container filter program
+func (b *ProgramBuilder) CreateLegacyProgram(id workloadfilter.FilterIdentifier, include, exclude []string) program.FilterProgram {
+	name := id.GetFilterName()
+
+	var initErrors []error
+	filter, err := containers.NewFilter(containers.GlobalFilter, include, exclude)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		b.logger.Warnf("Failed to create filter '%s': %v", name, err)
+	}
+
+	return program.LegacyFilterProgram{
+		Name:                 name,
+		Filter:               filter,
+		InitializationErrors: initErrors,
+	}
+}
+
+// CreateAnnotationsProgram creates an annotations-based filter program
+func (b *ProgramBuilder) CreateAnnotationsProgram(id workloadfilter.FilterIdentifier, excludePrefix string) program.FilterProgram {
+	return program.AnnotationsProgram{
+		Name:          id.GetFilterName(),
+		ExcludePrefix: excludePrefix,
+	}
+}
+
+// CreateRegexProgram creates a regex-based filter program
+func (b *ProgramBuilder) CreateRegexProgram(
+	id workloadfilter.FilterIdentifier,
+	patterns []string,
+	extractFieldFunc func(entity workloadfilter.Filterable) string,
+) program.FilterProgram {
+	name := id.GetFilterName()
+	var initErrors []error
+
+	if len(patterns) == 0 {
+		return &program.RegexProgram{
+			Name:                 name,
+			ExtractField:         extractFieldFunc,
+			InitializationErrors: initErrors,
+		}
+	}
+
+	combinedPattern := strings.Join(patterns, "|")
+	excludeRegex, err := regexp.Compile(combinedPattern)
+	if err != nil {
+		initErrors = append(initErrors, err)
+		b.logger.Warnf("Error compiling regex pattern for %s: %v", name, err)
+		return &program.RegexProgram{
+			Name:                 name,
+			ExtractField:         extractFieldFunc,
+			InitializationErrors: initErrors,
+		}
+	}
+
+	return &program.RegexProgram{
+		Name:                 name,
+		ExcludeRegex:         []*regexp.Regexp{excludeRegex},
+		ExtractField:         extractFieldFunc,
+		InitializationErrors: initErrors,
+	}
+}

--- a/comp/core/workloadfilter/catalog/common.go
+++ b/comp/core/workloadfilter/catalog/common.go
@@ -9,78 +9,75 @@ package catalog
 // This file contains filter programs that can be shared across different entity types.
 
 import (
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
-// AutodiscoveryAnnotations creates a CEL program for autodiscovery annotations.
-func AutodiscoveryAnnotations() program.FilterProgram {
-	return program.AnnotationsProgram{
-		Name:          string(workloadfilter.ContainerADAnnotations),
-		ExcludePrefix: "",
-	}
+// AutodiscoveryAnnotations creates an annotations program for autodiscovery
+func AutodiscoveryAnnotations(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateAnnotationsProgram(workloadfilter.ContainerADAnnotations, "")
 }
 
-// AutodiscoveryMetricsAnnotations creates a CEL program for autodiscovery metrics annotations.
-func AutodiscoveryMetricsAnnotations() program.FilterProgram {
-	return program.AnnotationsProgram{
-		Name:          string(workloadfilter.ContainerADAnnotationsMetrics),
-		ExcludePrefix: "metrics_",
-	}
+// AutodiscoveryMetricsAnnotations creates an annotations program for metrics autodiscovery
+func AutodiscoveryMetricsAnnotations(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateAnnotationsProgram(workloadfilter.ContainerADAnnotationsMetrics, "metrics_")
 }
 
-// AutodiscoveryLogsAnnotations creates a CEL program for autodiscovery logs annotations.
-func AutodiscoveryLogsAnnotations() program.FilterProgram {
-	return program.AnnotationsProgram{
-		Name:          string(workloadfilter.ContainerADAnnotationsLogs),
-		ExcludePrefix: "logs_",
-	}
+// AutodiscoveryLogsAnnotations creates an annotations program for logs autodiscovery
+func AutodiscoveryLogsAnnotations(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateAnnotationsProgram(workloadfilter.ContainerADAnnotationsLogs, "logs_")
 }
 
 // LegacyContainerGlobalProgram creates a legacy filter program for global containerized filtering
-func LegacyContainerGlobalProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyGlobal), cfg.ContainerInclude, cfg.ContainerExclude, logger)
+func LegacyContainerGlobalProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyGlobal,
+		b.config.ContainerInclude,
+		b.config.ContainerExclude,
+	)
 }
 
 // LegacyContainerMetricsProgram creates a legacy filter program for containerized metrics filtering
-func LegacyContainerMetricsProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyMetrics), cfg.ContainerIncludeMetrics, cfg.ContainerExcludeMetrics, logger)
+func LegacyContainerMetricsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyMetrics,
+		b.config.ContainerIncludeMetrics,
+		b.config.ContainerExcludeMetrics,
+	)
 }
 
 // LegacyContainerLogsProgram creates a legacy filter program for containerized logs filtering
-func LegacyContainerLogsProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyLogs), cfg.ContainerIncludeLogs, cfg.ContainerExcludeLogs, logger)
+func LegacyContainerLogsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyLogs,
+		b.config.ContainerIncludeLogs,
+		b.config.ContainerExcludeLogs,
+	)
 }
 
 // LegacyContainerACExcludeProgram creates a legacy filter program for containerized AC exclusion filtering
-func LegacyContainerACExcludeProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyACExclude), nil, cfg.ACExclude, logger)
+func LegacyContainerACExcludeProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyACExclude,
+		nil,
+		b.config.ACExclude,
+	)
 }
 
 // LegacyContainerACIncludeProgram creates a legacy filter program for containerized AC inclusion filtering
-func LegacyContainerACIncludeProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyACInclude), cfg.ACInclude, nil, logger)
+func LegacyContainerACIncludeProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyACInclude,
+		b.config.ACInclude,
+		nil,
+	)
 }
 
 // LegacyContainerSBOMProgram creates a legacy filter program for containerized SBOM filtering
-func LegacyContainerSBOMProgram(cfg *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacySBOM), cfg.SBOMContainerInclude, cfg.SBOMContainerExclude, logger)
-}
-
-func createLegacyContainerProgram(programName string, include, exclude []string, logger log.Component) program.FilterProgram {
-	var initErrors []error
-
-	filter, err := containers.NewFilter(containers.GlobalFilter, include, exclude)
-	if err != nil {
-		initErrors = append(initErrors, err)
-		logger.Warnf("Failed to create filter '%s': %v", programName, err)
-	}
-
-	return program.LegacyFilterProgram{
-		Name:                 programName,
-		Filter:               filter,
-		InitializationErrors: initErrors,
-	}
+func LegacyContainerSBOMProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacySBOM,
+		b.config.SBOMContainerInclude,
+		b.config.SBOMContainerExclude,
+	)
 }

--- a/comp/core/workloadfilter/catalog/container.go
+++ b/comp/core/workloadfilter/catalog/container.go
@@ -7,47 +7,54 @@
 package catalog
 
 import (
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 // ContainerPausedProgram creates a program for filtering paused containers
-func ContainerPausedProgram(_ *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerPaused), nil, containers.GetPauseContainerExcludeList(), logger)
+func ContainerPausedProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerPaused,
+		nil,
+		containers.GetPauseContainerExcludeList(),
+	)
 }
 
 // ContainerCELMetricsProgram creates a program for filtering container metrics via CEL rules
-func ContainerCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.ContainerType)
-	return createCELExcludeProgram(string(workloadfilter.ContainerCELMetrics), rule, workloadfilter.ContainerType, logger)
+func ContainerCELMetricsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.ContainerCELMetrics, workloadfilter.ProductMetrics)
 }
 
 // ContainerCELLogsProgram creates a program for filtering container logs via CEL rules
-func ContainerCELLogsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductLogs, workloadfilter.ContainerType)
-	return createCELExcludeProgram(string(workloadfilter.ContainerCELLogs), rule, workloadfilter.ContainerType, logger)
+func ContainerCELLogsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.ContainerCELLogs, workloadfilter.ProductLogs)
 }
 
 // ContainerCELSBOMProgram creates a program for filtering container SBOMs via CEL rules
-func ContainerCELSBOMProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductSBOM, workloadfilter.ContainerType)
-	return createCELExcludeProgram(string(workloadfilter.ContainerCELSBOM), rule, workloadfilter.ContainerType, logger)
+func ContainerCELSBOMProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.ContainerCELSBOM, workloadfilter.ProductSBOM)
 }
 
 // ContainerCELGlobalProgram creates a program for filtering containers globally via CEL rules
-func ContainerCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.ContainerType)
-	return createCELExcludeProgram(string(workloadfilter.ContainerCELGlobal), rule, workloadfilter.ContainerType, logger)
+func ContainerCELGlobalProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.ContainerCELGlobal, workloadfilter.ProductGlobal)
 }
 
 // ContainerLegacyRuntimeSecurityProgram creates a program for filtering containers for runtime security
-func ContainerLegacyRuntimeSecurityProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyRuntimeSecurity), filterConfig.ContainerRuntimeSecurityInclude, filterConfig.ContainerRuntimeSecurityExclude, logger)
+func ContainerLegacyRuntimeSecurityProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyRuntimeSecurity,
+		b.config.ContainerRuntimeSecurityInclude,
+		b.config.ContainerRuntimeSecurityExclude,
+	)
 }
 
 // ContainerLegacyComplianceProgram creates a program for filtering containers for compliance
-func ContainerLegacyComplianceProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	return createLegacyContainerProgram(string(workloadfilter.ContainerLegacyCompliance), filterConfig.ContainerComplianceInclude, filterConfig.ContainerComplianceExclude, logger)
+func ContainerLegacyComplianceProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateLegacyProgram(
+		workloadfilter.ContainerLegacyCompliance,
+		b.config.ContainerComplianceInclude,
+		b.config.ContainerComplianceExclude,
+	)
 }

--- a/comp/core/workloadfilter/catalog/kube_endpoints.go
+++ b/comp/core/workloadfilter/catalog/kube_endpoints.go
@@ -7,19 +7,16 @@
 package catalog
 
 import (
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 )
 
 // EndpointCELMetricsProgram creates a program for filtering endpoints metrics via CEL rules
-func EndpointCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.KubeEndpointType)
-	return createCELExcludeProgram(string(workloadfilter.KubeEndpointCELMetrics), rule, workloadfilter.KubeEndpointType, logger)
+func EndpointCELMetricsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.KubeEndpointCELMetrics, workloadfilter.ProductMetrics)
 }
 
 // EndpointCELGlobalProgram creates a program for filtering endpoints globally via CEL rules
-func EndpointCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.KubeEndpointType)
-	return createCELExcludeProgram(string(workloadfilter.KubeEndpointCELGlobal), rule, workloadfilter.KubeEndpointType, logger)
+func EndpointCELGlobalProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.KubeEndpointCELGlobal, workloadfilter.ProductGlobal)
 }

--- a/comp/core/workloadfilter/catalog/kube_service.go
+++ b/comp/core/workloadfilter/catalog/kube_service.go
@@ -7,19 +7,16 @@
 package catalog
 
 import (
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 )
 
 // ServiceCELMetricsProgram creates a program for filtering services metrics via CEL rules
-func ServiceCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.KubeServiceType)
-	return createCELExcludeProgram(string(workloadfilter.KubeServiceCELMetrics), rule, workloadfilter.KubeServiceType, logger)
+func ServiceCELMetricsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.KubeServiceCELMetrics, workloadfilter.ProductMetrics)
 }
 
 // ServiceCELGlobalProgram creates a program for filtering services globally via CEL rules
-func ServiceCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.KubeServiceType)
-	return createCELExcludeProgram(string(workloadfilter.KubeServiceCELGlobal), rule, workloadfilter.KubeServiceType, logger)
+func ServiceCELGlobalProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.KubeServiceCELGlobal, workloadfilter.ProductGlobal)
 }

--- a/comp/core/workloadfilter/catalog/pod.go
+++ b/comp/core/workloadfilter/catalog/pod.go
@@ -7,19 +7,16 @@
 package catalog
 
 import (
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
 )
 
 // PodCELMetricsProgram creates a program for filtering pods metrics via CEL rules
-func PodCELMetricsProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductMetrics, workloadfilter.PodType)
-	return createCELExcludeProgram(string(workloadfilter.PodCELMetrics), rule, workloadfilter.PodType, logger)
+func PodCELMetricsProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.PodCELMetrics, workloadfilter.ProductMetrics)
 }
 
 // PodCELGlobalProgram creates a program for filtering pods globally via CEL rules
-func PodCELGlobalProgram(filterConfig *FilterConfig, logger log.Component) program.FilterProgram {
-	rule := filterConfig.GetCELRulesForProduct(workloadfilter.ProductGlobal, workloadfilter.PodType)
-	return createCELExcludeProgram(string(workloadfilter.PodCELGlobal), rule, workloadfilter.PodType, logger)
+func PodCELGlobalProgram(b *ProgramBuilder) program.FilterProgram {
+	return b.CreateCELProgram(workloadfilter.PodCELGlobal, workloadfilter.ProductGlobal)
 }

--- a/comp/core/workloadfilter/catalog/remote.go
+++ b/comp/core/workloadfilter/catalog/remote.go
@@ -11,10 +11,8 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
-	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/telemetry"
 )
 
 const (
@@ -23,13 +21,13 @@ const (
 )
 
 // NewRemoteProgram creates a new remote program.
-func NewRemoteProgram(name string, objectType workloadfilter.ResourceType, logger log.Component, telemetryStore *telemetry.Store, provider program.ClientProvider) program.FilterProgram {
+func NewRemoteProgram(name string, objectType workloadfilter.ResourceType, builder *ProgramBuilder, provider program.ClientProvider) program.FilterProgram {
 	return &program.RemoteProgram{
 		Name:           name,
 		ObjectType:     string(objectType),
-		Logger:         logger,
-		Provider:       provider,
-		TelemetryStore: telemetryStore,
+		Logger:         builder.logger,
+		TelemetryStore: builder.telemetryStore,
 		Cache:          cache.New(defaultCacheExpire, defaultCachePurge),
+		Provider:       provider,
 	}
 }

--- a/comp/core/workloadfilter/catalog/utils.go
+++ b/comp/core/workloadfilter/catalog/utils.go
@@ -14,11 +14,19 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/util/celprogram"
 )
 
-func createCELExcludeProgram(name string, rules string, objectType workloadfilter.ResourceType, logger log.Component) program.FilterProgram {
-	excludeProgram, excludeErr := celprogram.CreateCELProgram(rules, objectType)
+// createCELProgram creates a CEL-based filter program
+func createCELProgram(
+	name string,
+	rules string,
+	resourceType workloadfilter.ResourceType,
+	_ *telemetry.Store,
+	logger log.Component,
+) program.FilterProgram {
+	excludeProgram, excludeErr := celprogram.CreateCELProgram(rules, resourceType)
 	if excludeErr != nil {
 		logger.Criticalf(`failed to compile '%s' from 'cel_workload_exclude' filters: %v`, name, excludeErr)
 		logger.Flush()

--- a/comp/core/workloadfilter/catalog/utils_nocel.go
+++ b/comp/core/workloadfilter/catalog/utils_nocel.go
@@ -12,9 +12,16 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/program"
+	"github.com/DataDog/datadog-agent/comp/core/workloadfilter/telemetry"
 )
 
-// createCELExcludeProgram is a stub to allow compilation without CEL support.
-func createCELExcludeProgram(_ string, _ string, _ workloadfilter.ResourceType, _ log.Component) program.FilterProgram {
+// createCELProgram is a stub to allow compilation without CEL support.
+func createCELProgram(
+	_ string,
+	_ string,
+	_ workloadfilter.ResourceType,
+	_ *telemetry.Store,
+	_ log.Component,
+) program.FilterProgram {
 	return nil
 }

--- a/comp/core/workloadfilter/remoteimpl/remote.go
+++ b/comp/core/workloadfilter/remoteimpl/remote.go
@@ -116,8 +116,8 @@ func newFilter(cfg config.Component, logger log.Component, telemetryComp coretel
 
 	for _, cfg := range remoteProgramConfig {
 		if remoteFilter.FilterConfig.CELProductRules[cfg.productType][cfg.filterID.TargetResource()] != nil {
-			fn := func(_ *catalog.FilterConfig, logger log.Component) program.FilterProgram {
-				return catalog.NewRemoteProgram(cfg.filterID.GetFilterName(), cfg.filterID.TargetResource(), logger, remoteFilter.TelemetryStore, remoteFilter)
+			fn := func(builder *catalog.ProgramBuilder) program.FilterProgram {
+				return catalog.NewRemoteProgram(cfg.filterID.GetFilterName(), cfg.filterID.TargetResource(), builder, remoteFilter)
 			}
 			remoteFilter.RegisterFactory(cfg.filterID, fn)
 		}


### PR DESCRIPTION
### What does this PR do?

Implements a Builder for the WorkloadFilter Catalog. This Builder keeps common parameters like the filterConfig, logger, and telemetryStore to simplify function signatures. The builder also centralizes the methods for building the various filterPrograms.

### Motivation

Make it easier to introduce new arguments to filter programs without needing to change dozens of different function signatures to match an interface. This will be useful for introducing more telemetry features in the filter programs. Currently, only the remoteProgram has telemetry configured.

### Describe how you validated your changes

Unit Tests and CI. No functional changes. All filter tests continue to pass.
