### PR TITLE
Fuzz CompressBound in pkg/util/compression, fix formula bugs

### DIFF
--- a/pkg/serializer/internal/stream/column_test.go
+++ b/pkg/serializer/internal/stream/column_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestColumn(t *testing.T) {
 	cs := zlib.New()
-	cc := NewColumnCompressor(cs, 10, 62, 128)
+	cc := NewColumnCompressor(cs, 10, 67, 128)
 
 	txn := cc.NewTransaction()
 

--- a/pkg/serializer/internal/stream/compressor_test.go
+++ b/pkg/serializer/internal/stream/compressor_test.go
@@ -176,7 +176,7 @@ func TestMaxCompressedSizePayload(t *testing.T) {
 		kind           string
 		maxPayloadSize int
 	}{
-		"zlib": {kind: compression.ZlibKind, maxPayloadSize: 22},
+		"zlib": {kind: compression.ZlibKind, maxPayloadSize: 27},
 		"zstd": {kind: compression.ZstdKind, maxPayloadSize: 90},
 	}
 	logger := logmock.New(t)
@@ -232,7 +232,7 @@ func TestTwoPayload(t *testing.T) {
 		kind           string
 		maxPayloadSize int
 	}{
-		"zlib": {kind: compression.ZlibKind, maxPayloadSize: 22},
+		"zlib": {kind: compression.ZlibKind, maxPayloadSize: 27},
 		"zstd": {kind: compression.ZstdKind, maxPayloadSize: 70},
 	}
 	logger := logmock.New(t)
@@ -295,7 +295,7 @@ func TestBuildWithOnErrItemTooBigPolicyMetadata(t *testing.T) {
 		kind                       string
 		maxUncompressedPayloadSize int
 	}{
-		"zlib": {kind: compression.ZlibKind, maxUncompressedPayloadSize: 40},
+		"zlib": {kind: compression.ZlibKind, maxUncompressedPayloadSize: 45},
 		"zstd": {kind: compression.ZstdKind, maxUncompressedPayloadSize: 170},
 	}
 	logger := logmock.New(t)

--- a/pkg/util/compression/impl-gzip/gzip_strategy.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy.go
@@ -53,10 +53,12 @@ func (s *GzipStrategy) Compress(src []byte) (result []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	err = gzipWriter.Flush()
-	if err != nil {
-		return nil, err
-	}
+	// Close calls Flush internally, writing out the final stored
+	// block. There is no need to call Flush explicitly before Close. Doing
+	// so only writes a 5-byte sync block, inflating the output but to not
+	// purpose.
+	//
+	// Should Go's internals change FuzzGzipCompressBound will fail.
 	err = gzipWriter.Close()
 	if err != nil {
 		return nil, err
@@ -84,18 +86,35 @@ func (s *GzipStrategy) Decompress(src []byte) ([]byte, error) {
 }
 
 // CompressBound returns the worst case size needed for a destination buffer
-// when using gzip
-//
-// The worst case expansion is a few bytes for the gzip file header, plus
-// 5 bytes per 32 KiB block, or an expansion ratio of 0.015% for large files.
-// The additional 18 bytes comes from the header (10 bytes) and trailer
-// (8 bytes). There is no theoretical maximum to the header,
-// but we don't set any extra header fields so it is safe to assume
-//
-// Source: https://www.gnu.org/software/gzip/manual/html_node/Overview.html
-// More details are in the linked RFC: https://www.ietf.org/rfc/rfc1952.txt
+// when using gzip. Return value will be > `sourceLen`.
 func (s *GzipStrategy) CompressBound(sourceLen int) int {
-	return sourceLen + (sourceLen/32768)*5 + 18
+	// The formula is: sourceLen + ceil(sourceLen/65535)*5 + 23
+	//
+	// Stored block overhead (ceil(sourceLen/65535)*5):
+	//
+	//   - 65535 bytes: maximum data per deflate stored block (16-bit LEN field)
+	//   - 5 bytes per block: header (3 bits type + 5 bits padding + 16 bits LEN + 16 bits NLEN)
+	//
+	// When deflate cannot compress data, it falls back to stored blocks. Each
+	// block holds up to 65535 bytes with a 5-byte header. We compute
+	// ceil(sourceLen/65535) via (sourceLen+65534)/65535, minimum 1 block.
+	//
+	// Constant 23 breakdown:
+	//
+	//   - 10 bytes: gzip header (magic, method, flags, mtime, xfl, os)
+	//   - 8 bytes: gzip trailer (CRC32 + ISIZE)
+	//   - 5 bytes: Go's compress/flate empty final block on Close()
+	//
+	// Go's compress/flate writes an empty stored block (01 00 00 ff ff) when
+	// Close() is called.
+	//
+	// REF https://www.ietf.org/rfc/rfc1952.txt
+	// REF compress/flate/deflate.go compressor.close() -> writeStoredHeader(0, true)
+	storedBlocks := (sourceLen + 65534) / 65535
+	if storedBlocks == 0 {
+		storedBlocks = 1
+	}
+	return sourceLen + storedBlocks*5 + 23
 }
 
 // ContentEncoding returns the content encoding value for gzip

--- a/pkg/util/compression/impl-gzip/gzip_strategy_test.go
+++ b/pkg/util/compression/impl-gzip/gzip_strategy_test.go
@@ -37,3 +37,33 @@ func FuzzGzipIdentity(f *testing.F) {
 		}
 	})
 }
