### PR TITLE
[ AGNTLOG-493 ] Allow users to alter the default application name assignment for jounald container-based entries

### DIFF
--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -60,6 +60,8 @@ type LogsConfig struct {
 	IncludeMatches     StringSliceField `mapstructure:"include_matches" json:"include_matches" yaml:"include_matches"`          // Journald
 	ExcludeMatches     StringSliceField `mapstructure:"exclude_matches" json:"exclude_matches" yaml:"exclude_matches"`          // Journald
 	ContainerMode      bool             `mapstructure:"container_mode" json:"container_mode" yaml:"container_mode"`             // Journald
+	// Intentionally nillable string, as journald will decide on non-standard defaults if the field is not set.
+	DefaultApplicationName *string `mapstructure:"default_application_name" json:"default_application_name" yaml:"default_application_name"` // Journald
 
 	Image string // Docker
 	Label string // Docker

--- a/comp/logs/agent/config/parser_test.go
+++ b/comp/logs/agent/config/parser_test.go
@@ -258,6 +258,7 @@ logs:
     service: random-logger
     include_units:
       random-logger.service
+    default_application_name: random-logger
 `),
 			assert: func(t *testing.T, configs []*LogsConfig, err error) {
 				assert.Nil(t, err)
@@ -269,6 +270,8 @@ logs:
 				assert.Equal(t, "random-logger", config.Service)
 				require.Equal(t, len(config.IncludeSystemUnits), 1)
 				assert.Equal(t, "random-logger.service", config.IncludeSystemUnits[0])
+				assert.NotNil(t, config.DefaultApplicationName)
+				assert.Equal(t, "random-logger", *config.DefaultApplicationName)
 			},
 		},
 		{
@@ -309,6 +312,7 @@ logs:
 				assert.Equal(t, "journald", config.Type)
 				assert.Equal(t, "hello", config.Service)
 				assert.Equal(t, "custom_log", config.Source)
+				assert.Nil(t, config.DefaultApplicationName)
 			},
 		},
 		{
@@ -341,6 +345,7 @@ logs:
     exclude_matches:
       - some_exclude_match
     container_mode: true
+    default_application_name: "container-runtime"
     image: test_image
     label: test_label
     name: test_container
@@ -382,6 +387,8 @@ logs:
 				require.Equal(t, len(config.IncludeMatches), 1)
 				require.Equal(t, len(config.ExcludeMatches), 1)
 				assert.Equal(t, true, config.ContainerMode)
+				require.NotNil(t, config.DefaultApplicationName, "DefaultApplicationName should be set")
+				assert.Equal(t, "container-runtime", *config.DefaultApplicationName)
 				assert.Equal(t, "test_image", config.Image)
 				assert.Equal(t, "test_label", config.Label)
 				assert.Equal(t, "test_container", config.Name)

--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -30,8 +30,10 @@ import (
 
 // defaultWaitDuration represents the delay before which we try to collect a new log from the journal
 const (
-	defaultWaitDuration    = 1 * time.Second
-	defaultApplicationName = "docker"
+	defaultWaitDuration = 1 * time.Second
+
+	dockerApplicationName = "docker" // Legacy compliant default for unset defaultApplicationName
+	emptyApplicationName  = ""       // Empty string is used to indicate that no default application name should be assumed
 )
 
 // Tailer collects logs from a journal.
@@ -53,9 +55,10 @@ type Tailer struct {
 
 	// tagProvider provides additional tags to be attached to each log message.  It
 	// is called once for each log message.
-	tagProvider tag.Provider
-	tagger      tagger.Component
-	registry    auditor.Registry
+	tagProvider            tag.Provider
+	tagger                 tagger.Component
+	registry               auditor.Registry
+	defaultApplicationName *string
 }
 
 // NewTailer returns a new tailer.
@@ -68,16 +71,17 @@ func NewTailer(source *sources.LogSource, outputChan chan *message.Message, jour
 	}
 
 	return &Tailer{
-		decoder:           decoder.NewNoopDecoder(),
-		source:            source,
-		outputChan:        outputChan,
-		journal:           journal,
-		stop:              make(chan struct{}, 1),
-		done:              make(chan struct{}, 1),
-		processRawMessage: processRawMessage,
-		tagProvider:       tag.NewLocalProvider(source.Config.Tags),
-		tagger:            tagger,
-		registry:          registry,
+		decoder:                decoder.NewNoopDecoder(),
+		source:                 source,
+		outputChan:             outputChan,
+		journal:                journal,
+		stop:                   make(chan struct{}, 1),
+		done:                   make(chan struct{}, 1),
+		processRawMessage:      processRawMessage,
+		tagProvider:            tag.NewLocalProvider(source.Config.Tags),
+		tagger:                 tagger,
+		registry:               registry,
+		defaultApplicationName: source.Config.DefaultApplicationName,
 	}
 }
 
@@ -435,7 +439,14 @@ func (t *Tailer) getApplicationName(entry *sdjournal.JournalEntry, tags []string
 			}
 		}
 
-		return defaultApplicationName
+		// If no default application name is set in the config, use the legacy compliant default
+		if t.defaultApplicationName == nil {
+			return dockerApplicationName
+		}
+
+		if *t.defaultApplicationName != emptyApplicationName {
+			return *t.defaultApplicationName
+		}
 	}
 
 	for _, key := range applicationKeys {

--- a/releasenotes/notes/journald-default-app-name-9a746edcba423fd4.yaml
+++ b/releasenotes/notes/journald-default-app-name-9a746edcba423fd4.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a new, optional configuration setting for journald logs: ``default_application_name``.
+    If set to a non-empty string, the value will replace "docker" as the default application
+    name for contained based journald logs.
+    If set to an empty string, the application name will be determined by the systemd journal fields,
+    like all non-container based journald logs.


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new optional configuration field `default_application_name` for journald log sources, allowing users to customize or disable the default application name fallback when tailing container logs from journald. Previously, journald logs that had CONTAINER_ID_FULL field present in the journal entry but had container_mode disabled and/or did not have a discoverable shortname would be assigned a default application name of "docker". This completely overrode the non-container name discovery, which examined SYSLOG_IDENTIFIER, _SYSTEMD_USER_UNIT, etc for name determination.

The new `default_application_name` option has two main functionalities: if it is set to a non-empty string, then that value replaces "docker" as the default application name. If the configuration is set to an empty string, then the name determination will fall back to the non-container logic, where it attempts to find relevant identifier fields in the journal entry.

Example Usage
```
logs:
  - type: journald
    service: my-containers
    default_application_name: "podman"  # For Podman environments
```
```
logs:
  - type: journald
    service: my-containers
    default_application_name: ""  # Disable default, use journal fields only
```
```
logs:
  - type: journald
    service: my-containers
    # Not specifying a default_application_name defaults it to "docker"
```
### Motivation

### Describe how you validated your changes

### Additional Notes
