### PR TITLE
[networks] Remove faulty PID reuse detection logic

### DIFF
--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -13,14 +13,12 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
 	"go4.org/intern"
 
 	"github.com/DataDog/datadog-agent/pkg/network/events"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestStripResolvConf(t *testing.T) {
@@ -270,7 +268,6 @@ func TestReadContainerItemProcessRunningVsNotRunning(t *testing.T) {
 					result: tt.readResolvConfResult,
 					err:    tt.readResolvConfErr,
 				},
-				log.NewLogLimit(999, time.Second),
 			)
 			// Override isProcessStillRunning for mocking
 			cr.isProcessStillRunning = func(_ context.Context, _ *events.Process) (bool, error) {

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -107,7 +107,7 @@ func NewContainerStore(maxContainers int) (*ContainerStore, error) {
 		errorLimit: errorLimit,
 		debugLimit: debugLimit,
 
-		containerReader: newContainerReader(makeResolvStripper(resolvConfInputMaxSizeBytes), debugLimit),
+		containerReader: newContainerReader(makeResolvStripper(resolvConfInputMaxSizeBytes)),
 	}
 	// this function is only ever replaced in tests for mocking purposes
 	cs.readContainerItem = cs.containerReader.readContainerItem

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3378,15 +3378,6 @@ func (s *TracerSuite) TestDNSWorkload() {
 	cfg.DNSTimeout = 1 * time.Second
 	cfg.CollectLocalDNS = true
 
-	// Container ID resolution (not resolv.conf resolution) fails in this test before 5.11.
-	// I think it's related to this patch:
-	// https://github.com/torvalds/linux/commit/3ae700ecfae913316e3b4fe5f60c72b6131aaa1f#diff-360c5854af72f475f4ebbf588f1c163c9b9694f618088f5ff1e399b36e339901
-	// It changes the way that timestamps are offered in /proc/<pid>/stat.
-	// It's likely my test's injection of process events via HandleEvents is wrong on older kernels
-	if kv < kernel.VersionCode(5, 11, 0) {
-		t.Skip("Not supported before 5.11")
-	}
-
 	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -3378,6 +3378,15 @@ func (s *TracerSuite) TestDNSWorkload() {
 	cfg.DNSTimeout = 1 * time.Second
 	cfg.CollectLocalDNS = true
 
+	// Container ID resolution (not resolv.conf resolution) fails in this test before 5.11.
+	// I think it's related to this patch:
+	// https://github.com/torvalds/linux/commit/3ae700ecfae913316e3b4fe5f60c72b6131aaa1f#diff-360c5854af72f475f4ebbf588f1c163c9b9694f618088f5ff1e399b36e339901
+	// It changes the way that timestamps are offered in /proc/<pid>/stat to respect time namespaces.
+	// This means the processCache doesn't always work properly in pre-5.11
+	if kv < kernel.VersionCode(5, 11, 0) {
+		t.Skip("Not supported before 5.11")
+	}
+
 	skipOnEbpflessNotSupported(t, cfg)
 
 	tr := setupTracer(t, cfg)


### PR DESCRIPTION
### What does this PR do?
This PR removes PID reuse detection logic which resulted in way too many false positives.  The root cause was, the EVP stream doesn't have the same clock timestamp as procfs data, making PID reuse detection with this method impossible.

Bryce had [commented on this](https://github.com/DataDog/datadog-agent/pull/43099#discussion_r2539804795) originally, noting that the rest of the agent doesn't currently catch this scenario, in retrospect I should have deleted this code back then.

### Motivation
Improve resolv.conf detection rate.

### Describe how you validated your changes
The buggy code no longer exists. TestDNSWorkload should continue to pass.

