### PR TITLE
[BARX-1552] push e2e images to dedicated QA repositories

### DIFF
--- a/.gitlab/deploy/dev_container_deploy/e2e.yml
+++ b/.gitlab/deploy/dev_container_deploy/e2e.yml
@@ -14,7 +14,7 @@ qa_agent:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-winltsc2022-amd64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 qa_agent_fips:
   extends: .docker_publish_job_definition
@@ -30,7 +30,7 @@ qa_agent_fips:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-winltsc2022-servercore-amd64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
 
 qa_agent_jmx:
   extends: .docker_publish_job_definition
@@ -46,7 +46,7 @@ qa_agent_jmx:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-winltsc2022-amd64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-jmx
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-jmx
 
 qa_agent_fips_jmx:
   extends: .docker_publish_job_definition
@@ -62,7 +62,7 @@ qa_agent_fips_jmx:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-winltsc2022-servercore-amd64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-jmx
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-jmx
 
 qa_agent_full:
   extends: .docker_publish_job_definition
@@ -76,7 +76,7 @@ qa_agent_full:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full
+    IMG_DESTINATIONS: agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full
 
 qa_ot_agent_standalone:
   extends: .docker_publish_job_definition
@@ -90,7 +90,7 @@ qa_ot_agent_standalone:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_OTEL_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-    IMG_DESTINATIONS: otel-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: otel-agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 qa_dca:
   extends: .docker_publish_job_definition
@@ -105,7 +105,7 @@ qa_dca:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: cluster-agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 qa_dca_fips:
   extends: .docker_publish_job_definition
@@ -120,7 +120,7 @@ qa_dca_fips:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-amd64,${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-arm64
-    IMG_DESTINATIONS: cluster-agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
+    IMG_DESTINATIONS: cluster-agent-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
 
 qa_dogstatsd:
   extends: .docker_publish_job_definition
@@ -135,7 +135,7 @@ qa_dogstatsd:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    IMG_DESTINATIONS: dogstatsd:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: dogstatsd-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 .qa_cws_instrumentation:
   extends: .docker_publish_job_definition
@@ -146,7 +146,7 @@ qa_dogstatsd:
   variables:
     IMG_REGISTRIES: agent-qa
     IMG_SOURCES: ${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_CWS_INSTRUMENTATION}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    IMG_DESTINATIONS: cws-instrumentation:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    IMG_DESTINATIONS: cws-instrumentation-qa:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
 
 qa_cws_instrumentation:
   extends: .qa_cws_instrumentation

--- a/test/e2e-framework/components/datadog/agent/docker_image.go
+++ b/test/e2e-framework/components/datadog/agent/docker_image.go
@@ -57,11 +57,11 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 			tag += otelSuffix
 		}
 
-		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/agent", e.InternalRegistry()), tag)
+		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/agent-qa", e.InternalRegistry()), tag)
 		if err != nil || !exists {
-			panic(fmt.Sprintf("image %s/agent:%s not found in the internal registry", e.InternalRegistry(), tag))
+			panic(fmt.Sprintf("image %s/agent-qa:%s not found in the internal registry", e.InternalRegistry(), tag))
 		}
