### PR TITLE
Update Chainguard file for CodeQL Scan

### DIFF
--- a/.github/chainguard/codeql.sts.yaml
+++ b/.github/chainguard/codeql.sts.yaml
@@ -1,10 +1,6 @@
-issuer: https://gitlab.ddbuild.io
-subject_pattern: "project_path:DataDog/datadog-agent:ref_type:branch:ref:.*"
+issuer: https://vault.us1.ddbuild.io/v1/identity/oidc
+subject_pattern: "bf4480b0-ee11-5050-758d-189b036f7ee8"
 claim_pattern:
-  project_path: "DataDog/datadog-agent"
-  ref_type: "branch"
-  ref: ".+"
-  ref_path: "refs/heads/.+"
-  ref_protected: "true"
+  name: "gitlab-runner-datadog-agent-datadog-agent"
 permissions:
   security_events: write


### PR DESCRIPTION
### What does this PR do?
- Changed the issuer from https://gitlab.ddbuild.io to https://vault.us1.ddbuild.io/v1/identity/oidc 
### Motivation

### Describe how you validated your changes

The JWT Claim suggests the runner is running in Kubernetes (the .us1.ddbuild.io cluster) and it belongs to the k8s_gitlab-runner-datadog-agent_robots group. Hence updating the chainguard for codeql.sts.yaml

```
[32;1m$ dd-octo-sts debug --scope DataDog/datadog-agent --policy codeql || true[0;m
2026-01-27T17:51:18.113471Z 01O ✅ Verified JWT Claims:
2026-01-27T17:51:18.113476Z 01O {
2026-01-27T17:51:18.113502Z 01O   "aud": "dd-octo-sts",
2026-01-27T17:51:18.113511Z 01O   "datacenter": "us1.ddbuild.io",
2026-01-27T17:51:18.113516Z 01O   "email": "gitlab-runner-datadog-agent.datadog-agent@kubernetes.us1.ddbuild.io",
2026-01-27T17:51:18.113532Z 01O   "exp": 1769557877,
2026-01-27T17:51:18.113534Z 01O   "groups": [
2026-01-27T17:51:18.113541Z 01O     "k8s_gitlab-runner-datadog-agent_robots"
2026-01-27T17:51:18.113547Z 01O   ],
2026-01-27T17:51:18.113549Z 01O   "iat": 1769536277,
2026-01-27T17:51:18.113553Z 01O   "iss": "https://vault.us1.ddbuild.io/v1/identity/oidc",
2026-01-27T17:51:18.113559Z 01O   "name": "gitlab-runner-datadog-agent-datadog-agent",
2026-01-27T17:51:18.113561Z 01O   "namespace": "root",
2026-01-27T17:51:18.113564Z 01O   "sub": "bf4480b0-ee11-5050-758d-189b036f7ee8"
2026-01-27T17:51:18.113570Z 01O }
```

### Additional Notes
