### PR TITLE
host-profiler: update dockerfile for go 1.25.6 compatibility

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -252,3 +252,10 @@ jira_issue_type = "Task"
 jira_statuses = ["To do", "In Development", "Done"]
 github_team = "data-streams-monitoring"
 github_labels = ["team/data-streams-monitoring"]
+
+[teams."Profiling Full Host"]
+jira_project = "PROF"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "profiling-full-host"
+github_labels = ["team/profiling-full-host"]

--- a/tools/host-profiler/Dockerfile
+++ b/tools/host-profiler/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-bookworm@sha256:5117d68695f57faa6c2b3a49a6f3187ec1f66c75d5b080e4360bfe4c1ada398c
+FROM golang:1.25.6-bookworm@sha256:fae400019c7fb0400bca0b749fde2015f993ff0e0293ca6f8dbaf919650bb419
 
 RUN apt-get update -y && apt-get dist-upgrade -y && \
     apt-get install -y sudo && \
@@ -13,6 +13,7 @@ RUN useradd -ms /bin/bash build -u ${UID} -g ${GID}
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN adduser build sudo
 RUN chown -R build:build /go
+ENV GOTOOLCHAIN=auto
 
 USER build
 


### PR DESCRIPTION
### What does this PR do?

Updates dev container base image to go 1.25.6 and adds GOTOOLCHAIN=auto to support automatic toolchain version management when building with go 1.23+.

### Motivation

Fix the error that stems from go.work setting 1.25.6 and GOTOOLCHAIN=local being the default

### Describe how you validated your changes

Tested and validated on a workspace

### Additional Notes

N/A
