### PR TITLE
Backport config fixes

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -352,7 +352,7 @@ func (c *ntmConfig) UnsetForSource(key string, source model.Source) {
 	}
 
 	// Replace the child with the node from the previous layer
-	parentNode.InsertChildNode(childName, prevNode.Clone())
+	parentNode.InsertChildNode(childName, prevNode)
 
 	newValue := c.leafAtPathFromNode(key, c.root).Get()
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1099,6 +1099,21 @@ func TestUnsetForSource(t *testing.T) {
         leaf(#ptr<000006>), val:6, source:file`
 	assert.Equal(t, expect, txt)
 
+	// [AGENTCFG-314] Prevent the test from being flakey.
+	// This keeps a reference to the node for `input_chan_size`, which helps prevent
+	// an edge case that can cause this test to fail on rare occasions.
+	// Because UnsetForSource removes nodes, and we allocate more nodes later in this
+	// test, if the GC timing is right, it's possible that a future node reuses the
+	// same address as this node. Since the Stringifier caches node addresses in order
+	// to determine their unique ID, this address reuse would cause it to get confused
+	// and reuse the ID of `input_chan_size`. By holding this reference we prevent the
+	// reuse of this node's address, and prevent this edge case from occurring.
+	var keepNode Node
+	if ncfg, ok := cfg.(NodeTreeConfig); ok {
+		keepNode, _ = ncfg.GetNode("network_path.collector.input_chan_size")
+	}
+	assert.NotNil(t, keepNode)
+
 	// No change if source doesn't match
 	cfg.UnsetForSource("network_path.collector.input_chan_size", model.SourceFile)
 	assert.Equal(t, expect, txt)
@@ -1296,7 +1311,7 @@ tree(#ptr<000014>) source=environment-variable
   > collector
     inner(#ptr<000002>)
     > input_chan_size
-        leaf(#ptr<000017>), val:100000, source:default
+        leaf(#ptr<000009>), val:100000, source:default
     > pathtest_contexts_limit
         leaf(#ptr<000004>), val:100000, source:default
     > processing_chan_size

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -241,19 +241,6 @@ func (n *nodeImpl) dumpSettings(includeDefaults bool) map[string]interface{} {
 	return res
 }
 
-// Clone clones a LeafNode
-func (n *nodeImpl) Clone() *nodeImpl {
-	if n.IsLeafNode() {
-		return newLeafNode(n.val, n.source)
-	}
-
-	children := make(map[string]*nodeImpl)
-	for k, node := range n.children {
-		children[k] = node.Clone()
-	}
-	return newInnerNode(children)
-}
-
 // SourceGreaterThan returns true if the source of the current node is greater than the one given as a
 // parameter
 func (n *nodeImpl) SourceGreaterThan(source model.Source) bool {

--- a/pkg/config/nodetreemodel/node_ops_fuzz_test.go
+++ b/pkg/config/nodetreemodel/node_ops_fuzz_test.go
@@ -56,10 +56,6 @@ func FuzzNodeOps(f *testing.F) {
 			_, _ = child.GetChild("nonexistent")
 		}
 
-		// Clone and operate on the cloned node tree
-		cloned := root.Clone()
-		_ = cloned.ChildrenKeys()
-
 		_ = root.dumpSettings(true)
 
 		// Build a secondary tree using newNodeTree from a map and merge it

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2852,10 +2852,15 @@ func envVarAreSetAndNotEqual(lhsName string, rhsName string) bool {
 
 // sanitizeAPIKeyConfig strips newlines and other control characters from a given key.
 func sanitizeAPIKeyConfig(config pkgconfigmodel.Config, key string) {
-	if !config.IsKnown(key) || !config.IsSet(key) {
+	if !config.IsKnown(key) || !config.IsConfigured(key) {
 		return
 	}
-	config.Set(key, strings.TrimSpace(config.GetString(key)), config.GetSource(key))
+	original := config.GetString(key)
+	trimmed := strings.TrimSpace(original)
+	if original == trimmed {
+		return
+	}
+	config.Set(key, trimmed, pkgconfigmodel.SourceAgentRuntime)
 }
 
 // sanitizeExternalMetricsProviderChunkSize ensures the value of `external_metrics_provider.chunk_size` is within an acceptable range

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1172,43 +1172,8 @@ use_proxy_for_cloud_metadata: true
 	assert.Equal(t, err.Error(), "index out of range 5 >= 2")
 }
 
-// configRetrieveFromPath gets a setting from the config, handling URLs correctly
-// viper would do this by looking for "known" keys and reconstructing the url piece by piece
-// This method should only be needed by tests
-// In nodetreemodel, settings like additional_endpoints are leaf values
-// We should be able to simplify this implementation once ntm is in use everywhere
-func configRetrieveFromPath(cfg pkgconfigmodel.Config, settingPath string) (interface{}, error) {
-	parts := strings.Split(settingPath, ".")
-
-	if ncfg, ok := cfg.(nodetreemodel.NodeTreeConfig); ok {
-		for i := range parts {
-			if i == 0 {
-				continue
-			}
-			partial := strings.Join(parts[0:i], ".")
-			node, err := ncfg.GetNode(partial)
-			if err != nil {
-				return nil, err
-			}
-			if node.IsLeafNode() {
-				// if we find a leaf, can't get a child of it
-				leafValue := node.Get()
-				if leafMap, isMap := leafValue.(map[string]interface{}); isMap {
-					remain := strings.Join(parts[i:], ".")
-					return leafMap[remain], nil
-				}
-			}
-		}
-	}
-
-	return cfg.Get(settingPath), nil
-}
-
 func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
-
 	config := newTestConf(t)
-	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
-	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1225,20 +1190,21 @@ func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
 	err = configAssignAtPath(config, []string{"process_config", "additional_endpoints", "https://url2.eu", "0"}, "modified")
 	assert.NoError(t, err)
 
-	var expected interface{} = `different`
-	res, err := configRetrieveFromPath(config, "secret_backend_command")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
+	require.Equal(t, "different", config.Get("secret_backend_command"))
 
-	expected = []interface{}([]interface{}{"first", "changed"})
-	res, err = configRetrieveFromPath(config, "additional_endpoints.https://url1.com")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
-
-	expected = []interface{}([]interface{}{"modified"})
-	res, err = configRetrieveFromPath(config, "process_config.additional_endpoints.https://url2.eu")
-	assert.NoError(t, err)
-	require.Equal(t, expected, res)
+	assert.Equal(t,
+		map[string]interface{}(
+			map[string]interface{}{
+				"https://url1.com": []interface{}{"first", "changed"},
+				"https://url2.eu":  []interface{}{"third"},
+			}),
+		config.Get("additional_endpoints"))
+	assert.Equal(t,
+		map[string]interface{}(
+			map[string]interface{}{
+				"https://url1.com": []interface{}{"fourth", "fifth"},
+				"https://url2.eu":  []interface{}{"modified"}}),
+		config.Get("process_config.additional_endpoints"))
 }
 
 var testSimpleConf = []byte(`process_config:

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -7,6 +7,7 @@
 package teeconfig
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
@@ -393,8 +394,9 @@ func (t *teeConfig) ReadInConfig() error {
 
 // ReadConfig wraps Viper for concurrent access
 func (t *teeConfig) ReadConfig(in io.Reader) error {
-	err1 := t.baseline.ReadConfig(in)
-	err2 := t.compare.ReadConfig(in)
+	data, _ := io.ReadAll(in)
+	err1 := t.baseline.ReadConfig(bytes.NewBuffer(data))
+	err2 := t.compare.ReadConfig(bytes.NewBuffer(data))
 	if (err1 != nil && err2 == nil) || (err1 == nil && err2 != nil) {
 		log.Warnf("difference in config: ReadConfig() -> base error: %v | compare error: %v", err1, err2)
 	}
@@ -403,8 +405,9 @@ func (t *teeConfig) ReadConfig(in io.Reader) error {
 
 // MergeConfig wraps Viper for concurrent access
 func (t *teeConfig) MergeConfig(in io.Reader) error {
-	err1 := t.baseline.MergeConfig(in)
-	err2 := t.compare.MergeConfig(in)
+	data, _ := io.ReadAll(in)
+	err1 := t.baseline.MergeConfig(bytes.NewBuffer(data))
+	err2 := t.compare.MergeConfig(bytes.NewBuffer(data))
 	if (err1 != nil && err2 == nil) || (err1 == nil && err2 != nil) {
 		log.Warnf("difference in config: MergeConfig() -> base error: %v | compare error: %v", err1, err2)
 	}
@@ -545,7 +548,7 @@ func (t *teeConfig) BindEnvAndSetDefault(key string, val interface{}, env ...str
 }
 
 func (t *teeConfig) Warnings() *model.Warnings {
-	return nil
+	return t.baseline.Warnings()
 }
 
 func (t *teeConfig) Object() model.Reader {

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -53,7 +53,6 @@ func (t *teeConfig) RevertFinishedBackToBuilder() model.BuildableConfig {
 // Callbacks are only called if the value is effectively changed.
 func (t *teeConfig) OnUpdate(callback model.NotificationReceiver) {
 	t.baseline.OnUpdate(callback)
-	t.compare.OnUpdate(callback)
 }
 
 // SetTestOnlyDynamicSchema allows more flexible usage of the config, should only be used by tests

--- a/pkg/config/viperconfig/validate_basic.go
+++ b/pkg/config/viperconfig/validate_basic.go
@@ -47,7 +47,7 @@ func ValidateBasicTypes(value interface{}) bool {
 	}
 
 	// Allow existing callers that are using SetWithoutSource. Fix these later
-	for _, stackSkip := range []int{2, 3} {
+	for _, stackSkip := range []int{2, 3, 4} {
 		_, absfile, _, _ := runtime.Caller(stackSkip)
 		for _, allowSource := range allowlistCaller {
 			if strings.HasSuffix(absfile, allowSource) {

--- a/pkg/network/tracer/conntracker_test.go
+++ b/pkg/network/tracer/conntracker_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vishvananda/netns"
 	"go4.org/netipx"
 
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -73,6 +74,7 @@ func TestConntrackers(t *testing.T) {
 
 func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *config.Config) (netlink.Conntracker, error)) {
 	t.Run("IPv4", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		ct, err := createFn(t, cfg)
 		require.NoError(t, err)
@@ -83,6 +85,7 @@ func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *co
 		testConntracker(t, net.ParseIP("1.1.1.1"), net.ParseIP("2.2.2.2"), ct, cfg)
 	})
 	t.Run("IPv6", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		ct, err := createFn(t, cfg)
 		require.NoError(t, err)
@@ -93,6 +96,7 @@ func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *co
 		testConntracker(t, net.ParseIP("fd00::1"), net.ParseIP("fd00::2"), ct, cfg)
 	})
 	t.Run("cross namespace - NAT rule on test namespace", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		if name == "netlink" {
 			if kv >= kernel.VersionCode(5, 19, 0) && kv < kernel.VersionCode(6, 3, 0) {
 				// see https://lore.kernel.org/netfilter-devel/CALvGib_xHOVD2+6tKm2Sf0wVkQwut2_z2gksZPcGw30tOvOAAA@mail.gmail.com/T/#u
@@ -109,6 +113,7 @@ func runConntrackerTest(t *testing.T, name string, createFn func(*testing.T, *co
 		testConntrackerCrossNamespace(t, ct)
 	})
 	t.Run("cross namespace - NAT rule on root namespace", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		cfg.EnableConntrackAllNamespaces = true
 		ct, err := createFn(t, cfg)
@@ -151,6 +156,7 @@ func runAlternateProbesTest(t *testing.T, testFn func(t *testing.T)) {
 
 func runNFConntrackHashCheckInsertTest(t *testing.T, createFn func(*testing.T, *config.Config) (netlink.Conntracker, error)) {
 	t.Run("IPv4", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		ct, err := createFn(t, cfg)
 		require.NoError(t, err)
@@ -161,6 +167,7 @@ func runNFConntrackHashCheckInsertTest(t *testing.T, createFn func(*testing.T, *
 		testNFConntrackHashCheckInsert(t, "10.0.0.100", "2.2.2.2", "1.1.1.1", network.AFINET, ct, cfg)
 	})
 	t.Run("IPv6", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		ct, err := createFn(t, cfg)
 		require.NoError(t, err)
@@ -171,6 +178,7 @@ func runNFConntrackHashCheckInsertTest(t *testing.T, createFn func(*testing.T, *
 		testNFConntrackHashCheckInsert(t, "fd00::100", "fd00::2", "fd00::1", network.AFINET6, ct, cfg)
 	})
 	t.Run("cross namespace - NAT rule on test namespace", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		cfg.EnableConntrackAllNamespaces = true
 		ct, err := createFn(t, cfg)
@@ -180,6 +188,7 @@ func runNFConntrackHashCheckInsertTest(t *testing.T, createFn func(*testing.T, *
 		testNFConntrackHashCheckInsertCrossNamespace(t, ct)
 	})
 	t.Run("cross namespace - NAT rule on root namespace", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		cfg := config.New()
 		cfg.EnableConntrackAllNamespaces = true
 		ct, err := createFn(t, cfg)
@@ -195,6 +204,7 @@ func testNFConntrackHashCheckInsert(t *testing.T, srcIP, dstIP, replySrcIP strin
 	require.NoError(t, err)
 
 	t.Run("TCP", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		srcPort := 54320
 		dstPort := 8080
 
@@ -220,6 +230,7 @@ func testNFConntrackHashCheckInsert(t *testing.T, srcIP, dstIP, replySrcIP strin
 	})
 
 	t.Run("UDP", func(t *testing.T) {
+		mock.NewSystemProbe(t)
 		if family == network.AFINET6 && !cfg.CollectUDPv6Conns {
 			t.Skip("UDPv6 disabled")
 		}


### PR DESCRIPTION
### What does this PR do?

Those fixes are all related to each other but fixed by different members of the team, hence 1 backport for all of them.
Those are required to allow us to run TeeConfig and NTM on staging/prod with 7.76.

This PR backport the a list of fixes:
- #45532
- #45543
- #45500
- #45402
- #45511
- #45377

### Describe how you validated your changes

Running the CI.