### PR TITLE
Add custom omnibus builder method to invoke bazel with the right platform

### DIFF
--- a/omnibus/config/software/bzip2.rb
+++ b/omnibus/config/software/bzip2.rb
@@ -27,5 +27,5 @@ skip_transitive_dependency_licensing true
 dependency "zlib"
 
 build do
-  command_on_repo_root "bazelisk run -- @bzip2//:install --destdir=#{install_dir}"
+  bazel "run", "-- @bzip2//:install --destdir=#{install_dir}"
 end

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -14,7 +14,7 @@ dependency 'datadog-agent-data-plane' if linux_target? && !heroku_target?
 
 if (linux_target? && !heroku_target?) || windows_target?
   build do
-    command_on_repo_root "bazelisk run -- //deps/compile_policy:install --destdir=#{install_dir}"
+    bazel "run", "-- //deps/compile_policy:install --destdir=#{install_dir}"
   end
 end
 
@@ -31,13 +31,13 @@ dependency "systemd" if linux_target?
 
 if linux_target? and !heroku_target? # system-probe dependency
   build do
-    command_on_repo_root "bazelisk run -- @libpcap//:install --destdir=#{install_dir}/embedded"
+    bazel "run", "-- @libpcap//:install --destdir=#{install_dir}/embedded"
   end
 end
 
 # Include traps db file in snmp.d/traps_db/
 build do
-    command_on_repo_root "bazelisk run -- //deps/snmp_traps:install --destdir=#{install_dir}"
+    bazel "run", "-- //deps/snmp_traps:install --destdir=#{install_dir}"
 end
 
 dependency 'datadog-agent-integrations-py3'
@@ -45,7 +45,7 @@ dependency 'datadog-agent-integrations-py3'
 # Additional software
 if windows_target?
   build do
-    command_on_repo_root "bazelisk run -- //packages/windows:install_drivers --destdir=#{install_dir}"
+    bazel "run", "-- //packages/windows:install_drivers --destdir=#{install_dir}"
   end
 end
 

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -27,13 +27,13 @@ build do
         # Push all the pieces built with Bazel.
 
         # TODO: flavor can be defaulted and set from the bazel wrapper based on the environment.
-        command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install"
+        bazel "run", "--//:install_dir=#{install_dir} --//packages/agent:flavor=#{flavor_arg} -- //packages/install_dir:install"
 
 	if linux_target?
 	    if heroku_target?
-               command_on_repo_root "bazelisk run -- //packages/agent/heroku:license_files_install --destdir=#{install_dir}"
+               bazel "run", "-- //packages/agent/heroku:license_files_install --destdir=#{install_dir}"
             else
-               command_on_repo_root "bazelisk run -- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
+               bazel "run", "-- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
             end
         end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -13,6 +13,6 @@ if linux_target?
 
   build do
     # gstatus binary used by the glusterfs integration
-    command_on_repo_root "bazelisk run -- //deps/gstatus:install --destdir='#{install_dir}'"
+    bazel "run", "-- //deps/gstatus:install --destdir='#{install_dir}'"
   end
 end

--- a/omnibus/config/software/init-scripts-agent.rb
+++ b/omnibus/config/software/init-scripts-agent.rb
@@ -14,7 +14,7 @@ build do
     if debian_target?
       # building into / is not acceptable. We'll continue to to that for now,
       # but the replacement has to build to a build output tree.
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/debian/etc:install --verbose --destdir=#{destdir}"
+      bazel "run", "--//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/debian/etc:install --verbose --destdir=#{destdir}"
 
       # sysvinit support for debian only for now
       mkdir "/etc/init.d"
@@ -26,7 +26,7 @@ build do
       project.extra_package_file '/etc/init.d/datadog-agent-data-plane'
       project.extra_package_file '/etc/init.d/datadog-agent-action'
     elsif redhat_target? || suse_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}"
