### PR TITLE
host profiler: set default reporter_interval to 60s

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -10,6 +10,7 @@ package receiver
 import (
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/dd-otel-host-profiler/config"
@@ -94,6 +95,8 @@ func (c *Config) Validate() error {
 func defaultConfig() component.Config {
 	cfg := ebpfcollector.NewFactory().CreateDefaultConfig().(*ebpfconfig.Config)
 	cfg.Tracers = getDefaultTracersString()
+	// 60s batches more samples per report, improving compression and reducing upload bandwidth
+	cfg.ReporterInterval = 60 * time.Second
 
 	return Config{
 		EbpfCollectorConfig: cfg,

--- a/comp/host-profiler/collector/impl/receiver/config_test.go
+++ b/comp/host-profiler/collector/impl/receiver/config_test.go
@@ -10,10 +10,17 @@ package receiver
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/dd-otel-host-profiler/reporter"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReporterInterval(t *testing.T) {
+	config := defaultConfig()
+	cfg := config.(Config)
+	require.Equal(t, 60*time.Second, cfg.EbpfCollectorConfig.ReporterInterval)
+}
 
 func TestTracers(t *testing.T) {
 	config := defaultConfig()


### PR DESCRIPTION
### What does this PR do?

set the default reporter interval to 60s

### Motivation

60s batches more samples per report, improving compression and reducing upload bandwidth

### Describe how you validated your changes

tested and validated on a workspace

### Additional Notes

N/A
