### PR TITLE
Accept 2c as valid snmp_version value for snmp autodiscovery

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -406,7 +406,7 @@ func (a *Authentication) BuildSNMPParams(deviceIP string, port uint16) (*gosnmp.
 	var version gosnmp.SnmpVersion
 	if a.Version == "1" {
 		version = gosnmp.Version1
-	} else if a.Version == "2" || (a.Version == "" && a.Community != "") {
+	} else if a.Version == "2" || a.Version == "2c" || a.Version == "2C" || (a.Version == "" && a.Community != "") {
 		version = gosnmp.Version2c
 	} else if a.Version == "3" || (a.Version == "" && a.User != "") {
 		version = gosnmp.Version3

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -42,6 +42,20 @@ func TestBuildSNMPParams(t *testing.T) {
 	assert.Equal(t, "192.168.0.1", params.Target)
 
 	authentication = snmp.Authentication{
+		Community: "public",
+		Version:   "2c",
+	}
+	params, _ = authentication.BuildSNMPParams("192.168.0.1", 0)
+	assert.Equal(t, gosnmp.Version2c, params.Version)
+
+	authentication = snmp.Authentication{
+		Community: "public",
+		Version:   "2C",
+	}
+	params, _ = authentication.BuildSNMPParams("192.168.0.1", 0)
+	assert.Equal(t, gosnmp.Version2c, params.Version)
+
+	authentication = snmp.Authentication{
 		User: "admin",
 	}
 	params, _ = authentication.BuildSNMPParams("192.168.0.2", 0)


### PR DESCRIPTION
### What does this PR do?
This accepts `2c` as a valid value for snmp_version config in the datadog.yaml file for customer utilizing the snmp autodiscovery. Customers previously could only use `snmp_version:2` which caused confusion since most customers run snmp walks with `2c`

### Motivation

SNMP auto discovery was not working for a support ticket where they had `snmp_version:2c`

### Describe how you validated your changes

### Additional Notes
