### PR TITLE
Add Claude Code skills for building and testing Datadog Agent

### DIFF
--- a/.claude/skills/build-agent/SKILL.md
+++ b/.claude/skills/build-agent/SKILL.md
@@ -21,6 +21,7 @@ The skill automatically:
 3. Executes the build
 
 This works seamlessly in both the main repo and worktrees.
+If you are working in a worktree, it must have been created [in relative mode](https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt---relative-paths).
 
 ## Arguments
 

--- a/.claude/skills/build-agent/SKILL.md
+++ b/.claude/skills/build-agent/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: build-agent
+description: Build the Datadog Agent using dda inv agent.build. Use when compiling the agent, after code changes, or when the user requests a build. Supports build options like --rebuild, --build-exclude, --flavor. Requires dev container to be running.
+argument-hint: [build options]
+allowed-tools: Bash(.claude/skills/build-agent/scripts/build.sh *)
+---
+
+# Build Agent
+
+Builds the Datadog Agent in a dev container from the current working directory.
+
+## Prerequisites
+
+The dev container must be running. If not, use `/start-dev-container` first.
+
+## Usage
+
+The skill automatically:
+1. Computes path relative to main repo root
+2. Changes to the current working directory inside the container
+3. Executes the build
+
+This works seamlessly in both the main repo and worktrees.
+
+## Arguments
+
+Pass any arguments supported by `dda inv agent.build`:
+- `--rebuild`: Force a clean rebuild
+- `--build-exclude=systemd`: Exclude systemd from build
+- `--flavor=base|iot|serverless`: Specify agent flavor
+- `--race`: Enable race detection
+- `--development`: Development mode
+
+## Examples
+
+```
+/build-agent
+/build-agent --rebuild
+/build-agent --build-exclude=systemd --flavor=base
+```
+
+## Implementation
+
+Executes: `~/.claude/skills/build-agent/scripts/build.sh $ARGUMENTS`

--- a/.claude/skills/build-agent/scripts/build.sh
+++ b/.claude/skills/build-agent/scripts/build.sh
@@ -1,48 +1,11 @@
 #!/bin/bash
 set -e
 
-# Get path relative to main repo root
-get_relative_path() {
-    local common_git_dir
-    local main_repo_root
-    local current_dir
-    local relative_path
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Shared library - shellcheck can't follow dynamic paths but the file exists
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../lib/run-in-container.sh"
 
-    # Get the common git directory (main repo's .git)
-    common_git_dir=$(git rev-parse --git-common-dir)
-    # Main repo root is parent of .git
-    main_repo_root=$(dirname "$common_git_dir")
-    current_dir=$(git rev-parse --show-toplevel)
-
-    # Get relative path from main repo root to current worktree
-    relative_path="${current_dir#"$main_repo_root"}"
-
-    # Remove leading slash if present
-    relative_path="${relative_path#/}"
-
-    # If empty, we're at the main repo root
-    if [ -z "$relative_path" ]; then
-        echo "."
-    else
-        echo "$relative_path"
-    fi
-}
-
-# Main execution
-main() {
-    local relative_path
-    relative_path=$(get_relative_path)
-
-    echo "Building Datadog Agent..."
-    echo "Working directory: $relative_path"
-
-    if [ "$relative_path" = "." ]; then
-        dda env dev run -- dda inv agent.build "$@"
-    else
-        dda env dev run -- bash -c "cd '$relative_path' && dda inv agent.build $*"
-    fi
-
-    echo "Build completed successfully"
-}
-
-main "$@"
+echo "Building Datadog Agent..."
+run_inv_in_container agent.build "$@"
+echo "Build completed successfully"

--- a/.claude/skills/build-agent/scripts/build.sh
+++ b/.claude/skills/build-agent/scripts/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+# Get path relative to main repo root
+get_relative_path() {
+    local common_git_dir
+    local main_repo_root
+    local current_dir
+    local relative_path
+
+    # Get the common git directory (main repo's .git)
+    common_git_dir=$(git rev-parse --git-common-dir)
+    # Main repo root is parent of .git
+    main_repo_root=$(dirname "$common_git_dir")
+    current_dir=$(git rev-parse --show-toplevel)
+
+    # Get relative path from main repo root to current worktree
+    relative_path="${current_dir#"$main_repo_root"}"
+
+    # Remove leading slash if present
+    relative_path="${relative_path#/}"
+
+    # If empty, we're at the main repo root
+    if [ -z "$relative_path" ]; then
+        echo "."
+    else
+        echo "$relative_path"
+    fi
+}
+
+# Main execution
+main() {
+    local relative_path
+    relative_path=$(get_relative_path)
+
+    echo "Building Datadog Agent..."
+    echo "Working directory: $relative_path"
+
+    if [ "$relative_path" = "." ]; then
+        dda env dev run -- dda inv agent.build "$@"
+    else
+        dda env dev run -- bash -c "cd '$relative_path' && dda inv agent.build $*"
+    fi
+
+    echo "Build completed successfully"
+}
+
+main "$@"

