### PR TITLE
Support AWS IRSA credentials chain

### DIFF
--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -152,17 +153,32 @@ func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {
 	return tags, nil
 }
 
+func createEC2Client(ctx context.Context, region string, creds aws.CredentialsProvider) (*ec2.Client, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if creds != nil {
+		opts = append(opts, config.WithCredentialsProvider(creds))
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS SDK config: %w", err)
+	}
+	return ec2.NewFromConfig(cfg), nil
+}
+
 func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	instanceIdentity, err := ec2internal.GetInstanceIdentity(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// First, try automatic credentials detection. This works in most scenarios,
-	// except when a more specific role (e.g. task role in ECS) does not have
-	// EC2:DescribeTags permission, but a more general role (e.g. instance role)
-	// does have it.
-	tags, err := getTagsWithCreds(ctx, instanceIdentity, nil)
+	// default client chain (IRSA/ECS/env/instance-profile chain)
+	ec2Client, err := createEC2Client(ctx, instanceIdentity.Region, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tags, err := getTagsWithClient(ctx, ec2Client, instanceIdentity)
 	if err == nil {
 		return tags, nil
 	}
@@ -176,22 +192,18 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	}
 
 	awsCreds := credentials.NewStaticCredentialsProvider(iamParams.AccessKeyID, iamParams.SecretAccessKey, iamParams.Token)
-	return getTagsWithCreds(ctx, instanceIdentity, awsCreds)
+	legacyClient, err := createEC2Client(ctx, instanceIdentity.Region, awsCreds)
+	if err != nil {
+		return nil, err
+	}
+	return getTagsWithClient(ctx, legacyClient, instanceIdentity)
 }
 
-func getTagsWithCreds(ctx context.Context, instanceIdentity *ec2internal.EC2Identity, awsCreds aws.CredentialsProvider) ([]string, error) {
-	connection := ec2.New(ec2.Options{
-		Region:      instanceIdentity.Region,
-		Credentials: awsCreds,
-	})
-
-	// We want to use 'ec2_metadata_timeout' here instead of current context. 'ctx' comes from the agent main and will
-	// only be canceled if the agent is stopped. The default timeout for the AWS SDK is 1 minutes (20s timeout with
-	// 3 retries). Since we call getTagsWithCreds twice in a row, it can be a 2 minutes latency.
+func getTagsWithClient(ctx context.Context, client *ec2.Client, instanceIdentity *ec2internal.EC2Identity) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, pkgconfigsetup.Datadog().GetDuration("ec2_metadata_timeout")*time.Millisecond)
 	defer cancel()
 
