### PR TITLE
[CSPM] use hostname component in `compliance check` cli

### DIFF
--- a/cmd/cluster-agent/subcommands/compliance/command.go
+++ b/cmd/cluster-agent/subcommands/compliance/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -61,6 +62,7 @@ func complianceCheckCommand(globalParams *command.GlobalParams) *cobra.Command {
 				logscompressionfx.Module(),
 				statsd.Module(),
 				ipcfx.ModuleReadOnly(),
+				hostnameimpl.Module(),
 			)
 		},
 	}

--- a/cmd/security-agent/subcommands/compliance/command.go
+++ b/cmd/security-agent/subcommands/compliance/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
@@ -67,6 +68,7 @@ func CheckCommand(globalParams *command.GlobalParams) *cobra.Command {
 				logscompressionfx.Module(),
 				statsd.Module(),
 				ipcfx.ModuleInsecure(),
+				remotehostnameimpl.Module(),
 			)
 		},
 	}

--- a/cmd/system-probe/subcommands/compliance/command.go
+++ b/cmd/system-probe/subcommands/compliance/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
@@ -65,6 +66,7 @@ func CheckCommand(globalParams *command.GlobalParams) *cobra.Command {
 				logscompressionfx.Module(),
 				statsd.Module(),
 				ipcfx.ModuleInsecure(),
+				remotehostnameimpl.Module(),
 			)
 		},
 	}

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
@@ -28,9 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
-	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
 // CheckParams needs to be exported because the compliance subcommand is tightly coupled to this subcommand and tests need to be able to access this type.
@@ -56,14 +55,8 @@ func FillCheckFlags(flagSet *pflag.FlagSet, checkArgs *CheckParams) {
 }
 
 // RunCheck runs a check
-func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, ipc ipc.Component) error {
-	var hname string
-	var err error
-	if flavor.GetFlavor() == flavor.ClusterAgent {
-		hname, err = hostname.Get(context.TODO())
-	} else {
-		hname, err = hostnameutils.GetHostnameWithContextAndFallback(context.Background(), ipc)
-	}
+func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, ipc ipc.Component, hostname hostnameinterface.Component) error {
+	hname, err := hostname.Get(context.Background())
 	if err != nil {
 		return err
 	}

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -55,7 +55,7 @@ func FillCheckFlags(flagSet *pflag.FlagSet, checkArgs *CheckParams) {
 }
 
 // RunCheck runs a check
-func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, ipc ipc.Component, hostname hostnameinterface.Component) error {
+func RunCheck(log log.Component, config config.Component, _ secrets.Component, statsdComp statsd.Component, checkArgs *CheckParams, compression logscompression.Component, _ ipc.Component, hostname hostnameinterface.Component) error {
 	hname, err := hostname.Get(context.Background())
 	if err != nil {
 		return err


### PR DESCRIPTION
### What does this PR do?

This PR switches the `compliance check` CLI to use the hostname component (either local/non-remote hostname in the cluster agent, or remote one in the security-agent/system-probe). It allows to remove one ugly "flavor" check, and also removes the last user of the hostnameutils package (all other users have been migrated to the hostname component).

No behavior change expected from this PR.

### Motivation

### Describe how you validated your changes

### Additional Notes
