### PR TITLE
Fix RAR log on deregistering unhealthy client

### DIFF
--- a/comp/core/remoteagentregistry/impl/registry.go
+++ b/comp/core/remoteagentregistry/impl/registry.go
@@ -250,7 +250,7 @@ func (ra *remoteAgentRegistry) start() {
 					remoteAgentClient, ok := ra.agentMap[sessionID]
 					if ok {
 						if remoteAgentClient.unhealthy {
-							log.Warnf("Remote agent '%s' deregistered due to session ID validation failure (expected: %s, got: %s)", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentClient.RegisteredAgent.SessionID, sessionID)
+							log.Warnf("Remote agent '%s' deregistered: %v", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentClient.unhealthyReason)
 						} else {
 							log.Infof("Remote agent '%s' deregistered after being idle for %s.", remoteAgentClient.RegisteredAgent.DisplayName, remoteAgentIdleTimeout)
 						}


### PR DESCRIPTION
### What does this PR do?
Fix the log when deregistering a client to show the actual reason, not assume it's invalid session id.

### Motivation
The log was using the wrong session id so it resulted in weird logs (see below).
```
Remote agent 'System Probe' deregistered due to session ID validation failure (expected: e3aae813-96d3-4882-9cb7-fd5b06b35508, got: e3aae813-96d3-4882-9cb7-fd5b06b35508)
Failed to collect telemetry metrics from remoteAgent system-probe: session_id mismatch: expected 0b745572-53b1-49f4-9ae1-b7ac5d8e8cf0, got 228a4e1a-8e0f-42f4-918a-08c025a0d951
```

Also the failure could be something else than session id mismatch, so we should avoid assuming this, and just print the error.

### Describe how you validated your changes

### Additional Notes
