### PR TITLE
[ AGNTLOG-513 ] Remove pkgconfigsetup references from the diagnostic log package

### DIFF
--- a/comp/anomalydetection/logssource/impl/pipeline.go
+++ b/comp/anomalydetection/logssource/impl/pipeline.go
@@ -45,7 +45,7 @@ func newObserverPipeline(
 		outputChan,
 		processingRules,
 		processor.PassthroughEncoder,
-		diagnostic.NewBufferedMessageReceiver(nil, hostname),
+		diagnostic.NewBufferedMessageReceiver(nil, hostname, cfg),
 		hostname,
 		pipelineMonitor,
 		pipelineID,

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -777,8 +777,9 @@ func NewNoopEventPlatformForwarder(hostname hostnameinterface.Component, compres
 }
 
 func newNoopEventPlatformForwarder(hostname hostnameinterface.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
+	config := pkgconfigsetup.Datadog()
 	hostnameStr := hostname.GetSafe(context.Background())
-	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression, hostnameStr, secretsnoopimpl.NewComponent().Comp)
+	f := newDefaultEventPlatformForwarder(config, eventplatformreceiverimpl.NewReceiver(hostname, config).Comp, compression, hostnameStr, secretsnoopimpl.NewComponent().Comp)
 	// remove the senders
 	for _, p := range f.pipelines {
 		p.strategy = nil

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_mock.go
@@ -8,12 +8,13 @@
 package eventplatformimpl
 
 import (
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
-	"go.uber.org/fx"
 )
 
 // MockModule defines the fx options for the mock component.

--- a/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/BUILD.bazel
+++ b/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//comp/api/api/def",
         "//comp/api/api/utils/stream",
+        "//comp/core/config",
         "//comp/core/hostname/hostnameinterface",
         "//comp/forwarder/eventplatform",
         "//comp/forwarder/eventplatformreceiver",

--- a/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/eventplatformreceiver.go
+++ b/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl/eventplatformreceiver.go
@@ -13,6 +13,7 @@ import (
 
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	apiutils "github.com/DataDog/datadog-agent/comp/api/api/utils/stream"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -38,8 +39,8 @@ func streamEventPlatform(eventPlatformReceiver eventplatformreceiver.Component) 
 }
 
 // NewReceiver returns a new event platform receiver.
-func NewReceiver(hostname hostnameinterface.Component) provides { // nolint:revive
-	epr := diagnostic.NewBufferedMessageReceiver(&epFormatter{}, hostname)
+func NewReceiver(hostname hostnameinterface.Component, config configComponent.Component) provides { // nolint:revive
+	epr := diagnostic.NewBufferedMessageReceiver(&epFormatter{}, hostname, config)
 	return provides{
 		Comp:     epr,
 		Endpoint: api.NewAgentEndpointProvider(streamEventPlatform(epr), "/stream-event-platform", "POST"),

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -38,7 +38,7 @@ import (
 // NewAgent returns a new Logs Agent
 func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta option.Option[workloadmeta.Component], integrationsLogs integrations.Component, fingerprintConfig types.FingerprintConfig) {
 	destinationsCtx := client.NewDestinationsContext()
-	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, a.hostname)
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, a.hostname, a.config)
 
 	// setup the pipeline provider that provides pairs of processor and sender
 	pipelineProvider := buildPipelineProvider(a, processingRules, diagnosticMessageReceiver, destinationsCtx)

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -41,7 +41,7 @@ func (a *logAgent) SetupPipeline(
 	_ integrations.Component,
 	fingerprintConfig types.FingerprintConfig,
 ) {
-	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(streamlogs.Formatter{}, a.hostname)
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(streamlogs.Formatter{}, a.hostname, a.config)
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender

--- a/comp/logs/agent/agentimpl/analyze_logs_init.go
+++ b/comp/logs/agent/agentimpl/analyze_logs_init.go
@@ -37,7 +37,7 @@ func SetUpLaunchers(conf configComponent.Component, sourceProvider *sources.Conf
 		return nil, nil, nil, err
 	}
 
-	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, nil)
+	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, nil, conf)
 	pipelineProvider := pipeline.NewProcessorOnlyProvider(diagnosticMessageReceiver, processingRules, nil, conf)
 
 	// setup the launchers

--- a/pkg/logs/diagnostic/BUILD.bazel
+++ b/pkg/logs/diagnostic/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//comp/core/hostname/hostnameinterface",
-        "//pkg/config/setup",
+        "//pkg/config/model",
         "//pkg/logs/message",
     ],
 )
@@ -24,6 +24,8 @@ go_test(
     deps = [
         "//comp/core/hostname/hostnameinterface",
         "//comp/logs/agent/config",
+        "//pkg/config/mock",
+        "//pkg/config/model",
         "//pkg/logs/message",
         "//pkg/logs/sources",
         "@com_github_stretchr_testify//assert",

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -5,7 +5,8 @@ go 1.25.0
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.75.4
-	github.com/DataDog/datadog-agent/pkg/config/setup v0.75.4
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.75.4
+	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2
 	github.com/DataDog/datadog-agent/pkg/logs/message v0.75.4
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.75.4
 	github.com/stretchr/testify v1.11.1
@@ -24,8 +25,8 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/create v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/helper v0.75.4 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/model v0.77.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.75.4 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/setup v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.75.4 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.75.4 // indirect

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
@@ -20,8 +22,14 @@ func getNewHostname(name hostnameinterface.MockHostname) hostnameinterface.Mock 
 	return mock
 }
 
+func getTestConfig(t *testing.T) pkgconfigmodel.Reader {
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("logs_config.message_channel_size", 100)
+	return cfg
+}
+
 func TestEnableDisable(t *testing.T) {
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	assert.True(t, b.SetEnabled(true))
 	assert.False(t, b.SetEnabled(true))
 
@@ -54,7 +62,7 @@ func TestEnableDisable(t *testing.T) {
 
 func TestFilterAll(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -74,7 +82,7 @@ func TestFilterAll(t *testing.T) {
 
 func TestFilterTypeAndSource(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -92,7 +100,7 @@ func TestFilterTypeAndSource(t *testing.T) {
 
 func TestFilterTypeAndService(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -110,7 +118,7 @@ func TestFilterTypeAndService(t *testing.T) {
 
 func TestFilterSourceAndService(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -128,7 +136,7 @@ func TestFilterSourceAndService(t *testing.T) {
 
 func TestFilterName(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -146,7 +154,7 @@ func TestFilterName(t *testing.T) {
 
 func TestFilterSource(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -164,7 +172,7 @@ func TestFilterSource(t *testing.T) {
 
 func TestFilterType(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -182,7 +190,7 @@ func TestFilterType(t *testing.T) {
 
 func TestFilterService(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {
@@ -200,7 +208,7 @@ func TestFilterService(t *testing.T) {
 
 func TestNoFilters(t *testing.T) {
 
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	for i := 0; i < 5; i++ {

--- a/pkg/logs/diagnostic/message_receiver_test.go
+++ b/pkg/logs/diagnostic/message_receiver_test.go
@@ -233,7 +233,7 @@ func TestNoFilters(t *testing.T) {
 // exit rather than calling the formatter with a zero-value (nil-msg)
 // messagePair. Regression test for AGNTLOG-323.
 func TestFilterStopWhileStreaming(t *testing.T) {
-	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"))
+	b := NewBufferedMessageReceiver(nil, getNewHostname("unknown"), getTestConfig(t))
 	b.SetEnabled(true)
 
 	done := make(chan struct{})


### PR DESCRIPTION
### What does this PR do?

Replaces direct usage of `pkgconfigsetup.Datadog()` in `pkg/logs/diagnostic` with a `config.Reader` accepted through the constructor. Callers (`agent_core_init`, `agent_serverless_init`, `analyze_logs_init`, `epforwarder`) pass their existing config component through.

### Motivation

The `pkg/logs/diagnostic` package is being moved to `comp/logs-library/` as part of the logs library componentization. Packages under `comp/` are subject to a linter that prohibits direct access to the global config (`pkgconfigsetup.Datadog()`). Before moving the package, all dynamic config access must be shifted to dependency injection so the code stays in compliance after the move.

### Describe how you validated your changes

- `bazel test //pkg/logs/diagnostic/...` passes
- `go test ./pkg/logs/diagnostic/...` passes (10 tests)
- `inv tidy` and `bazel run //:gazelle` produce no diff
- CI pipeline validates full test suite

### Additional Notes

Part of the logs-library refactor stack (AGNTLOG-513). This is the next PR after the client PR (#45598) was merged.