### PR TITLE
[AGENTCFG-314] UnsetForSource doesn't clone, fix flakey test

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -352,7 +352,7 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	}
 
 	// Replace the child with the node from the previous layer
-	parentNode.InsertChildNode(childName, prevNode.Clone())
+	parentNode.InsertChildNode(childName, prevNode)
 
 	newValue := c.leafAtPathFromNode(key, c.root).Get()
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1296,7 +1296,7 @@ tree(#ptr<000014>) source=environment-variable
   > collector
     inner(#ptr<000002>)
     > input_chan_size
-        leaf(#ptr<000017>), val:100000, source:default
+        leaf(#ptr<000009>), val:100000, source:default
     > pathtest_contexts_limit
         leaf(#ptr<000004>), val:100000, source:default
     > processing_chan_size

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1101,13 +1101,13 @@ func TestUnsetForSource(t *testing.T) {
 
 	// [AGENTCFG-314] Prevent the test from being flakey.
 	// This keeps a reference to the node for `input_chan_size`, which helps prevent
-	// an edge case that can cause this test to fail on rare occassions.
+	// an edge case that can cause this test to fail on rare occasions.
 	// Because UnsetForSource removes nodes, and we allocate more nodes later in this
 	// test, if the GC timing is right, it's possible that a future node reuses the
 	// same address as this node. Since the Stringifier caches node addresses in order
 	// to determine their unique ID, this address reuse would cause it to get confused
 	// and reuse the ID of `input_chan_size`. By holding this reference we prevent the
-	// reuse of this node's address, and prevent this edge case from occuring.
+	// reuse of this node's address, and prevent this edge case from occurring.
 	var keepNode Node
 	if ncfg, ok := cfg.(NodeTreeConfig); ok {
 		keepNode, _ = ncfg.GetNode("network_path.collector.input_chan_size")

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1099,6 +1099,21 @@ func TestUnsetForSource(t *testing.T) {
         leaf(#ptr<000006>), val:6, source:file`
 	assert.Equal(t, expect, txt)
 
+	// [AGENTCFG-314] Prevent the test from being flakey.
+	// This keeps a reference to the node for `input_chan_size`, which helps prevent
+	// an edge case that can cause this test to fail on rare occassions.
+	// Because UnsetForSource removes nodes, and we allocate more nodes later in this
+	// test, if the GC timing is right, it's possible that a future node reuses the
+	// same address as this node. Since the Stringifier caches node addresses in order
+	// to determine their unique ID, this address reuse would cause it to get confused
+	// and reuse the ID of `input_chan_size`. By holding this reference we prevent the
+	// reuse of this node's address, and prevent this edge case from occuring.
+	var keepNode Node
+	if ncfg, ok := cfg.(NodeTreeConfig); ok {
+		keepNode, _ = ncfg.GetNode("network_path.collector.input_chan_size")
+	}
+	assert.NotNil(t, keepNode)
+
 	// No change if source doesn't match
 	cfg.UnsetForSource("network_path.collector.input_chan_size", model.SourceFile)
 	assert.Equal(t, expect, txt)

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -241,19 +241,6 @@ func (n *nodeImpl) dumpSettings(includeDefaults bool) map[string]interface{} {
 	return res
 }
 
-// Clone clones a LeafNode
-func (n *nodeImpl) Clone() *nodeImpl {
-	if n.IsLeafNode() {
-		return newLeafNode(n.val, n.source)
-	}
-
-	children := make(map[string]*nodeImpl)
-	for k, node := range n.children {
-		children[k] = node.Clone()
-	}
-	return newInnerNode(children)
-}
-
 // SourceGreaterThan returns true if the source of the current node is greater than the one given as a
 // parameter
 func (n *nodeImpl) SourceGreaterThan(source model.Source) bool {

--- a/pkg/config/nodetreemodel/node_ops_fuzz_test.go
+++ b/pkg/config/nodetreemodel/node_ops_fuzz_test.go
@@ -56,10 +56,6 @@ func FuzzNodeOps(f *testing.F) {
 			_, _ = child.GetChild("nonexistent")
 		}
 
-		// Clone and operate on the cloned node tree
-		cloned := root.Clone()
-		_ = cloned.ChildrenKeys()
-
 		_ = root.dumpSettings(true)
 
 		// Build a secondary tree using newNodeTree from a map and merge it


### PR DESCRIPTION
### What does this PR do?

In `UnsetForSource`, when inserting an older node into the merged tree, don't clone what is being added back. Also, fix flakey test `TestUnsetForSource` by holding a reference to the removed node (only needed to fix the behavior of `Stringify`).

### Motivation

General correctness of `UnsetForSource`.

### Describe how you validated your changes

Unit tests cover the behavior, and a comment describes why the test was flakey and why this fixes it.

### Additional Notes
