### PR TITLE
add macOS to go deps for system-probe

### DIFF
--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -61,7 +61,10 @@ BINARIES: dict[str, dict] = {
         "entrypoint": "cmd/sbomgen",
         "platforms": ["linux/x64", "linux/arm64"],
     },
-    "system-probe": {"entrypoint": "cmd/system-probe", "platforms": ["linux/x64", "linux/arm64", "win32/x64"]},
+    "system-probe": {
+        "entrypoint": "cmd/system-probe",
+        "platforms": ["linux/x64", "linux/arm64", "win32/x64", "darwin/x64", "darwin/arm64"],
+    },
     "cws-instrumentation": {
         "entrypoint": "cmd/cws-instrumentation",
         "platforms": ["linux/x64", "linux/arm64"],


### PR DESCRIPTION
### What does this PR do?

Adds macOS (`darwin`) to list of platforms for `system-probe`

### Motivation

PRs will report changes to macOS Go dependencies

### Describe how you validated your changes

### Additional Notes
