### PR TITLE
[EBPF] ebpf: follow jumps in the printk patcher

### DIFF
--- a/pkg/ebpf/printk_patcher.go
+++ b/pkg/ebpf/printk_patcher.go
@@ -9,6 +9,7 @@ package ebpf
 
 import (
 	"errors"
+	"fmt"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
@@ -18,6 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+const maxLookbackLimit = 150
+const maxRecursionLimit = 2
 
 // patchPrintkNewline patches log_debug calls to always print one newline, no matter what the kernel does.
 //
@@ -44,169 +48,289 @@ func patchPrintkNewline(m *manager.Manager) error {
 	var errs []error
 
 	for _, p := range progs {
-		_, err := patchPrintkInstructions(p)
+		patcher := newPrintkPatcher(p)
+		_, err := patcher.patch()
 		errs = append(errs, err)
 	}
 
 	return errors.Join(errs...)
 }
 
-// patchPrintkInstructions patches the instructions of a program to remove the newline character
+type printkPatcher struct {
+	jumpSources       map[int][]int
+	program           *ebpf.ProgramSpec
+	indexToRealOffset map[int]int // maps the actual offset (the one used by the verifier and llvm) to the index of that instruction in the slice. Required to account for double-wide instructions when calculating jump offsets
+	realOffsetToIndex map[int]int // maps the actual offset (the one used by the verifier and llvm) to the index of that instruction in the slice. Required to account for double-wide instructions when calculating jump offsets
+
+	movImmOpCode  asm.OpCode
+	ldDWImmOpCode asm.OpCode
+	movRegOpCode  asm.OpCode
+	addImmOpCode  asm.OpCode
+}
+
+func newPrintkPatcher(p *ebpf.ProgramSpec) *printkPatcher {
+	return &printkPatcher{
+		jumpSources:       make(map[int][]int),
+		program:           p,
+		indexToRealOffset: make(map[int]int),
+		realOffsetToIndex: make(map[int]int),
+
+		// Precompute some opcodes we'll need
+		movImmOpCode:  asm.Mov.Op(asm.ImmSource),
+		ldDWImmOpCode: asm.LoadImmOp(asm.DWord),
+		movRegOpCode:  asm.Mov.Op(asm.RegSource),
+		addImmOpCode:  asm.Add.Op(asm.ImmSource),
+	}
+}
+
+func (p *printkPatcher) precomputeOffsets() {
+	iter := p.program.Instructions.Iterate()
+	for iter.Next() {
+		idx := int(iter.Offset)
+		p.indexToRealOffset[iter.Index] = idx
+		p.realOffsetToIndex[idx] = iter.Index
+	}
+}
+
+func (p *printkPatcher) populateJumpData() {
+	for idx, ins := range p.program.Instructions {
+		jumpOp := ins.OpCode.JumpOp()
+		if jumpOp != asm.Call && jumpOp != asm.Exit && jumpOp != asm.InvalidJumpOp {
+			sourceOffset := p.indexToRealOffset[idx]
+			targetOffset := sourceOffset + int(ins.Offset) + 1
+			targetIdx := p.realOffsetToIndex[targetOffset]
+
+			p.jumpSources[targetIdx] = append(p.jumpSources[targetIdx], idx)
+			log.Tracef("Found jump %d -> %d (offsets %d -> %d) in %s: %v", idx, targetIdx, sourceOffset, targetOffset, p.program.Name, ins)
+		}
+	}
+
+	log.Tracef("Found %d jump sources in %s", len(p.jumpSources), p.program.Name)
+}
+
+// patch patches the instructions of a program to remove the newline character
 // It's separated from patchPrintkNewline so it can be tested independently, also so that we can
 // check how many patches are performed
-func patchPrintkInstructions(p *ebpf.ProgramSpec) (int, error) {
+func (p *printkPatcher) patch() (int, error) {
 	var errs []error // list of errors that happened while patching, if any
 	numPatches := 0  // number of patches performed
 
-	// Compute some opcodes we'll need
-	movImmOpCode := asm.Mov.Op(asm.ImmSource)
-	ldDWImmOpCode := asm.LoadImmOp(asm.DWord)
-	movRegOpCode := asm.Mov.Op(asm.RegSource)
-	addImmOpCode := asm.Add.Op(asm.ImmSource)
+	// Precompute the offsets of the instructions so we can use them to calculate jump offsets properly, accounting for double-wide instructions
+	p.precomputeOffsets()
+
+	// Create a map of jump targets to the instruction index that jumps to it so that we
+	// can backtrack in case the compiler reuses the same "call 6" instruction for multiple calls to bpf_trace_printk.
+	p.populateJumpData()
 
 	// In some cases the compiler might reuse the same instruction for multiple calls to bpf_trace_printk,
 	// keep track of that to avoid errors when we don't find a newline in an instruction we've already patched.
 	patchedInstructionIndexes := make(map[int]bool)
+	patchedLengthLoadIndexes := make(map[int]bool)
 
-	log.Tracef("Start patching instructions for %s", p.Name)
-	for idx, ins := range p.Instructions {
+	log.Tracef("Start patching instructions for %s", p.program.Name)
+	for idx, ins := range p.program.Instructions {
 		if !ins.IsBuiltinCall() || ins.Constant != int64(asm.FnTracePrintk) {
 			continue // Not a call to bpf_trace_printk, skip
 		}
-		maxLookback := max(0, idx-100) // For safety, don't look back more than 100 instructions
-		log.Tracef("Found call to bpf_trace_printk at index %d in %s, maxLookback=%d", idx, p.Name, maxLookback)
+		realOffset := p.indexToRealOffset[idx]
+		log.Tracef("Found call to bpf_trace_printk at index %d in %s", realOffset, p.program.Name)
 
-		// We found the call to bpf_trace_printk, now we need to find
-		// the string on the stack and patch it.
-		// For that, find first the value of the second register, which is the second argument
+		// For safety, set a limit on look back and recursion depth, to avoid
+		// exploring the entire program every time we find a call to
+		// bpf_trace_printk.
+		requisiteInstructions, err := p.findRequisiteInstructions(idx, maxLookbackLimit, maxRecursionLimit, requisiteInstructions{})
+		if len(requisiteInstructions) == 0 && err != nil {
+			// Only log errors from the findRequisiteInstructions if we didn't have anything to patch
+			errs = append(errs, fmt.Errorf("error finding requisite instructions for bpf_trace_printk call %d in %s: %w", realOffset, p.program.Name, err))
+		}
+
+		for _, reqs := range requisiteInstructions {
+			// Perform the patching for this set of instructions
+			// This is the load instruction that's putting the newline character on the stack
+			// Now we need to patch it to put a null character instead
+			bitOffset := uint64(reqs.newlineOffsetInInstruction) * 8
+			mask := uint64(0xff) << bitOffset
+			if reqs.stringLoad.Constant&int64(mask) == int64('\n')<<int64(bitOffset) { // Sanity check: don't overwrite anything if it's not a newline
+				reqs.stringLoad.Constant &= int64(^mask) // Set the newline byte to 0
+
+				// We've correctly patched this instruction, reduce the length in one byte if we hadn't done before and continue looking for more
+				if !patchedLengthLoadIndexes[reqs.lengthLoadIndex] {
+					reqs.lengthLoad.Constant--
+					patchedLengthLoadIndexes[reqs.lengthLoadIndex] = true
+				}
+				patchedInstructionIndexes[reqs.stringLoadIndex] = true // Keep track of which instructions we've patched
+				numPatches++
+				log.Tracef("Patched instruction %v for bpf_trace_printk call %d in %s", reqs.stringLoad, realOffset, p.program.Name)
+			} else if patchedInstructionIndexes[reqs.stringLoadIndex] {
+				// We don't have a newline in the expected spot but we've already patched this instruction. The compiler
+				// can reuse the same instruction for multiple calls to bpf_trace_printk, and in that case
+				// we only need to patch it once. However, we do need to reduce the length in one byte because
+				// in some systems the printk call will not be made if the length is not consistent.
+				log.Tracef("Instruction %v was already patched for bpf_trace_printk call %d in %s", reqs.stringLoad, realOffset, p.program.Name)
+				if !patchedLengthLoadIndexes[reqs.lengthLoadIndex] {
+					reqs.lengthLoad.Constant--
+					patchedLengthLoadIndexes[reqs.lengthLoadIndex] = true
+				}
+				numPatches++
+			} else {
+				errs = append(errs, log.Warnf("Instruction %v (index %d) does not have a newline we can patch for bpf_trace_printk_call %d in %s", reqs.stringLoad, reqs.stringLoadIndex, realOffset, p.program.Name))
+			}
+
+		}
+	}
+	log.Debugf("Patched %d instructions for %s, errors: %v", numPatches, p.program.Name, errs)
+
+	return numPatches, errors.Join(errs...)
+}
+
+// requisiteInstructions is a struct that contains the instructions that are necessary for a printk call
+// All of these are needed to know to be able to patch the call
+type requisiteInstructions struct {
+	lengthLoad                 *asm.Instruction // The instruction that loads the length of the string into r2
+	lengthLoadIndex            int              // The index of the length load instruction in the program
+	stackOffset                *asm.Instruction // The instruction that loads the stack pointer into r1
+	stringStore                *asm.Instruction // The instruction that stores the string into the stack from a register
+	stringLoad                 *asm.Instruction // The instruction that loads the string from an immediate value to the register
+	stringLoadIndex            int              // The index of the string load instruction in the program
+	newlineOffsetInInstruction int              // The offset of the newline character in the instruction
+}
+
+func (r *requisiteInstructions) isComplete() bool {
+	return r.lengthLoad != nil && r.stackOffset != nil && r.stringStore != nil && r.stringLoad != nil
+}
+
+func (r *requisiteInstructions) newlineOffset() int16 {
+	return int16(r.stackOffset.Constant + r.lengthLoad.Constant - 2) // -1 because the last character is the null character
+}
+
+func (p *printkPatcher) findRequisiteInstructions(startIdx int, lookbackLimit int, recursionLimit int, currentInstructions requisiteInstructions) ([]requisiteInstructions, error) {
+	var errs []error // list of errors that happened while patching, if any
+	var foundInstructions []requisiteInstructions
+
+	insLimit := max(startIdx-lookbackLimit, 0)
+	for idx := startIdx; idx >= insLimit && !currentInstructions.isComplete(); idx-- {
+		ins := &p.program.Instructions[idx]
+		realOffset := p.indexToRealOffset[idx]
+
+		// If current instruction is an unconditional jump, we can't follow it,
+		// so stop (unless it's the first instruction we landed on, in which
+		// case it just means it's the source of the jump we took previously)
+		if ins.OpCode.JumpOp() == asm.Ja && idx != startIdx {
+			log.Tracef("Found unconditional jump instruction %v at %d in %s, stopping search", ins, realOffset, p.program.Name)
+			break
+		}
+
+		// Inspect the current instruction and see if it's any of the ones we need
+
+		// For the length load instruction, find first the value of the second register, which is the second argument
 		// to the call, which is the length of the string.
 		// Example instruction: MovImm dst: r2 imm: 0x0000000000000009 which
 		// sets the length of the formatting to 9
-		var lengthLoadIns *asm.Instruction
-		for i := idx - 1; i >= maxLookback; i-- {
-			candidate := &p.Instructions[i]
-			if candidate.OpCode == movImmOpCode && candidate.Dst == asm.R2 {
-				lengthLoadIns = candidate
-				break
-			}
+		if currentInstructions.lengthLoad == nil && ins.OpCode == p.movImmOpCode && ins.Dst == asm.R2 {
+			currentInstructions.lengthLoad = ins
+			currentInstructions.lengthLoadIndex = idx
+			log.Tracef("Found length load instruction %v at %d in %s", ins, realOffset, p.program.Name)
 		}
-		if lengthLoadIns == nil {
-			errs = append(errs, log.Warnf("Could not find length load instruction for bpf_trace_printk call %d in %s", idx, p.Name))
-			continue // Skip this call instruction
-		}
-		log.Tracef("Found length load instruction %v for bpf_trace_printk call %d in %s", lengthLoadIns, idx, p.Name)
 
-		// Now we have to find in which part the stack is the string being stored
-		// For that we need to find the mov instruction that puts the stack pointer
+		// For the stack offset instruction that tells us where the string is stored on the stack,
+		// we need to find the mov instruction that puts the stack pointer
 		// into r1 and then the add that modifies the stack offset
 		// We are looking for a sequence like this:
 		// MovReg dst: r1 src: rfp                 | Sets r1 to the stack pointer
 		// AddImm dst: r1 imm: 0x-000000000000048  | Adjusts the offset
-		var stackOffsetIns *asm.Instruction
-		for i := idx - 1; i >= maxLookback && stackOffsetIns == nil; i-- {
-			candidate := &p.Instructions[i]
-			if candidate.OpCode == movRegOpCode && candidate.Dst == asm.R1 && candidate.Src == asm.RFP {
-				// Ok, so we found the instruction that loads the stack pointer into r1
-				// From that, advance until we find the add instruction that modifies the stack offset
-				// (the AddImm instruction in the example above)
-				for j := i + 1; j < idx; j++ {
-					candidate = &p.Instructions[j]
-					if candidate.OpCode == addImmOpCode && candidate.Dst == asm.R1 {
-						stackOffsetIns = candidate
-						break
-					} else if (candidate.OpCode.Class().IsALU() || candidate.OpCode.Class().IsLoad()) && candidate.Dst == asm.R1 {
-						errs = append(errs, log.Warnf("Found instruction %v that modifies r1, aborting stack offset search for bpf_trace_printk call %d in %s", candidate, idx, p.Name))
-						break
-					}
+		if currentInstructions.stackOffset == nil && ins.OpCode == p.movRegOpCode && ins.Dst == asm.R1 && ins.Src == asm.RFP {
+			// Ok, so we found the instruction that loads the stack pointer into r1
+			// From that, advance until we find the add instruction that modifies the stack offset
+			// (the AddImm instruction in the example above)
+			for j := idx + 1; j < startIdx; j++ {
+				candidate := &p.program.Instructions[j]
+				if candidate.OpCode == p.addImmOpCode && candidate.Dst == asm.R1 {
+					currentInstructions.stackOffset = candidate
+					log.Tracef("Found stack offset instruction %v at %d in %s", candidate, realOffset, p.program.Name)
+					break
+				} else if (candidate.OpCode.Class().IsALU() || candidate.OpCode.Class().IsLoad()) && candidate.Dst == asm.R1 {
+					return nil, log.Warnf("Found instruction %v that modifies r1, aborting stack offset search for bpf_trace_printk", candidate, realOffset, p.program.Name)
 				}
 			}
 		}
-		if stackOffsetIns == nil {
-			errs = append(errs, log.Warnf("Could not find stack offset instruction for bpf_trace_printk call %d in %s", idx, p.Name))
-			continue
-		}
-		newlineOffset := int16(stackOffsetIns.Constant + lengthLoadIns.Constant - 2) // -1 because the last character is the null character
-		log.Tracef("Found stack offset instruction %v for bpf_trace_printk call %d in %s, newlineOffset=%d", stackOffsetIns, idx, p.Name, newlineOffset)
 
-		// Now find which store instruction is responsible for putting the newline character on the stack.
+		// For the string store instruction that tells us where the string is stored on the stack,
+		// we need to find which store instruction is responsible for putting the newline character on the stack.
 		// We will find all store instructions that copy to RFP and check that it's changing the string
 		// at the position we expect the newline to be in. After that, we will check the value of the source register.
 		// The instruction we're looking for is something like this:
 		// StXMemDW dst: rfp src: r1 off: -72 imm: 0x0000000000000000
-		stringStoreInsIdx := -1
-		inInstructionOffset := 0
-		for i := idx - 1; i >= maxLookback; i-- {
-			candidate := &p.Instructions[i]
-			if candidate.OpCode.Class() == asm.StXClass && candidate.Dst == asm.RFP {
-				if candidate.OpCode.Size() == asm.InvalidSize {
-					errs = append(errs, log.Warnf("BUG: store instruction %v returned asm.InvalidSize", candidate))
+		// We also need the stackOffset and lengthLoad instructions to be known at this point
+		if currentInstructions.stackOffset != nil && currentInstructions.lengthLoad != nil && currentInstructions.stringStore == nil {
+			if ins.OpCode.Class() == asm.StXClass && ins.Dst == asm.RFP {
+				if ins.OpCode.Size() == asm.InvalidSize {
+					errs = append(errs, log.Warnf("BUG: store instruction %v returned asm.InvalidSize", ins))
 					continue
 				}
 
-				minOffset := candidate.Offset
-				maxOffset := minOffset + int16(candidate.OpCode.Size().Sizeof())
+				minOffset := ins.Offset
+				maxOffset := minOffset + int16(ins.OpCode.Size().Sizeof())
+				newlineOffset := currentInstructions.newlineOffset()
 
 				if newlineOffset >= minOffset && newlineOffset < maxOffset {
 					// We found the store instruction that loads the newline character, exit the loop
-					stringStoreInsIdx = i
-					inInstructionOffset = int(newlineOffset - minOffset)
-					break
+					currentInstructions.stringStore = ins
+					currentInstructions.newlineOffsetInInstruction = int(newlineOffset - minOffset)
+					log.Tracef("Found string store instruction %v at %d in %s, newlineOffsetInInstruction=%d", ins, realOffset, p.program.Name, currentInstructions.newlineOffsetInInstruction)
 				}
-			} else if candidate.Dst == asm.RFP {
-				// Something is modifying the stack pointer and it's not a store instruction,
-				// we cannot be sure any longer that we're in the same call. Abort this search.
-				errs = append(errs, log.Warnf("Found instruction %v that modifies the stack pointer, aborting search for bpf_trace_printk call %d in %s", candidate, idx, p.Name))
+			} else if ins.Dst == asm.RFP {
+				// Something is modifying the stack pointer and it's not a store
+				// instruction. We found it after the stack offset and length
+				// loading instructions were found, but before we could find the
+				// string store instruction. We cannot be sure any longer that
+				// we're in the same call. Abort this search.
+				return nil, log.Warnf("Found instruction %v at %d that modifies the stack pointer, aborting search for bpf_trace_printk", ins, realOffset)
+			}
+		}
+
+		// For the string load instruction that tells us where the string is loaded from,
+		// check the one that loads into the register that was used for the store instruction.
+		// Something like this:  LdImmDW dst: r1 imm: 0x000a363534333231
+		// Note: in hex, the newline character is 0x0a
+		if currentInstructions.stringStore != nil {
+			targetReg := currentInstructions.stringStore.Src
+			if (ins.OpCode == p.movImmOpCode || ins.OpCode == p.ldDWImmOpCode) && ins.Dst == targetReg {
+				// This is the load instruction that's putting the newline character on the stack
+				// It's the last instruction we needed, so we can return and end this branch of the search here
+				currentInstructions.stringLoad = ins
+				currentInstructions.stringLoadIndex = idx
+				foundInstructions = append(foundInstructions, currentInstructions)
+				log.Tracef("Found string load instruction %v at %d in %s", ins, realOffset, p.program.Name)
+				log.Tracef("Instruction set complete, stopping search, len(foundInstructions)=%d", len(foundInstructions))
+
 				break
 			}
 		}
-		if stringStoreInsIdx == -1 {
-			errs = append(errs, log.Warnf("Could not find store instruction for bpf_trace_printk call %d in %s", idx, p.Name))
-			continue
-		}
-		log.Tracef("Found string store instruction %v for bpf_trace_printk call %d in %s, inInstructionOffset=%d", p.Instructions[stringStoreInsIdx], idx, p.Name, inInstructionOffset)
 
-		// Now try to find the load instruction that loads the string into the register
-		// that was used for the store instruction above.
-		// Something like this:  LdImmDW dst: r1 imm: 0x000a363534333231
-		// Note: in hex, the newline character is 0x0a
-		targetReg := p.Instructions[stringStoreInsIdx].Src
-		foundLoadIns := false
-		for i := stringStoreInsIdx - 1; i >= maxLookback && !foundLoadIns; i-- {
-			candidate := &p.Instructions[i]
-			if (candidate.OpCode == movImmOpCode || candidate.OpCode == ldDWImmOpCode) && candidate.Dst == targetReg {
-				// This is the load instruction that's putting the newline character on the stack
-				// Now we need to patch it to put a null character instead
-				bitOffset := uint64(inInstructionOffset) * 8
-				mask := uint64(0xff) << bitOffset
-				if candidate.Constant&int64(mask) == int64('\n')<<int64(bitOffset) { // Sanity check: don't overwrite anything if it's not a newline
-					candidate.Constant &= int64(^mask) // Set the newline byte to 0
+		// If we haven't found all the instructions we need, check if the
+		// current instruction is a jump target. If it is, we want to follow the
+		// jump source too, unless we've already reached the recursion limit
+		sources, ok := p.jumpSources[idx]
+		if recursionLimit > 0 && ok {
+			newLookbackLimit := lookbackLimit - (startIdx - idx) // Ensure we account for the instructions we already looked back
+			newRecursionLimit := recursionLimit - 1
 
-					// We've correctly patched this instruction, reduce the length in one byte and continue looking for more
-					lengthLoadIns.Constant--
-					patchedInstructionIndexes[i] = true // Keep track of which instructions we've patched
-					numPatches++
-					log.Tracef("Patched instruction %v for bpf_trace_printk call %d in %s", candidate, idx, p.Name)
-				} else if patchedInstructionIndexes[i] {
-					// We don't have a newline in the expected spot but we've already patched this instruction. The compiler
-					// can reuse the same instruction for multiple calls to bpf_trace_printk, and in that case
-					// we only need to patch it once. However, we do need to reduce the length in one byte because
-					// in some systems the printk call will not be made if the length is not consistent.
-					log.Tracef("Instruction %v was already patched for bpf_trace_printk call %d in %s", candidate, idx, p.Name)
-					lengthLoadIns.Constant--
-				} else {
-					errs = append(errs, log.Warnf("Instruction %v does not have a newline we can patch for bpf_trace_printk_call %d in %s", candidate, idx, p.Name))
+			for _, source := range sources {
+				log.Tracef("Backtracking jump from %d to %d (offsets %d -> %d) in %s, new lookback limit: %d, new recursion limit: %d", source, idx, p.indexToRealOffset[source], p.indexToRealOffset[idx], p.program.Name, newLookbackLimit, newRecursionLimit)
+				insns, err := p.findRequisiteInstructions(source, newLookbackLimit, newRecursionLimit, currentInstructions)
+				foundInstructions = append(foundInstructions, insns...)
+				log.Tracef("Finished backtracking jump from %d to %d (offsets %d -> %d) in %s, found %d instruction sets", source, idx, p.indexToRealOffset[source], p.indexToRealOffset[idx], p.program.Name, len(insns))
+				if err != nil {
+					errs = append(errs, err)
 				}
-				foundLoadIns = true
 			}
 		}
-		if !foundLoadIns {
-			errs = append(errs, log.Warnf("Could not find load instruction for bpf_trace_printk call %d in %s", idx, p.Name))
-			continue
-		}
 	}
-	log.Debugf("Patched %d instructions for %s, errors: %v", numPatches, p.Name, errs)
 
-	return numPatches, errors.Join(errs...)
+	if len(foundInstructions) > 0 {
+		return foundInstructions, nil // We found some instructions, return them, ignore errors from other branches
+	}
+	return nil, errors.Join(errs...)
 }
 
 // PrintkPatcherModifier adds an InstructionPatcher to the manager that removes the newline character from log_debug calls if needed

--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -8,8 +8,10 @@
 package ebpf
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -17,11 +19,14 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestPatchPrintkNewline(t *testing.T) {
@@ -131,6 +136,122 @@ func TestPatchPrintkNewline(t *testing.T) {
 	}
 }
 
+func TestPatchPrintkManualAssembly(t *testing.T) {
+	type testCase struct {
+		name                string
+		instructions        asm.Instructions
+		expectedImms        map[int]int64
+		expectedJumpSources map[int][]int
+		patches             int
+	}
+
+	testCases := []testCase{
+		{
+			name: "base-case",
+			instructions: asm.Instructions{
+				asm.LoadImm(asm.R3, 0x00000000000a6261, asm.DWord),
+				asm.StoreMem(asm.RFP, -16, asm.R3, asm.DWord),
+				asm.Mov.Reg(asm.R1, asm.RFP),
+				asm.Add.Imm(asm.R1, -16),
+				asm.Mov.Imm(asm.R2, 4),
+				asm.FnTracePrintk.Call(),
+				asm.Return(),
+			},
+			expectedImms: map[int]int64{
+				0: int64(0x0000000000006261),
+				4: 3,
+			},
+			expectedJumpSources: map[int][]int{},
+			patches:             1,
+		},
+		{
+			name: "branch-to-shared-call",
+			instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R3, 0x00000000000a333231),                    // off 0
+				asm.StoreMem(asm.RFP, -32, asm.R3, asm.DWord),                // off 1
+				asm.Mov.Reg(asm.R1, asm.RFP),                                 // off 2
+				asm.Add.Imm(asm.R1, -32),                                     // off 3
+				asm.Mov.Imm(asm.R2, 5),                                       // off 4
+				asm.Instruction{OpCode: asm.Ja.Op(asm.ImmSource), Offset: 5}, // off 5 -> 11
+				asm.Mov.Imm(asm.R4, 0x00000000000a6261),                      // off 6
+				asm.StoreMem(asm.RFP, -16, asm.R4, asm.DWord),                // off 7
+				asm.Mov.Reg(asm.R1, asm.RFP),                                 // off 8
+				asm.Add.Imm(asm.R1, -16),                                     // off 9
+				asm.Mov.Imm(asm.R2, 4),                                       // off 10
+				asm.FnTracePrintk.Call(),                                     // off 11
+				asm.Return(),                                                 // off 12
+			},
+			expectedImms: map[int]int64{
+				0:  int64(0x000000000000333231),
+				4:  4,
+				6:  int64(0x0000000000006261),
+				10: 3,
+			},
+			expectedJumpSources: map[int][]int{
+				11: {5},
+			},
+			patches: 2,
+		},
+		{
+			name: "jump-over-double-wide",
+			instructions: asm.Instructions{
+				asm.LoadImm(asm.R3, 0x00000000000a333231, asm.DWord),         // off 0-1 (double-wide)
+				asm.StoreMem(asm.RFP, -32, asm.R3, asm.DWord),                // off 2
+				asm.Mov.Reg(asm.R1, asm.RFP),                                 // off 3
+				asm.Add.Imm(asm.R1, -32),                                     // off 4
+				asm.Mov.Imm(asm.R2, 5),                                       // off 5
+				asm.Instruction{OpCode: asm.Ja.Op(asm.ImmSource), Offset: 9}, // off 6 -> 15, indexes 5 -> 13
+				asm.LoadImm(asm.R7, 0x1122334455667788, asm.DWord),           // off 7-8 (double-wide filler)
+				asm.Mov.Imm(asm.R0, 0),                                       // off 9
+				asm.LoadImm(asm.R4, 0x00000000000a6261, asm.DWord),           // off 10-11 (double-wide)
+				asm.StoreMem(asm.RFP, -16, asm.R4, asm.DWord),                // off 12
+				asm.Mov.Reg(asm.R1, asm.RFP),                                 // off 13
+				asm.Add.Imm(asm.R1, -16),                                     // off 14
+				asm.Mov.Imm(asm.R2, 4),                                       // off 15
+				asm.FnTracePrintk.Call(),                                     // off 16
+				asm.Return(),                                                 // off 17
+			},
+			expectedImms: map[int]int64{
+				0:  int64(0x000000000000333231),
+				4:  4,
+				8:  int64(0x0000000000006261),
+				12: 3,
+			},
+			expectedJumpSources: map[int][]int{
+				13: {5}, // the jump map is populated with the index of the instruction, not the offset, so doesn't take into account the double-wide instruction
+			},
+			patches: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			program := &ebpf.ProgramSpec{
+				Name:         tc.name,
+				Type:         ebpf.Kprobe,
+				Instructions: tc.instructions,
+				License:      "GPL",
+			}
+
+			patcher := newPrintkPatcher(program)
+			patches, err := patcher.patch()
+
+			log.Flush() // Ensure we flush logs before assertions to avoid messing the output
+			require.NoError(t, err)
+			assert.Equal(t, tc.patches, patches, "number of patches does not match expected ones")
+
+			assert.ElementsMatch(t, slices.Collect(maps.Keys(tc.expectedJumpSources)), slices.Collect(maps.Keys(patcher.jumpSources)), "jump sources keys do not match expected ones")
+			for target, sources := range tc.expectedJumpSources {
+				assert.ElementsMatch(t, sources, patcher.jumpSources[target], "detected jump sources for target %d do not match expected ones", target)
+			}
+
+			for idx, expected := range tc.expectedImms {
+				require.Equal(t, expected, tc.instructions[idx].Constant, "immediate for instruction %d does not match expected one", idx)
+			}
+		})
+	}
+}
+
 func TestPatchPrintkAllAssets(t *testing.T) {
 	cfg := NewConfig()
 	require.NotNil(t, cfg)
@@ -151,12 +272,14 @@ func TestPatchPrintkAllAssets(t *testing.T) {
 		}
 
 		t.Run(progname, func(t *testing.T) {
+			log.Tracef("Testing program %s, path: %s", progname, path)
 			spec, err := ebpf.LoadCollectionSpec(path)
 			require.NoError(t, err)
 
 			for _, prog := range spec.Programs {
 				t.Run(prog.Name, func(t *testing.T) {
-					patches, err := patchPrintkInstructions(prog)
+					patcher := newPrintkPatcher(prog)
+					patches, err := patcher.patch()
 					require.NoError(t, err)
 					totalPatches += patches
 				})


### PR DESCRIPTION
### What does this PR do?

Modifies the printk patcher so that it tracks instructions across jumps.

In order to do that, the code is modified to have a recursive (with a depth limit of 2) search function, copying the set of requisite functions for the patching until all of them are found.

### Motivation

Fix issues when the compiler re-uses instructions for the `bpf_trace_printk` call across jumps. The instructions were generated with code such as

```c 
if (something) {
    log_debug("something!");
    goto cleanup;
}

if (otherthing) {
    log_debug("otherthing!");
    goto cleanup;
}

return 0;

cleanup:
return -1;
}
``` 

The corresponding assembly code was something like the following:

``` 
// prepare registers for the first call
goto 100

// prepare registers for the second call
goto 100 

100: 
call 6 (bpf_trace_printk)
``` 

### Describe how you validated your changes

Existing unit test, plus added new ones with the instructions that were causing the failure.

### Additional Notes
