### PR TITLE
Fix zstd cgo/nocgo strategy incompatibility in pkg/util/compression 

### DIFF
--- a/comp/serializer/logscompression/go.sum
+++ b/comp/serializer/logscompression/go.sum
@@ -37,6 +37,8 @@ github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb h1:PGufWXXDq9yaev6x
 github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb/go.mod h1:QiyDdbZLaJ/mZP4Zwc9g2QsfaEA4o7XvvgZegSci5/E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/comp/serializer/metricscompression/go.sum
+++ b/comp/serializer/metricscompression/go.sum
@@ -37,6 +37,8 @@ github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb h1:PGufWXXDq9yaev6x
 github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb/go.mod h1:QiyDdbZLaJ/mZP4Zwc9g2QsfaEA4o7XvvgZegSci5/E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/pkg/util/compression/compression_test.go
+++ b/pkg/util/compression/compression_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package compression_test
+
+import (
+	"bytes"
+	"testing"
+
+	zstdimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zstd"
+	zstdnocgoimpl "github.com/DataDog/datadog-agent/pkg/util/compression/impl-zstd-nocgo"
+)
+
+// Asserts that data compressed by zstd CGO can be decompressed by zstd NoCGO
+// and vice versa, for all b.
+func FuzzZstdCrossCompatibility(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	cgo := zstdimpl.New(zstdimpl.Requires{Level: 1})
+	nocgo := zstdnocgoimpl.New(zstdnocgoimpl.Requires{Level: 1})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Test: CGO compress -> NoCGO decompress
+		cgoCompressed, err := cgo.Compress(data)
+		if err != nil {
+			t.Fatalf("CGO Compress failed: %v", err)
+		}
+
+		nocgoDecompressed, err := nocgo.Decompress(cgoCompressed)
+		if err != nil {
+			t.Fatalf("NoCGO Decompress of CGO-compressed data failed: %v", err)
+		}
+
+		if !bytes.Equal(data, nocgoDecompressed) {
+			t.Errorf("CGO->NoCGO cross-compatibility failed")
+		}
+
+		// Test: NoCGO compress -> CGO decompress
+		nocgoCompressed, err := nocgo.Compress(data)
+		if err != nil {
+			t.Fatalf("NoCGO Compress failed: %v", err)
+		}
+
+		cgoDecompressed, err := cgo.Decompress(nocgoCompressed)
+		if err != nil {
+			t.Fatalf("CGO Decompress of NoCGO-compressed data failed: %v", err)
+		}
+
+		if !bytes.Equal(data, cgoDecompressed) {
+			t.Errorf("NoCGO->CGO cross-compatibility failed")
+		}
+	})
+}


### PR DESCRIPTION
### What does this PR do?

This commit fixes an incompatibility between our zstd strategies. The
cgo implementation returns a valid zstd frame for empty inputs, our
nocgo originally did not. This is a known-behavior of the underlying
dependency -- documented inline in the patch -- and said dependency
admits a configuration option to control this behavior.

### Motivation

This commit is motivated by the potential end state in spike
 PR #45519. That is, if we want to make non-trivial changes to
 this package systematic testing of the package is warranted.

### Describe how you validated your changes

The incompatibility here is a fuzzing discovered edge-case in the nocgo 
zstd strategy. The cgo implementation is what we use in our default build.
That is, this bug is unlikely to be explored in practice. 

### Additional Notes

This PR is peer to #45534.
