### PR TITLE
fix(installer): Remove datadog-agent deb / rpm  when installing DJM

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -70,10 +70,13 @@ fi
 if command -v dpkg >/dev/null && dpkg -s datadog-installer >/dev/null 2>&1; then
   "${sudo_cmd[@]+"${sudo_cmd[@]}"}" datadog-installer purge >/dev/null 2>&1 || true
   "${sudo_cmd[@]+"${sudo_cmd[@]}"}" dpkg --purge datadog-installer >/dev/null 2>&1 || true
+  DATADOG_AGENT_OPTIONAL_REMOVE_DEB_CMD
 elif command -v rpm >/dev/null && rpm -q datadog-installer >/dev/null 2>&1; then
   "${sudo_cmd[@]+"${sudo_cmd[@]}"}" datadog-installer purge >/dev/null 2>&1 || true
   "${sudo_cmd[@]+"${sudo_cmd[@]}"}" rpm -e datadog-installer >/dev/null 2>&1 || true
 fi
+
+DATADOG_AGENT_OPTIONAL_REMOVE_CMD
 
 "${sudo_cmd[@]+"${sudo_cmd[@]}"}" mkdir -p "$tmp_dir"
 


### PR DESCRIPTION
### What does this PR do?

Removes the `datadog-agent` deb/rpm package during DJM installation before extracting the installer binary.

### Motivation

Since Agent 7.75.0, purging the agent cleans up `/opt/datadog-packages/tmp` in the preInstall hook. This causes DJM installations to fail:
1. DJM script extracts installer to `/opt/datadog-packages/tmp`
2. Installing the Agent package purges any existing agent
3. The purge removes `/opt/datadog-packages/tmp`, deleting the installer binary
4. DJM tries to use the now-missing installer → installation fails

This PR removes any existing agent package before extracting the installer (DJM flavors only), preventing the cleanup from deleting the installer binary.

### Describe how you validated your changes

Manual QA on test VMs and EMR clusters with existing Agent 7.75.0+ installations.

### Additional Notes

Related incident: #48597