+      bazel "run", "--//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/redhat/etc:install --verbose --destdir=#{destdir}"
     end
     project.extra_package_file '/etc/init/datadog-agent.conf'
     project.extra_package_file '/etc/init/datadog-agent-process.conf'

--- a/omnibus/config/software/init-scripts-ddot.rb
+++ b/omnibus/config/software/init-scripts-ddot.rb
@@ -10,12 +10,12 @@ build do
   output_config_dir = ENV["OUTPUT_CONFIG_DIR"] || ""
   if linux_target?
     if debian_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}"
+      bazel "run", "--//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/debian:install --verbose --destdir=#{destdir}"
 
       project.extra_package_file '/etc/init.d/datadog-agent-ddot'
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     elsif redhat_target? || suse_target?
-      command_on_repo_root "bazelisk run --//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}"
+      bazel "run", "--//:output_config_dir='#{output_config_dir}' --//:install_dir=#{install_dir} -- //packages/ddot/redhat:install --verbose --destdir=#{destdir}"
 
       project.extra_package_file '/etc/init/datadog-agent-ddot.conf'
     end

--- a/omnibus/config/software/libffi.rb
+++ b/omnibus/config/software/libffi.rb
@@ -25,8 +25,8 @@ skip_transitive_dependency_licensing true
 build do
   sh_lib = if linux_target? then "libffi.so" else "libffi.dylib" end
 
-  command_on_repo_root "bazelisk run -- @libffi//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @libffi//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libffi.pc" \
     " #{install_dir}/embedded/lib/#{sh_lib}"
 end

--- a/omnibus/config/software/libgcrypt.rb
+++ b/omnibus/config/software/libgcrypt.rb
@@ -18,9 +18,9 @@ name "libgcrypt"
 default_version "1.10.2"
 
 build do
-  command_on_repo_root "bazelisk run -- @gpg-error//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- @gcrypt//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @gpg-error//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- @gcrypt//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libgcrypt.pc" \
     " #{install_dir}/embedded/lib/libgcrypt.so" \
     " #{install_dir}/embedded/lib/libgpg-error.so" \

--- a/omnibus/config/software/liblzma.rb
+++ b/omnibus/config/software/liblzma.rb
@@ -30,10 +30,10 @@ source url: "https://tukaani.org/xz/xz-#{version}.tar.gz"
 relative_path "xz-#{version}"
 
 build do
-  command_on_repo_root "bazelisk run -- @xz//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- @xz//:install --destdir='#{install_dir}/embedded'"
 
   sh_lib = if linux_target? then "liblzma.so" else "liblzma.dylib" end
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
     "#{install_dir}/embedded/lib/pkgconfig/liblzma.pc " \
     "#{install_dir}/embedded/lib/#{sh_lib}"
 end

--- a/omnibus/config/software/libsqlite3.rb
+++ b/omnibus/config/software/libsqlite3.rb
@@ -12,9 +12,9 @@ relative_path "sqlite-autoconf-3500400"
 build do
   license "Public-Domain"
 
-  command_on_repo_root "bazelisk run -- @sqlite3//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- @sqlite3//:install --destdir='#{install_dir}/embedded'"
   sh_lib = if linux_target? then "libsqlite3.so" else "libsqlite3.dylib" end
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
      "#{install_dir}/embedded/lib/pkgconfig/sqlite3.pc " \
      "#{install_dir}/embedded/lib/#{sh_lib}"
 end

--- a/omnibus/config/software/libxml2.rb
+++ b/omnibus/config/software/libxml2.rb
@@ -31,8 +31,8 @@ source url: "https://download.gnome.org/sources/libxml2/2.14/libxml2-#{version}.
 relative_path "libxml2-#{version}"
 
 build do
-  command_on_repo_root "bazelisk run -- @libxml2//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @libxml2//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libxml-2.0.pc" \
     " #{install_dir}/embedded/lib/libxml2.so"
 end

