### PR TITLE
Report Windows ddinjector telemetry

### DIFF
--- a/.gitlab/test/e2e_install_packages/windows.yml
+++ b/.gitlab/test/e2e_install_packages/windows.yml
@@ -254,3 +254,5 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestEnableDisable$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSIWithIIS$"
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSIWithJava$"
+      - EXTRA_PARAMS: --run "TestInjectorStats/TestQueryStatsViaSystemProbe$"
+      - EXTRA_PARAMS: --run "TestInjectorStats/TestQueryStatsAfterInjection$"

--- a/cmd/system-probe/modules/injector_windows.go
+++ b/cmd/system-probe/modules/injector_windows.go
@@ -1,0 +1,226 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package modules
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/windowsdriver/ddinjector"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// minInjectorQueryDelay is the minimum delay between queries to the injector driver.
+	minInjectorQueryDelay = 5 * time.Second
+)
+
+func init() { registerModule(Injector) }
+
+var _ module.Module = &injectorModule{}
+
+// Injector Factory
+var Injector = &module.Factory{
+	Name:             config.InjectorModule,
+	ConfigNamespaces: []string{},
+	Fn: func(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
+		log.Infof("Creating Windows Injector module")
+
+		m := &injectorModule{
+			telemetry:      deps.Telemetry,
+			sysProbeConfig: deps.SysprobeConfig,
+		}
+
+		m.initializeMetrics()
+
+		return m, nil
+	},
+}
+
+type injectorModule struct {
+	lastCheck      atomic.Int64
+	collectMutex   sync.Mutex
+	telemetry      telemetry.Component
+	counters       ddinjector.InjectorCounters
+	sysProbeConfig sysprobeconfig.Component
+}
+
+// Register registers the endpoint for this module
+func (m *injectorModule) Register(_ *module.Router) error {
+	if m.sysProbeConfig.GetBool("injector.enable_telemetry") {
+		log.Info("Windows Injector telemetry enabled")
+		m.telemetry.RegisterCollector(m)
+	} else {
+		log.Info("Windows Injector telemetry disabled")
+	}
+
+	return nil
+}
+
+// Close cleans up module resources
+func (m *injectorModule) Close() {
+	if m.sysProbeConfig.GetBool("injector.enable_telemetry") {
+		m.telemetry.UnregisterCollector(m)
+	}
+}
+
+// GetStats prints the injector stats as part of /debug/stats.
+func (m *injectorModule) GetStats() map[string]interface{} {
+	// Sanity check in case the metrics have not been initialized.
+	if m.counters.ProcessesAddedToInjectionTracker == nil {
+		return map[string]interface{}{}
+	}
+
+	// If last_check_timestamp is 0, the Collect callback has not yet been trigered.
+	return map[string]interface{}{
+		"last_check_timestamp":                     m.lastCheck.Load(),
+		"processes_added_to_injection_tracker":     m.counters.ProcessesAddedToInjectionTracker.Get(),
+		"processes_removed_from_injection_tracker": m.counters.ProcessesRemovedFromInjectionTracker.Get(),
+		"processes_skipped_subsystem":              m.counters.ProcessesSkippedSubsystem.Get(),
+		"processes_skipped_container":              m.counters.ProcessesSkippedContainer.Get(),
+		"processes_skipped_protected":              m.counters.ProcessesSkippedProtected.Get(),
+		"processes_skipped_system":                 m.counters.ProcessesSkippedSystem.Get(),
+		"processes_skipped_excluded":               m.counters.ProcessesSkippedExcluded.Get(),
+		"injection_attempts":                       m.counters.InjectionAttempts.Get(),
+		"injection_attempt_failures":               m.counters.InjectionAttemptFailures.Get(),
+		"injection_max_time_us":                    m.counters.InjectionMaxTimeUs.Get(),
+		"injection_successes":                      m.counters.InjectionSuccesses.Get(),
+		"injection_failures":                       m.counters.InjectionFailures.Get(),
+		"pe_caching_failures":                      m.counters.PeCachingFailures.Get(),
+		"import_directory_restoration_failures":    m.counters.ImportDirectoryRestorationFailures.Get(),
+		"pe_memory_allocation_failures":            m.counters.PeMemoryAllocationFailures.Get(),
+		"pe_injection_context_allocated":           m.counters.PeInjectionContextAllocated.Get(),
+		"pe_injection_context_cleanedup":           m.counters.PeInjectionContextCleanedup.Get(),
+	}
+}
+
+////////////////////////////////////////////////////
+// RAR/prometheus/telemetry related implementations
+
+func (m *injectorModule) initializeMetrics() {
+	const subsystem = "injector"
+
+	m.counters.ProcessesAddedToInjectionTracker = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_added_to_injection_tracker",
+		"Number of processes added to injection tracker")
+
+	m.counters.ProcessesRemovedFromInjectionTracker = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_removed_from_injection_tracker",
+		"Number of processes removed from injection tracker")
+
+	m.counters.ProcessesSkippedSubsystem = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_skipped_subsystem",
+		"Number of skipped subsystem processes")
+
+	m.counters.ProcessesSkippedContainer = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_skipped_container",
+		"Number of skipped container processes")
+
+	m.counters.ProcessesSkippedProtected = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_skipped_protected",
+		"Number of skipped protected processes")
+
+	m.counters.ProcessesSkippedSystem = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_skipped_system",
+		"Number of skipped system processes")
+
+	m.counters.ProcessesSkippedExcluded = m.telemetry.NewSimpleGauge(
+		subsystem, "processes_skipped_excluded",
+		"Number of skipped processes due to exclusion")
+
+	m.counters.InjectionAttempts = m.telemetry.NewSimpleGauge(
+		subsystem, "injection_attempts",
+		"Number of injection attempts")
+
+	m.counters.InjectionAttemptFailures = m.telemetry.NewSimpleGauge(
+		subsystem, "injection_attempt_failures",
+		"Number of injection attempt failures")
+
+	m.counters.InjectionMaxTimeUs = m.telemetry.NewSimpleGauge(
+		subsystem, "injection_max_time_us",
+		"Maximum injection time in microseconds")
+
+	m.counters.InjectionSuccesses = m.telemetry.NewSimpleGauge(
+		subsystem, "injection_successes",
+		"Number of successful injections")
+
+	m.counters.InjectionFailures = m.telemetry.NewSimpleGauge(
+		subsystem, "injection_failures",
+		"Number of failed injections")
+
+	m.counters.PeCachingFailures = m.telemetry.NewSimpleGauge(
+		subsystem, "pe_caching_failures",
+		"Number of PE caching failures")
+
+	m.counters.ImportDirectoryRestorationFailures = m.telemetry.NewSimpleGauge(
+		subsystem, "import_directory_restoration_failures",
+		"Number of import directory restoration failures")
+
+	m.counters.PeMemoryAllocationFailures = m.telemetry.NewSimpleGauge(
+		subsystem, "pe_memory_allocation_failures",
+		"Number of PE memory allocation failures")
+
+	m.counters.PeInjectionContextAllocated = m.telemetry.NewSimpleGauge(
+		subsystem, "pe_injection_context_allocated",
+		"Number of PE injection contexts allocated")
+
+	m.counters.PeInjectionContextCleanedup = m.telemetry.NewSimpleGauge(
+		subsystem, "pe_injection_context_cleanedup",
+		"Number of PE injection contexts cleaned up")
+}
+
+// Describe implements prometheus.Collector - no-op for dynamic metrics
+func (m *injectorModule) Describe(_ chan<- *prometheus.Desc) {
+}
+
+// Collect implements prometheus.Collector. Fetches stats from the injector.
+func (m *injectorModule) Collect(_ chan<- prometheus.Metric) {
+	if m.telemetry == nil {
+		return
+	}
+
+	// Protect against concurrent collect calls from multiple sources:
+	// 1. Telemetry scheduler
+	// 2. RAR queries
+	// 3. /telemetry endpoint
+	// 4. Prometheus scraper
+	m.collectMutex.Lock()
+	defer m.collectMutex.Unlock()
+
+	// Soft limiter to prevent spamming queries to the injector driver.
+	elapsed := time.Since(time.Unix(m.lastCheck.Load(), 0))
+	if elapsed < minInjectorQueryDelay {
+		return
+	}
+
+	m.lastCheck.Store(time.Now().Unix())
+
+	log.Debug("Collecting telemetry from Windows Injector")
+
+	// Query the driver for current counters
+	injector, err := ddinjector.NewInjector()
+	if err != nil {
+		log.Errorf("unable to open Windows Injector: %v", err)
+		return
+	}
+	defer injector.Close()
+
+	err = injector.GetCounters(&m.counters)
+	if err != nil {
+		log.Errorf("error getting Injector counters: %v", err)
+		return
+	}
+}

