### PR TITLE
chore(Autodiscovery): Optimize KubeEndpoint CELSelector File Provider

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -458,7 +458,7 @@ func (ac *AutoConfig) GetTelemetryStore() *acTelemetry.Store {
 }
 
 func (ac *AutoConfig) initializeConfiguration(config *integration.Config) error {
-	prg, celADID, compileErr, recErr := createMatchingProgram(config.CELSelector)
+	prg, celADID, compileErr, recErr := integration.CreateMatchingProgram(config.CELSelector)
 	if compileErr != nil {
 		return compileErr
 	}

--- a/comp/core/autodiscovery/integration/matching_program_noop.go
+++ b/comp/core/autodiscovery/integration/matching_program_noop.go
@@ -5,14 +5,14 @@
 
 //go:build !cel
 
-package autodiscoveryimpl
+package integration
 
 import (
 	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 )
 
-func createMatchingProgram(_ workloadfilter.Rules) (program integration.MatchingProgram, celADID adtypes.CelIdentifier, compileErr error, recError error) {
+// CreateMatchingProgram is a no-op when CEL is not enabled
+func CreateMatchingProgram(_ workloadfilter.Rules) (program MatchingProgram, celADID adtypes.CelIdentifier, compileErr error, recError error) {
 	return nil, "", nil, nil
 }

--- a/comp/core/autodiscovery/integration/matching_program_test.go
+++ b/comp/core/autodiscovery/integration/matching_program_test.go
@@ -5,7 +5,7 @@
 
 //go:build cel
 
-package autodiscoveryimpl
+package integration
 
 import (
 	"testing"
@@ -44,7 +44,7 @@ func TestCreateMatchingProgram_EmptyRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			program, celADID, compileErr, recErr := createMatchingProgram(tt.rules)
+			program, celADID, compileErr, recErr := CreateMatchingProgram(tt.rules)
 			assert.Nil(t, program)
 			assert.Empty(t, celADID)
 			assert.NoError(t, compileErr)
@@ -104,7 +104,7 @@ func TestCreateMatchingProgram_ValidRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			program, celADID, compileErr, recErr := createMatchingProgram(tt.rules)
+			program, celADID, compileErr, recErr := CreateMatchingProgram(tt.rules)
 			assert.NotNil(t, program)
 			assert.NotEmpty(t, celADID)
 			assert.NoError(t, compileErr)
@@ -165,7 +165,7 @@ func TestCreateMatchingProgram_RecommendationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			program, celADID, compileErr, recErr := createMatchingProgram(tt.rules)
+			program, celADID, compileErr, recErr := CreateMatchingProgram(tt.rules)
 			// The function should return a program but with a recommendation error
 			assert.NotNil(t, program)
 			assert.NotEmpty(t, celADID)
@@ -210,7 +210,7 @@ func TestCreateMatchingProgram_PriorityOrder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			program, celADID, compileErr, recErr := createMatchingProgram(tt.rules)
+			program, celADID, compileErr, recErr := CreateMatchingProgram(tt.rules)
 			assert.NotNil(t, program)
 			assert.NotEmpty(t, celADID)
 			assert.NoError(t, compileErr)

--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -12,10 +12,12 @@ import (
 	"fmt"
 	"sync"
 
+	adtypes "github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/types"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/telemetry"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -203,9 +205,41 @@ func (p *KubeEndpointsFileConfigProvider) buildConfigStore(templates []integrati
 
 		// Configuration defined using only CEL selectors
 		if len(tpl.AdvancedADIdentifiers) == 0 && len(tpl.CELSelector.KubeEndpoints) > 0 {
+			// Create matching program from CEL rules
+			matchingProg, celADID, compileErr, recError := integration.CreateMatchingProgram(tpl.CELSelector)
+			if celADID != adtypes.CelEndpointIdentifier {
+				log.Errorf("CEL selector for template %s is not targeting endpoints", tpl.Name)
+				continue
+			}
+			if compileErr != nil {
+				log.Errorf("Failed to compile CEL selector for template %s: %v", tpl.Name, compileErr)
+				continue
+			}
+			if recError != nil {
+				log.Errorf("Failed to check rule recommendations for CEL selector for template %s: %v", tpl.Name, recError)
+				continue
+			}
+			tpl.SetMatchingProgram(matchingProg)
+
 			p.store.insertTemplate(celEndpointID, tpl, kubeEndpointResolveAuto)
 		}
 	}
+}
+
+// matchesAnyCELTemplate checks if an endpoint matches any CEL template.
+func (s *store) matchesAnyCELTemplate(ep *v1.Endpoints) bool {
+	celEpConfig, celFound := s.epConfigs[celEndpointID]
+	if !celFound || len(celEpConfig.templates) == 0 {
+		return false
+	}
+
+	filterableEp := workloadfilter.CreateKubeEndpoint(ep.Name, ep.Namespace, ep.GetAnnotations())
+	for _, tpl := range celEpConfig.templates {
+		if tpl.IsMatched(filterableEp) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldHandle returns whether an endpoints object should be tracked.
@@ -213,9 +247,9 @@ func (s *store) shouldHandle(ep *v1.Endpoints) bool {
 	s.RLock()
 	defer s.RUnlock()
 
-	_, celFound := s.epConfigs[celEndpointID]
+	// Check for AdvancedADIdentifer OR CEL Selector based match
 	_, found := s.epConfigs[epID(ep.Namespace, ep.Name)]
-	return found || celFound
+	return found || s.matchesAnyCELTemplate(ep)
 }
 
 // insertTemplate caches config templates with a specific resolve mode.
@@ -239,17 +273,7 @@ func (s *store) insertEp(ep *v1.Endpoints) bool {
 	s.Lock()
 	defer s.Unlock()
 
-	// Configuration defined using only CEL selectors
-	celEpConfig, celFound := s.epConfigs[celEndpointID]
-	if celFound {
-		if celEpConfig.eps == nil {
-			celEpConfig.eps = make(map[*v1.Endpoints]struct{})
-		}
-		celEpConfig.eps[ep] = struct{}{}
-		celEpConfig.shouldCollect = true
-	}
-
-	// Configuration defined using Advanced AD identifiers
+	// Configuration defined using Advanced AD identifiers (exact namespace/name match)
 	epConfig, found := s.epConfigs[epID(ep.Namespace, ep.Name)]
 	if found {
 		if epConfig.eps == nil {
@@ -257,9 +281,21 @@ func (s *store) insertEp(ep *v1.Endpoints) bool {
 		}
 		epConfig.eps[ep] = struct{}{}
 		epConfig.shouldCollect = true
+		return true
 	}
 
-	return celFound || found
+	// Endpoint matches any CEL template (CEL Selector based match)
+	if s.matchesAnyCELTemplate(ep) {
+		celEpConfig := s.epConfigs[celEndpointID]
+		if celEpConfig.eps == nil {
+			celEpConfig.eps = make(map[*v1.Endpoints]struct{})
+		}
+		celEpConfig.eps[ep] = struct{}{}
+		celEpConfig.shouldCollect = true
+		return true
+	}
+
+	return false
 }
 
 // deleteEp handles endpoint objects deletion.

--- a/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
@@ -3,26 +3,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build clusterchecks && kubeapiserver
+//go:build clusterchecks && kubeapiserver && cel
 
 package providers
 
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
-
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
 )
 
 var tplCel = integration.Config{
 	Name: "check-cel",
 	CELSelector: workloadfilter.Rules{
-		KubeEndpoints: []string{`v`},
+		KubeEndpoints: []string{`kube_endpoint.namespace == "default"`},
 	},
 }
 
@@ -114,7 +114,24 @@ func TestBuildConfigStore(t *testing.T) {
 			p := &KubeEndpointsFileConfigProvider{}
 			p.buildConfigStore(tt.templates)
 
-			assert.EqualValues(t, tt.want, p.store.epConfigs)
+			// For CEL templates, verify that a matching program was set on the template
+			if tt.name == "with cel template" {
+				assert.Contains(t, p.store.epConfigs, celEndpointID)
+				assert.Len(t, p.store.epConfigs[celEndpointID].templates, 1, "Should have 1 template")
+				// Verify the template has a matching program set (by checking if IsMatched works)
+				tpl := p.store.epConfigs[celEndpointID].templates[0]
+				// Test that IsMatched returns false for non-matching endpoint (the template requires namespace=="default")
+				nonMatchingEp := workloadfilter.CreateKubeEndpoint("test", "production", nil)
+				assert.False(t, tpl.IsMatched(nonMatchingEp), "Template should not match non-default namespace")
+				// Test that IsMatched returns true for matching endpoint
+				matchingEp := workloadfilter.CreateKubeEndpoint("test", "default", nil)
+				assert.True(t, tpl.IsMatched(matchingEp), "Template should match default namespace")
+
+				assert.Equal(t, tt.want[celEndpointID].resolveMode, p.store.epConfigs[celEndpointID].resolveMode)
+				assert.Equal(t, tt.want[celEndpointID].shouldCollect, p.store.epConfigs[celEndpointID].shouldCollect)
+			} else {
+				assert.EqualValues(t, tt.want, p.store.epConfigs)
+			}
 		})
 	}
 }
@@ -151,11 +168,21 @@ func TestStoreInsertEp(t *testing.T) {
 			wantEpConfigs: map[string]*epConfig{"ns1/ep1": {templates: []integration.Config{tpl}, eps: map[*v1.Endpoints]struct{}{ep1: {}}, shouldCollect: true}},
 		},
 		{
-			name:          "found cel",
-			epConfigs:     map[string]*epConfig{celEndpointID: {templates: []integration.Config{tplCel}, eps: nil, shouldCollect: false}},
-			ep:            ep1,
-			want:          true,
-			wantEpConfigs: map[string]*epConfig{celEndpointID: {templates: []integration.Config{tplCel}, eps: map[*v1.Endpoints]struct{}{ep1: {}}, shouldCollect: true}},
+			name: "found cel without matching program",
+			epConfigs: map[string]*epConfig{celEndpointID: {
+				templates: []integration.Config{
+					// Template without a matching program set (shouldn't happen in practice, but test the safeguard)
+					{Name: "check-cel"},
+				},
+				eps: nil,
+			}},
+			ep:   ep1,
+			want: false, // Should not insert if template has no matching program
+			wantEpConfigs: map[string]*epConfig{celEndpointID: {
+				templates:     []integration.Config{{Name: "check-cel"}},
+				eps:           nil,
+				shouldCollect: false,
+			}},
 		},
 	}
 	for _, tt := range tests {
@@ -168,6 +195,104 @@ func TestStoreInsertEp(t *testing.T) {
 			assert.EqualValues(t, tt.wantEpConfigs, s.epConfigs)
 		})
 	}
