### PR TITLE
Introduce identity properties for `pkg/util/compression`

### DIFF
--- a/pkg/util/compression/impl-gzip/gzip_strategy_test.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package gzipimpl
+
+import (
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+// Asserts that b == decompress(compress(b)) for all b.
+func FuzzGzipIdentity(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	c := New(Requires{Level: gzip.BestSpeed})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress failed: %v", err)
+		}
+
+		if !bytes.Equal(data, decompressed) {
+			t.Errorf("Identity property violated: decompress(compress(b)) != b")
+		}
+	})
+}

--- a/pkg/util/compression/impl-zlib/zlib_strategy_test.go
+++ b/pkg/util/compression/impl-zlib/zlib_strategy_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package zlibimpl
+
+import (
+	"bytes"
+	"testing"
+)
+
+// Asserts that b == decompress(compress(b)) for all b.
+func FuzzZlibIdentity(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	c := New()
+	f.Fuzz(func(t *testing.T, data []byte) {
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress failed: %v", err)
+		}
+
+		if !bytes.Equal(data, decompressed) {
+			t.Errorf("Identity property violated: decompress(compress(b)) != b")
+		}
+	})
+}

--- a/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
+++ b/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package zstdimpl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/compression"
+)
+
+// Asserts that b == decompress(compress(b)) for all b.
+func FuzzZstdNoCgoIdentity(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	c := New(Requires{Level: compression.ZstdCompressionLevel(1)})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress failed: %v", err)
+		}
+
+		if !bytes.Equal(data, decompressed) {
+			t.Errorf("Identity property violated: decompress(compress(b)) != b")
+		}
+	})
+}

--- a/pkg/util/compression/impl-zstd/zstd_strategy_test.go
+++ b/pkg/util/compression/impl-zstd/zstd_strategy_test.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package zstdimpl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/compression"
+)
+
+// Asserts that b == decompress(compress(b)) for all b.
+func FuzzZstdIdentity(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	c := New(Requires{Level: compression.ZstdCompressionLevel(1)})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		decompressed, err := c.Decompress(compressed)
+		if err != nil {
+			t.Fatalf("Decompress failed: %v", err)
+		}
+
+		if !bytes.Equal(data, decompressed) {
+			t.Errorf("Identity property violated: decompress(compress(b)) != b")
+		}
+	})
+}


### PR DESCRIPTION
### What does this PR do?

I have introduced tests to confirm that for all the strategies
supported by this package less noop that:

- the identity `b == decompress(compress(b))` holds

### Motivation 

This commit is motivated by the potential end state in spike
PR #45519. That is, if we want to make non-trivial changes to
this package systematic testing of the package is warranted.


