### PR TITLE
Fixing a typo on example config file 

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -136,7 +136,7 @@ instances:
         ## - server: The provided server of the instance.
         ## - port: The port number of the instance.
         ## - service_name: The provided service name of the instance.
-        ## - cbd_name: The resolved CBD name of the instance.
+        ## - cdb_name: The resolved CDB name of the instance.
         ## In addition, you can use any key from the `tags` section of the configuration.
         #
         # template: <DATABASE_IDENTIFIER_TEMPLATE>


### PR DESCRIPTION
### What does this PR do?
Fixes a small typo on the oracle example config file
### Motivation
Identified the typo during a demo to prospect
### Describe how you validated your changes
Fixes a small typo
### Additional Notes
