### PR TITLE
[NCM] Remove `ndm-core` from code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -376,7 +376,7 @@
 /comp/haagent @DataDog/ndm-core
 /comp/healthplatform @DataDog/agent-health
 /comp/languagedetection/client @DataDog/container-platform
-/comp/networkdeviceconfig @DataDog/ndm-core @DataDog/ndm-integrations
+/comp/networkdeviceconfig @DataDog/ndm-integrations
 /comp/notableevents @DataDog/windows-products
 /comp/privateactionrunner @DataDog/action-platform
 /comp/publishermetadatacache @DataDog/windows-products
@@ -481,7 +481,7 @@
 /pkg/collector/corechecks/embed/apm/               @DataDog/agent-apm
 /pkg/collector/corechecks/embed/process/           @DataDog/container-experiences
 /pkg/collector/corechecks/gpu/                     @DataDog/ebpf-platform
-/pkg/collector/corechecks/networkconfigmanagement/ @DataDog/ndm-core @DataDog/ndm-integrations
+/pkg/collector/corechecks/networkconfigmanagement/ @DataDog/ndm-integrations
 /pkg/collector/corechecks/network-devices/         @DataDog/ndm-integrations
 /pkg/collector/corechecks/orchestrator/   @DataDog/kubernetes-experiences
 /pkg/collector/corechecks/net/          @DataDog/agent-runtimes
@@ -649,7 +649,7 @@
 /pkg/network/tracer/*_windows*.go               @DataDog/windows-products
 /pkg/network/usm/                       @DataDog/universal-service-monitoring
 /pkg/network/usm/tests/*_windows*.go    @DataDog/windows-products @DataDog/universal-service-monitoring
-/pkg/networkconfigmanagement/           @DataDog/ndm-core @DataDog/ndm-integrations
+/pkg/networkconfigmanagement/           @DataDog/ndm-integrations
 /pkg/ebpf/                              @DataDog/ebpf-platform
 /pkg/ebpf/map_cleaner*.go               @DataDog/universal-service-monitoring
 /pkg/compliance/                        @DataDog/agent-cspm

--- a/comp/README.md
+++ b/comp/README.md
@@ -781,7 +781,7 @@ Package client implements a component to send process metadata to the Cluster-Ag
 
 ### [comp/networkdeviceconfig](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkdeviceconfig)
 
-*Datadog Team*: ndm-core ndm-integrations
+*Datadog Team*: ndm-integrations
 
 Package networkdeviceconfig provides the component for retrieving network device configurations.
 

--- a/comp/networkdeviceconfig/def/component.go
+++ b/comp/networkdeviceconfig/def/component.go
@@ -6,7 +6,7 @@
 // Package networkdeviceconfig provides the component for retrieving network device configurations.
 package networkdeviceconfig
 
-// team: ndm-core ndm-integrations
+// team: ndm-integrations
 
 // Component is the component type.
 type Component interface {


### PR DESCRIPTION
### What does this PR do?
NCM is migrating to full NDM integrations ownership :'-( 

removing `ndm-core` so as to not bombard w/ PR requests, etc. 

uncertain if i need to change ownership anywhere else that i may be forgetting but feel free to lmk !

### Motivation

### Describe how you validated your changes

### Additional Notes