-		return utils.BuildDockerImagePath(fmt.Sprintf("%s/agent", e.InternalRegistry()), tag)
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/agent-qa", e.InternalRegistry()), tag)
 	}
 
 	if useOtel {
@@ -122,11 +122,11 @@ func dockerClusterAgentFullImagePath(e config.Env, repositoryPath string, fips b
 			tag += fipsSuffix
 		}
 
-		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/cluster-agent", e.InternalRegistry()), tag)
+		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/cluster-agent-qa", e.InternalRegistry()), tag)
 		if err != nil || !exists {
-			panic(fmt.Sprintf("image %s/cluster-agent:%s not found in the internal registry", e.InternalRegistry(), tag))
+			panic(fmt.Sprintf("image %s/cluster-agent-qa:%s not found in the internal registry", e.InternalRegistry(), tag))
 		}
-		return utils.BuildDockerImagePath(fmt.Sprintf("%s/cluster-agent", e.InternalRegistry()), tag)
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/cluster-agent-qa", e.InternalRegistry()), tag)
 	}
 
 	if useFips {
@@ -150,11 +150,11 @@ func dockerOTelAgentGatewayFullImagePath(e config.Env, repositoryPath, imageTag 
 	if e.PipelineID() != "" && e.CommitSHA() != "" && imageTag == "" {
 		tag := fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA())
 
-		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/otel-agent", e.InternalRegistry()), tag)
+		exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/otel-agent-qa", e.InternalRegistry()), tag)
 		if err != nil || !exists {
-			panic(fmt.Sprintf("image %s/otel-agent:%s not found in the internal registry", e.InternalRegistry(), tag))
+			panic(fmt.Sprintf("image %s/otel-agent-qa:%s not found in the internal registry", e.InternalRegistry(), tag))
 		}
-		return utils.BuildDockerImagePath(fmt.Sprintf("%s/otel-agent", e.InternalRegistry()), tag)
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/otel-agent-qa", e.InternalRegistry()), tag)
 	}
 
 	if repositoryPath == "" {

--- a/test/e2e-framework/components/datadog/dogstatsd-standalone/docker_image.go
+++ b/test/e2e-framework/components/datadog/dogstatsd-standalone/docker_image.go
@@ -25,7 +25,7 @@ func dockerDogstatsdFullImagePath(e config.Env, repositoryPath string) string {
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return utils.BuildDockerImagePath(fmt.Sprintf("%s/dogstatsd", e.InternalRegistry()), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/dogstatsd-qa", e.InternalRegistry()), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {

--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -295,7 +295,7 @@ func getCWSInstrumentationFullImagePath(e *configCommon.CommonEnvironment) strin
 	}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return fmt.Sprintf("669783387624.dkr.ecr.us-east-1.amazonaws.com/cws-instrumentation:%s-%s", e.PipelineID(), e.CommitSHA())
+		return fmt.Sprintf("669783387624.dkr.ecr.us-east-1.amazonaws.com/cws-instrumentation-qa:%s-%s", e.PipelineID(), e.CommitSHA())
 	}
 
 	return cwsInstrumentationDefaultImagePath
@@ -307,7 +307,7 @@ func getAgentFullImagePath(e *configCommon.CommonEnvironment) string {
 	}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return fmt.Sprintf("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent:%s-%s", e.PipelineID(), e.CommitSHA())
+		return fmt.Sprintf("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent-qa:%s-%s", e.PipelineID(), e.CommitSHA())
 	}
 
 	return agentDefaultImagePath

--- a/test/new-e2e/tests/fips-compliance/cluster_agent_fips_test.go
+++ b/test/new-e2e/tests/fips-compliance/cluster_agent_fips_test.go
@@ -42,7 +42,7 @@ func buildClusterAgentImagePath() string {
 	tag := fmt.Sprintf("%s-%s-fips", pipelineID, commitSHA)
 	registry := "669783387624.dkr.ecr.us-east-1.amazonaws.com"
 
-	return fmt.Sprintf("%s/cluster-agent:%s", registry, tag)
+	return fmt.Sprintf("%s/cluster-agent-qa:%s", registry, tag)
 }
 
 type fipsServerClusterAgentSuite struct {


### PR DESCRIPTION
### What does this PR do?

Updates the CI/CD pipeline and e2e test framework to use dedicated QA repositories for pipeline-specific test images:

**Commit 1 - GitLab deploy jobs:**
- Changes `IMG_DESTINATIONS` in `.gitlab/deploy/dev_container_deploy/e2e.yml` from main repositories to dedicated QA repositories:
  - `agent:` → `agent-qa:`
  - `cluster-agent:` → `cluster-agent-qa:`
  - `dogstatsd:` → `dogstatsd-qa:`
  - `otel-agent:` → `otel-agent-qa:`
  - `cws-instrumentation:` → `cws-instrumentation-qa:`

**Commit 2 - E2E test framework:**
- Updates image path construction in:
  - `test/e2e-framework/components/datadog/agent/docker_image.go`
  - `test/e2e-framework/components/datadog/dogstatsd-standalone/docker_image.go`
  - `test/new-e2e/tests/cws/fargate_test.go`
  - `test/new-e2e/tests/fips-compliance/cluster_agent_fips_test.go`

### Motivation

Pipeline-specific test images (tagged with `${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}`) were being pushed to the same repositories as public/release images (`agent`, `cluster-agent`, etc.). This pollutes the public registry tags with numerous ephemeral test images that are only needed for CI e2e testing.

By using dedicated `-qa` suffixed repositories, we keep the main repositories clean while maintaining the same infrastructure for testing.

### Describe how you validated your changes

CI

### Additional Notes
