### PR TITLE
[CWS] share string interner across dentry resolver and activity tree

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -87,6 +87,18 @@ var (
 	// Tags: -
 	MetricDentryERPCResolutionTimeUs = newRuntimeMetric(".dentry_resolver.erpc_avg_resolution_time_usec")
 
+	// String interner metrics
+
+	// MetricStringInternerHits is the counter of hits in a string interner
+	// Tags: interner
+	MetricStringInternerHits = newRuntimeMetric(".string_interner.hits")
+	// MetricStringInternerMisses is the counter of misses in a string interner
+	// Tags: interner
+	MetricStringInternerMisses = newRuntimeMetric(".string_interner.misses")
+	// MetricStringInternerSize is the current size of a string interner
+	// Tags: interner
+	MetricStringInternerSize = newRuntimeMetric(".string_interner.size")
+
 	// DNS Resolver metrics
 
 	// MetricDNSResolverIPResolverCache is the counter for the IP resolver (A and AAAA records)

--- a/pkg/security/probe/fuzz_test.go
+++ b/pkg/security/probe/fuzz_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	securityprofile "github.com/DataDog/datadog-agent/pkg/security/security_profile"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
@@ -104,7 +105,7 @@ func newFuzzEBPFProbe(tb testing.TB) *EBPFProbe {
 		tb.Fatalf("failed to create test process resolver: %v", err)
 	}
 
-	dentryResolver, err := dentry.NewResolver(probeConfig, noopSD, nil)
+	dentryResolver, err := dentry.NewResolver(probeConfig, noopSD, nil, utils.NewLRUStringInterner(16384, "basename"))
 	if err != nil {
 		tb.Fatalf("failed to create dentry resolver: %v", err)
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1018,6 +1018,17 @@ func (p *EBPFProbe) SendStats() error {
 		}
 	}
 
+	if p.Resolvers.BasenameInterner != nil {
+		if err := p.Resolvers.BasenameInterner.SendStats(p.statsdClient, metrics.MetricStringInternerHits, metrics.MetricStringInternerMisses, metrics.MetricStringInternerSize); err != nil {
+			return err
+		}
+	}
+	if p.Resolvers.PathInterner != nil {
+		if err := p.Resolvers.PathInterner.SendStats(p.statsdClient, metrics.MetricStringInternerHits, metrics.MetricStringInternerMisses, metrics.MetricStringInternerSize); err != nil {
+			return err
+		}
+	}
+
 	value := p.BPFFilterTruncated.Swap(0)
 	if err := p.statsdClient.Count(metrics.MetricBPFFilterTruncated, int64(value), []string{}, 1.0); err != nil {
 		return err
@@ -3189,7 +3200,13 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 		WorkloadMeta:             opts.WorkloadMeta,
 	}
 
-	p.Resolvers, err = resolvers.NewEBPFResolvers(config, p.Manager, probe.StatsdClient, probe.scrubber, p.Erpc, resolversOpts)
+	// String interners. Basenames are shared between the dentry resolver and the activity tree
+	// FileNode.Name. Full paths are stored only on activity tree FileNode leaves and have a much
+	// higher cardinality, so they get their own larger LRU to avoid evicting basenames.
+	basenameInterner := utils.NewLRUStringInterner(16384, "basename")
+	pathInterner := utils.NewLRUStringInterner(65536, "path")
+
+	p.Resolvers, err = resolvers.NewEBPFResolvers(config, p.Manager, probe.StatsdClient, probe.scrubber, p.Erpc, resolversOpts, basenameInterner, pathInterner)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3200,13 +3200,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, hostname string, opts Opt
 		WorkloadMeta:             opts.WorkloadMeta,
 	}
 