--- a/.claude/skills/lib/run-in-container.sh
+++ b/.claude/skills/lib/run-in-container.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Shared library for running dda inv commands in dev container
+
+# Get path relative to main repo root
+get_relative_path() {
+    local common_git_dir
+    local main_repo_root
+    local current_dir
+    local relative_path
+
+    # Get the common git directory (main repo's .git)
+    common_git_dir=$(git rev-parse --git-common-dir)
+    # Main repo root is parent of .git
+    main_repo_root=$(dirname "$common_git_dir")
+    current_dir=$(git rev-parse --show-toplevel)
+
+    # Get relative path from main repo root to current worktree
+    relative_path="${current_dir#"$main_repo_root"}"
+
+    # Remove leading slash if present
+    relative_path="${relative_path#/}"
+
+    # If empty, we're at the main repo root
+    if [ -z "$relative_path" ]; then
+        echo "."
+    else
+        echo "$relative_path"
+    fi
+}
+
+# Run dda inv command in container
+# Usage: run_inv_in_container <command> <args...>
+run_inv_in_container() {
+    local inv_command="$1"
+    shift
+    local relative_path
+    relative_path=$(get_relative_path)
+
+    echo "Working directory: $relative_path"
+
+    if [ "$relative_path" = "." ]; then
+        dda env dev run -- dda inv "$inv_command" "$@"
+    else
+        dda env dev run -- bash -c "cd '$relative_path' && dda inv $inv_command $*"
+    fi
+}

--- a/.claude/skills/start-dev-container/SKILL.md
+++ b/.claude/skills/start-dev-container/SKILL.md
@@ -2,7 +2,7 @@
 name: start-dev-container
 description: Start the dda dev container. Use when the dev container is not running and build or test commands fail.
 argument-hint: ""
-allowed-tools: Bash(.claude/skills/start-dev-container/scripts/start.sh)
+allowed-tools: Bash(dda env dev start)
 ---
 
 # Start Dev Container

--- a/.claude/skills/start-dev-container/SKILL.md
+++ b/.claude/skills/start-dev-container/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: start-dev-container
+description: Start the dda dev container. Use when the dev container is not running and build or test commands fail.
+argument-hint: ""
+allowed-tools: Bash(.claude/skills/start-dev-container/scripts/start.sh)
+---
+
+# Start Dev Container
+
+Starts the dda dev container for building and testing.
+
+## When to Use
+
+Use this skill when:
+- `/build-agent` or `/test-agent` fails with connection errors
+- You get "dev container not running" type errors
+- Starting a new development session
+
+## Examples
+
+```
+/start-dev-container
+```
+
+## Implementation
+
+Executes: `dda env dev start`

--- a/.claude/skills/start-dev-container/scripts/start.sh
+++ b/.claude/skills/start-dev-container/scripts/start.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-dda env dev start

--- a/.claude/skills/start-dev-container/scripts/start.sh
+++ b/.claude/skills/start-dev-container/scripts/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+dda env dev start

--- a/.claude/skills/test-agent/SKILL.md
+++ b/.claude/skills/test-agent/SKILL.md
@@ -21,6 +21,7 @@ The skill automatically:
 3. Executes tests
 
 This works seamlessly in both the main repo and worktrees.
+If you are working in a worktree, it must have been created [in relative mode](https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt---relative-paths).
 
 ## Arguments
 

--- a/.claude/skills/test-agent/SKILL.md
+++ b/.claude/skills/test-agent/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: test-agent
+description: Run Go tests for the Datadog Agent using dda inv test. Use when running unit tests, after code changes, or when the user requests tests. Supports test options like --targets, --coverage, --module. Requires dev container to be running.
+argument-hint: [test options]
+allowed-tools: Bash(.claude/skills/test-agent/scripts/test.sh *)
+---
+
+# Test Agent
+
+Runs Go unit tests for the Datadog Agent in a dev container from the current working directory.
+
+## Prerequisites
+
+The dev container must be running. If not, use `/start-dev-container` first.
+
+## Usage
+
+The skill automatically:
+1. Computes path relative to main repo root
+2. Changes to the current working directory inside the container
+3. Executes tests
+
+This works seamlessly in both the main repo and worktrees.
+
+## Arguments
+
+Pass any arguments supported by `dda inv test`:
+- `--targets=./pkg/aggregator`: Test specific package(s)
+- `--module=<module>`: Test specific module
+- `--coverage`: Enable coverage reporting
+- `--race`: Enable race detection
+- `--flavor=base|iot|serverless`: Specify agent flavor
+
+## Examples
+
+```
+/test-agent
+/test-agent --targets=./pkg/aggregator
+/test-agent --targets=./pkg/collector --coverage
+```
+
+## Implementation
+
+Executes: `~/.claude/skills/test-agent/scripts/test.sh $ARGUMENTS`

