### PR TITLE
[Backport 7.76.x] Hotfix: NetFlow - pass flush config to flow scheduler

### DIFF
--- a/comp/netflow/flowaggregator/aggregator.go
+++ b/comp/netflow/flowaggregator/aggregator.go
@@ -95,7 +95,9 @@ func NewFlowAggregator(sender sender.Sender, epForwarder eventplatform.Forwarder
 	}
 
 	var topNFilter FlowFlushFilter = topn.NoopFilter{}
-	var flowScheduler FlowScheduler = ImmediateFlowScheduler{}
+	var flowScheduler FlowScheduler = ImmediateFlowScheduler{
+		flushConfig: flushConfig,
+	}
 	if config.AggregatorMaxFlowsPerPeriod > 0 {
 		topNFilter = topn.NewPerFlushFilter(int64(config.AggregatorMaxFlowsPerPeriod), flushConfig, sender, logger)
 		flowScheduler = JitterFlowScheduler{flushConfig: flushConfig}

--- a/releasenotes/notes/netflow-hotfix-event-submissions-431aca71ec50928e.yaml
+++ b/releasenotes/notes/netflow-hotfix-event-submissions-431aca71ec50928e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Resolves an issue where NetFlow metrics are submitted every 10 seconds, instead of aggregating
+    for the full interval per Source/Destination pair.


### PR DESCRIPTION
Backport f3e194a7d4a769c0a41b3dd97fc8768a2758612d from #45561.

 ___

### What does this PR do?

This PR fixes an issue where we are not passing the flush config to the flow scheduler

### Motivation

Without this config, flows are not collected for 5min at a time, and are instead scheduled to fire immediately when the aggregator goes to flush

### Describe how you validated your changes

Load tests were done against the agent pre + post patch to verify that they are submitted correctly at the flush interval.