--- a/cmd/system-probe/modules/modules.go
+++ b/cmd/system-probe/modules/modules.go
@@ -33,6 +33,7 @@ var moduleOrder = []types.ModuleName{
 	config.GPUMonitoringModule, // GPU monitoring needs to be initialized after EventMonitor, so that we have the event consumer ready
 	config.SoftwareInventoryModule,
 	config.PrivilegedLogsModule,
+	config.InjectorModule,
 }
 
 // nolint: deadcode, unused // may be unused with certain build tag combinations

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -479,8 +479,8 @@ func TestRun(t *testing.T) {
 		totalProfiles += len(job.profiles)
 	}
 	fmt.Println(totalProfiles)
-	// Default config has 14 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, trace-agent, gpu, cluster-agent)
-	assert.Equal(t, 14, totalProfiles)
+	// Default config has 15 profiles total (checks, logs-and-metrics, database, synthetics, connectivity, service-discovery, runtime-started, runtime-running, hostname, rtloader, otlp, trace-agent, gpu, cluster-agent, injector)
+	assert.Equal(t, 15, totalProfiles)
 }
 
 func TestReportMetricBasic(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -463,6 +463,32 @@ var defaultProfiles = `
       start_after: 30
       iterations: 0
       period: 900
+  - name: injector
+    metric:
+      exclude:
+        zero_metric: true
+      metrics:
+        - name: injector.processes_added_to_injection_tracker
+        - name: injector.processes_removed_from_injection_tracker
+        - name: injector.processes_skipped_subsystem
+        - name: injector.processes_skipped_container
+        - name: injector.processes_skipped_protected
+        - name: injector.processes_skipped_system
+        - name: injector.processes_skipped_excluded
+        - name: injector.injection_attempts
+        - name: injector.injection_attempt_failures
+        - name: injector.injection_max_time_us
+        - name: injector.injection_successes
+        - name: injector.injection_failures
+        - name: injector.pe_caching_failures
+        - name: injector.import_directory_restoration_failures
+        - name: injector.pe_memory_allocation_failures
+        - name: injector.pe_injection_context_allocated
+        - name: injector.pe_injection_context_cleanedup
+    schedule:
+      start_after: 30
+      iterations: 0
+      period: 900
 `
 
 func compileMetricsExclude(p *Profile) error {

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -232,7 +232,8 @@ func TestTimeout(t *testing.T) {
 				"process_config.run_in_core_agent.enabled": true,
 			},
 			extraSysCfgs: map[string]interface{}{
-				"network_config.enabled": true,
+				"network_config.enabled":      true,
+				"system_probe_config.enabled": true,
 			},
 			profileDuration: 10 * time.Second,
 			expTimeout:      baseTimeout + 8*(10*time.Second),
@@ -244,6 +245,7 @@ func TestTimeout(t *testing.T) {
 			},
 			extraSysCfgs: map[string]interface{}{
 				"service_monitoring_config.enabled": true,
+				"system_probe_config.enabled":       true,
 			},
 			profileDuration: 10 * time.Second,
 			expTimeout:      baseTimeout + 8*(10*time.Second),

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -79,8 +79,27 @@ type remoteagentImpl struct {
 
 func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
 	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-	// Add here the metric names that should be included in the telemetry response.
-	// This is useful to avoid sending too many metrics to the Core Agent.
+		// Add here the metric names that should be included in the telemetry response.
+		// This is useful to avoid sending too many metrics to the Core Agent.
+
+		// Windows Injector metrics (using double underscore format from telemetry component)
+		"injector__processes_added_to_injection_tracker",
+		"injector__processes_removed_from_injection_tracker",
+		"injector__processes_skipped_subsystem",
+		"injector__processes_skipped_container",
+		"injector__processes_skipped_protected",
+		"injector__processes_skipped_system",
+		"injector__processes_skipped_excluded",
+		"injector__injection_attempts",
+		"injector__injection_attempt_failures",
+		"injector__injection_max_time_us",
+		"injector__injection_successes",
+		"injector__injection_failures",
+		"injector__pe_caching_failures",
+		"injector__import_directory_restoration_failures",
+		"injector__pe_memory_allocation_failures",
+		"injector__pe_injection_context_allocated",
+		"injector__pe_injection_context_cleanedup",
 	))
 	if err != nil {
 		return nil, err

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -374,6 +374,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_interval", 30*time.Second)
 	cfg.BindEnvAndSetDefault("gpu_monitoring.cgroup_reapply_infinitely", false)
 
+	// Windows Injector telemetry, enabled by default
+	cfg.BindEnvAndSetDefault("injector.enable_telemetry", true)
+
 	// gpu - stream config
 	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_kernel_launches", 1000)
 	cfg.BindEnvAndSetDefault("gpu_monitoring.streams.max_mem_alloc_events", 1000)

--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -42,6 +42,7 @@ const (
 	GPUMonitoringModule          types.ModuleName = "gpu"
 	SoftwareInventoryModule      types.ModuleName = "software_inventory"
 	PrivilegedLogsModule         types.ModuleName = "privileged_logs"
+	InjectorModule               types.ModuleName = "injector"
 )
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -187,6 +188,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(wcdNS("enabled")) {
 		c.EnabledModules[WindowsCrashDetectModule] = struct{}{}
 	}
+
 	if runtime.GOOS == "windows" {
 		if c.ModuleIsEnabled(NetworkTracerModule) || c.ModuleIsEnabled(EventMonitorModule) {
 			// enable the windows crash detection module if the network tracer
@@ -195,6 +197,21 @@ func load() (*types.Config, error) {
 		}
 		if swEnabled {
 			c.EnabledModules[SoftwareInventoryModule] = struct{}{}
+		}
+
+		// injector telemetry is enabled by default, disable only if explicitly configured by the user
+		injectorDefaultEnabled := false
+		if !cfg.IsConfigured("injector.enable_telemetry") {
+			injectorDefaultEnabled = true
+		} else if cfg.GetBool("injector.enable_telemetry") {
+			c.EnabledModules[InjectorModule] = struct{}{}
+		}
+
+		// This check must be last for any default modules on Windows,
+		// Only add default modules if other explicit modules have been enabled
+		// because the count of enabled modules will implicitly enable system probe.
+		if len(c.EnabledModules) > 0 && injectorDefaultEnabled {
+			c.EnabledModules[InjectorModule] = struct{}{}
 		}
 	}
 

--- a/pkg/windowsdriver/ddinjector/ddinjector.go
+++ b/pkg/windowsdriver/ddinjector/ddinjector.go
@@ -1,0 +1,165 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+// Package ddinjector provides an interface to the Windows ddinjector driver.
+package ddinjector
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// ddInjectorDeviceName is the device name for the APM injector driver
+	ddInjectorDeviceName = `\\.\DDInjector`
+
+	countersVersion = 1
+)
+
+// InjectorCounters encapsulates ddinjector counters to be reported upstream.
+type InjectorCounters struct {
+	// v1 fields
+	ProcessesAddedToInjectionTracker     telemetry.SimpleGauge
+	ProcessesRemovedFromInjectionTracker telemetry.SimpleGauge
+	ProcessesSkippedSubsystem            telemetry.SimpleGauge
+	ProcessesSkippedContainer            telemetry.SimpleGauge
+	ProcessesSkippedProtected            telemetry.SimpleGauge
+	ProcessesSkippedSystem               telemetry.SimpleGauge
+	ProcessesSkippedExcluded             telemetry.SimpleGauge
+	InjectionAttempts                    telemetry.SimpleGauge
+	InjectionAttemptFailures             telemetry.SimpleGauge
+	InjectionMaxTimeUs                   telemetry.SimpleGauge
+	InjectionSuccesses                   telemetry.SimpleGauge
+	InjectionFailures                    telemetry.SimpleGauge
+	PeCachingFailures                    telemetry.SimpleGauge
+	ImportDirectoryRestorationFailures   telemetry.SimpleGauge
+	PeMemoryAllocationFailures           telemetry.SimpleGauge
+	PeInjectionContextAllocated          telemetry.SimpleGauge
+	PeInjectionContextCleanedup          telemetry.SimpleGauge
+}
+
+// Injector represents an opened instance to the ddinjector driver.
+type Injector struct {
+	handle windows.Handle
+}
+
+// function pointers to swap out driver-specific calls to facilitate unit testing
+var doOpenDriverHandle = openDriverHandle
+var doQueryDriverCounters = queryDriverCounters
+
+// NewInjector opens a handle to ddinjector to allow subsequent queries.
+func NewInjector() (*Injector, error) {
+	h, err := doOpenDriverHandle()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ddinjector: %w", err)
+	}
+	return &Injector{handle: h}, nil
+}
+
+// GetCounters queries the ddinjector current counters.
+func (inj *Injector) GetCounters(counters *InjectorCounters) error {
+	request := DDInjectorCounterRequest{}
+	request.RequestedVersion = countersVersion
+
+	rawCounters := DDInjectorCountersV1{}
+
+	err := doQueryDriverCounters(inj.handle, &request, &rawCounters)
+	if err != nil {
+		return fmt.Errorf("ddinjector DeviceIoControl failed: %w", err)
+	}
+
+	counters.ProcessesAddedToInjectionTracker.Set(float64(rawCounters.ProcessesAddedToInjectionTracker))
+	counters.ProcessesRemovedFromInjectionTracker.Set(float64(rawCounters.ProcessesRemovedFromInjectionTracker))
+	counters.ProcessesSkippedSubsystem.Set(float64(rawCounters.ProcessesSkippedSubsystem))
+	counters.ProcessesSkippedContainer.Set(float64(rawCounters.ProcessesSkippedContainer))
+	counters.ProcessesSkippedProtected.Set(float64(rawCounters.ProcessesSkippedProtected))
+	counters.ProcessesSkippedSystem.Set(float64(rawCounters.ProcessesSkippedSystem))
+	counters.ProcessesSkippedExcluded.Set(float64(rawCounters.ProcessesSkippedExcluded))
+	counters.InjectionAttempts.Set(float64(rawCounters.InjectionAttempts))
+	counters.InjectionAttemptFailures.Set(float64(rawCounters.InjectionAttemptFailures))
+	counters.InjectionMaxTimeUs.Set(float64(rawCounters.InjectionMaxTimeUs))
+	counters.InjectionSuccesses.Set(float64(rawCounters.InjectionSuccesses))
+	counters.InjectionFailures.Set(float64(rawCounters.InjectionFailures))
+	counters.PeCachingFailures.Set(float64(rawCounters.PeCachingFailures))
+	counters.ImportDirectoryRestorationFailures.Set(float64(rawCounters.ImportDirectoryRestorationFailures))
+	counters.PeMemoryAllocationFailures.Set(float64(rawCounters.PeMemoryAllocationFailures))
+	counters.PeInjectionContextAllocated.Set(float64(rawCounters.PeInjectionContextAllocated))
+	counters.PeInjectionContextCleanedup.Set(float64(rawCounters.PeInjectionContextCleanedup))
+
+	return nil
+}
+
+// Close closes the handle to ddinjector.
+func (inj *Injector) Close() error {
+	if inj.handle != windows.InvalidHandle && inj.handle != windows.Handle(0) {
+		err := windows.CloseHandle(inj.handle)
+		if err != nil {
+			return fmt.Errorf("failed to close driver handle: %w", err)
+		}
+
+		log.Debugf("ddinjector closed")
+		inj.handle = windows.Handle(0)
+	}
+	return nil
+}
+
+// openInjectorDriverHandle opens a handle to the APM injector driver
+func openDriverHandle() (windows.Handle, error) {
+	// Use statshandle path similar to ddnpm driver pattern
+	fullpath := ddInjectorDeviceName
+	pFullPath, err := windows.UTF16PtrFromString(fullpath)
+	if err != nil {
+		return windows.InvalidHandle, fmt.Errorf("failed to convert path to UTF16: %w", err)
+	}
+
+	log.Debugf("Opening ddinjector: %s", fullpath)
+
+	handle, err := windows.CreateFile(
+		pFullPath,
+		windows.GENERIC_READ,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		0, // no overlapped I/O for stats queries
+		windows.Handle(0),
+	)
+
+	if err != nil {
+		return windows.InvalidHandle, fmt.Errorf("failed to open ddinjector (%s): %w", fullpath, err)
+	}
+
+	log.Debugf("ddinjector opened")
+	return handle, nil
+}
+
+// queryDriverCounters calls DeviceIoControl on ddinjector to query raw counters.
+func queryDriverCounters(handle windows.Handle, request *DDInjectorCounterRequest, counters *DDInjectorCountersV1) error {
+	var bytesReturned uint32
+
+	if handle == windows.InvalidHandle || handle == 0 {
+		return errors.New("invalid handle to ddinjector, cannot query")
+	}
+
+	err := windows.DeviceIoControl(
+		handle,
+		GetCountersIOCTL,
+		(*byte)(unsafe.Pointer(request)),  // input buffer
+		uint32(unsafe.Sizeof(*request)),   // input size
+		(*byte)(unsafe.Pointer(counters)), // output buffer
+		uint32(unsafe.Sizeof(*counters)),  // output size
+		&bytesReturned,
+		nil, // not overlapped
+	)
+
+	return err
+}

--- a/pkg/windowsdriver/ddinjector/ddinjector_test.go
+++ b/pkg/windowsdriver/ddinjector/ddinjector_test.go
@@ -1,0 +1,206 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package ddinjector
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+var currentTest *testing.T
+var mockCounters DDInjectorCountersV1
+var mockQueryCountersError error
+
+// //////////////////////////////////////////////////////////
+// Mock telemetry gauge implementation
+
+type mockSimpleGauge struct {
+	value atomic.Uint64 // stored as bits of float64
+}
+
+func (g *mockSimpleGauge) Inc() {
+	g.Add(1.0)
+}
+
+func (g *mockSimpleGauge) Dec() {
+	g.Sub(1.0)
+}
+
+func (g *mockSimpleGauge) Add(v float64) {
+	oldBits := g.value.Load()
+	oldVal := float64frombits(oldBits)
+	newVal := oldVal + v
+	newBits := float64bits(newVal)
+	g.value.Store(newBits)
+}
+
+func (g *mockSimpleGauge) Sub(v float64) {
+	g.Add(-v)
+}
+
+func (g *mockSimpleGauge) Set(v float64) {
+	g.value.Store(float64bits(v))
+}
+
+func (g *mockSimpleGauge) Get() float64 {
+	return float64frombits(g.value.Load())
+}
+
+// float64bits and float64frombits convert between float64 and uint64 representations.
+func float64bits(f float64) uint64 {
+	return *(*uint64)(unsafe.Pointer(&f))
+}
+
+func float64frombits(b uint64) float64 {
+	return *(*float64)(unsafe.Pointer(&b))
+}
+
+// createCounters creates a new InjectorCounters with mock telemetry gauges for testing.
+func createCounters() *InjectorCounters {
+	return &InjectorCounters{
+		ProcessesAddedToInjectionTracker:     &mockSimpleGauge{},
+		ProcessesRemovedFromInjectionTracker: &mockSimpleGauge{},
+		ProcessesSkippedSubsystem:            &mockSimpleGauge{},
+		ProcessesSkippedContainer:            &mockSimpleGauge{},
+		ProcessesSkippedProtected:            &mockSimpleGauge{},
+		ProcessesSkippedSystem:               &mockSimpleGauge{},
+		ProcessesSkippedExcluded:             &mockSimpleGauge{},
+		InjectionAttempts:                    &mockSimpleGauge{},
+		InjectionAttemptFailures:             &mockSimpleGauge{},
+		InjectionMaxTimeUs:                   &mockSimpleGauge{},
+		InjectionSuccesses:                   &mockSimpleGauge{},
+		InjectionFailures:                    &mockSimpleGauge{},
+		PeCachingFailures:                    &mockSimpleGauge{},
+		ImportDirectoryRestorationFailures:   &mockSimpleGauge{},
+		PeMemoryAllocationFailures:           &mockSimpleGauge{},
+		PeInjectionContextAllocated:          &mockSimpleGauge{},
+		PeInjectionContextCleanedup:          &mockSimpleGauge{},
+	}
+}
+
+////////////////////////////////////////////////////////////
+
+// testOpenDriverHandle is a mock implementation to avoid opening a real driver.
+func testOpenDriverHandle() (windows.Handle, error) {
+	return windows.InvalidHandle, nil
+}
+
+// testQueryDriverCounters is a mock implementation of queryDriverCounters for testing.
+func testQueryDriverCounters(_ windows.Handle, request *DDInjectorCounterRequest, counters *DDInjectorCountersV1) error {
+	assert.NotNil(currentTest, request)
+	assert.NotNil(currentTest, counters)
+	assert.Equal(currentTest, int(request.RequestedVersion), countersVersion)
+	*counters = mockCounters
+	return mockQueryCountersError
+}
+
+// overrideDriverCallbacks swaps out driver specific API calls to facilitate mocking.
+func overrideDriverCallbacks() {
+	OverrideOpenDriverHandle(testOpenDriverHandle)
+	OverrideQueryDriverCounters(testQueryDriverCounters)
+}
+
+// restoreDriverCallbacks restores the original driver specific API calls.
+func restoreDriverCallbacks() {
+	OverrideOpenDriverHandle(openDriverHandle)
+	OverrideQueryDriverCounters(queryDriverCounters)
+}
+
+func TestQueryCounters(t *testing.T) {
+	// needed for assertions in callbacks
+	currentTest = t
+
+	overrideDriverCallbacks()
+	defer restoreDriverCallbacks()
+
+	inj, err := NewInjector()
+	assert.NoError(t, err)
+	assert.NotNil(t, inj)
+
+	// setup fake values
+	mockCounters.ProcessesAddedToInjectionTracker = 1
+	mockCounters.ProcessesRemovedFromInjectionTracker = 2
+	mockCounters.ProcessesSkippedSubsystem = 3
+	mockCounters.ProcessesSkippedContainer = 4
+	mockCounters.ProcessesSkippedProtected = 5
+	mockCounters.ProcessesSkippedSystem = 6
+	mockCounters.ProcessesSkippedExcluded = 7
+	mockCounters.InjectionAttempts = 8
+	mockCounters.InjectionAttemptFailures = 9
+	mockCounters.InjectionMaxTimeUs = 10
+	mockCounters.InjectionSuccesses = 11
+	mockCounters.InjectionFailures = 12
+	mockCounters.PeCachingFailures = 13
+	mockCounters.ImportDirectoryRestorationFailures = 14
+	mockCounters.PeMemoryAllocationFailures = 15
+	mockCounters.PeInjectionContextAllocated = 16
+	mockCounters.PeInjectionContextCleanedup = 17
+
+	// setup no error
+	mockQueryCountersError = nil
+
+	// Create counters with mock telemetry gauges
+	counters := createCounters()
+
+	// Call GetCounters with new API (pass pointer)
+	err = inj.GetCounters(counters)
+	assert.NoError(t, err)
+	assertCountersEqual(t, &mockCounters, counters)
+
+	inj.Close()
+}
+
+func TestQueryCountersError(t *testing.T) {
+	// needed for assertions in callbacks
+	currentTest = t
+
+	overrideDriverCallbacks()
+	defer restoreDriverCallbacks()
+
+	inj, err := NewInjector()
+	assert.NoError(t, err)
+	assert.NotNil(t, inj)
+
+	// setup fake error
+	mockQueryCountersError = errors.New("mock error")
+
+	// Create counters with mock telemetry gauges
+	counters := createCounters()
+
+	// Call GetCounters with new API (pass pointer) - should return error
+	err = inj.GetCounters(counters)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "mock error")
+
+	inj.Close()
+}
+
+func assertCountersEqual(t *testing.T, expected *DDInjectorCountersV1, actual *InjectorCounters) {
+	assert.Equal(t, float64(expected.ProcessesAddedToInjectionTracker), actual.ProcessesAddedToInjectionTracker.Get())
+	assert.Equal(t, float64(expected.ProcessesRemovedFromInjectionTracker), actual.ProcessesRemovedFromInjectionTracker.Get())
+	assert.Equal(t, float64(expected.ProcessesSkippedSubsystem), actual.ProcessesSkippedSubsystem.Get())
+	assert.Equal(t, float64(expected.ProcessesSkippedContainer), actual.ProcessesSkippedContainer.Get())
+	assert.Equal(t, float64(expected.ProcessesSkippedProtected), actual.ProcessesSkippedProtected.Get())
+	assert.Equal(t, float64(expected.ProcessesSkippedSystem), actual.ProcessesSkippedSystem.Get())
+	assert.Equal(t, float64(expected.ProcessesSkippedExcluded), actual.ProcessesSkippedExcluded.Get())
+	assert.Equal(t, float64(expected.InjectionAttempts), actual.InjectionAttempts.Get())
+	assert.Equal(t, float64(expected.InjectionAttemptFailures), actual.InjectionAttemptFailures.Get())
+	assert.Equal(t, float64(expected.InjectionMaxTimeUs), actual.InjectionMaxTimeUs.Get())
+	assert.Equal(t, float64(expected.InjectionSuccesses), actual.InjectionSuccesses.Get())
+	assert.Equal(t, float64(expected.InjectionFailures), actual.InjectionFailures.Get())
+	assert.Equal(t, float64(expected.PeCachingFailures), actual.PeCachingFailures.Get())
+	assert.Equal(t, float64(expected.ImportDirectoryRestorationFailures), actual.ImportDirectoryRestorationFailures.Get())
+	assert.Equal(t, float64(expected.PeMemoryAllocationFailures), actual.PeMemoryAllocationFailures.Get())
+	assert.Equal(t, float64(expected.PeInjectionContextAllocated), actual.PeInjectionContextAllocated.Get())
+	assert.Equal(t, float64(expected.PeInjectionContextCleanedup), actual.PeInjectionContextCleanedup.Get())
+}