--- a/.claude/skills/test-agent/scripts/test.sh
+++ b/.claude/skills/test-agent/scripts/test.sh
@@ -1,48 +1,11 @@
 #!/bin/bash
 set -e
 
-# Get path relative to main repo root
-get_relative_path() {
-    local common_git_dir
-    local main_repo_root
-    local current_dir
-    local relative_path
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Shared library - shellcheck can't follow dynamic paths but the file exists
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../../lib/run-in-container.sh"
 
-    # Get the common git directory (main repo's .git)
-    common_git_dir=$(git rev-parse --git-common-dir)
-    # Main repo root is parent of .git
-    main_repo_root=$(dirname "$common_git_dir")
-    current_dir=$(git rev-parse --show-toplevel)
-
-    # Get relative path from main repo root to current worktree
-    relative_path="${current_dir#"$main_repo_root"}"
-
-    # Remove leading slash if present
-    relative_path="${relative_path#/}"
-
-    # If empty, we're at the main repo root
-    if [ -z "$relative_path" ]; then
-        echo "."
-    else
-        echo "$relative_path"
-    fi
-}
-
-# Main execution
-main() {
-    local relative_path
-    relative_path=$(get_relative_path)
-
-    echo "Running tests..."
-    echo "Working directory: $relative_path"
-
-    if [ "$relative_path" = "." ]; then
-        dda env dev run -- dda inv test "$@"
-    else
-        dda env dev run -- bash -c "cd '$relative_path' && dda inv test $*"
-    fi
-
-    echo "Tests completed successfully"
-}
-
-main "$@"
+echo "Running tests..."
+run_inv_in_container test "$@"
+echo "Tests completed successfully"

--- a/.claude/skills/test-agent/scripts/test.sh
+++ b/.claude/skills/test-agent/scripts/test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+# Get path relative to main repo root
+get_relative_path() {
+    local common_git_dir
+    local main_repo_root
+    local current_dir
+    local relative_path
+
+    # Get the common git directory (main repo's .git)
+    common_git_dir=$(git rev-parse --git-common-dir)
+    # Main repo root is parent of .git
+    main_repo_root=$(dirname "$common_git_dir")
+    current_dir=$(git rev-parse --show-toplevel)
+
+    # Get relative path from main repo root to current worktree
+    relative_path="${current_dir#"$main_repo_root"}"
+
+    # Remove leading slash if present
+    relative_path="${relative_path#/}"
+
+    # If empty, we're at the main repo root
+    if [ -z "$relative_path" ]; then
+        echo "."
+    else
+        echo "$relative_path"
+    fi
+}
+
+# Main execution
+main() {
+    local relative_path
+    relative_path=$(get_relative_path)
+
+    echo "Running tests..."
+    echo "Working directory: $relative_path"
+
+    if [ "$relative_path" = "." ]; then
+        dda env dev run -- dda inv test "$@"
+    else
+        dda env dev run -- bash -c "cd '$relative_path' && dda inv test $*"
+    fi
+
+    echo "Tests completed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
### What does this PR do?

Add three [Claude Code skills](https://code.claude.com/docs/en/skills) to smooth development workflow with Claude. Skills are shell scripts that Claude can invoke automatically when relevant.

This adds:
- `/start-dev-container` - Start the dda dev container
- `/build-agent` - Build the agent using `dda inv agent.build`
- `/test-agent` - Run tests using `dda inv test`

### How It Works

Claude Code skills are defined in `.claude/skills/` and can be invoked either manually by users (e.g., typing `/build-agent`) or automatically by Claude when it determines a skill is relevant to the task at hand.

These skills use a single dev container with path-based navigation. They compute the relative path from the main repo root using `git rev-parse --git-common-dir`, so they work seamlessly whether you're in the main repo or a worktree.

The build and test skills require the dev container to be running. When Claude attempts to build or test and gets a connection error, it will autonomously run `/start-dev-container` and retry.

### Examples

```bash
/start-dev-container
/build-agent --rebuild --build-exclude=systemd
/test-agent --targets=./pkg/aggregator --coverage

For main repo:
dda env dev run -- dda inv agent.build

For worktree at .worktrees/my-feature:
dda env dev run -- bash -c "cd .worktrees/my-feature && dda inv agent.build"
```

### Additional Notes
Due to mismatch between the host path of the repo, and the mounted path in the dev container, worktrees must be created in [relative mode](https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt---relative-paths). 