### PR TITLE
Make `bazel:mod-deps` job more actionable for rules_* lock files

### DIFF
--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -2,17 +2,22 @@ bazel:mod-deps:
   extends: .bazel:runner:linux-amd64
   stage: lint
   script:
-    - |
-      if ! bazel mod deps --lockfile_mode=error; then
-        echo >&2 "🟡️ triggering in-memory cache refresh to try again"
-        bazel mod deps --lockfile_mode=refresh
-        git diff --exit-code || git restore MODULE.bazel.lock
-        bazel mod deps --lockfile_mode=error
-      fi
+    # Why not `bazel mod deps --lockfile_mode=error`:
+    # 1. `bazel` servers on persistent runners cache non-local repository rules, causing stale checks (#incident-46079),
+    # 2. `--lockfile_mode=error` doesn't print discrepancies exhaustively, especially on rules_* lock files.
+    #
+    # Instead:
+    # 1. use `--lockfile_mode=refresh` to forcibly re-evaluate non-local repository rules,
+    # 2. use `--repo_env=REPIN=1` to regenerate rules_* lock files:
+    #    - rules_jvm_external: implies RULES_JVM_EXTERNAL_REPIN=1 for maven_install.json,
+    #    - rules_rust: implies CARGO_BAZEL_REPIN=1 for Cargo.Bazel.lock,
+    # 3. use `git diff --exit-code` to still fail on any discrepancies while printing them exhaustively.
+    - bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
+    - git diff --exit-code
   after_script:
     - |-
       if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel mod deps"
+        echo >&2 "💡 bazel mod deps --repo_env=REPIN=1"
       fi
 
 bazel:mod-tidy:


### PR DESCRIPTION
### What does this PR do?
Make the `bazel:mod-deps` CI job use `--repo_env=REPIN=1` to regenerate `rules_*` lock files (like `Cargo.Bazel.lock`) during validation, ensuring discrepancies are exhaustively reported via `git diff`.

This also adds a detailed comment explaining the limitations of the earlier `bazel mod deps --lockfile_mode=error` and our revised approach.

### Motivation
Not an incident, but a monitor got triggered on a failing MQ pipeline, leading to [quite some time being spent](https://dd.slack.com/archives/C08SK4B0FK8/p1769590494878479).

The current job output was indeed not actionable in this case, nor was the earlier `🟡️ triggering in-memory cache refresh to try again` fruitful ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1382470259)).

### Describe how you validated your changes
Running this very small shell snippet produces the desired behavior:
```sh
bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
git diff --exit-code
echo $?
```

In the said case:
```sh
$ bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
WARNING: Option 'remote_local_fallback_strategy' is deprecated
<root> (@_)

$ git diff --exit-code
diff --git a/pkg/discovery/module/rust/Cargo.Bazel.lock b/pkg/discovery/module/rust/Cargo.Bazel.lock
index 59a7b20732..aa0ced62e3 100644
--- a/pkg/discovery/module/rust/Cargo.Bazel.lock
+++ b/pkg/discovery/module/rust/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "b1a72466a2da35e48e947208b3d77fe770abf8f32983219790fb3ad234d13e3e",
+  "checksum": "17ced1be3876d67498d68cf2655e1b2fac5ef070170a8ea33066bca0ac4674a6",
   "crates": {
     "adler2 2.0.1": {
       "name": "adler2",
@@ -6841,8 +6841,10 @@
         "edition": "2024",
         "version": "0.1.0"
       },
-      "license": null,
-      "license_ids": [],
+      "license": "Apache-2.0",
+      "license_ids": [
+        "Apache-2.0"
+      ],
       "license_file": null
     },
     "serde 1.0.228": {

$ echo $?
1
```

### Additional Notes
`--repo_env=` variables do **not** invalidate `bazel`'s build cache.

`REPIN=1` acts as `--lockfile_mode=update|refresh` for `rules_*` lock files:
- `rules_jvm_external`: https://github.com/bazel-contrib/rules_jvm_external/blob/6.9/README.md?plain=1#L307
- `rules_rust`: https://github.com/bazelbuild/rules_rust/blob/0.68.1/crate_universe/extensions.bzl#L130
- probably other `rules_*`...

:question: bazelbuild/rules_rust#3828