+}
+func TestCELSelector(t *testing.T) {
+	// Template 1: Only production namespace
+	tpl1 := integration.Config{
+		Name: "prod-check",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`kube_endpoint.namespace == "production"`},
+		},
+	}
+
+	// Template 2: Only redis endpoints
+	tpl2 := integration.Config{
+		Name: "redis-check",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`kube_endpoint.name == "redis"`},
+		},
+	}
+
+	p := &KubeEndpointsFileConfigProvider{}
+	p.buildConfigStore([]integration.Config{tpl1, tpl2})
+
+	// Verify both templates were stored with their matching programs
+	assert.Contains(t, p.store.epConfigs, celEndpointID)
+	assert.Len(t, p.store.epConfigs[celEndpointID].templates, 2, "Should have 2 templates")
+
+	// Verify each template has a matching program by testing IsMatched
+	templates := p.store.epConfigs[celEndpointID].templates
+
+	prodEp := workloadfilter.CreateKubeEndpoint("test", "production", nil)
+	devEp := workloadfilter.CreateKubeEndpoint("test", "development", nil)
+	assert.True(t, templates[0].IsMatched(prodEp))
+	assert.False(t, templates[0].IsMatched(devEp))
+
+	redisEp := workloadfilter.CreateKubeEndpoint("redis", "default", nil)
+	mongoEp := workloadfilter.CreateKubeEndpoint("mongo", "default", nil)
+	assert.True(t, templates[1].IsMatched(redisEp))
+	assert.False(t, templates[1].IsMatched(mongoEp))
+
+	// Create the dummy endpoints for each service
+	prodRedis := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis",
+			Namespace: "production",
+		},
+	}
+
+	devRedis := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redis",
+			Namespace: "development",
+		},
+	}
+
+	prodMongo := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mongo",
+			Namespace: "production",
+		},
+	}
+
+	devMongo := &v1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mongo",
+			Namespace: "development",
+		},
+	}
+
+	// Test insertEp - should cache endpoints passing any matching program
+	s := p.store
+
+	// prodRedis matches BOTH templates (production namespace AND redis name)
+	updated := s.insertEp(prodRedis)
+	assert.True(t, updated, "prodRedis should match")
+	assert.Contains(t, s.epConfigs[celEndpointID].eps, prodRedis)
+
+	// devRedis matches only template 2 (redis name)
+	updated = s.insertEp(devRedis)
+	assert.True(t, updated, "devRedis should match (name=redis)")
+	assert.Contains(t, s.epConfigs[celEndpointID].eps, devRedis)
+
+	// prodMongo matches only template 1 (production namespace)
+	updated = s.insertEp(prodMongo)
+	assert.True(t, updated, "prodMongo should match (namespace=production)")
+	assert.Contains(t, s.epConfigs[celEndpointID].eps, prodMongo)
+
+	// devMongo matches NEITHER template
+	updated = s.insertEp(devMongo)
+	assert.False(t, updated, "devMongo should NOT match")
+	assert.NotContains(t, s.epConfigs[celEndpointID].eps, devMongo)
+
+	// Verify all 3 matching endpoints are cached
+	assert.Len(t, s.epConfigs[celEndpointID].eps, 3, "Should have 3 cached endpoints")
+
+	// Test shouldHandle
+	assert.True(t, s.shouldHandle(prodRedis), "prodRedis should be handled")
+	assert.True(t, s.shouldHandle(devRedis), "devRedis should be handled")
+	assert.True(t, s.shouldHandle(prodMongo), "prodMongo should be handled")
+	assert.False(t, s.shouldHandle(devMongo), "devMongo should NOT be handled")
 }
 
 func TestStoreGenerateConfigs(t *testing.T) {
@@ -268,7 +393,7 @@ func TestStoreGenerateConfigs(t *testing.T) {
 					Name:                  "check-cel",
 					ServiceID:             "kube_endpoint_uid://ns1/ep1/10.0.0.1",
 					ADIdentifiers:         []string{"kube_endpoint_uid://ns1/ep1/10.0.0.1", "kubernetes_pod://pod-1"},
-					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`v`}},
+					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`kube_endpoint.namespace == "default"`}},
 					AdvancedADIdentifiers: nil,
 					NodeName:              "node1",
 					Provider:              "kubernetes-endpoints-file",
