### PR TITLE
omnibus: include the bazel folder in the cache key computation

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -191,6 +191,7 @@ def omnibus_compute_cache_key(ctx, env: dict[str, str]) -> str:
             'omnibus/resources',
             'omnibus/omnibus.rb',
             'deps',
+            'bazel',
         ],
     )
     print(f'Current hash value: {h.hexdigest()}')


### PR DESCRIPTION
### What does this PR do?

Include the `bazel` folder to the omnibus cache key computation

### Motivation

Until now, changing a rule definition or any other bazel source would not cause a cache miss, which means our CI will likely not test the changes

For instance, this job shouldn't have managed to restore something from cache: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1385822922

### Describe how you validated your changes

### Additional Notes
