### PR TITLE
[NCM] Add device profile: DellOS10

### DIFF
--- a/pkg/networkconfigmanagement/profile/default_profiles/dellos10.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/dellos10.json
@@ -36,6 +36,26 @@
           }
         ]
       }
+    },
+    {
+      "type": "startup",
+      "values": [
+        "show startup-configuration"
+      ],
+      "processing_rules": {
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "(?m)^hostname\\s+\\S+"
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(password )(\\S+)",
+            "replacement": "${1}<secret hidden>"
+          }
+        ]
+      }
     }
   ]
 }

--- a/pkg/networkconfigmanagement/profile/default_profiles/dellos10.json
+++ b/pkg/networkconfigmanagement/profile/default_profiles/dellos10.json
@@ -1,0 +1,41 @@
+{
+  "commands": [
+    {
+      "type": "running",
+      "values": [
+        "show running-configuration"
+      ],
+      "processing_rules": {
+        "metadata": [
+          {
+            "type": "timestamp",
+            "regex": "(?m)^! Last configuration change at (.*)$",
+            "format": "Jan 2 15:04:05 2006"
+          }
+        ],
+        "validation": [
+          {
+            "type": "valid_output",
+            "pattern": "! Version (.*)?"
+          }
+        ],
+        "redaction": [
+          {
+            "regex": "(password )(\\S+)",
+            "replacement": "${1}<secret hidden>"
+          },
+          {
+            "regex": "(?m)^! Version .*$\\s*(?:^!\\s*$\\s*)?",
+            "replacement": "",
+            "multiline": true
+          },
+          {
+            "regex": "(?m)^! Last configuration change at .*$\\s*(?:^!\\s*$\\s*)?",
+            "replacement": "",
+            "multiline": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/networkconfigmanagement/profile/default_profiles_test.go
+++ b/pkg/networkconfigmanagement/profile/default_profiles_test.go
@@ -146,6 +146,12 @@ func Test_DefaultProfiles_Startup(t *testing.T) {
 				Author:    "admin",
 			},
 		},
+		{
+			name:                      "dellos10",
+			profile:                   DefaultProfile("dellos10"),
+			fixture:                   loadFixture("dellos10", Startup),
+			expectedExtractedMetadata: &ExtractedMetadata{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/networkconfigmanagement/profile/default_profiles_test.go
+++ b/pkg/networkconfigmanagement/profile/default_profiles_test.go
@@ -84,6 +84,14 @@ func Test_DefaultProfiles_Running(t *testing.T) {
 			fixture:                   loadFixture("fortios", Running),
 			expectedExtractedMetadata: &ExtractedMetadata{},
 		},
+		{
+			name:    "DellOS10",
+			profile: DefaultProfile("dellos10"),
+			fixture: loadFixture("dellos10", Running),
+			expectedExtractedMetadata: &ExtractedMetadata{
+				Timestamp: 1491873902,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/networkconfigmanagement/profile/fixtures/dellos10/running/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/dellos10/running/expected.txt
@@ -1,0 +1,30 @@
+username admin password <secret hidden>
+aaa authentication local
+snmp-server contact http://www.dell.com/support
+snmp-server location "United States"
+logging monitor disable
+ip route 0.0.0.0/0 10.11.58.1
+!
+interface ethernet1/1/1
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/2
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/3
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/4
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/5
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/6
+switchport access vlan 1
+no shutdown

--- a/pkg/networkconfigmanagement/profile/fixtures/dellos10/running/initial.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/dellos10/running/initial.txt
@@ -1,0 +1,33 @@
+! Version 10.2.9999E
+! Last configuration change at Apr 11 01:25:02 2017
+!
+username admin password $6$q9QBeYjZ$jfxzVqGhkxX3smxJSH9DDz7/3OJc6m5wjF8nnLD7/VKx8SloIhp4NoGZs0I/UNwh8WVuxwfd9q4pWIgNs5BKH.
+aaa authentication local
+snmp-server contact http://www.dell.com/support
+snmp-server location "United States"
+logging monitor disable
+ip route 0.0.0.0/0 10.11.58.1
+!
+interface ethernet1/1/1
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/2
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/3
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/4
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/5
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/6
+switchport access vlan 1
+no shutdown

--- a/pkg/networkconfigmanagement/profile/fixtures/dellos10/startup/expected.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/dellos10/startup/expected.txt
@@ -1,0 +1,29 @@
+!
+hostname LEAF-01
+!
+username admin password <secret hidden>
+aaa authentication local
+snmp-server contact http://www.dell.com/support
+snmp-server location "United States"
+ip route 0.0.0.0/0 10.11.58.1
+!
+interface ethernet1/1/1
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/2
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/3
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/4
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/5
+switchport access vlan 1
+no shutdown
+!

--- a/pkg/networkconfigmanagement/profile/fixtures/dellos10/startup/initial.txt
+++ b/pkg/networkconfigmanagement/profile/fixtures/dellos10/startup/initial.txt
@@ -1,0 +1,29 @@
+!
+hostname LEAF-01
+!
+username admin password $6$q9QBeYjZ$jfxzVqGhkxX3smxJSH9DDz7/3OJc6m5wjF8nnLD7/VKx8SloIhp4NoGZs0I/UNwh8WVuxwfd9q4pWIgNs5BKH.
+aaa authentication local
+snmp-server contact http://www.dell.com/support
+snmp-server location "United States"
+ip route 0.0.0.0/0 10.11.58.1
+!
+interface ethernet1/1/1
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/2
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/3
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/4
+switchport access vlan 1
+no shutdown
+!
+interface ethernet1/1/5
+switchport access vlan 1
+no shutdown
+!


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/NDINT-435
add device profile for dellos10 devices (smartfabric os10?)
* reference model from oxidized: `os10.rb`
* no test specs from oxidized afaik - found from these dell os10 docs: (running) (startup)
* they are limited in nature, hard to find other ones, i could ask chatgpt 🤔 but we're releasing to customers so maybe helpful to get direct context from them

currently:
* adds `running` and `startup` config support
  * for some reason `running` shows example of last modified timestamp but none for startup, assuming none is possible? 
* may possibly run into more secrets that need redactions but uncertain atm

### Motivation

### Describe how you validated your changes

### Additional Notes