@@ -278,7 +403,7 @@ func TestStoreGenerateConfigs(t *testing.T) {
 					Name:                  "check-cel",
 					ServiceID:             "kube_endpoint_uid://ns1/ep1/10.0.0.2",
 					ADIdentifiers:         []string{"kube_endpoint_uid://ns1/ep1/10.0.0.2", "kubernetes_pod://pod-2"},
-					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`v`}},
+					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`kube_endpoint.namespace == "default"`}},
 					AdvancedADIdentifiers: nil,
 					NodeName:              "node2",
 					Provider:              "kubernetes-endpoints-file",
@@ -288,7 +413,7 @@ func TestStoreGenerateConfigs(t *testing.T) {
 					Name:                  "check-cel",
 					ServiceID:             "kube_endpoint_uid://ns2/ep2/10.0.1.1",
 					ADIdentifiers:         []string{"kube_endpoint_uid://ns2/ep2/10.0.1.1", "kubernetes_pod://pod-3"},
-					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`v`}},
+					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`kube_endpoint.namespace == "default"`}},
 					AdvancedADIdentifiers: nil,
 					NodeName:              "node1",
 					Provider:              "kubernetes-endpoints-file",
@@ -298,7 +423,7 @@ func TestStoreGenerateConfigs(t *testing.T) {
 					Name:                  "check-cel",
 					ServiceID:             "kube_endpoint_uid://ns2/ep2/10.0.1.2",
 					ADIdentifiers:         []string{"kube_endpoint_uid://ns2/ep2/10.0.1.2", "kubernetes_pod://pod-4"},
-					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`v`}},
+					CELSelector:           workloadfilter.Rules{KubeEndpoints: []string{`kube_endpoint.namespace == "default"`}},
 					AdvancedADIdentifiers: nil,
 					NodeName:              "node2",
 					Provider:              "kubernetes-endpoints-file",


### PR DESCRIPTION
### What does this PR do?

For legacy reasons, the `kube_endpoint_file` Autodiscovery config provider does not function independently like other file providers. This provider also listens to KubeEndpoints as well to provide some additional configuration to the check config. The provider ends up caching all the Endpoint objects which are tied to a config.

With the previous implementation, every single Endpoint on a cluster could be potentially associated with a config using a CELSelector and thus this provider would end up caching every endpoint definition even if it ends up being unneeded downstream.

Thus, this PR shifts up the CELSelector filtering for KubeEndpoints upstream into the KubeEndpointsFileConfigProvider so that the decision to store an endpoint earlier and can properly discard endpoints that will never be monitored.

Note: no additional cost is paid by users who don't have an CELSelector based KubeEndpoint check definitions defined on the Cluster Agent's filesystem.

### Motivation

Clean up implementation for `kube_endpoint_file` Autodiscovery config provider to avoid caching unneeded Endpoints in memory.

[CONTP-1048]

### Describe how you validated your changes

Unit Tests and CI

[CONTP-1048]: https://datadoghq.atlassian.net/browse/CONTP-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