### PR TITLE
[CWS] Ensure rule engine is stopped before API server

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -331,13 +331,15 @@ func (c *CWSConsumer) Stop() {
 
 	c.cancelFnc()
 
-	if c.apiServer != nil {
-		c.apiServer.Stop()
-	}
-
+	// Stop the rule engine first to stop goroutines that send heartbeat/ruleset loaded events to the reporter
 	c.ruleEngine.Stop()
 
 	c.wg.Wait()
+
+	// Now we shouldn't have anymore events to send so we can safely stop the API server to close reporter channels
+	if c.apiServer != nil {
+		c.apiServer.Stop()
+	}
 
 	c.grpcCmdServer.Stop()
 	if c.grpcEventServer != nil {


### PR DESCRIPTION
### What does this PR do?

Stops the rule engine go routines before closing the API server reporter channels to ensure these goroutines do not send ruleset or heartbeat events on a closed channel.

### Motivation

Avoid `send on closed channel` panics when system-probe is shutting down.

```
panic: send on closed channel
goroutine 1689 [running]:
github.com/DataDog/datadog-agent/pkg/security/reporter.(*RuntimeReporter).ReportRaw(0xc003ea66c0, {0xc00a422000, 0x50b0b, 0x52000}, {0xc000612c08, 0xd}, {0x10?, 0x44?, 0x0?}, {0xc000bd1208, ...})
	github.com/DataDog/datadog-agent/pkg/security/reporter/reporter.go:40 +0x1ff
github.com/DataDog/datadog-agent/pkg/security/module.(*DirectEventMsgSender).Send(0xc0030170e0, 0xc002b7cf00, 0x3a?)
	github.com/DataDog/datadog-agent/pkg/security/module/msg_sender.go:103 +0x12f
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).SendEvent(0xc00072a6e0, 0xc0083eae10, {0x2d05ee0, 0xc00848b1d0}, 0x0, {0x0, 0x0})
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:545 +0xdac
github.com/DataDog/datadog-agent/pkg/security/module.(*CWSConsumer).SendEvent(0xc003b180d0, 0xc0083eae10, {0x2d05ee0, 0xc00848b1d0}, 0x0, {0x0, 0x0})
	github.com/DataDog/datadog-agent/pkg/security/module/cws.go:348 +0x96
github.com/DataDog/datadog-agent/pkg/security/rules/monitor.ReportRuleSetLoaded({0xc0083eae10?, 0xc00848b1d0?}, {0x2ce4600, 0xc003b180d0}, {0x2d1fb00?, 0xc000892010?})
	github.com/DataDog/datadog-agent/pkg/security/rules/monitor/policy_monitor.go:145 +0x142
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).LoadPolicies(0xc00361b1e0, {0xc00177ea40, 0x4, 0x4}, 0x1)
	github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:420 +0xa30
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).ReloadPolicies(0xc00361b1e0)
	github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:338 +0x51
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).Start.func2()
	github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:205 +0x85
created by github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:201 +0x61d
```

### Describe how you validated your changes

### Additional Notes
