### PR TITLE
Fix typo in Oracle config example: cbd_name -> cdb_name 

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -136,7 +136,7 @@ instances:
         ## - server: The provided server of the instance.
         ## - port: The port number of the instance.
         ## - service_name: The provided service name of the instance.
-        ## - cbd_name: The resolved CBD name of the instance.
+        ## - cdb_name: The resolved CDB name of the instance.
         ## In addition, you can use any key from the `tags` section of the configuration.
         #
         # template: <DATABASE_IDENTIFIER_TEMPLATE>


### PR DESCRIPTION
…y: Claude Sonnet 4.5 <noreply@anthropic.com> and wasted many Tokens

### What does this PR do?
Fix the Typo in conf.yaml.example file 
### Motivation
Identified the Typo during a customer call. 
### Describe how you validated your changes

### Additional Notes
