### PR TITLE
See if we can hack a way around project.extra_package_file

### DIFF
--- a/omnibus/config/projects/ddot.rb
+++ b/omnibus/config/projects/ddot.rb
@@ -82,10 +82,11 @@ maintainer 'Datadog Packages <package@datadoghq.com>'
 # Dependencies
 # ------------------------------------
 if do_build
+  dependency 'init-scripts-ddot'
   dependency 'datadog-otel-agent'
 elsif do_package
-  dependency 'package-artifact'
   dependency 'init-scripts-ddot'
+  dependency 'package-artifact'
 end
 
 disable_version_manifest do_package

--- a/omnibus/config/software/init-scripts-ddot.rb
+++ b/omnibus/config/software/init-scripts-ddot.rb
@@ -7,8 +7,8 @@ always_build true
 build do
   # This is horrible.
   destdir = "/"
-  packager_input = ENV["OMNIBUS_PACKAGE_ARTIFACT_DIR"] || destdir
-  if linux_target? and packager_input != ""
+  packager_input = ENV["OMNIBUS_PACKAGE_ARTIFACT_DIR"] || ENV["OMNIBUS_PACKAGE_DIR"] || "/"
+  if linux_target? and packager_input != "" and packager_input != "/"
     if debian_target?
       command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/ddot/debian:hacky_packager_install --verbose --destdir=#{packager_input}", :live_stream => Omnibus.logger.live_stream(:info)
 

--- a/omnibus/config/software/init-scripts-ddot.rb
+++ b/omnibus/config/software/init-scripts-ddot.rb
@@ -7,15 +7,13 @@ always_build true
 build do
   # This is horrible.
   destdir = "/"
-  output_config_dir = ENV["OUTPUT_CONFIG_DIR"] || ""
-  if linux_target?
+  packager_input = ENV["OMNIBUS_PACKAGE_ARTIFACT_DIR"] || destdir
+  if linux_target? and packager_input != ""
     if debian_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/ddot/debian:hacky_packager_install --verbose --destdir=#{packager_input}", :live_stream => Omnibus.logger.live_stream(:info)
 
-      project.extra_package_file '/etc/init.d/datadog-agent-ddot'
-      project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     elsif redhat_target? || suse_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}"
 
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     end

--- a/omnibus/config/software/package-artifact.rb
+++ b/omnibus/config/software/package-artifact.rb
@@ -13,6 +13,7 @@ build do
   block "Extract intermediate build artifacts" do
     Dir.glob("*.tar.xz", base: input_dir).each do |input|
       path = File.join(input_dir, input)
+      shellout! "tar tvf #{path}", :live_stream => Omnibus.logger.live_stream(:info)
       shellout! "tar xf #{path} -C /"
       FileUtils.rm path
     end

--- a/packages/ddot/debian/BUILD.bazel
+++ b/packages/ddot/debian/BUILD.bazel
@@ -1,10 +1,11 @@
 """Rules to build /etc for ddot."""
 
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 
-package(default_visibility = ["//packages:__subpackages__"])
+package(default_visibility = ["//visibility:private"])
 
 dd_agent_expand_template(
     name = "upstart_debian_ddot_conf_gen",
@@ -26,11 +27,34 @@ pkg_filegroup(
         ":sysvinit_debian_ddot_gen",
         ":upstart_debian_ddot_conf_gen",
     ],
+    visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [
         ":all_files",
+    ],
+)
+
+pkg_tar(
+    name = "init_scripts_tar",
+    srcs = [
+        ":all_files",
+    ],
+    out = "init_scripts_ddot.tar.xz",
+)
+
+pkg_files(
+    name = "init_scripts_ddot_tar",
+    srcs = [
+        ":init_scripts_tar",
+    ],
+)
+
+pkg_install(
+    name = "hacky_packager_install",
+    srcs = [
+        ":init_scripts_ddot_tar",
     ],
 )


### PR DESCRIPTION
See if we can hack a way around the `project.extra_package_file` by writing tarballs directly to OMNIBUS_PACKAGE_ARTIFACT_DIR.

This would be a temporary solution until the time when we can completely replace the package-artifact.rb.  After migration, we'll just depend on these special targets in the srcs of the package target.

One of the key motivations is to be able to build the product without stomping /etc.  That is a key step in being able to build without being root.