--- a/pkg/windowsdriver/ddinjector/ddinjector_testutil.go
+++ b/pkg/windowsdriver/ddinjector/ddinjector_testutil.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package ddinjector
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+type openDriverHandleType func() (windows.Handle, error)
+type queryDriverCountersType func(handle windows.Handle, request *DDInjectorCounterRequest, counters *DDInjectorCountersV1) error
+
+// OverrideOpenDriverHandle replaces opening the ddinjector driver with a mock implementation.
+func OverrideOpenDriverHandle(fn openDriverHandleType) {
+	doOpenDriverHandle = fn
+}
+
+// OverrideQueryDriverCounters replaces the device call to query counters with a mock implementation.
+func OverrideQueryDriverCounters(fn queryDriverCountersType) {
+	doQueryDriverCounters = fn
+}

--- a/pkg/windowsdriver/ddinjector/types.go
+++ b/pkg/windowsdriver/ddinjector/types.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package ddinjector
+
+/*
+//! These includes are needed to use constants defined in the ddprocmonapi
+#include <WinDef.h>
+#include <WinIoCtl.h>
+
+//! Defines the objects used to communicate with the driver as well as its control codes
+#include "../include/ddinjector_public.h"
+#include <stdlib.h>
+*/
+import "C"
+
+//const Signature = C.DD_PROCMONDRIVER_SIGNATURE
+
+const (
+	GetCountersIOCTL = uint32(C.IOCTL_GET_COUNTERS)
+)
+
+type DDInjectorCounterRequest C.struct__COUNTER_REQUEST
+type DDInjectorCountersV1 C.struct__DRIVER_COUNTERS_V1
+
+const DDInjectorCounterRequestSize = C.sizeof_struct__COUNTER_REQUEST
+const DDInjectorCountersV1Size = C.sizeof_struct__DRIVER_COUNTERS_V1

