### PR TITLE
Decrease Windows disk pressure in CI

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -296,20 +296,26 @@ function Invoke-BuildScript {
         }
 
         if ($BuildOutOfSource) {
+            # Expand modcache from c:\mnt to avoid needlessly xcopy'ing large tarballs
+            if ($InstallDeps) {
+                Expand-ModCache -root "c:\mnt" -modcache modcache
+            }
+            if ($InstallTestingDeps) {
+                Expand-ModCache -root "c:\mnt" -modcache modcache_tools
+            }
             Enter-BuildRoot
         } else {
             Enter-RepoRoot
+            # Expand modcache from current directory otherwise
+            if ($InstallDeps) {
+                Expand-ModCache -modcache modcache
+            }
+            if ($InstallTestingDeps) {
+                Expand-ModCache -modcache modcache_tools
+            }
         }
 
         Enable-DevEnv
-
-        # Expand modcache
-        if ($InstallDeps) {
-            Expand-ModCache -modcache modcache
-        }
-        if ($InstallTestingDeps) {
-            Expand-ModCache -modcache modcache_tools
-        }
 
         # Install deps
         if ($InstallDeps) {


### PR DESCRIPTION
### What does this PR do?
Tentatively fix rare Windows CI failures potentially caused by disk space consumption during the build-out-of-source process, by reordering operations to extract `modcache` archives before copying files to the buildroot.

### Motivation
In `BuildOutOfSource` mode, the script was:
1. copying ~3GB of modcache tar files from c:\mnt to c:\buildroot\datadog-agent
2. extracting them to c:\modcache\cache
3. deleting the tar files from buildroot

This could cause OOM or disk exhaustion, leading to silent container failures before tests even start, for example:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1378728179

### Additional Notes
Pressure estimates:
- c:\mnt\modcache.tar.xz: ~1.6 GB
- c:\buildroot\datadog-agent\modcache.tar.xz: ~1.6 GB (unnecessary copy)
- c:\buildroot\datadog-agent\modcache.tar: ~1.8 GB (temporary during extraction)
- c:\modcache\cache\**: ~1.8 GB (extracted)

This could save something like ~3.5GB of temporary disk usage and ~30 seconds of `xcopy` time.