### PR TITLE
[ABLD-351] Remove the //compliance:licenses target and move its remnants to //packages/install_dir

### DIFF
--- a/compliance/BUILD.bazel
+++ b/compliance/BUILD.bazel
@@ -1,7 +1,4 @@
-load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "filter_directory", "pkg_files")
 load("@rules_python//python:py_binary.bzl", "py_binary")
-load("//compliance:license_csv.bzl", "license_csv")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,82 +7,4 @@ py_binary(
     srcs = ["gather_licenses.py"],
     visibility = ["//visibility:private"],
     deps = ["//tasks:licenses"],
-)
-
-filegroup(
-    name = "all_agent_deps",
-    srcs = [
-        "//deps:all_deps",
-    ] + select({
-        "//packages/agent:linux_heroku": [],
-        "//conditions:default": [
-            # This will become "//deps/openscap:all_deps" in the future
-            "@popt",
-        ],
-    }),
-)
-
-# Gather the licenses for dependencies that not built by omnibus any more.
-# The target is a temporary hack. In the future, it should become //distrib:agent.
-license_csv(
-    name = "licenses",
-    csv_out = "licenses.csv",
-    licenses_dir = "licenses_dir",
-    offers_dir = "sources_dir",
-    tags = ["manual"],
-    target = ":all_agent_deps",
-)
-
-# Turn the copied licenses into a target we can feed to other rules.
-filegroup(
-    name = "copied_license_dir",
-    srcs = [":licenses"],
-    output_group = "licenses",
-)
-
-# This silliness is to strip the directory name of the license
-# TreeArtifact.
-filter_directory(
-    name = "license_dir_stripped",
-    src = ":copied_license_dir",
-    outdir_name = "LICENSES",
-    strip_prefix = ".",
-)
-
-# You would expect that filter_directory returns something usuable to pkg_* rules.
-# It does not, so we have to wrap it.
-pkg_files(
-    name = "license_copies",
-    srcs = [":license_dir_stripped"],
-)
-
-# Turn the copied offers into a target we can feed to other rules.
-filegroup(
-    name = "copied_offer_dir",
-    srcs = [":licenses"],
-    output_group = "offers",
-)
-
-# This silliness is to strip the directory name of the offer
-# TreeArtifact.
-filter_directory(
-    name = "offer_dir_stripped",
-    src = ":copied_offer_dir",
-    outdir_name = "sources",
-    strip_prefix = ".",
-)
-
-# You would expect that filter_directory returns something usable to pkg_* rules.
-# It does not, so we have to wrap it.
-pkg_files(
-    name = "offer_copies",
-    srcs = [":offer_dir_stripped"],
-)
-
-pkg_install(
-    name = "install_licenses",
-    srcs = [
-        ":license_copies",
-        ":offer_copies",
-    ],
 )

--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -12,13 +12,17 @@ filegroup(
         "@bzip2//:bz2",
         "@libffi//:ffi",
         "@libyaml",
-        "@lua//:liblua",
         "@patchelf",
         "@sqlite3",
         "@xz//:lzma",
         "@zlib//:z",
     ] + select({
-        "@platforms//os:linux": [
+        "//packages/agent:linux_default": [
+            "@gpg-error",
+            "@lua//:liblua",
+            "@nghttp2",
+        ],
+        "//packages/agent:linux_heroku": [
             "@gpg-error",
             "@nghttp2",
         ],

--- a/packages/agent/BUILD.bazel
+++ b/packages/agent/BUILD.bazel
@@ -43,3 +43,11 @@ selects.config_setting_group(
         "@platforms//os:linux",
     ],
 )
+
+selects.config_setting_group(
+    name = "linux_default",
+    match_all = [
+        ":base_flavor",
+        "@platforms//os:linux",
+    ],
+)

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//compliance:package_licenses.bzl", "package_licenses")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -7,26 +8,40 @@ pkg_filegroup(
     name = "embedded",
     srcs = [
         "//deps/gstatus:bin_files",
+        # have to include this explicitly because it is not hooked up with package_metadata
+        "//deps/gstatus:license_file",
     ] + select({
         "@platforms//os:linux": [
             "//deps/compile_policy:bin_files",
+            # have to include this explicitly because it is not hooked up with package_metadata
+            "//deps/compile_policy:license_file",
         ],
         "//conditions:default": [],
     }),
 )
 
-pkg_filegroup(
-    name = "licenses",
+# This is a placeholder for an eventual group containg (the future) top level binaries
+# such as //cmd/agent:agent
+filegroup(
+    name = "all_deps",
     srcs = [
-        "//compliance:license_copies",
-        "//compliance:offer_copies",
-        "//deps/gstatus:license_file",
+        "//deps:all_deps",
     ] + select({
-        "@platforms//os:linux": [
-            "//deps/compile_policy:license_file",
+        "//packages/agent:linux_heroku": [],
+        "//packages/agent:linux_default": [
+            "//deps/openscap:all_deps",
         ],
-        "//conditions:default": [],
+        "//conditions:default": [
+            # This will become "//deps/openscap:all_deps" in the future
+            "@popt",
+        ],
     }),
+)
+
+# Walk the graph of all depths to collect license info.
+package_licenses(
+    name = "license_files",
+    src = ":all_deps",
 )
 
 # All the things that belong in /etc
@@ -49,7 +64,7 @@ pkg_install(
     srcs = [
         ":embedded",
         ":etc",
-        ":licenses",
+        ":license_files",
     ],
     destdir_flag = "//:install_dir",
 )


### PR DESCRIPTION
Remove the //compliance:licenses target and move its remnants to //packages/install_dir

Last month we added a macro to replace the complex chain of targets need to run the license gather aspect to build the set of license files. It is used in //packages/agent/linux and //packages/agent/heroku.  This change applies the same macro to //packages/install_dir.

This is only an interim cleanup.  As we create the top level targets for each package, we'll apply the same pattern at those target points and stop gathering licenses in //packages/install_dir. The cleanup now will make future changes easier to reason about.

Related change: Fix //deps:all_deps to reflect the difference between plain and heroku versions. We were including too much in all_deps, resulting in false license declarations in the heroku build. This is also only an interim cleanup. We will eventually move the deps into the openscap build file and not need them in all_deps. 

## test plan
```
On main:
$ bazelisk run --//:install_dir=/tmp/l.1 -- //packages/install_dir:install

On PR
$ bazelisk run --//:install_dir=/tmp/l.2 -- //packages/install_dir:install
$ diff -r /tmp/l.1 /tmp/l.2
Only in /tmp/l.2/LICENSES: acl-COPYING.LGPL
Only in /tmp/l.2/LICENSES: attr-COPYING.LGPL
Only in /tmp/l.2/LICENSES: gcrypt-COPYING.LIB
Only in /tmp/l.2/LICENSES: libpcap-LICENSE
Only in /tmp/l.2/LICENSES: libsepol-LICENSE
Only in /tmp/l.2/LICENSES: openscap-COPYING
Only in /tmp/l.2/sources: acl
Only in /tmp/l.2/sources: attr
Only in /tmp/l.2/sources: libsepol
```
This shows that we retained all the old licenses from before this PR, and have correctly included the ones we use for openscap on this linux test. On macos, we do not see the openscap additions.