+
+// Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
+func FuzzGzipCompressBound(f *testing.F) {
+	f.Add([]byte("hello world"), gzip.BestSpeed)
+	f.Add([]byte(""), gzip.NoCompression)
+	f.Add([]byte("a"), gzip.BestCompression)
+	f.Add([]byte(string(make([]byte, 1000))), gzip.DefaultCompression)
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"), gzip.HuffmanOnly)
+	f.Add(bytes.Repeat([]byte("abcd"), 250), gzip.BestSpeed)
+
+	f.Fuzz(func(t *testing.T, data []byte, level int) {
+		// Clamp level to valid gzip range: HuffmanOnly (-2) to BestCompression (9)
+		if level < gzip.HuffmanOnly {
+			level = gzip.HuffmanOnly
+		} else if level > gzip.BestCompression {
+			level = gzip.BestCompression
+		}
+
+		c := New(Requires{Level: level})
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		bound := c.CompressBound(len(data))
+		if len(compressed) > bound {
+			t.Errorf("CompressBound violated at level %d: len(compress(b))=%d > CompressBound(len(b))=%d", level, len(compressed), bound)
+		}
+	})
+}

--- a/pkg/util/compression/impl-zlib/zlib_strategy_test.go
+++ b/pkg/util/compression/impl-zlib/zlib_strategy_test.go
@@ -36,3 +36,26 @@ func FuzzZlibIdentity(f *testing.F) {
 		}
 	})
 }
+
+// Asserts that len(compress(b)) <= CompressBound(len(b)) for all b.
+func FuzzZlibCompressBound(f *testing.F) {
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte("a"))
+	f.Add([]byte(string(make([]byte, 1000))))
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"))
+	f.Add(bytes.Repeat([]byte("abcd"), 250))
+
+	c := New()
+	f.Fuzz(func(t *testing.T, data []byte) {
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		bound := c.CompressBound(len(data))
+		if len(compressed) > bound {
+			t.Errorf("CompressBound violated: len(compress(b))=%d > CompressBound(len(b))=%d", len(compressed), bound)
+		}
+	})
+}

--- a/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
+++ b/pkg/util/compression/impl-zstd-nocgo/zstd_nocgo_strategy_test.go
@@ -38,3 +38,33 @@ func FuzzZstdNoCgoIdentity(f *testing.F) {
 		}
 	})
 }
+
+// Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
+func FuzzZstdNoCgoCompressBound(f *testing.F) {
+	f.Add([]byte("hello world"), 1)
+	f.Add([]byte(""), 3)
+	f.Add([]byte("a"), 5)
+	f.Add([]byte(string(make([]byte, 1000))), 10)
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"), 15)
+	f.Add(bytes.Repeat([]byte("abcd"), 250), 22)
+
+	f.Fuzz(func(t *testing.T, data []byte, level int) {
+		// Clamp level to valid zstd range: 1 to 22
+		if level < 1 {
+			level = 1
+		} else if level > 22 {
+			level = 22
+		}
+
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		bound := c.CompressBound(len(data))
+		if len(compressed) > bound {
+			t.Errorf("CompressBound violated at level %d: len(compress(b))=%d > CompressBound(len(b))=%d", level, len(compressed), bound)
+		}
+	})
+}

--- a/pkg/util/compression/impl-zstd/zstd_strategy_test.go
+++ b/pkg/util/compression/impl-zstd/zstd_strategy_test.go
@@ -38,3 +38,33 @@ func FuzzZstdIdentity(f *testing.F) {
 		}
 	})
 }
+
+// Asserts that len(compress(b)) <= CompressBound(len(b)) for all b and levels.
+func FuzzZstdCompressBound(f *testing.F) {
+	f.Add([]byte("hello world"), 1)
+	f.Add([]byte(""), 3)
+	f.Add([]byte("a"), 5)
+	f.Add([]byte(string(make([]byte, 1000))), 10)
+	f.Add([]byte("The quick brown fox jumps over the lazy dog"), 15)
+	f.Add(bytes.Repeat([]byte("abcd"), 250), 22)
+
+	f.Fuzz(func(t *testing.T, data []byte, level int) {
+		// Clamp level to valid zstd range: 1 to 22
+		if level < 1 {
+			level = 1
+		} else if level > 22 {
+			level = 22
+		}
+
+		c := New(Requires{Level: compression.ZstdCompressionLevel(level)})
+		compressed, err := c.Compress(data)
+		if err != nil {
+			t.Fatalf("Compress failed: %v", err)
+		}
+
+		bound := c.CompressBound(len(data))
+		if len(compressed) > bound {
+			t.Errorf("CompressBound violated at level %d: len(compress(b))=%d > CompressBound(len(b))=%d", level, len(compressed), bound)
+		}
+	})
+}


### PR DESCRIPTION
### What does this PR do?

This commit adds fuzz tests for CompressBound in our zstd, zlib and
gzip strategies asserting the following property:

- `len(compress(b)) <= CompressBound(len(b))` for all `b`

I found no defects with our zstd strategy implementations. For zlib I
    did find that the original formula was correct to the C implementation
    but Go adds an additional 5 bytes that the C zlib does not. Likewise,
    I found that the gzip implementation made a redundant Flush which
    added an unnecessary empty block into the compressed bytes.

### Motivation

This commit is peer to PR #45534 and #45655. It is motivated by the
    potential end state in spike PR #45519. That is, if we want to make
    non-trivial changes to this package systematic testing of the package
    is warranted.

### Describe how you validated your changes

The CompressBound function is used to estimate whether items will
    compress into payload limits. Zlib and Gzip underestimated, meaning
    payloads would be potentially oversized and rejected on
    transmission. Given that Zstd is accurate and the current default it
    is not believed that this bug is explored in practice.