-	// String interners. Basenames are shared between the dentry resolver and the activity tree
-	// FileNode.Name. Full paths are stored only on activity tree FileNode leaves and have a much
-	// higher cardinality, so they get their own larger LRU to avoid evicting basenames.
-	basenameInterner := utils.NewLRUStringInterner(16384, "basename")
-	pathInterner := utils.NewLRUStringInterner(65536, "path")
-
-	p.Resolvers, err = resolvers.NewEBPFResolvers(config, p.Manager, probe.StatsdClient, probe.scrubber, p.Erpc, resolversOpts, basenameInterner, pathInterner)
+	p.Resolvers, err = resolvers.NewEBPFResolvers(config, p.Manager, probe.StatsdClient, probe.scrubber, p.Erpc, resolversOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -76,6 +76,8 @@ type Resolver struct {
 	erpcResolutionAvgTime   float64
 	erpcResolutionNumValues int64
 	erpcResolutionTimesLock sync.Mutex
+
+	interner *utils.LRUStringInterner
 }
 
 // ErrEntryNotFound is thrown when a path key was not found in the cache
@@ -464,7 +466,7 @@ func (dr *Resolver) cacheEntries(keys []model.PathKey, names [][]byte) error {
 
 	for i, k := range keys {
 		cacheEntry := PathEntry{
-			Name: string(names[i]),
+			Name: dr.interner.Deduplicate(string(names[i])),
 		}
 		if len(keys) > i+1 {
 			cacheEntry.Parent = keys[i+1]
@@ -763,7 +765,7 @@ func (dr *Resolver) Close() error {
 }
 
 // NewResolver returns a new dentry resolver
-func NewResolver(config *config.Config, statsdClient statsd.ClientInterface, e *erpc.ERPC) (*Resolver, error) {
+func NewResolver(config *config.Config, statsdClient statsd.ClientInterface, e *erpc.ERPC, interner *utils.LRUStringInterner) (*Resolver, error) {
 	hitsCounters := make(map[counterEntry]*atomic.Int64)
 	missCounters := make(map[counterEntry]*atomic.Int64)
 	for _, resolution := range metrics.AllResolutionsTags {
@@ -802,5 +804,6 @@ func NewResolver(config *config.Config, statsdClient statsd.ClientInterface, e *
 		missCounters:  missCounters,
 		numCPU:        numCPU,
 		challenge:     rand.Uint32(),
+		interner:      interner,
 	}, nil
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -495,7 +495,7 @@ type argsEnvsCacheEntry struct {
 	truncated bool
 }
 
-var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize)
+var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize, "args_envs")
 
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -45,6 +45,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 )
 
+const (
+	basenameInternerCacheSize = 64
+	pathInternerCacheSize     = 128
+)
+
 // EBPFResolvers holds the list of the event attribute resolvers
 type EBPFResolvers struct {
 	manager              *manager.Manager
@@ -76,7 +81,13 @@ type EBPFResolvers struct {
 }
 
 // NewEBPFResolvers creates a new instance of EBPFResolvers
-func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *utils.Scrubber, eRPC *erpc.ERPC, opts Opts, basenameInterner, pathInterner *utils.LRUStringInterner) (*EBPFResolvers, error) {
+func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *utils.Scrubber, eRPC *erpc.ERPC, opts Opts) (*EBPFResolvers, error) {
+	// String interners. Basenames are shared between the dentry resolver and the activity tree
+	// FileNode.Name. Full paths are stored only on activity tree FileNode leaves and have a much
+	// higher cardinality, so they get their own larger LRU to avoid evicting basenames.
+	basenameInterner := utils.NewLRUStringInterner(basenameInternerCacheSize, "basename")
+	pathInterner := utils.NewLRUStringInterner(pathInternerCacheSize, "path")
+
 	dentryResolver, err := dentry.NewResolver(config.Probe, statsdClient, eRPC, basenameInterner)
 	if err != nil {
 		return nil, err

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -66,12 +66,18 @@ type EBPFResolvers struct {
 	FileMetadataResolver *file.Resolver
 	SignatureResolver    *sign.Resolver
 
+	// BasenameInterner deduplicates path components (basenames). Shared between the dentry resolver
+	// cache entries and the activity tree FileNode.Name field.
+	BasenameInterner *utils.LRUStringInterner
+	// PathInterner deduplicates full reduced file paths stored on activity tree FileNode leaves.
+	PathInterner *utils.LRUStringInterner
+
 	SnapshotUsingListmount bool
 }
 
 // NewEBPFResolvers creates a new instance of EBPFResolvers
-func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *utils.Scrubber, eRPC *erpc.ERPC, opts Opts) (*EBPFResolvers, error) {
-	dentryResolver, err := dentry.NewResolver(config.Probe, statsdClient, eRPC)
+func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdClient statsd.ClientInterface, scrubber *utils.Scrubber, eRPC *erpc.ERPC, opts Opts, basenameInterner, pathInterner *utils.LRUStringInterner) (*EBPFResolvers, error) {
+	dentryResolver, err := dentry.NewResolver(config.Probe, statsdClient, eRPC, basenameInterner)
 	if err != nil {
 		return nil, err
 	}
@@ -218,6 +224,8 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		FileMetadataResolver:   fileMetadataResolver,
 		SnapshotUsingListmount: config.Probe.SnapshotUsingListmount,
 		SignatureResolver:      sign.NewSignatureResolver(),
+		BasenameInterner:       basenameInterner,
+		PathInterner:           pathInterner,
 	}
 
 	return resolvers, nil

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -47,6 +47,15 @@ func NewFileNode(fileEvent *model.FileEvent, event *model.Event, name string, im
 		resolvers.HashResolver.ComputeHashesFromEvent(event, fileEvent, 0)
 	}
 
+	if resolvers != nil {
+		if resolvers.BasenameInterner != nil {
+			name = resolvers.BasenameInterner.Deduplicate(name)
+		}
+		if resolvers.PathInterner != nil && reducedFilePath != "" {
+			reducedFilePath = resolvers.PathInterner.Deduplicate(reducedFilePath)
+		}
+	}
+
 	fan := &FileNode{
 		Name:           name,
 		GenerationType: generationType,

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/dentry"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 func TestDentryPathERPC(t *testing.T) {
@@ -332,7 +333,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc)
+	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc, utils.NewLRUStringInterner(16384, "basename"))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -401,7 +402,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc)
+	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc, utils.NewLRUStringInterner(16384, "basename"))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -469,7 +470,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc)
+	resolver, err := dentry.NewResolver(test.probe.Config.Probe, test.probe.StatsdClient, p.Erpc, utils.NewLRUStringInterner(16384, "basename"))
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/security/utils/lru_interner.go
+++ b/pkg/security/utils/lru_interner.go
@@ -8,25 +8,35 @@ package utils
 import (
 	"sync"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"go.uber.org/atomic"
 )
 
 // LRUStringInterner is a best-effort LRU-based string deduplicator
 type LRUStringInterner struct {
 	sync.Mutex
 	store *simplelru.LRU[string, string]
+	name  string
+
+	hits   *atomic.Int64
+	misses *atomic.Int64
 }
 
 // NewLRUStringInterner returns a new LRUStringInterner, with the cache size provided
-// if the cache size is negative this function will panic
-func NewLRUStringInterner(size int) *LRUStringInterner {
+// if the cache size is negative this function will panic. The name is used to tag
+// metrics emitted by SendStats.
+func NewLRUStringInterner(size int, name string) *LRUStringInterner {
 	store, err := simplelru.NewLRU[string, string](size, nil)
 	if err != nil {
 		panic(err)
 	}
 
 	return &LRUStringInterner{
-		store: store,
+		store:  store,
+		name:   name,
+		hits:   atomic.NewInt64(0),
+		misses: atomic.NewInt64(0),
 	}
 }
 
@@ -40,9 +50,11 @@ func (si *LRUStringInterner) Deduplicate(value string) string {
 
 func (si *LRUStringInterner) deduplicateUnsafe(value string) string {
 	if res, ok := si.store.Get(value); ok {
+		si.hits.Inc()
 		return res
 	}
 
+	si.misses.Inc()
 	si.store.Add(value, value)
 	return value
 }
@@ -55,4 +67,26 @@ func (si *LRUStringInterner) DeduplicateSlice(values []string) {
 	for i := range values {
 		values[i] = si.deduplicateUnsafe(values[i])
 	}
+}
+
+// SendStats sends interner metrics (hits, misses, size) tagged with the interner name.
+func (si *LRUStringInterner) SendStats(client statsd.ClientInterface, hitsMetric, missesMetric, sizeMetric string) error {
+	tags := []string{"interner:" + si.name}
+
+	if hits := si.hits.Swap(0); hits > 0 {
+		if err := client.Count(hitsMetric, hits, tags, 1.0); err != nil {
+			return err
+		}
+	}
+	if misses := si.misses.Swap(0); misses > 0 {
+		if err := client.Count(missesMetric, misses, tags, 1.0); err != nil {
+			return err
+		}
+	}
+
+	si.Lock()
+	size := si.store.Len()
+	si.Unlock()
+
+	return client.Gauge(sizeMetric, float64(size), tags, 1.0)
 }


### PR DESCRIPTION
### What does this PR do?

Instantiate the LRUStringInterner in probe_ebpf.go and share it with the
activity tree FileNode so the same deduplicated strings back the dentry
cache and the profile/dump file trees.

Two separate interners are used to avoid cardinality clash:
- BasenameInterner (16k entries): path components, shared between the
  dentry resolver cache and FileNode.Name.
- PathInterner (64k entries): full reduced file paths stored only on
  FileNode leaves.

Skip the path interner lookup when reducedFilePath is empty (internal
tree nodes), and expose hits/misses/size metrics on the interner,
tagged with an interner name for observability.


### Motivation

### Describe how you validated your changes

### Additional Notes
