### PR TITLE
Adding dd-octo-sts Chainguard file for CodeQL Scan

### DIFF
--- a/.github/chainguard/codeql.sts.yaml
+++ b/.github/chainguard/codeql.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://gitlab.ddbuild.io
+subject_pattern: "project_path:DataDog/datadog-agent:ref_type:branch:ref:.*"
+claim_pattern:
+  project_path: "DataDog/datadog-agent"
+  ref_type: "branch"
+  ref: ".+"
+  ref_path: "refs/heads/.+"
+  ref_protected: "true"
+permissions:
+  security_events: write


### PR DESCRIPTION
### What does this PR do?

- Adds dd-octo-sts Chainguard file for CodeQL Scan

### Motivation
- We want to remove the usage of GitHub App credentials for CodeQL scan and migrate to dd-octo-sts

### Describe how you validated your changes

- This PR needs to be merged to default branch in order to for dd-octo-sts permissions to take effect. 

### Additional Notes