--- a/omnibus/config/software/libxslt.rb
+++ b/omnibus/config/software/libxslt.rb
@@ -32,8 +32,8 @@ source url: "https://download.gnome.org/sources/libxslt/1.1/libxslt-#{version}.t
 relative_path "libxslt-#{version}"
 
 build do
-  command_on_repo_root "bazelisk run -- @libxslt//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @libxslt//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libxslt.pc" \
     " #{install_dir}/embedded/lib/pkgconfig/libexslt.pc" \
     " #{install_dir}/embedded/lib/libxslt.so" \

--- a/omnibus/config/software/libyaml.rb
+++ b/omnibus/config/software/libyaml.rb
@@ -27,9 +27,9 @@ source sha256: "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
 relative_path "yaml-#{version}"
 
 build do
-  command_on_repo_root "bazelisk run -- @libyaml//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- @libyaml//:install --destdir='#{install_dir}/embedded'"
   sh_lib = if linux_target? then "libyaml.so" else "libyaml.dylib" end
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
     "#{install_dir}/embedded/lib/pkgconfig/yaml-0.1.pc " \
     "#{install_dir}/embedded/lib/#{sh_lib}"
 end

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -16,38 +16,38 @@ ship_source_offer true
 source url: "https://github.com/OpenSCAP/openscap/releases/download/#{version}/openscap-#{version}.tar.gz"
 
 build do
-  command_on_repo_root "bazelisk run -- @acl//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @acl//:install --destdir='#{install_dir}'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libacl.pc" \
     " #{install_dir}/embedded/lib/libacl.so"
 
-  command_on_repo_root "bazelisk run -- @attr//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @attr//:install --destdir='#{install_dir}'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libattr.pc" \
     " #{install_dir}/embedded/lib/libattr.so"
 
-  command_on_repo_root "bazelisk run -- @dbus//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @dbus//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/dbus-1.pc"
 
-  command_on_repo_root "bazelisk run -- @libselinux//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @libselinux//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libselinux.pc" \
     " #{install_dir}/embedded/lib/libselinux.so"
 
-  command_on_repo_root "bazelisk run -- @libsepol//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @libsepol//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/libsepol.pc" \
     " #{install_dir}/embedded/lib/libsepol.so"
 
-  command_on_repo_root "bazelisk run -- @pcre2//:install --destdir=#{install_dir}/embedded"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix " \
+  bazel "run", "-- @pcre2//:install --destdir=#{install_dir}/embedded"
+  bazel "run", "-- //bazel/rules:replace_prefix " \
     "--prefix #{install_dir}/embedded " \
     "#{install_dir}/embedded/lib/pkgconfig/libpcre2*.pc " \
     "#{install_dir}/embedded/lib/libpcre2*.so"
 
-  command_on_repo_root "bazelisk run -- @util-linux//:blkid_install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @util-linux//:blkid_install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/blkid.pc" \
     " #{install_dir}/embedded/lib/libblkid.so"
 end

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -42,12 +42,12 @@ build do
       # openssl binaries on macos
       real_install_dir = if mac_os_x? then "/opt/datadog-agent" else install_dir end
       lib_extension = if linux_target? then ".so" else ".dylib" end
-      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{real_install_dir}/embedded" \
+      bazel "run", "-- //bazel/rules:replace_prefix --prefix #{real_install_dir}/embedded" \
         " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
         " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \
         " #{install_dir}/embedded/lib/pkgconfig/*.pc" \
         " #{install_dir}/embedded/bin/openssl"
-      command_on_repo_root "bazelisk run -- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
+      bazel "run", "-- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
         " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
         " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \
     end

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -35,7 +35,7 @@ build do
   if !fips_mode?
     # OpenSSL on Windows now gets installed as part of the Python install, so we don't need to do anything here
     if !windows?
