### PR TITLE
change `scatterDuration` log formatting

### DIFF
--- a/comp/core/secrets/impl/secrets.go
+++ b/comp/core/secrets/impl/secrets.go
@@ -926,7 +926,7 @@ func (r *secretResolver) getDebugInfo(stats map[string]interface{}, includeVersi
 	stats["refreshIntervalEnabled"] = r.refreshInterval > 0
 	if r.refreshInterval > 0 {
 		stats["refreshInterval"] = r.refreshInterval.String()
-		stats["scatterDuration"] = r.scatterDuration.String()
+		stats["scatterDuration"] = fmt.Sprintf("%.2fs", r.scatterDuration.Seconds())
 	}
 
 	stats["unresolvedSecrets"] = r.unresolvedSecrets


### PR DESCRIPTION
### What does this PR do?
uses `fmt.Sprintf("%.2fs")` to format the `scatterDuration` log

### Motivation

### Describe how you validated your changes

### Additional Notes