--- a/pkg/windowsdriver/include/ddinjector_public.h
+++ b/pkg/windowsdriver/include/ddinjector_public.h
@@ -1,0 +1,123 @@
+/**
+ * @file ddinjector_public.h
+ * @brief Public interface definitions for ddinjector driver.
+ * @copyright Copyright 2025-present Datadog, Inc.
+ *
+ * @details
+ * Defines the public IOCTL interface and counter structures for communication
+ * between the ddinjector kernel driver and user-mode services. This header
+ * is shared between kernel and user-mode components.
+ *
+ * VERSIONING POLICY:
+ * - Counter structures follow strict versioning for backward compatibility
+ * - V1 structures must NEVER be modified once released
+ * - New versions use macro-based field definitions to avoid deep nesting
+ * - Access pattern: counters.v1.field, counters.v2.field, counters.field (current)
+ * - Clients query MaxSupportedCounterVersion and request specific versions
+ *
+ */
+
+#ifndef DDINJECTOR_PUBLIC_H
+#define DDINJECTOR_PUBLIC_H
+
+
+//
+// IOCTL Definitions
+//
+#define DDINJECTOR_DEVICE_TYPE 0x8000
+
+#define IOCTL_GET_DRIVER_CAPABILITIES \
+    (unsigned int )(CTL_CODE(DDINJECTOR_DEVICE_TYPE, 0x800, METHOD_BUFFERED, FILE_READ_DATA))
+
+#define IOCTL_GET_COUNTERS \
+    (unsigned int )(CTL_CODE(DDINJECTOR_DEVICE_TYPE, 0x801, METHOD_OUT_DIRECT, FILE_READ_DATA))
+
+//
+// Version Definitions
+//
+#define DRIVER_COUNTERS_VERSION_1 1
+
+//
+// Structure Definitions
+//
+
+/**
+ * @brief Driver capabilities information.
+ */
+typedef struct _DRIVER_CAPABILITIES {
+    ULONG MaxSupportedCounterVersion; // Highest counter version supported
+    ULONG Reserved[3]; // Reserved for future use
+} DRIVER_CAPABILITIES, *PDRIVER_CAPABILITIES;
+
+/**
+ * @brief Counter request structure for specifying desired version.
+ */
+typedef struct _COUNTER_REQUEST {
+    ULONG RequestedVersion; // Version of counters to retrieve
+} COUNTER_REQUEST, *PCOUNTER_REQUEST;
+
+//
+// Counter Field Definitions (Macro-based for extensibility)
+//
+
+/**
+ * @brief V1 counter fields - Process management and injection performance.
+ * @warning These fields must NEVER be modified once released.
+ */
+#define DRIVER_COUNTERS_V1_FIELDS \
+    LONG64 ProcessesAddedToInjectionTracker; \
+    LONG64 ProcessesRemovedFromInjectionTracker; \
+    LONG64 ProcessesSkippedSubsystem; \
+    LONG64 ProcessesSkippedContainer; \
+    LONG64 ProcessesSkippedProtected; \
+    LONG64 ProcessesSkippedSystem; \
+    LONG64 ProcessesSkippedExcluded; \
+    LONG64 InjectionAttempts; \
+    LONG64 InjectionAttemptFailures; \
+    LONG64 InjectionMaxTimeUs; \
+    LONG64 InjectionSuccesses; \
+    LONG64 InjectionFailures; \
+    LONG64 PeCachingFailures; \
+    LONG64 ImportDirectoryRestorationFailures; \
+    LONG64 PeMemoryAllocationFailures; \
+    LONG64 PeInjectionContextAllocated; \
+    LONG64 PeInjectionContextCleanedup;
+
+//
+// Counter Structure Definitions
+//
+
+/**
+ * @brief Driver performance and diagnostic counters (Version 1).
+ * @warning This structure must NEVER be modified. Create V2 for new counters.
+ *
+ * @details
+ * This is the base version of counters. All fields are directly accessible.
+ * Future versions will nest this under a 'v1' namespace for clear versioning.
+ */
+typedef struct _DRIVER_COUNTERS_V1 {
+    DRIVER_COUNTERS_V1_FIELDS
+} DRIVER_COUNTERS_V1, *PDRIVER_COUNTERS_V1;
+
+/*
+ * FUTURE VERSION EXTENSION EXAMPLE:
+ *
+ * #define DRIVER_COUNTERS_VERSION_2 2
+ *
+ * #define DRIVER_COUNTERS_V2_FIELDS \
+ *     LONG64 MemoryPoolAllocations; \
+ *     LONG64 MemoryPoolFailures;
+ *
+ * typedef struct _DRIVER_COUNTERS_V2 {
+ *     struct {
+ *         DRIVER_COUNTERS_V1_FIELDS
+ *     } v1;
+ *     DRIVER_COUNTERS_V2_FIELDS
+ * } DRIVER_COUNTERS_V2, *PDRIVER_COUNTERS_V2;
+ *
+ * Usage:
+ *   counters.v1.ProcessesAddedToInjectionTracker  // V1 field
+ *   counters.MemoryPoolAllocations                // V2 field
+ */
+
+#endif // DDINJECTOR_PUBLIC_H

