### PR TITLE
Revert "[CWS] force re-adjustment of the config during functional tests (#44461)

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -883,12 +883,6 @@ func genTestConfigs(t testing.TB, cfgDir string, opts testOpts) (*emconfig.Confi
 		return nil, nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}
 
-	// reset the system-probe config to not be adjusted yet
-	// necessary because the config object is a global, and we want the adjustment
-	// to happen again
-	cfg := pkgconfigsetup.GlobalSystemProbeConfigBuilder()
-	cfg.Set("system_probe_config.adjusted", false, pkgconfigmodel.SourceAgentRuntime)
-
 	_, err = spconfig.New(sysprobeConfigName, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)

--- a/pkg/system-probe/config/adjust_security.go
+++ b/pkg/system-probe/config/adjust_security.go
@@ -31,12 +31,12 @@ func adjustSecurity(cfg model.Config) {
 	if cfg.GetBool(secNS("enabled")) {
 		// if runtime is enabled then we enable fim as well (except if force disabled)
 		if runtime.GOOS != "windows" || !cfg.IsConfigured(secNS("fim_enabled")) {
-			cfg.Set(secNS("fim_enabled"), true, model.SourceDefault)
+			cfg.Set(secNS("fim_enabled"), true, model.SourceAgentRuntime)
 		}
 	} else {
 		// if runtime is disabled then we force disable activity dumps and security profiles
-		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceDefault)
-		cfg.Set(secNS("security_profile.enabled"), false, model.SourceDefault)
+		cfg.Set(secNS("activity_dump.enabled"), false, model.SourceAgentRuntime)
+		cfg.Set(secNS("security_profile.enabled"), false, model.SourceAgentRuntime)
 	}
 
 	// further adjustments done in RuntimeSecurityConfig.sanitize


### PR DESCRIPTION
This reverts commit 29bcd1dfcca555a79b01c930c367d56f1169aefb from #44461.

### What does this PR do?

Keep force enabling `runtime_security_config.fim_enabled`

### Motivation

In the Datadog Agent helm-chart, we [explicitly](https://github.com/DataDog/helm-charts/blob/af7d091f87969eaca0f6aa05a1bce89c9a2070c9/charts/datadog/templates/system-probe-configmap.yaml#L96) set the fim_enabled system-probe config parameter based on the `datadog.securityAgent.runtime.fimEnabled` while the later is set to false by default.

Before the reverted changes, system-probe would force enable FIM at runtime if runtime_security_config.enabled was true so the helm-chart value would get overridden. This isn't the case anymore meaning that FIM is disabled by default for customers using the helm-chart and 7.75.x agent releases, and this behavior is most likely something that they don't want.

### Describe how you validated your changes

- TestKindSuite end to end testsuite passes.
- Tested locally using minikube + helm

### Additional Notes
