### PR TITLE
[NCM] Clean up existing profiles (AOSW, standardized redaction replacement)

### DIFF
--- a/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
@@ -9,7 +9,7 @@
         "validation": [
           {
             "type": "valid_output",
-            "pattern": "(?i)Building Configuration"
+            "pattern": "Building Configuration..."
           }
         ],
         "redaction": [

--- a/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
@@ -9,7 +9,7 @@
         "validation": [
           {
             "type": "valid_output",
-            "pattern": "Building Configuration"
+            "pattern": "(?i)Building Configuration"
           }
         ],
         "redaction": [
@@ -22,7 +22,7 @@
             "replacement": "$1 <secret removed>"
           },
           {
-            "regex": "(?m)^(.*PRE-SHARE) (\\S+)\\s?$",
+            "regex": "(?mi)^(.*pre-share) (\\S+)\\s?$",
             "replacement": "$1 <secret removed>"
           },
           {
@@ -80,6 +80,20 @@
           {
             "regex": "community (.*?)\\s*$",
             "replacement": "community <secret removed>"
+          },
+          {
+            "regex": "(?m)^(snmp-server host \\S+ (?:trap )?version (?:v?[123]c?|v3)) (\\S+)(.*)",
+            "replacement": "$1 <secret removed>$3"
+          },
+          {
+            "regex": "(?m)^(vrrp \\d+.*\\n.*\\n)(authentication) (\\S+)",
+            "replacement": "$1$2 <secret removed>",
+            "multiline": true
+          },
+          {
+            "regex": "Building Configuration...\\s*",
+            "replacement": "",
+            "multiline": true
           }
         ]
       }