--- a/releasenotes/notes/win_apm_inject_stats-0e360d7cecd12954.yaml
+++ b/releasenotes/notes/win_apm_inject_stats-0e360d7cecd12954.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Reports telemetry from the Windows Injector, enabled by default.
+    Disable this feature by setting ``injector.enable_telemetry=false`` in ``system-probe.yaml`` when running system-probe.

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/injector_stats_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/injector_stats_test.go
@@ -1,0 +1,364 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package injecttests contains E2E tests for the Injector package.
+// This file tests the injector statistics reporting functionality through system-probe.
+package injecttests
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
+	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	windowscommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
+type testInjectorStats struct {
+	baseSuite
+}
+
+// TestInjectorStats tests querying injector statistics via system-probe
+func TestInjectorStats(t *testing.T) {
+	e2e.Run(t, &testInjectorStats{},
+		e2e.WithProvisioner(
+			winawshost.ProvisionerNoAgentNoFakeIntake()))
+}
+
+func (s *testInjectorStats) AfterTest(suiteName, testName string) {
+	s.Installer().Purge()
+	s.baseSuite.AfterTest(suiteName, testName)
+}
+
+// TestQueryStatsViaSystemProbe tests querying injector stats through system-probe HTTP endpoint
+func (s *testInjectorStats) TestQueryStatsViaSystemProbe() {
+	// Install agent with APM inject enabled
+	s.installCurrentAgentVersionWithAPMInject(
+		installerwindows.WithExtraEnvVars(map[string]string{
+			"DD_APM_INSTRUMENTATION_ENABLED": "host",
+			// TODO: remove override once image is published in prod
+			"DD_INSTALLER_REGISTRY_URL":                           "install.datad0g.com",
+			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT": s.currentAPMInjectVersion.PackageVersion(),
+			"DD_APM_INSTRUMENTATION_LIBRARIES":                    "dotnet:3",
+		}),
+	)
+
+	// Verify the package is installed
+	s.assertSuccessfulPromoteExperiment()
+
+	// Explicitly enable injector telemetry in system-probe
+	s.enableInjectorTelemetry()
+
+	s.waitForServiceRunning()
+
+	stats := s.queryInjectorStats(false)
+	s.verifyStatsStructure(stats)
+}
+
+// TestQueryStatsAfterInjection tests that stats are updated after actual injection occurs
+func (s *testInjectorStats) TestQueryStatsAfterInjection() {
+	// Install agent with APM inject enabled
+	s.installCurrentAgentVersionWithAPMInject(
+		installerwindows.WithExtraEnvVars(map[string]string{
+			"DD_APM_INSTRUMENTATION_ENABLED": "host",
+			// TODO: remove override once image is published in prod
+			"DD_INSTALLER_REGISTRY_URL":                           "install.datad0g.com",
+			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT": s.currentAPMInjectVersion.PackageVersion(),
+			"DD_APM_INSTRUMENTATION_LIBRARIES":                    "dotnet:3",
+		}),
+	)
+
+	// Verify the package is installed
+	s.assertSuccessfulPromoteExperiment()
+
+	// Explicitly enable injector telemetry in system-probe
+	s.enableInjectorTelemetry()
+
+	s.waitForServiceRunning()
+
+	// Get initial stats
+	initialStats := s.queryInjectorStats(true)
+	s.verifyStatsStructure(initialStats)
+
+	// Trigger injection by running a process
+	s.assertDriverInjections(true)
+
+	// Wait a bit for stats to update
+	time.Sleep(5 * time.Second)
+
+	// Get updated stats
+	updatedStats := s.queryInjectorStats(true)
+	s.verifyStatsStructure(updatedStats)
+
+	// Verify that we did trigger the Collect callback and got back stats.
+	// If last_check_timestamp is 0, check whether ddinjector is running, check system-probe.yaml,
+	// and check the telemetry scheduler's delay start amount.
+	ts, ok := updatedStats["last_check_timestamp"].(float64)
+	s.Require().True(ok, "last_check_timestamp should be in stats: %+v", updatedStats)
+	if ts == 0 {
+		s.logInjectorDiagnostics()
+		s.Require().True(ts > 0, "stats did not refresh")
+	}
+
+	// Verify that some counters have increased (at least one injection should have occurred)
+	// Note: We can't guarantee specific counters will increase in all test environments,
+	// but we can verify the stats endpoint is working and returning valid data
+	s.T().Logf("Initial stats: %+v", initialStats)
+	s.T().Logf("Updated stats: %+v", updatedStats)
+
+	diffFound := false
+	for k, v1 := range initialStats {
+		v2, ok := updatedStats[k]
+		s.Require().True(ok, "updated injector stats should have key: %s", k)
+		if v1.(float64) != v2.(float64) {
+			diffFound = true
+			break
+		}
+	}
+
+	s.Assert().True(diffFound, "injector stats should have changed after injection")
+}
+
+// queryInjectorStats queries the system-probe for injector stats using NamedPipeCmd.exe
+func (s *testInjectorStats) queryInjectorStats(forceRefresh bool) map[string]interface{} {
+
+	if forceRefresh {
+		// Query system-probe's /telemetry endpoint to trigger the telemetry scheduler to collect stats.
+		_, _ = s.querySystemProbe("/telemetry")
+
+		// The scheduler has a delay start before running down the Collect callbacks.
+		// Give enough time for the delay start and collection.
+		time.Sleep(10 * time.Second)
+	}
+
+	// Query system-probe's /debug/stats endpoint.
+	// We cannot use the /telemetry endpoint because it returns a compressed output.
+	output, err := s.querySystemProbe("/debug/stats")
+	if output != "" {
+		s.T().Logf("system-probe output:\n\n%s\n", output)
+	}
+	s.Require().NoErrorf(err, "failed to query system-probe: %s", output)
+
+	// Parse JSON response
+	var jsonOutput map[string]interface{}
+	err = json.Unmarshal([]byte(output), &jsonOutput)
+	s.Require().NoErrorf(err, "failed to parse JSON response: %s", output)
+
+	stats, ok := jsonOutput["injector"].(map[string]interface{})
+	s.Require().True(ok, "injector stats not found in JSON response")
+
+	return stats
+}
+
+// verifyStatsStructure verifies that the stats JSON contains expected fields
+func (s *testInjectorStats) verifyStatsStructure(stats map[string]interface{}) {
+	// Verify that all expected counter fields are present
+	expectedFields := []string{
+		"processes_added_to_injection_tracker",
+		"processes_removed_from_injection_tracker",
+		"processes_skipped_subsystem",
+		"processes_skipped_container",
+		"processes_skipped_protected",
+		"processes_skipped_system",
+		"processes_skipped_excluded",
+		"injection_attempts",
+		"injection_attempt_failures",
+		"injection_max_time_us",
+		"injection_successes",
+		"injection_failures",
+		"pe_caching_failures",
+		"import_directory_restoration_failures",
+		"pe_memory_allocation_failures",
+		"pe_injection_context_allocated",
+		"pe_injection_context_cleanedup",
+	}
+
+	for _, field := range expectedFields {
+		s.Require().Contains(stats, field, "stats should contain field: %s", field)
+
+		// Verify the field value is a number (JSON unmarshals numbers as float64)
+		value, ok := stats[field].(float64)
+		s.Require().True(ok, "field %s should be a number, got %T", field, stats[field])
+		s.Require().GreaterOrEqual(value, float64(0), "counter %s should be non-negative", field)
+	}
+
+	// Log the stats for debugging
+	s.T().Logf("Injector Stats: %+v", stats)
+}
+
+// enableInjectorTelemetry enables reporting of injector telemetry via system-probe config
+// Uses the read/modify/write pattern to preserve existing config settings
+func (s *testInjectorStats) enableInjectorTelemetry() {
+	host := s.Env().RemoteHost
+	configRoot, err := windowsAgent.GetConfigRootFromRegistry(host)
+	s.Require().NoError(err)
+	configPath := filepath.Join(configRoot, "system-probe.yaml")
+
+	// Read existing config (or create empty map if file doesn't exist)
+	config, err := s.readYamlConfig(configPath)
+	if err != nil {
+		// If file doesn't exist, start with empty config
+		config = make(map[string]interface{})
+	}
+
+	// Explicitly enable injector telemetry.
+	// If /telemetry supports uncompressed output, make sure to also enable
+	// RAR with remote_agent_registry.enabled = true.
+	config["injector"] = map[string]interface{}{
+		"enable_telemetry": true,
+	}
+
+	// Write back the modified config
+	err = s.writeYamlConfig(configPath, config)
+	s.Require().NoErrorf(err, "failed to write system-probe config")
+
+	// Restart system-probe to pick up the config
+	err = windowscommon.RestartService(host, "datadog-system-probe")
+	s.Require().NoErrorf(err, "failed to restart system-probe")
+
+	s.waitForServiceRunning()
+}
+
+// readYamlConfig reads and unmarshals a YAML config file from the remote host
+func (s *testInjectorStats) readYamlConfig(path string) (map[string]interface{}, error) {
+	host := s.Env().RemoteHost
+	configBytes, err := host.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	config := make(map[string]interface{})
+	err = yaml.Unmarshal(configBytes, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// writeYamlConfig marshals and writes a YAML config file to the remote host
+func (s *testInjectorStats) writeYamlConfig(path string, config map[string]interface{}) error {
+	host := s.Env().RemoteHost
+	configYaml, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	_, err = host.WriteFile(path, configYaml)
+	return err
+}
+
+// installCurrentAgentVersionWithAPMInject installs the current agent version with APM inject via script
+func (s *testInjectorStats) installCurrentAgentVersionWithAPMInject(opts ...installerwindows.Option) {
+	output, err := s.InstallScript().Run(opts...)
+	if s.NoError(err) {
+		fmt.Printf("%s\n", output)
+	}
+	s.Require().NoErrorf(err, "failed to install the Datadog Agent package: %s", output)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogInstallerService().
+		HasARunningDatadogAgentService().
+		WithVersionMatchPredicate(func(version string) {
+			s.Require().Contains(version, s.CurrentAgentVersion().Version())
+		})
+
+	s.waitForServiceRunning()
+}
+
+func (s *testInjectorStats) waitForServiceRunning() {
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"ddinjector"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+}
+
+func (s *testInjectorStats) logInjectorDiagnostics() {
+	host := s.Env().RemoteHost
+
+	// Log if ddinjector is running at all.
+	out, err := host.Execute(`Get-Service ddinjector`)
+	if err != nil {
+		s.T().Errorf("failed to query ddinjector service: %v", err)
+	} else {
+		s.T().Logf("ddinjector service output:\n\n%s\n", out)
+	}
+
+	// Log the current config.
+	configRoot, err := windowsAgent.GetConfigRootFromRegistry(host)
+	if err != nil {
+		s.T().Errorf("failed to get config root from registry: %v", err)
+	} else {
+		configPath := filepath.Join(configRoot, "system-probe.yaml")
+		config, err := s.readYamlConfig(configPath)
+		if err != nil {
+			s.T().Errorf("failed to read system-probe.yaml: %v", err)
+		} else {
+			s.T().Logf("system-probe config:\n\n%+v\n", config)
+		}
+	}
+}
+
+func (s *testInjectorStats) querySystemProbe(queryPath string) (string, error) {
+	// PowerShell script with inline C# to query system-probe with a named pipe.
+	scriptTemplate := `
+$code = @"
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+
+public class NamedPipeClient
+{
+    public static string QuerySystemProbe(string pipeName, string httpPath)
+    {
+        using (var pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut))
+        {
+            pipe.Connect(5000); // 5 second timeout
+
+            // Send HTTP GET request
+            string request = string.Format("GET {0} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", httpPath);
+            byte[] requestBytes = Encoding.UTF8.GetBytes(request);
+            pipe.Write(requestBytes, 0, requestBytes.Length);
+            pipe.Flush();
+
+            // Read response
+            using (var reader = new StreamReader(pipe, Encoding.UTF8))
+            {
+                string response = reader.ReadToEnd();
+
+                // Extract JSON body from HTTP response (after headers)
+                int bodyStart = response.IndexOf("\r\n\r\n");
+                if (bodyStart > 0)
+                {
+                    return response.Substring(bodyStart + 4);
+                }
+
+                throw new Exception("Failed to parse HTTP response");
+            }
+        }
+    }
+}
+"@
+
+Add-Type -TypeDefinition $code -Language CSharp
+
+try {
+    $result = [NamedPipeClient]::QuerySystemProbe("dd_system_probe", "%s")
+    Write-Output $result
+} catch {
+    Write-Error "Failed to query system-probe: $_"
+    exit 1
+}`
+
+	script := fmt.Sprintf(scriptTemplate, queryPath)
+	host := s.Env().RemoteHost
+	return host.Execute(script)
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds periodic reporting of ddinjector stats (counters) as telemetry via the new RAR/Prometheus model.
This is enabled via system-probe.yaml, injector.enable_telemetry=true.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1887

### Describe how you validated your changes
New E2E tests and Go test.
Manually query system-probe with NamedPipeCmd.exe: namedpipecmd.exe -method GET -path /debug/stats -quiet
Manually queried telemetry diagnostics: `agent.exe diagnose show-metadata agent-telemetry`

### Additional Notes
ddinjector is still not in production.