-      command_on_repo_root "bazelisk run -- @openssl//:install --destdir=#{install_dir}/embedded"
+      bazel "run", "-- @openssl//:install --destdir=#{install_dir}/embedded"
       # build_agent_dmg.sh sets INSTALL_DIR to some temporary folder.
       # This messes up openssl's internal paths. So we have to use another variable
       # so that replace_prefix and fix_openssl_paths set path correctly inside of the

--- a/omnibus/config/software/popt.rb
+++ b/omnibus/config/software/popt.rb
@@ -22,8 +22,8 @@ license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 build do
-  command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @popt//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/popt.pc" \
     " #{install_dir}/embedded/lib/libpopt.so"
 end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -124,7 +124,7 @@ build do
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"
   else
-    command_on_repo_root "bazelisk run -- @cpython//:install --destdir=#{python_3_embedded}"
+    bazel "run", "-- @cpython//:install --destdir=#{python_3_embedded}"
   end
 end
 

--- a/omnibus/config/software/rpm.rb
+++ b/omnibus/config/software/rpm.rb
@@ -23,8 +23,8 @@ skip_transitive_dependency_licensing true
 ship_source_offer true
 
 build do
-  command_on_repo_root "bazelisk run -- @rpm//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @rpm//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/pkgconfig/rpm.pc" \
     " #{install_dir}/embedded/lib/librpm.so" \
     " #{install_dir}/embedded/lib/librpmio.so"

--- a/omnibus/config/software/unixodbc.rb
+++ b/omnibus/config/software/unixodbc.rb
@@ -3,8 +3,8 @@ name "unixodbc"
 default_version "2.3.9"
 
 build do
-  command_on_repo_root "bazelisk run -- @unixodbc//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @unixodbc//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libodbc.so" \
     " #{install_dir}/embedded/lib/libodbccr.so" \
     " #{install_dir}/embedded/lib/libodbcinst.so"

--- a/omnibus/config/software/xmlsec.rb
+++ b/omnibus/config/software/xmlsec.rb
@@ -22,8 +22,8 @@ license_file "Copyright"
 skip_transitive_dependency_licensing true
 
 build do
-  command_on_repo_root "bazelisk run -- @xmlsec//:install --destdir='#{install_dir}/embedded'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  bazel "run", "-- @xmlsec//:install --destdir='#{install_dir}/embedded'"
+  bazel "run", "-- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxmlsec1*.so" \
     " #{install_dir}/embedded/lib/pkgconfig/xmlsec1*.pc"
 end

--- a/omnibus/config/software/zlib.rb
+++ b/omnibus/config/software/zlib.rb
@@ -17,5 +17,5 @@
 name "zlib"
 
 build do
-  command_on_repo_root "bazelisk run -- @zlib//:install --destdir='#{install_dir}'"
+  bazel "run", "-- @zlib//:install --destdir='#{install_dir}'"
 end

--- a/omnibus/lib/project_extension.rb
+++ b/omnibus/lib/project_extension.rb
@@ -124,7 +124,7 @@ module Omnibus
         platform += "_fips"
       end
 
-      bazel_cmd = ["bazelisk", subcmd, "--platforms=//bazel/platforms:#{platform}", arg_str]
+      bazel_cmd = ["bazel", subcmd, "--platforms=//bazel/platforms:#{platform}", arg_str]
 
       command_on_repo_root(bazel_cmd.join(' '), **kwargs)
     end


### PR DESCRIPTION
### What does this PR do?

It adds an extra _DSL_ method to omnibus `Builder` such that we can invoke bazel passing the appropriate platform (the one matching omnibus' view) on the command line without having to add conditionals everywhere.

### Motivation

For #43852, I want to start leveraging the setup that treats `fips` as a platform constraint. This change makes that simpler. Doing it in a separate PR makes more sense than stuffing it in that one.

### Describe how you validated your changes

- Green CI, meaning all bazel commands executed successfully and that there's no visible change.
- I looked at the omnibus build logs for several of the variants, to see that `bazelisk` is being invoked with ther right `--platforms` command line flag.

### Additional Notes
