### PR TITLE
Remove the publish_internal_container_image-full job 

### DIFF
--- a/.gitlab/.post/post_rc_build/post_rc_tasks.yml
+++ b/.gitlab/.post/post_rc_build/post_rc_tasks.yml
@@ -14,8 +14,6 @@ update_rc_build_links:
       artifacts: false
     - job: publish_internal_dca_container_image
       artifacts: false
-    - job: publish_internal_container_image-full
-      artifacts: false
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   script:

--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -83,19 +83,6 @@ publish_internal_container_image-fips:
     RELEASE_TAG_SUFFIX: "-fips-jmx"
     TMPL_SRC_IMAGE_SUFFIX: "-7-fips-jmx"
 
-publish_internal_container_image-full:
-  extends: .docker_trigger_base
-  needs:
-    - job: docker_build_agent7_full
-      artifacts: false
-    - job: docker_build_agent7_full_arm64
-      artifacts: false
-  variables:
-    <<: *agent_variables
-    TMPL_ADP_VERSION: 0.1.7
-    RELEASE_TAG_SUFFIX: "-full"
-    TMPL_SRC_IMAGE_SUFFIX: "-7-full"
-
 publish_internal_container_image-ot_standalone:
   extends: .docker_trigger_base
   needs:

--- a/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/deploy/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -10,8 +10,6 @@ internal_kubernetes_deploy_experimental:
   needs:
     - job: publish_internal_container_image-jmx
       artifacts: false
-    - job: publish_internal_container_image-full
-      artifacts: false
     - job: publish_internal_container_image-ot_standalone
       artifacts: false
     - job: publish_internal_container_image-fips


### PR DESCRIPTION
### What does this PR do?

Remove the publish_internal_container_image-full job

### Motivation

- We no longer need it
- It's the biggest image and the one that takes the most time

https://datadoghq.atlassian.net/browse/BARX-1601

### Describe how you validated your changes

### Additional Notes
