### PR TITLE
[Backport 7.76.x] Disable default SNMP device scan

### DIFF
--- a/comp/snmpscanmanager/impl/flare_test.go
+++ b/comp/snmpscanmanager/impl/flare_test.go
@@ -28,6 +28,7 @@ func TestFillFlare(t *testing.T) {
 	testDir := t.TempDir()
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("run_path", testDir)
+	mockConfig.SetWithoutSource("network_devices.default_scan.enabled", true)
 
 	mockLifecycle := compdef.NewTestLifecycle(t)
 	mockLogger := logmock.New(t)

--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -157,7 +157,7 @@ func (m *snmpScanManagerImpl) RequestScan(req snmpscanmanager.ScanRequest, force
 	default:
 	}
 
-	if m.agentConfig.GetBool("network_devices.default_scan.disabled") {
+	if !m.agentConfig.GetBool("network_devices.default_scan.enabled") {
 		return
 	}
 

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -68,10 +68,8 @@ func TestRequestScan(t *testing.T) {
 		expectedDeviceScans     deviceScansByIP
 	}{
 		{
-			name: "default scan is disabled via config",
-			configContent: map[string]interface{}{
-				"network_devices.default_scan.disabled": true,
-			},
+			name:          "default scan is disabled by default",
+			configContent: map[string]interface{}{},
 			buildMockConfigProvider: func() *snmpConfigProviderMock {
 				mockConfigProvider := newSnmpConfigProviderMock()
 				return mockConfigProvider
@@ -94,8 +92,10 @@ func TestRequestScan(t *testing.T) {
 			expectedDeviceScans: deviceScansByIP{},
 		},
 		{
-			name:          "default scan is enabled",
-			configContent: map[string]interface{}{},
+			name: "default scan is enabled via config",
+			configContent: map[string]interface{}{
+				"network_devices.default_scan.enabled": true,
+			},
 			buildMockConfigProvider: func() *snmpConfigProviderMock {
 				mockConfigProvider := newSnmpConfigProviderMock()
 
@@ -835,6 +835,7 @@ func TestQueueDueScans(t *testing.T) {
 			testDir := t.TempDir()
 			mockConfig := configmock.New(t)
 			mockConfig.SetWithoutSource("run_path", testDir)
+			mockConfig.SetWithoutSource("network_devices.default_scan.enabled", true)
 
 			mockLifecycle := compdef.NewTestLifecycle(t)
 			mockLogger := logmock.New(t)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4068,6 +4068,19 @@ api_key:
 #
 #   namespace: default
 
+#   # @param default_scan - custom object - optional
+#   # Configuration for automatic SNMP device scanning.
+#   # When enabled, discovered SNMP devices are automatically scanned.
+#
+#   # default_scan:
+#
+#     # @param enabled - boolean - optional - default: false
+#     # Enable automatic scanning of discovered SNMP devices.
+#     # When enabled, devices discovered via autodiscovery or configured
+#     # directly will be scanned to collect OID data.
+#
+#     # enabled: false
+
 #   # @param autodiscovery - custom object - optional
 #   # Creates and schedules a listener to automatically discover your SNMP devices.
 #   # Discovered devices can then be monitored with the SNMP integration by using

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -536,6 +536,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.timeout", 5)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.retries", 3)
 
+	config.BindEnvAndSetDefault("network_devices.default_scan.enabled", false)
+
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.enabled", false)
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.port", 9162)

--- a/releasenotes/notes/disable-default-scan-8e224b53d8f843d9.yaml
+++ b/releasenotes/notes/disable-default-scan-8e224b53d8f843d9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Disable the SNMP device scan by default.


### PR DESCRIPTION
Backport a8a0d3f987cc947c270add2bb54410b2c780e2ef from #45552.

 ___

### What does this PR do?
Disable the default SNMP device scan introduced in #42376 

### Motivation
the device scan is causing Extreme Network switch (EXOS 33.1.1) devices to crash

### Describe how you validated your changes

### Additional Notes