### PR TITLE
add --run-flaky-tests option

### DIFF
--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -173,6 +173,7 @@ def trigger_agent_pipeline(
     e2e_tests=False,
     kmt_tests=False,
     rc_build=False,
+    run_flaky_tests=False,
 ) -> ProjectPipeline:
     """
     Trigger a pipeline on the datadog-agent repositories. Multiple options are available:
@@ -180,6 +181,7 @@ def trigger_agent_pipeline(
     - run a pipeline with all e2e tests,
     - run a pipeline with all end-to-end tests,
     - run a deploy pipeline (includes all builds & e2e tests + uploads artifacts to staging repositories);
+    - run a pipeline that does not skip flaky tests (by default, known flaky tests are skipped).
     """
 
     ref = ref or get_default_branch()
@@ -211,6 +213,9 @@ def trigger_agent_pipeline(
 
     if rc_build:
         args["RC_BUILD"] = "true"
+
+    if run_flaky_tests:
+        args["GO_TEST_SKIP_FLAKE"] = "false"
 
     print(
         "Creating pipeline for datadog-agent on branch/tag {} with args:\n{}".format(  # noqa: FS002

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -155,6 +155,7 @@ def run(
     e2e_tests=True,
     kmt_tests=True,
     rc_build=False,
+    run_flaky_tests=False,
 ):
     """
     Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
@@ -164,6 +165,7 @@ def run(
     Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
     Use --no-kmt-tests to not run all Kernel Matrix Tests on the pipeline.
     Use --e2e-tests to run all e2e tests on the pipeline.
+    Use --run-flaky-tests to run tests that are marked as flaky (by default, known flaky tests are skipped).
 
     Release Candidate related flags:
     Use --rc-build to mark the build as Release Candidate. Staging k8s deployment PR will be created during the build pipeline.
@@ -189,6 +191,9 @@ def run(
 
     Run a pipeline with e2e tets on the current branch:
       dda inv pipeline.run --here --e2e-tests
+
+    Run a pipeline that includes flaky tests on the current branch:
+      dda inv pipeline.run --here --run-flaky-tests
 
     Run a deploy pipeline on the 7.32.0 tag, uploading the artifacts to the stable branch of the staging repositories:
       dda inv pipeline.run --deploy --major-versions "6,7" --git-ref "7.32.0" --repo-branch "stable"
@@ -246,6 +251,7 @@ def run(
             e2e_tests=e2e_tests,
             kmt_tests=kmt_tests,
             rc_build=rc_build,
+            run_flaky_tests=run_flaky_tests,
         )
     except FilteredOutException:
         print(color_message(f"ERROR: pipeline does not match any workflow rule. Rules:\n{workflow_rules()}", "red"))


### PR DESCRIPTION
### What does this PR do?
add option to `pipeline.run` to run flaky tests
```
dda inv pipeline.run --here --run-flaky-tests
```

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2324
be able to run flaky tests in pipeline PRs to make sure they pass