-	ec2Tags, err := connection.DescribeTags(ctx,
+	out, err := client.DescribeTags(ctx,
 		&ec2.DescribeTagsInput{
 			Filters: []types.Filter{{
 				Name: aws.String("resource-id"),
@@ -207,7 +219,7 @@ func getTagsWithCreds(ctx context.Context, instanceIdentity *ec2internal.EC2Iden
 	}
 
 	tags := []string{}
-	for _, tag := range ec2Tags.Tags {
+	for _, tag := range out.Tags {
 		if isTagExcluded(*tag.Key) {
 			continue
 		}

--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -203,7 +203,7 @@ func getTagsWithClient(ctx context.Context, client *ec2.Client, instanceIdentity
 	ctx, cancel := context.WithTimeout(ctx, pkgconfigsetup.Datadog().GetDuration("ec2_metadata_timeout")*time.Millisecond)
 	defer cancel()
 
-	out, err := client.DescribeTags(ctx,
+	describeTagsOutput, err := client.DescribeTags(ctx,
 		&ec2.DescribeTagsInput{
 			Filters: []types.Filter{{
 				Name: aws.String("resource-id"),
@@ -219,7 +219,7 @@ func getTagsWithClient(ctx context.Context, client *ec2.Client, instanceIdentity
 	}
 
 	tags := []string{}
-	for _, tag := range out.Tags {
+	for _, tag := range describeTagsOutput.Tags {
 		if isTagExcluded(*tag.Key) {
 			continue
 		}

--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -174,15 +174,15 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 
 	// default client chain (IRSA/ECS/env/instance-profile chain)
 	ec2Client, err := createEC2Client(ctx, instanceIdentity.Region, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	tags, err := getTagsWithClientFunc(ctx, ec2Client, instanceIdentity)
 	if err == nil {
-		return tags, nil
+		tags, err := getTagsWithClientFunc(ctx, ec2Client, instanceIdentity)
+		if err == nil {
+			return tags, nil
+		}
+		log.Debugf("unable to get tags using default credentials (falling back to instance role): %s", err)
+	} else {
+		log.Debugf("unable to create EC2 client with default credentials (falling back to instance role): %s", err)
 	}
-	log.Debugf("unable to get tags using default credentials (falling back to instance role): %s", err)
 
 	// If the above fails, for backward compatibility, fall back to our legacy
 	// behavior, where we explicitly query instance role to get credentials.

--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -178,7 +178,7 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
-	tags, err := getTagsWithClient(ctx, ec2Client, instanceIdentity)
+	tags, err := getTagsWithClientFunc(ctx, ec2Client, instanceIdentity)
 	if err == nil {
 		return tags, nil
 	}
@@ -196,7 +196,7 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return getTagsWithClient(ctx, legacyClient, instanceIdentity)
+	return getTagsWithClientFunc(ctx, legacyClient, instanceIdentity)
 }
 
 func getTagsWithClient(ctx context.Context, client *ec2.Client, instanceIdentity *ec2internal.EC2Identity) ([]string, error) {
@@ -230,6 +230,7 @@ func getTagsWithClient(ctx context.Context, client *ec2.Client, instanceIdentity
 
 // for testing purposes
 var fetchTags = fetchEc2Tags
+var getTagsWithClientFunc = getTagsWithClient
 
 func fetchTagsFromCache(ctx context.Context) ([]string, error) {
 	if !configutils.IsCloudProviderEnabled(ec2internal.CloudProviderName, pkgconfigsetup.Datadog()) {

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -349,7 +349,7 @@ func TestFetchEc2TagsFromAPICredentialChain(t *testing.T) {
 		defer func() { getTagsWithClientFunc = getTagsWithClient }()
 
 		callCount := 0
-		getTagsWithClientFunc = func(ctx context.Context, client *ec2.Client, identity *ec2internal.EC2Identity) ([]string, error) {
+		getTagsWithClientFunc = func(_ context.Context, _ *ec2.Client, _ *ec2internal.EC2Identity) ([]string, error) {
 			callCount++
 			return []string{"Name:test"}, nil
 		}
@@ -364,7 +364,7 @@ func TestFetchEc2TagsFromAPICredentialChain(t *testing.T) {
 		defer func() { getTagsWithClientFunc = getTagsWithClient }()
 
 		callCount := 0
-		getTagsWithClientFunc = func(ctx context.Context, client *ec2.Client, identity *ec2internal.EC2Identity) ([]string, error) {
+		getTagsWithClientFunc = func(_ context.Context, _ *ec2.Client, _ *ec2internal.EC2Identity) ([]string, error) {
 			callCount++
 			if callCount == 1 {
 				return nil, errors.New("unauthorized")

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -18,7 +18,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -272,12 +274,106 @@ func TestCollectEC2InstanceInfo(t *testing.T) {
 func TestCreateEC2Client(t *testing.T) {
 	ctx := context.Background()
 
-	client, err := createEC2Client(ctx, "us-east-1", nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, client)
+	tests := []struct {
+		name        string
+		region      string
+		withCreds   bool
+		expectError bool
+	}{
+		{
+			name:        "default credential chain (IRSA-compatible)",
+			region:      "us-east-1",
+			withCreds:   false,
+			expectError: false,
+		},
+		{
+			name:        "explicit credentials (fallback path)",
+			region:      "us-west-2",
+			withCreds:   true,
+			expectError: false,
+		},
+		{
+			name:        "different region with default chain",
+			region:      "eu-west-1",
+			withCreds:   false,
+			expectError: false,
+		},
+	}
 
-	creds := credentials.NewStaticCredentialsProvider("key", "secret", "token")
-	client, err = createEC2Client(ctx, "us-west-2", creds)
-	assert.NoError(t, err)
-	assert.NotNil(t, client)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var creds aws.CredentialsProvider
+			if tt.withCreds {
+				creds = credentials.NewStaticCredentialsProvider("key", "secret", "token")
+			}
+			client, err := createEC2Client(ctx, tt.region, creds)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
+}
+
+func setupTestIMDS(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/latest/api/token":
+			io.WriteString(w, "test-token")
+		case "/latest/dynamic/instance-identity/document":
+			io.WriteString(w, `{"instanceId": "i-test", "region": "us-east-1"}`)
+		case "/iam/security-credentials/":
+			io.WriteString(w, "test-role")
+		case "/iam/security-credentials/test-role":
+			content, _ := os.ReadFile("payloads/security_cred.json")
+			w.Write(content)
+		}
+	}))
+
+	ec2internal.InstanceIdentityURL = ts.URL + "/latest/dynamic/instance-identity/document"
+	ec2internal.TokenURL = ts.URL + "/latest/api/token"
+	ec2internal.MetadataURL = ts.URL
+
+	t.Cleanup(func() { ts.Close() })
+}
+
+func TestFetchEc2TagsFromAPICredentialChain(t *testing.T) {
+	ctx := context.Background()
+	conf := configmock.New(t)
+	conf.SetWithoutSource("ec2_metadata_timeout", 1000)
+
+	t.Run("tries default credentials first (IRSA), no fallback needed", func(t *testing.T) {
+		setupTestIMDS(t)
+		defer func() { getTagsWithClientFunc = getTagsWithClient }()
+
+		callCount := 0
+		getTagsWithClientFunc = func(ctx context.Context, client *ec2.Client, identity *ec2internal.EC2Identity) ([]string, error) {
+			callCount++
+			return []string{"Name:test"}, nil
+		}
+
+		_, err := fetchEc2TagsFromAPI(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 1, callCount, "should only call once when default credentials work")
+	})
+
+	t.Run("falls back to instance credentials when default fails", func(t *testing.T) {
+		setupTestIMDS(t)
+		defer func() { getTagsWithClientFunc = getTagsWithClient }()
+
+		callCount := 0
+		getTagsWithClientFunc = func(ctx context.Context, client *ec2.Client, identity *ec2internal.EC2Identity) ([]string, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, errors.New("unauthorized")
+			}
+			return []string{"Name:test"}, nil
+		}
+
+		_, err := fetchEc2TagsFromAPI(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, callCount, "should call twice: default credentials fail, then fallback succeeds")
+	})
 }

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -266,4 +267,17 @@ func TestCollectEC2InstanceInfo(t *testing.T) {
 	tags, err = GetInstanceInfo(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, []string(nil), tags)
+}
+
+func TestCreateEC2Client(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := createEC2Client(ctx, "us-east-1", nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	creds := credentials.NewStaticCredentialsProvider("key", "secret", "token")
+	client, err = createEC2Client(ctx, "us-west-2", creds)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
 }

--- a/releasenotes/notes/aws-irsa-credentials-301543eea405aff2.yaml
+++ b/releasenotes/notes/aws-irsa-credentials-301543eea405aff2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enables the agent to support built-in credentials like IRSA for AWS cloud environments.


### PR DESCRIPTION
### What does this PR do?
Adds support for built in credentials and IRSA

### Motivation
addresses https://github.com/DataDog/datadog-agent/issues/29916 with a fix based off this stale PR https://github.com/DataDog/datadog-agent/pull/29784

### Describe how you validated your changes
CI, unit tests
<img width="429" height="460" alt="image" src="https://github.com/user-attachments/assets/fb6d8772-c5c7-4578-a281-529ffb30b9e1" />


QA guide:
<details>
<summary>General QA guide with AWS</summary>
prereqs: check what type of machine you are builidng on (ARM/x86) and setup your EKS cluster based on that.

1. login to aws cli: `aws sso login --profile ${AWS_PROFILE}`
2. get account ID: `aws sts get-caller-identity --query Account --output text`
3. login to ECR: 
```
aws ecr get-login-password --region ${AWS_REGION} --profile ${AWS_PROFILE} | \
      docker login --username AWS --password-stdin ${ECR_REGISTRY}
```
4. create ECR repo if non-exist
```
aws ecr create-repository --repository-name ${IMAGE_NAME} --region ${AWS_REGION} --profile ${AWS_PROFILE} 2>/dev/null || true
```
5. do a hacky build and push to the ecr repo (alternativly you can push a CI image already built)
```
dda env dev run --id awsc -- bash -c "dda inv agent.build --build-exclude=systemd --development && dda inv -e agent.hacky-dev-image-build --base-image=datadog/agent:7 --target-image=${FULL_IMAGE} --push"
```
6. create an EKS cluster
```
eksctl create cluster \
      --name ${CLUSTER_NAME} \
      --region ${AWS_REGION} \
      --node-type t4g.medium \
      --nodes 2 \
      --nodes-min 1 \
      --nodes-max 3 \
      --with-oidc \
      --profile ${AWS_PROFILE}
```
7. setup IRSA
```
setup_irsa() {
    # create IAM policy
    cat > /tmp/ec2-tags-policy.json <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "ec2:DescribeTags",
        "ec2:DescribeInstances"
      ],
      "Resource": "*"
    }
  ]
}
EOF

    export POLICY_ARN=$(aws iam create-policy \
      --policy-name DatadogAgentEC2TagsPolicy-${CLUSTER_NAME} \
      --policy-document file:///tmp/ec2-tags-policy.json \
      --profile ${AWS_PROFILE} \
      --query 'Policy.Arn' \
      --output text 2>/dev/null || \
      aws iam list-policies --query "Policies[?PolicyName=='DatadogAgentEC2TagsPolicy-${CLUSTER_NAME}'].Arn" --output text --profile ${AWS_PROFILE})

    # create IAM service account
    eksctl create iamserviceaccount \
      --name datadog-agent \
      --namespace default \
      --cluster ${CLUSTER_NAME} \
      --region ${AWS_REGION} \
      --attach-policy-arn ${POLICY_ARN} \
      --approve \
      --override-existing-serviceaccounts \
      --profile ${AWS_PROFILE}

    export IRSA_ROLE_ARN=$(kubectl get serviceaccount datadog-agent -n default -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}')

    # verify setup
    kubectl describe serviceaccount datadog-agent -n default
}
```
8. deploy the agent
```
deploy_agent() {
    # create secret
    kubectl create secret generic datadog-secret \
      --from-literal api-key=0000001 \
      --namespace default \
      --dry-run=client -o yaml | kubectl apply -f -

    # create agent deployment
    cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: datadog-agent-config
  namespace: default
data:
  datadog.yaml: |
    api_key: <key>
    log_level: debug
    collect_ec2_tags: true
    collect_ec2_tags_use_imds: false
    ec2_metadata_timeout: 5000
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: datadog-agent
  namespace: default
spec:
  selector:
    matchLabels:
      app: datadog-agent
  template:
    metadata:
      labels:
        app: datadog-agent
    spec:
      serviceAccountName: datadog-agent
      containers:
      - name: agent
        image: ${FULL_IMAGE}
        imagePullPolicy: Always
        env:
        - name: DD_API_KEY
          valueFrom:
            secretKeyRef:
              name: datadog-secret
              key: api-key
        - name: DD_LOG_LEVEL
          value: "debug"
        - name: DD_COLLECT_EC2_TAGS
          value: "true"
        - name: DD_COLLECT_EC2_TAGS_USE_IMDS
          value: "false"
        - name: DD_KUBERNETES_KUBELET_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_KUBERNETES_COLLECT_METADATA_TAGS
          value: "true"
        - name: KUBERNETES
          value: "true"
        - name: DD_HOSTNAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        volumeMounts:
        - name: config
          mountPath: /etc/datadog-agent/datadog.yaml
          subPath: datadog.yaml
        securityContext:
          capabilities:
            add:
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
      volumes:
      - name: config
        configMap:
          name: datadog-agent-config
EOF
```
9. validate for IRSA 
```
    if kubectl exec ${POD_NAME} -n default -- test -f /var/run/secrets/eks.amazonaws.com/serviceaccount/token 2>/dev/null; then
        local TOKEN_CONTENT=$(kubectl exec ${POD_NAME} -n default -- cat /var/run/secrets/eks.amazonaws.com/serviceaccount/token 2>/dev/null | head -c 50)
    else
        log_fail "IRSA token file does NOT exist in pod!"
    fi
```
10. check tags
```
local EC2_TAGS=$(echo "$AGENT_STATUS" | grep -A 50 "host tags:" | grep -E "aws:|eks:|Name:" | head -10)
if [ -n "${EC2_TAGS}" ]; then
        log_pass "EC2 tags successfully fetched via IRSA!"
    else
        log_fail "No EC2 tags found in agent status!"
    fi
```
</details>

<details>
<summary>QA bash script (generated by claude from my test runs)</summary>

```

#!/bin/bash
set -e

# IRSA QA Setup Script
# This script automates the setup of an EKS cluster with IRSA for testing the Datadog Agent

# Colors for output
RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
BLUE='\033[0;34m'
CYAN='\033[0;36m'
NC='\033[0m' # No Color

# Logging functions (defined early so they can be used anywhere)
log_info() {
    echo -e "${GREEN}[INFO]${NC} $1"
}

log_warn() {
    echo -e "${YELLOW}[WARN]${NC} $1"
}

log_error() {
    echo -e "${RED}[ERROR]${NC} $1"
}

log_pass() {
    echo -e "${GREEN}[✓]${NC} $1"
}

log_fail() {
    echo -e "${RED}[✗]${NC} $1"
}

log_section() {
    echo -e "\n${GREEN}=== $1 ===${NC}"
}

# Configuration - Auto-detected with overrides
# You can override these by setting environment variables before running the script
# Example: AWS_REGION=us-west-2 AWS_PROFILE=my-profile ./qa-irsa-setup.sh

# Get AWS profile from user if not set
if [ -z "${AWS_PROFILE}" ]; then
    echo ""
    read -p "Enter your AWS profile name: " AWS_PROFILE
    export AWS_PROFILE
    echo ""
fi

# Check if already authenticated
export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --profile ${AWS_PROFILE} --query Account --output text 2>/dev/null)

# If not authenticated, run SSO login
if [ -z "${AWS_ACCOUNT_ID}" ] || [ "${AWS_ACCOUNT_ID}" == "None" ]; then
    log_info "Authenticating with AWS SSO..."
    aws sso login --profile ${AWS_PROFILE}

    # Verify authentication worked
    export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --profile ${AWS_PROFILE} --query Account --output text 2>/dev/null)

    if [ -z "${AWS_ACCOUNT_ID}" ] || [ "${AWS_ACCOUNT_ID}" == "None" ]; then
        log_error "Authentication failed. Please check your AWS profile configuration."
        exit 1
    fi
fi

# Use AWS_REGION from environment, AWS config, or default to us-east-1
export AWS_REGION=${AWS_REGION:-$(aws configure get region --profile ${AWS_PROFILE} 2>/dev/null || echo "us-east-1")}

# Cluster and image names (can override via environment)
export CLUSTER_NAME=${CLUSTER_NAME:-irsa-agent-qa}
export IMAGE_NAME=${IMAGE_NAME:-irsa-agent-qa}

# Derived values
export ECR_REGISTRY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
export IMAGE_TAG="latest-irsa-qa-$(git rev-parse --short HEAD)"
export FULL_IMAGE="${ECR_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}"

log_info "Using AWS Profile: ${AWS_PROFILE}"
log_info "AWS Account ID: ${AWS_ACCOUNT_ID}"
log_info "AWS Region: ${AWS_REGION}"

# Check prerequisites
check_prerequisites() {
    log_info "Checking prerequisites..."

    command -v aws >/dev/null 2>&1 || { log_error "aws CLI is required but not installed."; exit 1; }
    command -v eksctl >/dev/null 2>&1 || { log_error "eksctl is required but not installed."; exit 1; }
    command -v kubectl >/dev/null 2>&1 || { log_error "kubectl is required but not installed."; exit 1; }
    command -v docker >/dev/null 2>&1 || { log_error "docker is required but not installed."; exit 1; }
    command -v dda >/dev/null 2>&1 || { log_error "dda is required but not installed."; exit 1; }

    log_info "All prerequisites are installed."
}

# Fixed hacky build - handles Python path issues
fixed_hacky_build() {
    local IMAGE_TAG="$1"

    log_info "Extracting Python from base image..."
    TEMP_DIR=$(mktemp -d)
    docker run --platform linux/arm64 --rm datadog/agent:7 bash -c 'tar --create /opt/datadog-agent/embedded/{bin,lib,include}/*python*' | tar --directory "$TEMP_DIR" --extract

    log_info "Building agent with extracted Python..."
    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$TEMP_DIR/opt/datadog-agent/embedded/lib"
    export DELVE=1

    # Clean everything
    rm -rf rtloader/build dev/lib dev/include bin/agent/agent

    # Build with cmake options pointing to extracted Python
    # Build for native architecture (ARM64)
    dda inv agent.build \
        --build-exclude=systemd \
        --development \
        --cmake-options="-DPython3_ROOT_DIR=$TEMP_DIR/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION"

    log_info "Checking what path is in the .so..."
    ACTUAL_PATH=$(strings dev/lib/libdatadog-agent-three.so | grep "python.*\.\.$" | head -1)
    log_info "Found path in .so: $ACTUAL_PATH"

    if echo "$ACTUAL_PATH" | grep -q "/tmp/"; then
        log_info "Path is from extracted Python, need to fix tmp path"
        PERL_PATTERN="/tmp/[^/]+/opt/datadog-agent/embedded(/lib/python\d+\.\d+/../..)"
    else
        log_info "Path is from system Python, need to replace it"
        # The actual path is like: /root/miniforge3/envs/ddpy3/lib/python3.12/../..
        # We want to replace it with: /opt/datadog-agent/embedded/lib/python3.12/../..
        PERL_PATTERN="/root/miniforge3/envs/[^/]+(/lib/python\d+\.\d+/../..)"
    fi

    log_info "Patching .so file with pattern: $PERL_PATTERN"
    perl -0777 -pe "s|$PERL_PATTERN|substr '/opt/datadog-agent/embedded' . \$1 . \"\\0\"x(length(\$&)-length('/opt/datadog-agent/embedded')-length(\$1)),0,length(\$&)|e or die 'pattern not found'" -i dev/lib/libdatadog-agent-three.so

    log_info "Verifying patch..."
    strings dev/lib/libdatadog-agent-three.so | grep "python.*\.\.$"

    log_info "Building Docker image..."
    cat > /tmp/Dockerfile.irsa-test <<EOF
FROM datadog/agent:7

# Copy custom agent binary and libraries
COPY bin/agent/agent /opt/datadog-agent/bin/agent/agent
COPY dev/lib/libdatadog-agent-rtloader.so* /opt/datadog-agent/embedded/lib/
COPY dev/lib/libdatadog-agent-three.so /opt/datadog-agent/embedded/lib/

# Make binary executable and update library cache
RUN chmod +x /opt/datadog-agent/bin/agent/agent && \\
    ldconfig /opt/datadog-agent/embedded/lib
EOF

    docker build --platform linux/arm64 -f /tmp/Dockerfile.irsa-test -t "$IMAGE_TAG" .

    log_info "Pushing image..."
    docker push "$IMAGE_TAG"

    # Cleanup
    rm -rf "$TEMP_DIR" /tmp/Dockerfile.irsa-test

    log_info "Done! Image: $IMAGE_TAG"
}

# Build and push agent image
build_and_push_image() {
    log_info "Building and pushing agent image..."

    # Login to AWS (skip if already authenticated)
    log_info "Checking AWS authentication..."
    if aws sts get-caller-identity --profile ${AWS_PROFILE} >/dev/null 2>&1; then
        log_info "✓ Already authenticated to AWS"
    else
        log_info "Logging into AWS..."
        aws sso login --profile ${AWS_PROFILE}
    fi

    # Login to ECR
    log_info "Logging into ECR..."
    aws ecr get-login-password --region ${AWS_REGION} --profile ${AWS_PROFILE} | \
      docker login --username AWS --password-stdin ${ECR_REGISTRY}

    # Create ECR repository if it doesn't exist
    log_info "Checking ECR repository..."
    if aws ecr describe-repositories --repository-names ${IMAGE_NAME} --region ${AWS_REGION} --profile ${AWS_PROFILE} >/dev/null 2>&1; then
        log_info "✓ ECR repository already exists"
    else
        log_info "Creating ECR repository..."
        aws ecr create-repository --repository-name ${IMAGE_NAME} --region ${AWS_REGION} --profile ${AWS_PROFILE}
    fi

    # Check if image exists, if not build it
    log_info "Checking if image already exists in ECR..."
    if aws ecr describe-images \
        --repository-name ${IMAGE_NAME} \
        --image-ids imageTag=${IMAGE_TAG} \
        --region ${AWS_REGION} \
        --profile ${AWS_PROFILE} >/dev/null 2>&1; then
        log_info "✓ Image found in ECR: ${FULL_IMAGE}"
    else
        log_info "Image not found. Building now (this takes 10-15 minutes)..."

        # Login to ECR from dev shell
        log_info "Logging into ECR from dev shell..."
        ECR_PASSWORD=$(aws ecr get-login-password --region ${AWS_REGION} --profile ${AWS_PROFILE})
        dda env dev run --id aws -- bash -c "echo '${ECR_PASSWORD}' | docker login --username AWS --password-stdin ${ECR_REGISTRY}"

        # Ask user which build method to use (or use environment variable)
        if [ -z "${USE_FIX_SCRIPT}" ]; then
            log_warn "Choose build method:"
            echo "  1) Standard build"
            echo "  2) Fixed build"
            read -p "Enter choice (1 or 2) [default: 1]: " BUILD_CHOICE
            BUILD_CHOICE=${BUILD_CHOICE:-1}
        else
            BUILD_CHOICE=${USE_FIX_SCRIPT}
        fi

        if [ "${BUILD_CHOICE}" == "2" ]; then
            # Use fixed build that handles the Python path issue
            log_info "Building with fixed build (handles Python path issues)..."

            # Create a temporary script for the fixed build (in repo dir so it's accessible in dev env)
            cat > .fixed-hacky-build-temp.sh <<'EOFSCRIPT'
#!/bin/bash
set -e

IMAGE_TAG="$1"

echo "[INFO] Extracting Python from base image..."
TEMP_DIR=$(mktemp -d)
docker run --platform linux/arm64 --rm datadog/agent:7 bash -c 'tar --create /opt/datadog-agent/embedded/{bin,lib,include}/*python*' | tar --directory "$TEMP_DIR" --extract

echo "[INFO] Building agent with extracted Python..."
export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$TEMP_DIR/opt/datadog-agent/embedded/lib"
export DELVE=1

rm -rf rtloader/build dev/lib dev/include bin/agent/agent

dda inv agent.build \
    --build-exclude=systemd \
    --development \
    --cmake-options="-DPython3_ROOT_DIR=$TEMP_DIR/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION"

echo "[INFO] Checking what path is in the .so..."
ACTUAL_PATH=$(strings dev/lib/libdatadog-agent-three.so | grep "python.*\.\.$" | head -1)
echo "Found path in .so: $ACTUAL_PATH"

if echo "$ACTUAL_PATH" | grep -q "/tmp/"; then
    echo "[INFO] Path is from extracted Python, need to fix tmp path"
    PERL_PATTERN="/tmp/[^/]+/opt/datadog-agent/embedded(/lib/python\d+\.\d+/../..)"
else
    echo "[INFO] Path is from system Python, need to replace it"
    PERL_PATTERN="/root/miniforge3/envs/[^/]+(/lib/python\d+\.\d+/../..)"
fi

echo "[INFO] Patching .so file with pattern: $PERL_PATTERN"
perl -0777 -pe "s|\$PERL_PATTERN|substr '/opt/datadog-agent/embedded' . \$1 . \"\\0\"x(length(\$&)-length('/opt/datadog-agent/embedded')-length(\$1)),0,length(\$&)|e or die 'pattern not found'" -i dev/lib/libdatadog-agent-three.so

echo "[INFO] Verifying patch..."
strings dev/lib/libdatadog-agent-three.so | grep "python.*\.\.$"

echo "[INFO] Building Docker image..."
cat > /tmp/Dockerfile.irsa-test <<EOF
FROM datadog/agent:7

# Copy custom agent binary and libraries
COPY bin/agent/agent /opt/datadog-agent/bin/agent/agent
COPY dev/lib/libdatadog-agent-rtloader.so* /opt/datadog-agent/embedded/lib/
COPY dev/lib/libdatadog-agent-three.so /opt/datadog-agent/embedded/lib/

# Make binary executable and update library cache
RUN chmod +x /opt/datadog-agent/bin/agent/agent && \\
    ldconfig /opt/datadog-agent/embedded/lib
EOF

docker build --platform linux/arm64 -f /tmp/Dockerfile.irsa-test -t "$IMAGE_TAG" .

echo "[INFO] Pushing image..."
docker push "$IMAGE_TAG"

rm -rf "$TEMP_DIR" /tmp/Dockerfile.irsa-test

echo "[INFO] Done! Image: $IMAGE_TAG"
EOFSCRIPT

            chmod +x .fixed-hacky-build-temp.sh
            dda env dev run --id aws -- bash .fixed-hacky-build-temp.sh ${FULL_IMAGE}
            rm .fixed-hacky-build-temp.sh
        else
            # Use standard hacky-dev-image-build
            log_info "Building with standard agent.hacky-dev-image-build..."
            dda env dev run --id aws -- bash -c "dda inv agent.build --build-exclude=systemd --development && dda inv -e agent.hacky-dev-image-build --base-image=datadog/agent:7 --target-image=${FULL_IMAGE} --push"
        fi

        log_info "✓ Image built and pushed: ${FULL_IMAGE}"
    fi
}

# Create EKS cluster
create_eks_cluster() {
    # Check if cluster already exists
    if eksctl get cluster --name ${CLUSTER_NAME} --region ${AWS_REGION} --profile ${AWS_PROFILE} >/dev/null 2>&1; then
        log_info "✓ Cluster ${CLUSTER_NAME} already exists, skipping creation"
        return 0
    fi

    log_info "Creating ARM64 EKS cluster (this will take ~15-20 minutes)..."

    eksctl create cluster \
      --name ${CLUSTER_NAME} \
      --region ${AWS_REGION} \
      --node-type t4g.medium \
      --nodes 2 \
      --nodes-min 1 \
      --nodes-max 3 \
      --with-oidc \
      --profile ${AWS_PROFILE}

    log_info "EKS cluster created successfully."
}

# Setup IRSA
setup_irsa() {
    log_info "Setting up IRSA..."

    # Create IAM policy
    log_info "Creating IAM policy..."
    cat > /tmp/ec2-tags-policy.json <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "ec2:DescribeTags",
        "ec2:DescribeInstances"
      ],
      "Resource": "*"
    }
  ]
}
EOF

    # Try to create policy, or get existing one
    set +e  # Temporarily disable exit on error
    POLICY_ARN=$(aws iam create-policy \
      --policy-name DatadogAgentEC2TagsPolicy-${CLUSTER_NAME} \
      --policy-document file:///tmp/ec2-tags-policy.json \
      --profile ${AWS_PROFILE} \
      --query 'Policy.Arn' \
      --output text 2>/dev/null)
    CREATE_EXIT_CODE=$?
    set -e  # Re-enable exit on error

    if [ $CREATE_EXIT_CODE -eq 0 ] && [ -n "${POLICY_ARN}" ]; then
        log_info "Created new IAM policy"
    else
        log_info "Policy already exists, fetching ARN..."
        POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='DatadogAgentEC2TagsPolicy-${CLUSTER_NAME}'].Arn" --output text --profile ${AWS_PROFILE})
    fi

    export POLICY_ARN
    log_info "Policy ARN: ${POLICY_ARN}"

    # Create IAM service account
    log_info "Creating IAM service account with IRSA..."

    # Check if service account already exists with IRSA annotation
    EXISTING_SA_ROLE=$(kubectl get serviceaccount datadog-agent -n default -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}' 2>/dev/null || echo "")

    if [ -n "${EXISTING_SA_ROLE}" ]; then
        log_info "✓ Service account already exists with IRSA role: ${EXISTING_SA_ROLE}"
        export IRSA_ROLE_ARN="${EXISTING_SA_ROLE}"
    else
        log_info "Creating new IAM service account..."
        eksctl create iamserviceaccount \
          --name datadog-agent \
          --namespace default \
          --cluster ${CLUSTER_NAME} \
          --region ${AWS_REGION} \
          --attach-policy-arn ${POLICY_ARN} \
          --approve \
          --override-existing-serviceaccounts \
          --profile ${AWS_PROFILE}

        export IRSA_ROLE_ARN=$(kubectl get serviceaccount datadog-agent -n default -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}')
        log_info "IRSA Role ARN: ${IRSA_ROLE_ARN}"
    fi

    # Verify setup
    log_info "Verifying IRSA setup..."
    kubectl describe serviceaccount datadog-agent -n default
}

# Deploy agent
deploy_agent() {
    log_info "Deploying Datadog Agent..."

    # Create secret
    log_info "Creating Datadog secret..."
    kubectl create secret generic datadog-secret \
      --from-literal api-key=0000001 \
      --namespace default \
      --dry-run=client -o yaml | kubectl apply -f -

    # Create agent deployment
    log_info "Creating agent DaemonSet..."
    cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: ConfigMap
metadata:
  name: datadog-agent-config
  namespace: default
data:
  datadog.yaml: |
    api_key: 0000001
    log_level: debug
    collect_ec2_tags: true
    collect_ec2_tags_use_imds: false
    ec2_metadata_timeout: 5000
---
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: datadog-agent
  namespace: default
spec:
  selector:
    matchLabels:
      app: datadog-agent
  template:
    metadata:
      labels:
        app: datadog-agent
    spec:
      serviceAccountName: datadog-agent
      containers:
      - name: agent
        image: ${FULL_IMAGE}
        imagePullPolicy: Always
        env:
        - name: DD_API_KEY
          valueFrom:
            secretKeyRef:
              name: datadog-secret
              key: api-key
        - name: DD_LOG_LEVEL
          value: "debug"
        - name: DD_COLLECT_EC2_TAGS
          value: "true"
        - name: DD_COLLECT_EC2_TAGS_USE_IMDS
          value: "false"
        - name: DD_KUBERNETES_KUBELET_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_KUBERNETES_COLLECT_METADATA_TAGS
          value: "true"
        - name: KUBERNETES
          value: "true"
        - name: DD_HOSTNAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        volumeMounts:
        - name: config
          mountPath: /etc/datadog-agent/datadog.yaml
          subPath: datadog.yaml
        securityContext:
          capabilities:
            add:
            - SYS_ADMIN
            - SYS_RESOURCE
            - SYS_PTRACE
            - NET_ADMIN
            - NET_BROADCAST
            - NET_RAW
            - IPC_LOCK
            - CHOWN
      volumes:
      - name: config
        configMap:
          name: datadog-agent-config
EOF

    # Restart DaemonSet to ensure new image is used
    log_info "Restarting DaemonSet to ensure new image is used..."
    kubectl rollout restart daemonset/datadog-agent -n default 2>/dev/null || log_warn "DaemonSet not found, will be created fresh"

    # Wait for pod
    log_info "Waiting for agent pod to be ready..."
    sleep 10
    kubectl wait --for=condition=ready pod -l app=datadog-agent --timeout=180s -n default || true

    export POD_NAME=$(kubectl get pods -l app=datadog-agent -n default -o jsonpath='{.items[0].metadata.name}')
    if [ -n "${POD_NAME}" ]; then
        log_info "Agent pod: ${POD_NAME}"
    else
        log_warn "No pod found yet, may still be starting..."
    fi
}

# Comprehensive IRSA verification (8 checks)
verify_irsa() {
    log_section "IRSA Verification"

    # Track overall success
    local ALL_CHECKS_PASSED=true

    # Get pod name
    local POD_NAME=$(kubectl get pods -l app=datadog-agent -n default -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)

    if [ -z "${POD_NAME}" ]; then
        log_fail "No agent pod found! Is the agent deployed?"
        return 1
    fi

    log_info "Found agent pod: ${POD_NAME}"

    # Check 1: Pod Status
    log_section "Check 1: Pod Status"
    local POD_STATUS=$(kubectl get pod ${POD_NAME} -n default -o jsonpath='{.status.phase}' 2>/dev/null)
    if [ "${POD_STATUS}" == "Running" ]; then
        log_pass "Pod is running"
    else
        log_fail "Pod status is: ${POD_STATUS}"
        ALL_CHECKS_PASSED=false
    fi

    # Wait for agent to be ready
    log_info "Waiting 5 seconds for agent to stabilize..."
    sleep 5

    # Check 2: IRSA Environment Variables
    log_section "Check 2: IRSA Environment Variables"
    if kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep -q "AWS_ROLE_ARN"; then
        local ROLE_ARN=$(kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep "AWS_ROLE_ARN" | cut -d'=' -f2)
        log_pass "AWS_ROLE_ARN is set"
        echo "       ${CYAN}${ROLE_ARN}${NC}"
    else
        log_fail "AWS_ROLE_ARN is NOT set - IRSA not configured!"
        ALL_CHECKS_PASSED=false
    fi

    if kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep -q "AWS_WEB_IDENTITY_TOKEN_FILE"; then
        local TOKEN_FILE=$(kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep "AWS_WEB_IDENTITY_TOKEN_FILE" | cut -d'=' -f2)
        log_pass "AWS_WEB_IDENTITY_TOKEN_FILE is set"
        echo "       ${CYAN}${TOKEN_FILE}${NC}"
    else
        log_fail "AWS_WEB_IDENTITY_TOKEN_FILE is NOT set - IRSA not configured!"
        ALL_CHECKS_PASSED=false
    fi

    if kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep -q "AWS_REGION"; then
        local REGION=$(kubectl exec ${POD_NAME} -n default -- env 2>/dev/null | grep "AWS_REGION" | cut -d'=' -f2)
        log_pass "AWS_REGION is set: ${REGION}"
    else
        log_warn "AWS_REGION is not set (may use default)"
    fi

    # Check 3: Service Account IRSA Annotation
    log_section "Check 3: Service Account IRSA Annotation"
    local SA_ANNOTATION=$(kubectl get serviceaccount datadog-agent -n default -o jsonpath='{.metadata.annotations.eks\.amazonaws\.com/role-arn}' 2>/dev/null)
    if [ -n "${SA_ANNOTATION}" ]; then
        log_pass "Service account has IRSA annotation"
        echo "       ${CYAN}${SA_ANNOTATION}${NC}"
    else
        log_fail "Service account does NOT have IRSA annotation!"
        ALL_CHECKS_PASSED=false
    fi

    # Check 4: IRSA Token File
    log_section "Check 4: IRSA Token File"
    if kubectl exec ${POD_NAME} -n default -- test -f /var/run/secrets/eks.amazonaws.com/serviceaccount/token 2>/dev/null; then
        log_pass "IRSA token file exists in pod"
        local TOKEN_CONTENT=$(kubectl exec ${POD_NAME} -n default -- cat /var/run/secrets/eks.amazonaws.com/serviceaccount/token 2>/dev/null | head -c 50)
        log_info "Token preview: ${TOKEN_CONTENT}..."
    else
        log_fail "IRSA token file does NOT exist in pod!"
        ALL_CHECKS_PASSED=false
    fi

    # Check 5: Agent Logs - No Fallback
    log_section "Check 5: Credential Chain (No Fallback)"
    local FALLBACK_COUNT=$(kubectl logs ${POD_NAME} -n default 2>/dev/null | grep "unable to create EC2 client with default credentials" | wc -l | tr -d ' ')
    if [ "${FALLBACK_COUNT}" -eq "0" ]; then
        log_pass "No fallback to instance profile detected"
        log_info "Agent is using IRSA credentials successfully"
    else
        log_fail "Detected ${FALLBACK_COUNT} fallback(s) to instance profile!"
        log_warn "Showing fallback log lines:"
        kubectl logs ${POD_NAME} -n default 2>/dev/null | grep "unable to create EC2 client with default credentials" | head -5
        ALL_CHECKS_PASSED=false
    fi

    # Check 6: EC2 Tags in Agent Status (THE KEY TEST)
    log_section "Check 6: EC2 Tags Collection (Key Test)"
    log_info "Fetching agent status to check EC2 tags..."
    local AGENT_STATUS=$(kubectl exec ${POD_NAME} -n default -- agent status 2>&1)

    # Extract host tags section
    local EC2_TAGS=$(echo "$AGENT_STATUS" | grep -A 50 "host tags:" | grep -E "aws:|eks:|Name:" | head -10)

    if [ -n "${EC2_TAGS}" ]; then
        log_pass "EC2 tags successfully fetched via IRSA!"
        echo ""
        echo "${CYAN}Sample EC2 tags found:${NC}"
        echo "${EC2_TAGS}" | head -5 | while IFS= read -r line; do
            echo "       ${line}"
        done
        echo ""

        # Check for specific AWS tags that prove EC2 API was called
        if echo "$EC2_TAGS" | grep -q "aws:"; then
            log_pass "AWS-specific tags present (proves EC2 API access)"
        fi

        # Extract instance ID
        local INSTANCE_ID=$(echo "$AGENT_STATUS" | grep "instance-id:" | awk '{print $2}')
        if [ -n "${INSTANCE_ID}" ]; then
            log_pass "Instance ID detected: ${INSTANCE_ID}"
        fi
    else
        log_fail "No EC2 tags found in agent status!"
        log_warn "This may indicate IRSA credentials are not working"
        ALL_CHECKS_PASSED=false
    fi

    # Check 7: No AWS Credential Errors in Logs
    log_section "Check 7: No AWS Credential Errors"
    local ERROR_COUNT=$(kubectl logs ${POD_NAME} -n default 2>/dev/null | grep -iE "error.*(credential|iam|sts|assume.*role|ec2.*tag|access.*denied)" | grep -iE "(aws|ec2)" | wc -l | tr -d ' ')
    if [ "${ERROR_COUNT}" -eq "0" ]; then
        log_pass "No AWS credential errors found"
    else
        log_warn "Found ${ERROR_COUNT} AWS credential error(s):"
        kubectl logs ${POD_NAME} -n default 2>/dev/null | grep -iE "error.*(credential|iam|sts|assume.*role|ec2.*tag|access.*denied)" | grep -iE "(aws|ec2)" | tail -5
    fi

    # Check 8: Agent Binary Architecture
    log_section "Check 8: Binary Architecture Match"
    local NODE_ARCH=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')
    log_info "Node architecture: ${NODE_ARCH}"
    if [ "${NODE_ARCH}" == "arm64" ]; then
        log_pass "Running on ARM64 nodes (Graviton)"
    elif [ "${NODE_ARCH}" == "amd64" ]; then
        log_pass "Running on x86_64 nodes"
    else
        log_warn "Unknown architecture: ${NODE_ARCH}"
    fi

    # Final Summary
    log_section "Final Summary"
    echo ""

    if [ "$ALL_CHECKS_PASSED" = true ] && [ -n "${EC2_TAGS}" ] && [ "${FALLBACK_COUNT}" -eq "0" ]; then
        echo -e "${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
        echo -e "${GREEN}║  ✓ IRSA QA VERIFICATION: SUCCESS                          ║${NC}"
        echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
    else
        echo -e "${RED}╔════════════════════════════════════════════════════════════╗${NC}"
        echo -e "${RED}║  ✗ IRSA QA VERIFICATION: ISSUES DETECTED                  ║${NC}"
        echo -e "${RED}╚════════════════════════════════════════════════════════════╝${NC}"
        echo ""
        log_warn "Review the checks above to identify issues"
    fi

    echo ""
    log_info "Full logs saved to /tmp/agent-logs-${POD_NAME}.txt"
    kubectl logs ${POD_NAME} -n default > /tmp/agent-logs-${POD_NAME}.txt 2>/dev/null

    log_info "Full agent status saved to /tmp/agent-status-${POD_NAME}.txt"
    kubectl exec ${POD_NAME} -n default -- agent status > /tmp/agent-status-${POD_NAME}.txt 2>&1

    # Return appropriate exit code
    if [ "$ALL_CHECKS_PASSED" = true ] && [ -n "${EC2_TAGS}" ] && [ "${FALLBACK_COUNT}" -eq "0" ]; then
        return 0
    else
        return 1
    fi
}

# Main execution
main() {
    log_info "Starting IRSA QA Setup"
    log_info "Cluster: ${CLUSTER_NAME}"
    log_info "Image: ${FULL_IMAGE}"
    echo ""

    # Phase 1: Verify image exists
    log_info "=== Phase 1: Verify Agent Image ==="
    build_and_push_image
    echo ""

    # Phase 2: Create EKS cluster
    log_info "=== Phase 2: Create EKS Cluster ==="
    create_eks_cluster
    echo ""

    # Phase 3: Setup IRSA
    log_info "=== Phase 3: Setup IRSA ==="
    setup_irsa
    echo ""

    # Phase 4: Deploy agent
    log_info "=== Phase 4: Deploy Agent ==="
    deploy_agent
    echo ""

    # Phase 5: Verify
    log_info "=== Phase 5: Verify IRSA ==="
    sleep 15  # Give agent time to start up

    if verify_irsa; then
        echo ""
        log_info "=== Setup Complete - Verification Passed! ==="
    else
        echo ""
        log_warn "=== Setup Complete - But Verification Found Issues ==="
        log_warn "Review the verification output above"
    fi
}

# Run main
check_prerequisites
main
```
</details>

<details>
<summary>cleanup script (generated by claude)</summary>

```
#!/bin/bash

# IRSA QA Cleanup Script
# This script cleans up all resources created during IRSA testing

# Colors for output
RED='\033[0;31m'
GREEN='\033[0;32m'
YELLOW='\033[1;33m'
NC='\033[0m' # No Color

# Logging functions
log_info() {
    echo -e "${GREEN}[INFO]${NC} $1"
}

log_warn() {
    echo -e "${YELLOW}[WARN]${NC} $1"
}

log_error() {
    echo -e "${RED}[ERROR]${NC} $1"
}

# Get AWS profile from user if not set
if [ -z "${AWS_PROFILE}" ]; then
    echo ""
    read -p "Enter your AWS profile name: " AWS_PROFILE
    export AWS_PROFILE
    echo ""
fi

# Check if already authenticated
export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --profile ${AWS_PROFILE} --query Account --output text 2>/dev/null)

# If not authenticated, run SSO login
if [ -z "${AWS_ACCOUNT_ID}" ] || [ "${AWS_ACCOUNT_ID}" == "None" ]; then
    log_info "Authenticating with AWS SSO..."
    aws sso login --profile ${AWS_PROFILE}

    export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --profile ${AWS_PROFILE} --query Account --output text 2>/dev/null)

    if [ -z "${AWS_ACCOUNT_ID}" ] || [ "${AWS_ACCOUNT_ID}" == "None" ]; then
        log_error "Authentication failed."
        exit 1
    fi
fi

# Use AWS_REGION from environment, AWS config, or default to us-east-1
export AWS_REGION=${AWS_REGION:-$(aws configure get region --profile ${AWS_PROFILE} 2>/dev/null || echo "us-east-1")}

# Cluster and image names (can override via environment)
export CLUSTER_NAME=${CLUSTER_NAME:-irsa-agent-qa}
export IMAGE_NAME=${IMAGE_NAME:-irsa-agent-qa}

log_info "Using AWS Profile: ${AWS_PROFILE}"
log_info "AWS Region: ${AWS_REGION}"
log_info "Cluster: ${CLUSTER_NAME}"

cleanup_k8s_resources() {
    kubectl delete daemonset datadog-agent -n default 2>/dev/null || true
    kubectl delete configmap datadog-agent-config -n default 2>/dev/null || true
    kubectl delete secret datadog-secret -n default 2>/dev/null || true
    # Note: ServiceAccount is deleted by eksctl delete iamserviceaccount
    # But delete explicitly in case IRSA cleanup fails
    kubectl delete serviceaccount datadog-agent -n default 2>/dev/null || true
}

cleanup_irsa() {
    # Delete IAM service account
    eksctl delete iamserviceaccount \
      --name datadog-agent \
      --namespace default \
      --cluster ${CLUSTER_NAME} \
      --region ${AWS_REGION} \
      --profile ${AWS_PROFILE} 2>/dev/null || true

    # Delete IAM policy
    POLICY_ARN=$(aws iam list-policies \
      --query "Policies[?PolicyName=='DatadogAgentEC2TagsPolicy-${CLUSTER_NAME}'].Arn" \
      --output text \
      --profile ${AWS_PROFILE} 2>/dev/null)

    if [ -n "${POLICY_ARN}" ]; then
        aws iam delete-policy --policy-arn ${POLICY_ARN} --profile ${AWS_PROFILE} 2>/dev/null || true
    fi
}

cleanup_eks_cluster() {
    eksctl delete cluster \
      --name ${CLUSTER_NAME} \
      --region ${AWS_REGION} \
      --profile ${AWS_PROFILE}
}

cleanup_ecr_repository() {
    read -p "Delete ECR repository? (y/N): " response
    if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
        log_info "Deleting ECR repository..."
        aws ecr delete-repository \
          --repository-name ${IMAGE_NAME} \
          --region ${AWS_REGION} \
          --force \
          --profile ${AWS_PROFILE} 2>/dev/null || true
    fi
}

main() {
    log_info "Starting IRSA QA Cleanup"
    echo ""

    # Check if cluster exists
    log_info "Checking for cluster: ${CLUSTER_NAME} in ${AWS_REGION}..."
    if eksctl get cluster --name ${CLUSTER_NAME} --region ${AWS_REGION} --profile ${AWS_PROFILE} >/dev/null 2>&1; then
        CLUSTER_EXISTS="yes"
    else
        CLUSTER_EXISTS="no"
    fi

    if [ "$CLUSTER_EXISTS" == "yes" ]; then
        log_info "✓ Cluster found"
        log_warn "This will delete: K8s resources, IAM role/policy, EKS cluster"
    else
        log_warn "Cluster not found"
        log_info "Will clean up: IAM policy, ECR repository"
        log_info "If cluster exists in a different region, cancel and specify: AWS_REGION=<region> ./qa-irsa-cleanup.sh"
    fi

    read -p "Continue? (yes/no): " response
    if [[ ! "$response" =~ ^([yY][eE][sS])$ ]]; then
        log_info "Cleanup cancelled."
        exit 0
    fi

    if [ "$CLUSTER_EXISTS" == "yes" ]; then
        echo ""
        log_info "Cleaning up Kubernetes resources..."
        cleanup_k8s_resources

        echo ""
        log_info "Cleaning up IRSA resources..."
        cleanup_irsa

        echo ""
        log_info "Deleting EKS cluster..."
        cleanup_eks_cluster
    else
        echo ""
        log_info "Cleaning up IRSA resources (cluster not found)..."
        # Delete IAM policy even if cluster is gone
        POLICY_ARN=$(aws iam list-policies \
          --query "Policies[?PolicyName=='DatadogAgentEC2TagsPolicy-${CLUSTER_NAME}'].Arn" \
          --output text \
          --profile ${AWS_PROFILE} 2>/dev/null)

        if [ -n "${POLICY_ARN}" ]; then
            log_info "Deleting IAM policy: ${POLICY_ARN}"
            aws iam delete-policy --policy-arn ${POLICY_ARN} --profile ${AWS_PROFILE} 2>/dev/null || true
        fi
    fi

    echo ""
    cleanup_ecr_repository

    echo ""
    log_info "Cleanup complete!"
}

# Run main
main
```
</details>

