### PR TITLE
Adjust CPU baseline to x86-64-v3, ARMv8.1-A with LSE

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -60,6 +60,17 @@ build do
 
   env = with_standard_compiler_flags(env)
 
+  # CPU baseline optimization
+  if amd64_target?
+    env['GOAMD64'] = 'v3'
+    env['CFLAGS'] = "#{env['CFLAGS']} -march=x86-64-v3"
+    env['CXXFLAGS'] = "#{env['CXXFLAGS']} -march=x86-64-v3"
+  elsif arm_target?
+    env['GOARM64'] = 'v8.1,lse'
+    env['CFLAGS'] = "#{env['CFLAGS']} -march=armv8.1-a"
+    env['CXXFLAGS'] = "#{env['CXXFLAGS']} -march=armv8.1-a"
+  end
+
   # Use msgo toolchain when fips mode is enabled
   if fips_mode?
     if windows_target?

--- a/omnibus/lib/ostools.rb
+++ b/omnibus/lib/ostools.rb
@@ -62,3 +62,11 @@ end
 def fips_mode?()
   return ENV['AGENT_FLAVOR'] == "fips" && (linux_target? || windows_target?)
 end
+
+def amd64_target?
+  ohai["kernel"]["machine"].match(/x86_64|amd64/)
+end
+
+def arm_target?
+  ohai["kernel"]["machine"].match(/aarch64|arm64/)
+end

--- a/rtloader/CMakeLists.txt
+++ b/rtloader/CMakeLists.txt
@@ -23,6 +23,15 @@ if(ARCH_I386)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
 endif()
 
+# CPU baseline optimization - x86-64-v3 / ARMv8.1-A
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=x86-64-v3")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64-v3")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8.1-a")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8.1-a")
+endif()
+
 ## Config options
 option(BUILD_DEMO "Build the demo app" ON)
 

--- a/rtloader/rtloader/BUILD.bazel
+++ b/rtloader/rtloader/BUILD.bazel
@@ -51,6 +51,10 @@ cc_library(
             "/MT",
         ],
         "//conditions:default": ["-O2"],
+    }) + select({
+        "@platforms//cpu:x86_64": ["-march=x86-64-v3"],
+        "@platforms//cpu:aarch64": ["-march=armv8.1-a"],
+        "//conditions:default": [],
     }),
     includes = ["."],
     local_defines = COMMON_DEFINES + select({

--- a/rtloader/three/BUILD.bazel
+++ b/rtloader/three/BUILD.bazel
@@ -69,6 +69,10 @@ cc_library(
             # TODO: only set if MSVC
             "/MT",
         ],
+    }) + select({
+        "@platforms//cpu:x86_64": ["-march=x86-64-v3"],
+        "@platforms//cpu:aarch64": ["-march=armv8.1-a"],
+        "//conditions:default": [],
     }),
     includes = [
         ".",

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -29,7 +29,7 @@ from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import ALLOWED_REPO_ALL_BRANCHES, REPO_PATH
 from tasks.libs.common.git import get_commit_sha, get_default_branch, set_git_config
 from tasks.libs.releasing.version import get_version
-from tasks.libs.types.arch import Arch
+from tasks.libs.types.arch import ARCH_AMD64, ARCH_ARM64, Arch
 
 if sys.platform == "darwin":
     RTLOADER_LIB_NAME = "libdatadog-agent-rtloader.dylib"
@@ -340,6 +340,16 @@ def get_build_flags(
         env["CGO_ENABLED"] = "1"  # If we're cross-compiling, CGO is disabled by default. Ensure it's always enabled
         env["CC"] = os.getenv("DD_CC_CROSS", arch.gcc_compiler())
         env["CXX"] = os.getenv("DD_CXX_CROSS", arch.gpp_compiler())
+
+    # CPU baseline optimization - x86-64-v3 / ARMv8.1-A
+    if arch == ARCH_AMD64:
+        env["GOAMD64"] = "v3"
+        env['CGO_CFLAGS'] = env.get('CGO_CFLAGS', '') + " -march=x86-64-v3"
+        env['CGO_CXXFLAGS'] = env.get('CGO_CXXFLAGS', env.get('CGO_CFLAGS', '')) + " -march=x86-64-v3"
+    elif arch == ARCH_ARM64:
+        env["GOARM64"] = "v8.1,lse"
+        env['CGO_CFLAGS'] = env.get('CGO_CFLAGS', '') + " -march=armv8.1-a"
+        env['CGO_CXXFLAGS'] = env.get('CGO_CXXFLAGS', env.get('CGO_CFLAGS', '')) + " -march=armv8.1-a"
 
     if extldflags:
         ldflags += f"'-extldflags={extldflags}' "


### PR DESCRIPTION
### What does this PR do?

This commit bumps the baseline build of Datadog Agent across the board to a 2013+ / 2016+ architecture by default. Exact target are controlled by ARCH_AMD64 and ARCH_ARM64.

### Motivation

Compiler choices for architecture support are conservative in a way that this project does not need to be.