### PR TITLE
Minor: replace JUnit upload stack trace with highlighted skip message

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -75,6 +75,10 @@ def junit_upload_from_tgz(junit_tgz, result_json, codeowners_path=".github/CODEO
     with open(codeowners_path) as f:
         codeowners = CodeOwners(f.read())
 
+    if not os.path.exists(junit_tgz):
+        print(color_message(f"Skipping JUnit upload: {junit_tgz} is missing from earlier step", "orange"))
+        return
+
     junit_tgz = find_tarball(junit_tgz)
 
     with (


### PR DESCRIPTION
### Motivation
When there's no test to run, we [currently get](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1379580063#L439):
```
No modules to test
Running unit tests...
Skipping Codecov upload: coverage.out is missing from earlier step
Uploading JUnit files for c:\mnt\junit-tests-windows-x64.tgz...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "c:\program files\Python312\Lib\site-packages\invoke\__main__.py", line 3, in <module>
    program.run()
  File "c:\program files\Python312\Lib\site-packages\invoke\program.py", line 398, in run
    self.execute()
  File "c:\program files\Python312\Lib\site-packages\invoke\program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "c:\program files\Python312\Lib\site-packages\invoke\executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildroot\datadog-agent\tasks\custom_task\custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\buildroot\datadog-agent\tasks\junit_tasks.py", line 12, in junit_upload
    junit_upload_from_tgz(tgz_path, result_json)
  File "C:\buildroot\datadog-agent\tasks\libs\common\junit_upload_core.py", line 87, in junit_upload_from_tgz
    with tarfile.open(junit_tgz) as tgz:
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\program files\Python312\Lib\tarfile.py", line 1835, in open
    return func(name, "r", fileobj, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\program files\Python312\Lib\tarfile.py", line 1903, in gzopen
    fileobj = GzipFile(name, mode + "b", compresslevel, fileobj)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\program files\Python312\Lib\gzip.py", line 192, in __init__
    fileobj = self.myfileobj = builtins.open(filename, mode or 'rb')
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\mnt\\junit-tests-windows-x64.tgz'
junit upload failed (non-fatal): junit upload failed with exit code 1
Test passed
```

The stack trace is verbose and the error is ignored, so it's just noisy.


### What does this PR do?
The present change aims at replacing it with:
```
No modules to test
Running unit tests...
Skipping Codecov upload: coverage.out is missing from earlier step
Skipping JUnit upload: c:\mnt\junit-tests-windows-x64.tgz is missing from earlier step
Test passed
```
... with the same highlighting as the earlier skip message.