--- a/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/aosw.json
@@ -15,79 +15,79 @@
         "redaction": [
           {
             "regex": "(?m)^(secret) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(enable secret) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?mi)^(.*pre-share) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(.*ipsec) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(.*community) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "( sha) (\\S+)",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "( des) (\\S+)",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(mobility-manager \\S+ user \\S+) (\\S+)",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(mgmt-user \\S+ (?:root|guest-provisioning|network-operations|read-only|location-api-mgmt)) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(mgmt-user \\S+) (\\S+)( (?:read-only|guest-mgmt))?\\s?$",
-            "replacement": "$1 <secret removed> $3"
+            "replacement": "$1 <secret hidden> $3"
           },
           {
             "regex": "(?m)^(.*key) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(vrrp-passphrase) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(wpa-passphrase) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(bkup-passwords) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(ap-console-password) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(virtual-controller-key) (\\S+)\\s?$",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "community (.*?)\\s*$",
-            "replacement": "community <secret removed>"
+            "replacement": "community <secret hidden>"
           },
           {
             "regex": "(?m)^(snmp-server host \\S+ (?:trap )?version (?:v?[123]c?|v3)) (\\S+)(.*)",
-            "replacement": "$1 <secret removed>$3"
+            "replacement": "$1 <secret hidden>$3"
           },
           {
             "regex": "(?m)^(vrrp \\d+.*\\n.*\\n)(authentication) (\\S+)",
-            "replacement": "$1$2 <secret removed>",
+            "replacement": "$1$2 <secret hidden>",
             "multiline": true
           },
           {

--- a/pkg/networkconfigmanagement/profile/default_profiles/cisco-ios.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/cisco-ios.json
@@ -21,6 +21,10 @@
           {
             "type": "valid_output",
             "pattern": "Building configuration..."
+          },
+          {
+            "type": "valid_output",
+            "pattern": "Current configuration :"
           }
         ],
         "redaction": [

--- a/pkg/networkconfigmanagement/profile/default_profiles/cisco-ios.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/cisco-ios.json
@@ -26,7 +26,7 @@
         "redaction": [
           {
             "regex": "(?m)^(snmp-server community).*",
-            "replacement": "$1 <configuration removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
@@ -118,7 +118,7 @@
           },
           {
             "regex": "(?m)^( +pre-shared-key).*",
-            "replacement": "$1 <configuration removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",
@@ -173,7 +173,7 @@
         "redaction": [
           {
             "regex": "(?m)^(snmp-server community).*",
-            "replacement": "$1 <configuration removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(snmp-server host \\S+( vrf \\S+)?( informs?)?( version (1|2c))?) +\\S+( .*)?$",
@@ -265,7 +265,7 @@
           },
           {
             "regex": "(?m)^( +pre-shared-key).*",
-            "replacement": "$1 <configuration removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(?m)^(.*server-key(?: \\d)?) \\S+",

--- a/pkg/networkconfigmanagement/profile/default_profiles/eos.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/eos.json
@@ -15,31 +15,31 @@
         "redaction": [
           {
             "regex": "^(snmp-server community).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(secret \\w+) (\\S+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(password \\d+) (\\S+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(service unsupported-transceiver).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(tacacs-server key \\d+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(radius-server .+ key \\d) \\S+",
-            "replacement": "$1 <<secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "( {6}key) ([0-9a-fA-F]+ 7) ([0-9a-fA-F]+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(localized|auth (md5|sha\\d{0,3})|priv (des|aes\\d{0,3})) \\S+",
@@ -79,31 +79,31 @@
         "redaction": [
           {
             "regex": "^(snmp-server community).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(secret \\w+) (\\S+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(password \\d+) (\\S+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(service unsupported-transceiver).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(tacacs-server key \\d+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "^(radius-server .+ key \\d) \\S+",
-            "replacement": "$1 <<secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "( {6}key) ([0-9a-fA-F]+ 7) ([0-9a-fA-F]+).*",
-            "replacement": "$1 <secret removed>"
+            "replacement": "$1 <secret hidden>"
           },
           {
             "regex": "(localized|auth (md5|sha\\d{0,3})|priv (des|aes\\d{0,3})) \\S+",

--- a/pkg/networkconfigmanagement/profile/default_profiles/junos.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/junos.json
@@ -26,11 +26,11 @@
         "redaction": [
           {
             "regex": "(?m)^(\\s*community) (\\S+) (\\{)",
-            "replacement": "$1 <hidden> {"
+            "replacement": "$1 <secret hidden> {"
           },
           {
             "regex":  " \\\"\\$\\d\\$\\S+; ## SECRET-DATA",
-            "replacement": " <secret removed>;"
+            "replacement": " <secret hidden>;"
           }
         ]
       }

--- a/pkg/networkconfigmanagement/profile/default_profiles/pan-os.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/pan-os.json
@@ -15,7 +15,7 @@
         "redaction": [
           {
             "regex": "<phash>.*?</phash>",
-            "replacement": "<phash><redacted></phash>"
+            "replacement": "<phash><secret hidden></phash>"
           }
         ]
       }

--- a/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/tmos.json
@@ -21,27 +21,27 @@
         "redaction": [
           {
             "regex": "^([\\s\\t]*)secret \\S+",
-            "replacement": "${1}secret <secret removed>"
+            "replacement": "${1}secret <secret hidden>"
           },
           {
             "regex": "^([\\s\\t]*\\S*)password \\S+",
-            "replacement": "${1}password <secret removed>"
+            "replacement": "${1}password <secret hidden>"
           },
           {
             "regex": "^([\\s\\t]*\\S*)passphrase \\S+",
-            "replacement": "${1}passphrase <secret removed>"
+            "replacement": "${1}passphrase <secret hidden>"
           },
           {
             "regex": "^(\\s*)community \\S+",
-            "replacement": "${1}community <secret removed>"
+            "replacement": "${1}community <secret hidden>"
           },
           {
             "regex": "^(\\s*)community-name \\S+",
-            "replacement": "${1}community-name <secret removed>"
+            "replacement": "${1}community-name <secret hidden>"
           },
           {
             "regex": "^([\\s\\t]*\\S*)encrypted \\S+$",
-            "replacement": "${1}encrypted <secret removed>"
+            "replacement": "${1}encrypted <secret hidden>"
           }
         ]
       }

--- a/pkg/networkconfigmanagement/profile/fixtures/aosw/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/aosw/running/expected.txt
@@ -1,11 +1,9 @@
-Building Configuration...
-
 version 8.10
 hostname "OXID-IZE01"
 clock timezone Europe/Berlin +02 0
 !
 vpn-dialer default-dialer
-ike authentication pre-share AAAAAAAAAABBBBBBBBBB
+ike authentication pre-share <secret removed>
 !
 !
 crypto isakmp policy 20
@@ -57,8 +55,8 @@ opmode wpa2-psk-aes
 !
 
 snmp-server enable trap
-snmp-server host 10.42.1.5 version 2c AAAAAAAAAABBBBBBBBBB udp-port 162
-snmp-server host 10.42.1.6 version 2c AAAAAAAAAABBBBBBBBBB udp-port 162
+snmp-server host 10.42.1.5 version 2c <secret removed> udp-port 162
+snmp-server host 10.42.1.6 version 2c <secret removed> udp-port 162
 !
 conductor-redundancy
 conductor-vrrp 255
@@ -66,7 +64,7 @@ peer-ip-address 10.42.0.3 ipsec <secret removed>
 !
 vrrp 254
 priority 110
-authentication AAAAAAAAAABBBBBBBBBB
+authentication <secret removed>
 ip address 10.42.0.8
 description "VRRP-Master"
 vlan 42

--- a/pkg/networkconfigmanagement/profile/fixtures/aosw/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/aosw/running/expected.txt
@@ -3,7 +3,7 @@ hostname "OXID-IZE01"
 clock timezone Europe/Berlin +02 0
 !
 vpn-dialer default-dialer
-ike authentication pre-share <secret removed>
+ike authentication pre-share <secret hidden>
 !
 !
 crypto isakmp policy 20
@@ -12,10 +12,10 @@ authentication pre-share
 !
 syslocation "LOCATION"
 syscontact "OXIDIZED"
-snmp-server community <secret removed>
-snmp-server community <secret removed>
+snmp-server community <secret hidden>
+snmp-server community <secret hidden>
 mgmt-user admin root ******************** node /
-mgmt-user oxidized root <secret removed>
+mgmt-user oxidized root <secret hidden>
 
 !
 country DE
@@ -23,21 +23,21 @@ change-config-node /
 !
 aaa authentication-server tacacs "tacacs1"
 host "10.42.0.12"
-key <secret removed>
+key <secret hidden>
 !
 aaa authentication-server tacacs "tacacs2"
 host "10.42.0.13"
-key <secret removed>
+key <secret hidden>
 !
 aaa authentication-server radius "radius1"
 host "10.42.0.14"
-key <secret removed>
+key <secret hidden>
 nas-identifier "OXID-IZE01"
 nas-ip 10.42.0.5
 !
 preemption
 state-sync
-pre-shared-key <secret removed>
+pre-shared-key <secret hidden>
 controller 10.42.0.2 role active
 controller 10.42.0.3 role standby
 !
@@ -45,26 +45,26 @@ ap system-profile "AP-PROFILE"
     session-acl ""
 lms-ip 10.42.0.52
 bkup-lms-ip 10.42.0.53
-ap-console-password <secret removed>
-bkup-passwords <secret removed>
+ap-console-password <secret hidden>
+bkup-passwords <secret hidden>
 !
 wlan ssid-profile "PSK-SSID"
 essid "PSK-SSID"
-wpa-passphrase <secret removed>
+wpa-passphrase <secret hidden>
 opmode wpa2-psk-aes
 !
 
 snmp-server enable trap
-snmp-server host 10.42.1.5 version 2c <secret removed> udp-port 162
-snmp-server host 10.42.1.6 version 2c <secret removed> udp-port 162
+snmp-server host 10.42.1.5 version 2c <secret hidden> udp-port 162
+snmp-server host 10.42.1.6 version 2c <secret hidden> udp-port 162
 !
 conductor-redundancy
 conductor-vrrp 255
-peer-ip-address 10.42.0.3 ipsec <secret removed>
+peer-ip-address 10.42.0.3 ipsec <secret hidden>
 !
 vrrp 254
 priority 110
-authentication <secret removed>
+authentication <secret hidden>
 ip address 10.42.0.8
 description "VRRP-Master"
 vlan 42

--- a/pkg/networkconfigmanagement/profile/fixtures/cisco-ios/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/cisco-ios/running/expected.txt
@@ -24,8 +24,8 @@ crypto key generate rsa modulus 2048
 ip ssh version 2
 !
 ! ---- SNMP (communities and hosts) ------------------------------------
-snmp-server community <configuration removed>
-snmp-server community <configuration removed>
+snmp-server community <secret hidden>
+snmp-server community <secret hidden>
 snmp-server host 10.0.0.5 version 2c <secret hidden>
 snmp-server host 10.0.0.6 vrf Mgmt-vrf informs version 2c <secret hidden> udp-port 162
 snmp-server location LAB-DC

--- a/pkg/networkconfigmanagement/profile/fixtures/cisco-ios/startup/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/cisco-ios/startup/expected.txt
@@ -93,7 +93,7 @@ ip ssh version 2
 !
 ipv6 ioam timestamp
 !
-snmp-server community <configuration removed>
+snmp-server community <secret hidden>
 snmp-server chassis-id
 !
 !

--- a/pkg/networkconfigmanagement/profile/fixtures/eos/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/eos/running/expected.txt
@@ -6,17 +6,17 @@ ip name-server vrf default 8.8.8.8
 !
 ntp server 10.101.0.1
 !
-snmp-server community <secret removed>
-snmp-server community <secret removed>
+snmp-server community <secret hidden>
+snmp-server community <secret hidden>
 !
 spanning-tree mode mstp
 !
 aaa authorization exec default local
 !
-enable secret 5 <secret removed>
+enable secret 5 <secret hidden>
 no aaa root
 !
-username admin privilege 15 role network-admin secret 5 <secret removed>
+username admin privilege 15 role network-admin secret 5 <secret hidden>
 !
 vlan 2,4093
 !

--- a/pkg/networkconfigmanagement/profile/fixtures/eos/startup/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/eos/startup/expected.txt
@@ -4,17 +4,17 @@ ip name-server vrf default 8.8.8.8
 !
 ntp server 10.101.0.1
 !
-snmp-server community <secret removed>
-snmp-server community <secret removed>
+snmp-server community <secret hidden>
+snmp-server community <secret hidden>
 !
 spanning-tree mode mstp
 !
 aaa authorization exec default local
 !
-enable secret 5 <secret removed>
+enable secret 5 <secret hidden>
 no aaa root
 !
-username admin privilege 15 role network-admin secret 5 <secret removed>
+username admin privilege 15 role network-admin secret 5 <secret hidden>
 !
 vlan 2,4093
 !

--- a/pkg/networkconfigmanagement/profile/fixtures/junos/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/junos/running/expected.txt
@@ -3,21 +3,21 @@ system {
     host-name core-switch-01;
     time-zone America/Chicago;
     root-authentication {
-        encrypted-password <secret removed>;
+        encrypted-password <secret hidden>;
     }
     login {
         user admin {
             uid 2000;
             class super-user;
             authentication {
-                encrypted-password <secret removed>;
+                encrypted-password <secret hidden>;
             }
         }
         user readonly {
             uid 2001;
             class read-only;
             authentication {
-                encrypted-password <secret removed>;
+                encrypted-password <secret hidden>;
             }
         }
     }
@@ -49,13 +49,13 @@ system {
     snmp {
         location "Data Center 1 - Row C Rack 12";
         contact "noc@example.com";
-        community <hidden> {
+        community <secret hidden> {
             authorization read-only;
             clients {
                 10.10.10.10/32;
             }
         }
-        community <hidden> {
+        community <secret hidden> {
             authorization read-write;
             clients {
                 10.10.10.20/32;
@@ -129,12 +129,12 @@ protocols {
 security {
     ssh-key {
         rsa {
-            private-key <secret removed>;
-            public-key <secret removed>;
+            private-key <secret hidden>;
+            public-key <secret hidden>;
         }
         ecdsa {
-            private-key <secret removed>;
-            public-key <secret removed>;
+            private-key <secret hidden>;
+            public-key <secret hidden>;
         }
     }
 }

--- a/pkg/networkconfigmanagement/profile/fixtures/pan-os/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/pan-os/running/expected.txt
@@ -3,7 +3,7 @@
   <mgt-config>
     <users>
       <entry name="admin">
-        <phash><redacted></phash>
+        <phash><secret hidden></phash>
         <permissions>
           <role-based>
             <superuser>yes</superuser>
@@ -16,7 +16,7 @@
             <superuser>yes</superuser>
           </role-based>
         </permissions>
-        <phash><redacted></phash>
+        <phash><secret hidden></phash>
       </entry>
     </users>
   </mgt-config>

--- a/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/tmos/running/expected.txt
@@ -9,7 +9,7 @@ ltm virtual /Common/web_vip {
     profiles {
         /Common/http { }
         /Common/clientssl {
-            passphrase <secret removed>
+            passphrase <secret hidden>
         }
     }
 }
@@ -25,23 +25,23 @@ ltm pool /Common/web_pool {
 sys snmp {
     communities {
         public {
-            community <secret removed>
+            community <secret hidden>
         }
         secure {
-            community-name <secret removed>
+            community-name <secret hidden>
         }
     }
 }
 
 auth user admin {
-    password <secret removed>
-    encrypted <secret removed>
+    password <secret hidden>
+    encrypted <secret hidden>
 }
 
 radius-server /Common/radius1 {
-    secret <secret removed>
+    secret <secret hidden>
 }
 
 tacacs-server /Common/tac1 {
-    secret <secret removed>
+    secret <secret hidden>
 }


### PR DESCRIPTION
### What does this PR do?

* general clean up of the `aosw` profile (remove more lines that aren't part of config), remove additional secrets not accommodated for by oxidized
* quick refactor by cursor for replacing non-standard redactions to use `<secret hidden>` for ease of searching this point onwards for all profiles

**TODO**
- [x] QA on QA-able profiles (cisco, namely)
- [x] determine other small-ish improvements i can fit into this pr - maybe worth starting a new one at that point
  - [x] during cisco QA - realizing `ios` devices are sometimes attributed to `aosw` devices (guessing b/c of the matching command for getting configs) thinking to prioritize more unique things (didn't keep in mind for validation rules) `nx-os` devices seemed ok but maybe there's something with the ordering of profiles in the case of vendors with the same command
  - [x] ok good news everyone, i refined the validation rules for now, but will need to follow up with another PR for better profile matching support

### Motivation

### Describe how you validated your changes
Pull in the ndm-tools/cml-qa repo and follow instructions for setting up the CLI ([link](https://github.com/DataDog/ndm-tools/tree/main/cml-qa))
```
python cml_template_generator.py \
  --deb-url <INSERT THE DEB FROM CI/CD BUILD> \
  --api-key <INSERT YOUR KEY> \
  --site "datad0g.com" \
  --title "<YOUR NAME/TITLE> NCM Agent QA"
```

QA on CML:
* go the NDM hosted CML ([docs](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5061640281/Getting+Started+with+Cisco+Modeling+Labs+CML))
* press Import
* pull in the YAML that gets created, start the lab

i made a custom YAML (added on to the generated base YAML) so that IOS + NX-OS device would appear on the same lab - will try to update `cml-qa` repo at some point to help with making it easy to generate that

<img width="492" height="303" alt="image" src="https://github.com/user-attachments/assets/fddfc2c1-1245-4165-b340-443083a451b0" />

```
cisco@qa-agent:~$ sudo -u dd-agent -- datadog-agent check network_config_management
check network_config_management

Multiple check instances found, running each of them
{"namespace":"cml-test-cleanup","configs":[{"device_id":"cml-test-cleanup:10.10.1.2","device_ip":"10.10.1.2","config_type":"running","config_source":"cli","timestamp":1769805515,"tags":["device_namespace:cml-test-cleanup","device_ip:10.10.1.2","device_id:cml-test-cleanup:10.10.1.2","config_source:cli","profile:nxos"],"content":"\nversion 10.5(1) Bios:version  \nhostname nxos9000-0\nvdc nxos9000-0 id 1\n  limit-resource vlan minimum 16 maximum 4094\n  limit-resource vrf minimum 2 maximum 4096\n  limit-resource port-channel minimum 0 maximum 511\n  limit-resource m4route-mem minimum 58 maximum 58\n  limit-resource m6route-mem minimum 8 maximum 8\n\nno password strength-check\nusername admin password 5 \u003csecret hidden\u003e  role network-admin\nusername adminbackup password 5 \u003csecret hidden\u003e  role network-operator\nusername adminbackup passphrase  lifetime 99999 warntime 14 gracetime 3\nusername cisco password 5 \u003csecret hidden\u003e  role network-operator\nusername cisco role network-admin\nusername cisco passphrase  lifetime 99999 warntime 14 gracetime 3\nusername lab password 5 \u003csecret hidden\u003e  role network-admin\nusername lab passphrase  lifetime 99999 warntime 14 gracetime 3\nssh key rsa 2048 \nip domain-lookup\ncopp profile strict\nsnmp-server user lab network-admin auth md5 \u003csecret hidden\u003e \nsnmp-server user admin network-admin auth md5 \u003csecret hidden\u003e \nsnmp-server user cisco network-operator auth md5 \u003csecret hidden\u003e \nsnmp-server user cisco network-admin\nrmon event 1 log trap public description FATAL(1) owner PMON@FATAL\nrmon event 2 log trap public description CRITICAL(2) owner PMON@CRITICAL\nrmon event 3 log trap public description ERROR(3) owner PMON@ERROR\nrmon event 4 log trap public description WARNING(4) owner PMON@WARNING\nrmon event 5 log trap public description INFORMATION(5) owner PMON@INFO\n\nvlan 1\n\nvrf context management\nhardware forwarding unicast trace\n\n\ninterface Ethernet1/1\n  description not connected\n  shutdown\n\ninterface Ethernet1/2\n  description not connected\n  shutdown\n\ninterface Ethernet1/3\n  description not connected\n  shutdown\n\ninterface Ethernet1/4\n\ninterface Ethernet1/5\n\ninterface Ethernet1/6\n\ninterface Ethernet1/7\n\ninterface Ethernet1/8\n\ninterface Ethernet1/9\n\ninterface Ethernet1/10\n\ninterface Ethernet1/11\n\ninterface Ethernet1/12\n\ninterface Ethernet1/13\n\ninterface Ethernet1/14\n\ninterface Ethernet1/15\n\ninterface Ethernet1/16\n\ninterface Ethernet1/17\n\ninterface Ethernet1/18\n\ninterface Ethernet1/19\n\ninterface Ethernet1/20\n\ninterface Ethernet1/21\n\ninterface Ethernet1/22\n\ninterface Ethernet1/23\n\ninterface Ethernet1/24\n\ninterface Ethernet1/25\n\ninterface Ethernet1/26\n\ninterface Ethernet1/27\n\ninterface Ethernet1/28\n\ninterface Ethernet1/29\n\ninterface Ethernet1/30\n\ninterface Ethernet1/31\n\ninterface Ethernet1/32\n\ninterface Ethernet1/33\n\ninterface Ethernet1/34\n\ninterface Ethernet1/35\n\ninterface Ethernet1/36\n\ninterface Ethernet1/37\n\ninterface Ethernet1/38\n\ninterface Ethernet1/39\n\ninterface Ethernet1/40\n\ninterface Ethernet1/41\n\ninterface Ethernet1/42\n\ninterface Ethernet1/43\n\ninterface Ethernet1/44\n\ninterface Ethernet1/45\n\ninterface Ethernet1/46\n\ninterface Ethernet1/47\n\ninterface Ethernet1/48\n\ninterface Ethernet1/49\n\ninterface Ethernet1/50\n\ninterface Ethernet1/51\n\ninterface Ethernet1/52\n\ninterface Ethernet1/53\n\ninterface Ethernet1/54\n\ninterface Ethernet1/55\n\ninterface Ethernet1/56\n\ninterface Ethernet1/57\n\ninterface Ethernet1/58\n\ninterface Ethernet1/59\n\ninterface Ethernet1/60\n\ninterface Ethernet1/61\n\ninterface Ethernet1/62\n\ninterface Ethernet1/63\n\ninterface Ethernet1/64\n\ninterface mgmt0\n  vrf member management\n  ip address 10.10.1.2/24\n\ninterface loopback0\n  description not connected\n  shutdown\nicam monitor scale\n\nline console\nline vty\nboot nxos bootflash:/nxos64-cs.10.5.1.F.bin \n\n\n\n"},{"device_id":"cml-test-cleanup:10.10.1.2","device_ip":"10.10.1.2","config_type":"startup","config_source":"cli","timestamp":1769805517,"tags":["device_namespace:cml-test-cleanup","device_ip:10.10.1.2","device_id:cml-test-cleanup:10.10.1.2","config_source:cli","profile:nxos"],"content":"\nversion 10.5(1) Bios:version  \nhostname nxos9000-0\nvdc nxos9000-0 id 1\n  limit-resource vlan minimum 16 maximum 4094\n  limit-resource vrf minimum 2 maximum 4096\n  limit-resource port-channel minimum 0 maximum 511\n  limit-resource m4route-mem minimum 58 maximum 58\n  limit-resource m6route-mem minimum 8 maximum 8\n\nno password strength-check\nusername admin password 5 \u003csecret hidden\u003e  role network-admin\nusername adminbackup password 5 \u003csecret hidden\u003e  role network-operator\nusername adminbackup passphrase  lifetime 99999 warntime 14 gracetime 3\nusername cisco password 5 \u003csecret hidden\u003e  role network-operator\nusername cisco role network-admin\nusername cisco passphrase  lifetime 99999 warntime 14 gracetime 3\nusername lab password 5 \u003csecret hidden\u003e  role network-admin\nusername lab passphrase  lifetime 99999 warntime 14 gracetime 3\nssh key rsa 2048 \nip domain-lookup\ncopp profile strict\nsnmp-server user lab network-admin auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user admin network-admin auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user cisco network-operator auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user cisco network-admin\nrmon event 1 log trap public description FATAL(1) owner PMON@FATAL\nrmon event 2 log trap public description CRITICAL(2) owner PMON@CRITICAL\nrmon event 3 log trap public description ERROR(3) owner PMON@ERROR\nrmon event 4 log trap public description WARNING(4) owner PMON@WARNING\nrmon event 5 log trap public description INFORMATION(5) owner PMON@INFO\n\nvlan 1\n\nvrf context management\nhardware forwarding unicast trace\n\n\ninterface Ethernet1/1\n  description not connected\n  shutdown\n\ninterface Ethernet1/2\n  description not connected\n  shutdown\n\ninterface Ethernet1/3\n  description not connected\n  shutdown\n\ninterface Ethernet1/4\n\ninterface Ethernet1/5\n\ninterface Ethernet1/6\n\ninterface Ethernet1/7\n\ninterface Ethernet1/8\n\ninterface Ethernet1/9\n\ninterface Ethernet1/10\n\ninterface Ethernet1/11\n\ninterface Ethernet1/12\n\ninterface Ethernet1/13\n\ninterface Ethernet1/14\n\ninterface Ethernet1/15\n\ninterface Ethernet1/16\n\ninterface Ethernet1/17\n\ninterface Ethernet1/18\n\ninterface Ethernet1/19\n\ninterface Ethernet1/20\n\ninterface Ethernet1/21\n\ninterface Ethernet1/22\n\ninterface Ethernet1/23\n\ninterface Ethernet1/24\n\ninterface Ethernet1/25\n\ninterface Ethernet1/26\n\ninterface Ethernet1/27\n\ninterface Ethernet1/28\n\ninterface Ethernet1/29\n\ninterface Ethernet1/30\n\ninterface Ethernet1/31\n\ninterface Ethernet1/32\n\ninterface Ethernet1/33\n\ninterface Ethernet1/34\n\ninterface Ethernet1/35\n\ninterface Ethernet1/36\n\ninterface Ethernet1/37\n\ninterface Ethernet1/38\n\ninterface Ethernet1/39\n\ninterface Ethernet1/40\n\ninterface Ethernet1/41\n\ninterface Ethernet1/42\n\ninterface Ethernet1/43\n\ninterface Ethernet1/44\n\ninterface Ethernet1/45\n\ninterface Ethernet1/46\n\ninterface Ethernet1/47\n\ninterface Ethernet1/48\n\ninterface Ethernet1/49\n\ninterface Ethernet1/50\n\ninterface Ethernet1/51\n\ninterface Ethernet1/52\n\ninterface Ethernet1/53\n\ninterface Ethernet1/54\n\ninterface Ethernet1/55\n\ninterface Ethernet1/56\n\ninterface Ethernet1/57\n\ninterface Ethernet1/58\n\ninterface Ethernet1/59\n\ninterface Ethernet1/60\n\ninterface Ethernet1/61\n\ninterface Ethernet1/62\n\ninterface Ethernet1/63\n\ninterface Ethernet1/64\n\ninterface mgmt0\n  vrf member management\n  ip address 10.10.1.2/24\n\ninterface loopback0\n  description not connected\n  shutdown\nicam monitor scale\n\nline console\nline vty\nboot nxos bootflash:/nxos64-cs.10.5.1.F.bin \n\n\n\n"}],"collect_timestamp":1769805536}
=== Series ===
[
  {
    "metric": "datadog.ncm.check_duration",
    "points": [
      [
        1769805536,
        6.806216548
      ]
    ],
    "tags": [
      "agent_host:qa-agent",
      "agent_version:7.77.0-devel+git.81.239821a",
      "config_source:cli",
      "device_id:cml-test-cleanup:10.10.1.2",
      "device_ip:10.10.1.2",
      "device_namespace:cml-test-cleanup",
      "profile:nxos"
    ],
    "host": "qa-agent",
    "type": "gauge",
    "interval": 0,
    "source_type_name": "System"
  }
]
=== ndmconfig ===
[
  {
    "EventType": "ndmconfig",
    "UnmarshalledEvent": {
      "collect_timestamp": 1769805536,
      "configs": [
        {
          "config_source": "cli",
          "config_type": "running",
          "content": "\nversion 10.5(1) Bios:version  \nhostname nxos9000-0\nvdc nxos9000-0 id 1\n  limit-resource vlan minimum 16 maximum 4094\n  limit-resource vrf minimum 2 maximum 4096\n  limit-resource port-channel minimum 0 maximum 511\n  limit-resource m4route-mem minimum 58 maximum 58\n  limit-resource m6route-mem minimum 8 maximum 8\n\nno password strength-check\nusername admin password 5 \u003csecret hidden\u003e  role network-admin\nusername adminbackup password 5 \u003csecret hidden\u003e  role network-operator\nusername adminbackup passphrase  lifetime 99999 warntime 14 gracetime 3\nusername cisco password 5 \u003csecret hidden\u003e  role network-operator\nusername cisco role network-admin\nusername cisco passphrase  lifetime 99999 warntime 14 gracetime 3\nusername lab password 5 \u003csecret hidden\u003e  role network-admin\nusername lab passphrase  lifetime 99999 warntime 14 gracetime 3\nssh key rsa 2048 \nip domain-lookup\ncopp profile strict\nsnmp-server user lab network-admin auth md5 \u003csecret hidden\u003e \nsnmp-server user admin network-admin auth md5 \u003csecret hidden\u003e \nsnmp-server user cisco network-operator auth md5 \u003csecret hidden\u003e \nsnmp-server user cisco network-admin\nrmon event 1 log trap public description FATAL(1) owner PMON@FATAL\nrmon event 2 log trap public description CRITICAL(2) owner PMON@CRITICAL\nrmon event 3 log trap public description ERROR(3) owner PMON@ERROR\nrmon event 4 log trap public description WARNING(4) owner PMON@WARNING\nrmon event 5 log trap public description INFORMATION(5) owner PMON@INFO\n\nvlan 1\n\nvrf context management\nhardware forwarding unicast trace\n\n\ninterface Ethernet1/1\n  description not connected\n  shutdown\n\ninterface Ethernet1/2\n  description not connected\n  shutdown\n\ninterface Ethernet1/3\n  description not connected\n  shutdown\n\ninterface Ethernet1/4\n\ninterface Ethernet1/5\n\ninterface Ethernet1/6\n\ninterface Ethernet1/7\n\ninterface Ethernet1/8\n\ninterface Ethernet1/9\n\ninterface Ethernet1/10\n\ninterface Ethernet1/11\n\ninterface Ethernet1/12\n\ninterface Ethernet1/13\n\ninterface Ethernet1/14\n\ninterface Ethernet1/15\n\ninterface Ethernet1/16\n\ninterface Ethernet1/17\n\ninterface Ethernet1/18\n\ninterface Ethernet1/19\n\ninterface Ethernet1/20\n\ninterface Ethernet1/21\n\ninterface Ethernet1/22\n\ninterface Ethernet1/23\n\ninterface Ethernet1/24\n\ninterface Ethernet1/25\n\ninterface Ethernet1/26\n\ninterface Ethernet1/27\n\ninterface Ethernet1/28\n\ninterface Ethernet1/29\n\ninterface Ethernet1/30\n\ninterface Ethernet1/31\n\ninterface Ethernet1/32\n\ninterface Ethernet1/33\n\ninterface Ethernet1/34\n\ninterface Ethernet1/35\n\ninterface Ethernet1/36\n\ninterface Ethernet1/37\n\ninterface Ethernet1/38\n\ninterface Ethernet1/39\n\ninterface Ethernet1/40\n\ninterface Ethernet1/41\n\ninterface Ethernet1/42\n\ninterface Ethernet1/43\n\ninterface Ethernet1/44\n\ninterface Ethernet1/45\n\ninterface Ethernet1/46\n\ninterface Ethernet1/47\n\ninterface Ethernet1/48\n\ninterface Ethernet1/49\n\ninterface Ethernet1/50\n\ninterface Ethernet1/51\n\ninterface Ethernet1/52\n\ninterface Ethernet1/53\n\ninterface Ethernet1/54\n\ninterface Ethernet1/55\n\ninterface Ethernet1/56\n\ninterface Ethernet1/57\n\ninterface Ethernet1/58\n\ninterface Ethernet1/59\n\ninterface Ethernet1/60\n\ninterface Ethernet1/61\n\ninterface Ethernet1/62\n\ninterface Ethernet1/63\n\ninterface Ethernet1/64\n\ninterface mgmt0\n  vrf member management\n  ip address 10.10.1.2/24\n\ninterface loopback0\n  description not connected\n  shutdown\nicam monitor scale\n\nline console\nline vty\nboot nxos bootflash:/nxos64-cs.10.5.1.F.bin \n\n\n\n",
          "device_id": "cml-test-cleanup:10.10.1.2",
          "device_ip": "10.10.1.2",
          "tags": [
            "device_namespace:cml-test-cleanup",
            "device_ip:10.10.1.2",
            "device_id:cml-test-cleanup:10.10.1.2",
            "config_source:cli",
            "profile:nxos"
          ],
          "timestamp": 1769805515
        },
        {
          "config_source": "cli",
          "config_type": "startup",
          "content": "\nversion 10.5(1) Bios:version  \nhostname nxos9000-0\nvdc nxos9000-0 id 1\n  limit-resource vlan minimum 16 maximum 4094\n  limit-resource vrf minimum 2 maximum 4096\n  limit-resource port-channel minimum 0 maximum 511\n  limit-resource m4route-mem minimum 58 maximum 58\n  limit-resource m6route-mem minimum 8 maximum 8\n\nno password strength-check\nusername admin password 5 \u003csecret hidden\u003e  role network-admin\nusername adminbackup password 5 \u003csecret hidden\u003e  role network-operator\nusername adminbackup passphrase  lifetime 99999 warntime 14 gracetime 3\nusername cisco password 5 \u003csecret hidden\u003e  role network-operator\nusername cisco role network-admin\nusername cisco passphrase  lifetime 99999 warntime 14 gracetime 3\nusername lab password 5 \u003csecret hidden\u003e  role network-admin\nusername lab passphrase  lifetime 99999 warntime 14 gracetime 3\nssh key rsa 2048 \nip domain-lookup\ncopp profile strict\nsnmp-server user lab network-admin auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user admin network-admin auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user cisco network-operator auth md5 \u003csecret hidden\u003e priv des \u003csecret hidden\u003e localizedkey\nsnmp-server user cisco network-admin\nrmon event 1 log trap public description FATAL(1) owner PMON@FATAL\nrmon event 2 log trap public description CRITICAL(2) owner PMON@CRITICAL\nrmon event 3 log trap public description ERROR(3) owner PMON@ERROR\nrmon event 4 log trap public description WARNING(4) owner PMON@WARNING\nrmon event 5 log trap public description INFORMATION(5) owner PMON@INFO\n\nvlan 1\n\nvrf context management\nhardware forwarding unicast trace\n\n\ninterface Ethernet1/1\n  description not connected\n  shutdown\n\ninterface Ethernet1/2\n  description not connected\n  shutdown\n\ninterface Ethernet1/3\n  description not connected\n  shutdown\n\ninterface Ethernet1/4\n\ninterface Ethernet1/5\n\ninterface Ethernet1/6\n\ninterface Ethernet1/7\n\ninterface Ethernet1/8\n\ninterface Ethernet1/9\n\ninterface Ethernet1/10\n\ninterface Ethernet1/11\n\ninterface Ethernet1/12\n\ninterface Ethernet1/13\n\ninterface Ethernet1/14\n\ninterface Ethernet1/15\n\ninterface Ethernet1/16\n\ninterface Ethernet1/17\n\ninterface Ethernet1/18\n\ninterface Ethernet1/19\n\ninterface Ethernet1/20\n\ninterface Ethernet1/21\n\ninterface Ethernet1/22\n\ninterface Ethernet1/23\n\ninterface Ethernet1/24\n\ninterface Ethernet1/25\n\ninterface Ethernet1/26\n\ninterface Ethernet1/27\n\ninterface Ethernet1/28\n\ninterface Ethernet1/29\n\ninterface Ethernet1/30\n\ninterface Ethernet1/31\n\ninterface Ethernet1/32\n\ninterface Ethernet1/33\n\ninterface Ethernet1/34\n\ninterface Ethernet1/35\n\ninterface Ethernet1/36\n\ninterface Ethernet1/37\n\ninterface Ethernet1/38\n\ninterface Ethernet1/39\n\ninterface Ethernet1/40\n\ninterface Ethernet1/41\n\ninterface Ethernet1/42\n\ninterface Ethernet1/43\n\ninterface Ethernet1/44\n\ninterface Ethernet1/45\n\ninterface Ethernet1/46\n\ninterface Ethernet1/47\n\ninterface Ethernet1/48\n\ninterface Ethernet1/49\n\ninterface Ethernet1/50\n\ninterface Ethernet1/51\n\ninterface Ethernet1/52\n\ninterface Ethernet1/53\n\ninterface Ethernet1/54\n\ninterface Ethernet1/55\n\ninterface Ethernet1/56\n\ninterface Ethernet1/57\n\ninterface Ethernet1/58\n\ninterface Ethernet1/59\n\ninterface Ethernet1/60\n\ninterface Ethernet1/61\n\ninterface Ethernet1/62\n\ninterface Ethernet1/63\n\ninterface Ethernet1/64\n\ninterface mgmt0\n  vrf member management\n  ip address 10.10.1.2/24\n\ninterface loopback0\n  description not connected\n  shutdown\nicam monitor scale\n\nline console\nline vty\nboot nxos bootflash:/nxos64-cs.10.5.1.F.bin \n\n\n\n",
          "device_id": "cml-test-cleanup:10.10.1.2",
          "device_ip": "10.10.1.2",
          "tags": [
            "device_namespace:cml-test-cleanup",
            "device_ip:10.10.1.2",
            "device_id:cml-test-cleanup:10.10.1.2",
            "config_source:cli",
            "profile:nxos"
          ],
          "timestamp": 1769805517
        }
      ],
      "namespace": "cml-test-cleanup"
    }
  }
]


  Running Checks
  ==============
    
    network_config_management
    -------------------------
      Instance ID: network_config_management:cml-test-cleanup:f26f7cad87ac49ec [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]
      Total Runs: 1
      Metric Samples: Last Run: 1, Total: 1
      Events: Last Run: 0, Total: 0
      ndmconfig: Last Run: 1, Total: 1
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 6.811s
      Last Execution Date : 2026-01-30 20:38:56.669 UTC (1769805536669)
      Last Successful Execution Date : 2026-01-30 20:38:56 UTC (1769805536000)
      
  Check Worker Utilization
  ========================
    No worker utilization data available

  Metadata
  ========
    config.hash: network_config_management:cml-test-cleanup:f26f7cad87ac49ec
    config.provider: file
    config.source: /etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[0]
{"namespace":"cml-test-cleanup","configs":[{"device_id":"cml-test-cleanup:10.10.2.1","device_ip":"10.10.2.1","config_type":"running","config_source":"cli","timestamp":1769805542,"tags":["device_namespace:cml-test-cleanup","device_ip:10.10.2.1","device_id:cml-test-cleanup:10.10.2.1","config_source:cli","profile:cisco-ios"],"content":"!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.2.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003csecret hidden\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n"},{"device_id":"cml-test-cleanup:10.10.2.1","device_ip":"10.10.2.1","config_type":"startup","config_source":"cli","timestamp":1769805542,"tags":["device_namespace:cml-test-cleanup","device_ip:10.10.2.1","device_id:cml-test-cleanup:10.10.2.1","config_source:cli","profile:cisco-ios"],"content":"!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.2.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003csecret hidden\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n"}],"collect_timestamp":1769805542}
=== Series ===
[
  {
    "metric": "datadog.ncm.check_duration",
    "points": [
      [
        1769805542,
        5.604060864
      ]
    ],
    "tags": [
      "agent_host:qa-agent",
      "agent_version:7.77.0-devel+git.81.239821a",
      "config_source:cli",
      "device_id:cml-test-cleanup:10.10.2.1",
      "device_ip:10.10.2.1",
      "device_namespace:cml-test-cleanup",
      "profile:cisco-ios"
    ],
    "host": "qa-agent",
    "type": "gauge",
    "interval": 0,
    "source_type_name": "System"
  }
]
=== ndmconfig ===
[
  {
    "EventType": "ndmconfig",
    "UnmarshalledEvent": {
      "collect_timestamp": 1769805542,
      "configs": [
        {
          "config_source": "cli",
          "config_type": "running",
          "content": "!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.2.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003csecret hidden\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n",
          "device_id": "cml-test-cleanup:10.10.2.1",
          "device_ip": "10.10.2.1",
          "tags": [
            "device_namespace:cml-test-cleanup",
            "device_ip:10.10.2.1",
            "device_id:cml-test-cleanup:10.10.2.1",
            "config_source:cli",
            "profile:cisco-ios"
          ],
          "timestamp": 1769805542
        },
        {
          "config_source": "cli",
          "config_type": "startup",
          "content": "!\nversion 15.9\nservice timestamps debug datetime msec\nservice timestamps log datetime msec\nno service password-encryption\n!\nhostname qa-device\n!\nboot-start-marker\nboot-end-marker\n!\n!\n!\nno aaa new-model\n!\n!\n!\nmmi polling-interval 60\nno mmi auto-configure\nno mmi pvc\nmmi snmp-timeout 180\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\nip domain name lab.local\nip cef\nno ipv6 cef\n!\nmultilink bundle-name authenticated\n!\n!\n!\n!\nusername cisco privilege 15 secret 9 \u003csecret hidden\u003e\n!\nredundancy\n!\n!\n! \n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\n!\ninterface GigabitEthernet0/0\n ip address 10.10.2.1 255.255.255.0\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/1\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/2\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\ninterface GigabitEthernet0/3\n no ip address\n shutdown\n duplex auto\n speed auto\n media-type rj45\n!\nip forward-protocol nd\n!\n!\nno ip http server\nno ip http secure-server\nip ssh version 2\n!\nipv6 ioam timestamp\n!\nsnmp-server community \u003csecret hidden\u003e\nsnmp-server chassis-id \n!\n!\ncontrol-plane\n!\n!\nline con 0\nline aux 0\nline vty 0 4\n login local\n transport input ssh\n!\nno scheduler allocate\n!\nend\n",
          "device_id": "cml-test-cleanup:10.10.2.1",
          "device_ip": "10.10.2.1",
          "tags": [
            "device_namespace:cml-test-cleanup",
            "device_ip:10.10.2.1",
            "device_id:cml-test-cleanup:10.10.2.1",
            "config_source:cli",
            "profile:cisco-ios"
          ],
          "timestamp": 1769805542
        }
      ],
      "namespace": "cml-test-cleanup"
    }
  }
]


  Running Checks
  ==============
    
    network_config_management
    -------------------------
      Instance ID: network_config_management:cml-test-cleanup:cacf04ea00e5cc10 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[1]
      Total Runs: 1
      Metric Samples: Last Run: 1, Total: 1
      Events: Last Run: 0, Total: 0
      ndmconfig: Last Run: 1, Total: 1
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 5.691s
      Last Execution Date : 2026-01-30 20:39:02.5 UTC (1769805542500)
      Last Successful Execution Date : 2026-01-30 20:39:02 UTC (1769805542000)
      
  Check Worker Utilization
  ========================
    No worker utilization data available

  Metadata
  ========
    config.hash: network_config_management:cml-test-cleanup:cacf04ea00e5cc10
    config.provider: file
    config.source: /etc/datadog-agent/conf.d/network_config_management.d/conf.yaml[1]
Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.
This check type has 2 instances. If you're looking for a different check instance, try filtering on a specific one using the --instance-filter flag or set --discovery-min-instances to a higher value
cisco@qa-agent:~$ 
```



### Additional Notes
