### PR TITLE
[CWS] use path_id for the mount resolution

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -11,12 +11,17 @@
 #include "dentry_resolver.h"
 #include "discarders.h"
 
+// the bump revision value is used to increase the mount id part of the path id when the mount is updated
+// this means that two different mount id can be considered as the same if the difference is less than the bump revision value
+// see the userspace equality check in the model_unix.go file
+#define MOUNT_REVISION_BUMP_VALUE 30
+
 static __attribute__((always_inline)) void bump_high_path_id(u32 mount_id) {
     u32 key = mount_id % PATH_ID_HIGH_MAP_SIZE;
 
     u32 *id = bpf_map_lookup_elem(&path_id_high, &key);
     if (id) {
-        __sync_fetch_and_add(id, 1);
+        __sync_fetch_and_add(id, MOUNT_REVISION_BUMP_VALUE);
     }
 }
 

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -14,7 +14,7 @@
 // the bump revision value is used to increase the mount id part of the path id when the mount is updated
 // this means that two different mount id can be considered as the same if the difference is less than the bump revision value
 // see the userspace equality check in the model_unix.go file
-#define MOUNT_REVISION_BUMP_VALUE 30
+#define MOUNT_REVISION_BUMP_VALUE 64
 
 static __attribute__((always_inline)) void bump_high_path_id(u32 mount_id) {
     u32 key = mount_id % PATH_ID_HIGH_MAP_SIZE;

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -20,7 +20,7 @@ int test_path_id_mount_and_invalidation() {
     bump_high_path_id(mount_id1);
 
     u32 mount_1_path_id_after_release = get_path_id(0, mount_id1, 1, PATH_ID_INVALIDATE_TYPE_NONE);
-    assert_equals(mount_1_path_id_after_release, PATH_ID(1, 1), "path id should have low and high id incremented");
+    assert_equals(mount_1_path_id_after_release, PATH_ID(1, 30), "path id should have low and high id incremented");
 
     return 1;
 }

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -20,7 +20,7 @@ int test_path_id_mount_and_invalidation() {
     bump_high_path_id(mount_id1);
 
     u32 mount_1_path_id_after_release = get_path_id(0, mount_id1, 1, PATH_ID_INVALIDATE_TYPE_NONE);
-    assert_equals(mount_1_path_id_after_release, PATH_ID(1, 30), "path id should have low and high id incremented");
+    assert_equals(mount_1_path_id_after_release, PATH_ID(30, 1), "path id should have low and high id incremented");
 
     return 1;
 }

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -20,7 +20,7 @@ int test_path_id_mount_and_invalidation() {
     bump_high_path_id(mount_id1);
 
     u32 mount_1_path_id_after_release = get_path_id(0, mount_id1, 1, PATH_ID_INVALIDATE_TYPE_NONE);
-    assert_equals(mount_1_path_id_after_release, PATH_ID(30, 1), "path id should have low and high id incremented");
+    assert_equals(mount_1_path_id_after_release, PATH_ID(64, 1), "path id should have low and high id incremented");
 
     return 1;
 }

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -130,7 +130,7 @@ func (fh *EBPFFieldHandlers) ResolveFileFilesystem(ev *model.Event, f *model.Fil
 		if f.IsFileless() {
 			f.Filesystem = model.TmpFS
 		} else {
-			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.MountID, ev.PIDContext.Pid)
+			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.PathKey, ev.PIDContext.Pid)
 			if err != nil {
 				ev.SetPathResolutionError(f, err)
 			}
@@ -180,7 +180,7 @@ func (fh *EBPFFieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.Mou
 		return "/"
 	}
 	if len(e.MountPointPath) == 0 {
-		mountPointPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, ev.PIDContext.Pid)
+		mountPointPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.RootPathKey, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountPointPathResolutionError = err
 			return ""
@@ -193,7 +193,7 @@ func (fh *EBPFFieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.Mou
 // ResolveMountSourcePath resolves a mount source path
 func (fh *EBPFFieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.MountEvent) string {
 	if e.BindSrcMountID != 0 && len(e.MountSourcePath) == 0 {
-		bindSourceMountPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, ev.PIDContext.Pid)
+		bindSourceMountPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(model.PathKey{MountID: e.BindSrcMountID}, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountSourcePathResolutionError = err
 			return ""
@@ -211,7 +211,7 @@ func (fh *EBPFFieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.Mo
 // ResolveMountRootPath resolves a mount root path
 func (fh *EBPFFieldHandlers) ResolveMountRootPath(ev *model.Event, e *model.MountEvent) string {
 	if len(e.MountRootPath) == 0 {
-		mountRootPath, _, _, err := fh.resolvers.MountResolver.ResolveMountRoot(e.MountID, ev.PIDContext.Pid)
+		mountRootPath, _, _, err := fh.resolvers.MountResolver.ResolveMountRoot(e.RootPathKey, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountRootPathResolutionError = err
 			return ""
@@ -532,7 +532,7 @@ func (fh *EBPFFieldHandlers) ResolveHashes(eventType model.EventType, process *m
 // ResolveCGroupVersion resolves the version of the cgroup API
 func (fh *EBPFFieldHandlers) ResolveCGroupVersion(ev *model.Event, e *model.CGroupContext) int {
 	if e.CGroupVersion == 0 {
-		if filesystem, _ := fh.resolvers.MountResolver.ResolveFilesystem(e.CGroupPathKey.MountID, ev.PIDContext.Pid); filesystem == "cgroup2" {
+		if filesystem, _ := fh.resolvers.MountResolver.ResolveFilesystem(e.CGroupPathKey, ev.PIDContext.Pid); filesystem == "cgroup2" {
 			e.CGroupVersion = 2
 		} else {
 			e.CGroupVersion = 1

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1253,7 +1253,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		// TODO: this should be moved in the resolver itself in order to handle the fallbacks
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootPathKey.Inode)
-			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.PIDContext.Pid)
+			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.RootPathKey, event.PIDContext.Pid)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
 			} else {
@@ -1268,7 +1268,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid)
+		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: event.Umount.MountID}, event.PIDContext.Pid)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.Resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -17,12 +17,12 @@ type ResolverInterface interface {
 	IsMountIDValid(mountID uint32) (bool, error)
 	SyncCache() error
 	Delete(mountID uint32, mountIDUnique uint64) error
-	ResolveFilesystem(mountID uint32, pid uint32) (string, error)
+	ResolveFilesystem(pathKey model.PathKey, pid uint32) (string, error)
 	Insert(m model.Mount) error
 	InsertMoved(m model.Mount) error
-	ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
+	ResolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error)
+	ResolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error)
+	ResolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	ToJSON() ([]byte, error)
 	Iterate(cb func(*model.Mount))

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -12,15 +12,16 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"golang.org/x/sys/unix"
 )
 
 // Flags needed by statmount
@@ -131,7 +132,10 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
-		MountID:       sm.MntIDOld,
+		MountID: sm.MntIDOld,
+		RootPathKey: model.PathKey{
+			MountID: sm.MntIDOld,
+		},
 		MountIDUnique: sm.MntID,
 		Device:        utils.Mkdev(sm.SbDevMajor, sm.SbDevMinor),
 		ParentPathKey: model.PathKey{

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -44,7 +44,7 @@ func (mr *NoOpResolver) Delete(_ uint32, _ uint64) error {
 }
 
 // ResolveFilesystem returns the name of the filesystem
-func (mr *NoOpResolver) ResolveFilesystem(_ uint32, _ uint32) (string, error) {
+func (mr *NoOpResolver) ResolveFilesystem(_ model.PathKey, _ uint32) (string, error) {
 	return "", nil
 }
 
@@ -54,17 +54,17 @@ func (mr *NoOpResolver) Insert(_ model.Mount) error {
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
-func (mr *NoOpResolver) ResolveMountRoot(_ uint32, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMountRoot(_ model.PathKey, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
 	return "", model.MountSourceUnknown, model.MountOriginUnknown, nil
 }
 
 // ResolveMountPath returns the path of a mount identified by its mount ID.
-func (mr *NoOpResolver) ResolveMountPath(_ uint32, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMountPath(_ model.PathKey, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
 	return "", model.MountSourceUnknown, model.MountOriginUnknown, nil
 }
 
 // ResolveMount returns the mount
-func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMount(_ model.PathKey, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	return nil, model.MountSourceUnknown, model.MountOriginUnknown, errors.New("not available")
 }
 

--- a/pkg/security/resolvers/mount/procfs_mountlister.go
+++ b/pkg/security/resolvers/mount/procfs_mountlister.go
@@ -9,14 +9,15 @@
 package mount
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/moby/sys/mountinfo"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/moby/sys/mountinfo"
 )
 
 // newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
@@ -49,7 +50,10 @@ func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
 		MountID: uint32(mnt.ID),
-		Device:  utils.Mkdev(uint32(mnt.Major), uint32(mnt.Minor)),
+		RootPathKey: model.PathKey{
+			MountID: uint32(mnt.ID),
+		},
+		Device: utils.Mkdev(uint32(mnt.Major), uint32(mnt.Minor)),
 		ParentPathKey: model.PathKey{
 			MountID: uint32(mnt.Parent),
 		},

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -135,16 +135,9 @@ func (mr *Resolver) syncCache() error {
 
 // syncCacheFromListMount Snapshots the current mountpoints using procfs
 func (mr *Resolver) syncPidProcfs(pid uint32) error {
-	mounts := []*model.Mount{}
-
 	err := GetPidProcfs(kernel.ProcFSRoot(), pid, func(sm *model.Mount) {
-		mr.mounts.Remove(sm.MountID)
-		mounts = append(mounts, sm)
+		mr.insert(sm)
 	})
-
-	for _, m := range mounts {
-		mr.insert(m)
-	}
 
 	if err != nil {
 		return fmt.Errorf("error synchronizing the pid procfs: %v", err)
@@ -154,16 +147,9 @@ func (mr *Resolver) syncPidProcfs(pid uint32) error {
 
 // syncCacheFromProcfs Snapshots the mounts of the pid namespace using the listmount api
 func (mr *Resolver) syncPidListmount(pid uint32) error {
-	mounts := []*model.Mount{}
-
 	err := GetPidListmount(kernel.ProcFSRoot(), pid, func(sm *model.Mount) {
-		mr.mounts.Remove(sm.MountID)
-		mounts = append(mounts, sm)
+		mr.insert(sm)
 	})
-
-	for _, m := range mounts {
-		mr.insert(m)
-	}
 
 	if err != nil {
 		return fmt.Errorf("error synchronizing from procfs: %v", err)

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -201,7 +201,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	mount.MountPointStr, _ = mr.dentryResolver.Resolve(mount.ParentPathKey, false)
 
 	mr.insert(mount)
-	_, _, _, _ = mr.getMountPath(mount.MountID, 0)
+	_, _, _, _ = mr.getMountPath(mount.RootPathKey, 0)
 
 	// Find all the mounts that I'm the parent of
 	for mnt := range mr.mounts.ValuesIter() {
@@ -217,7 +217,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	// Update the mount path for all the children
 	mr.walkMountSubtree(mount, func(child *model.Mount) {
 		child.Path = ""
-		_, _, _, _ = mr.getMountPath(child.MountID, 0)
+		_, _, _, _ = mr.getMountPath(child.RootPathKey, 0)
 	})
 }
 
@@ -297,11 +297,11 @@ func (mr *Resolver) Delete(mountID uint32, mountIDUnique uint64) error {
 }
 
 // ResolveFilesystem returns the name of the filesystem
-func (mr *Resolver) ResolveFilesystem(mountID uint32, pid uint32) (string, error) {
+func (mr *Resolver) ResolveFilesystem(pathKey model.PathKey, pid uint32) (string, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mount, _, _, err := mr.resolveMount(mountID, pid)
+	mount, _, _, err := mr.resolveMount(pathKey, pid)
 	if err != nil {
 		return model.UnknownFS, err
 	}
@@ -404,8 +404,8 @@ func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
 	return nil
 }
 
-func (mr *Resolver) lookupMount(mountID uint32) (*model.Mount, model.MountSource, model.MountOrigin) {
-	mount := mr.lookupByMountID(mountID)
+func (mr *Resolver) lookupMount(pathKey model.PathKey) (*model.Mount, model.MountSource, model.MountOrigin) {
+	mount := mr.lookupByMountID(pathKey.MountID)
 
 	if mount == nil {
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown
@@ -414,14 +414,14 @@ func (mr *Resolver) lookupMount(mountID uint32) (*model.Mount, model.MountSource
 	return mount, model.MountSourceMountID, mount.Origin
 }
 
-func (mr *Resolver) _getMountPath(mountID uint32, pid uint32, cache map[uint32]bool) (string, model.MountSource, model.MountOrigin, error) {
-	if _, err := mr.IsMountIDValid(mountID); err != nil {
+func (mr *Resolver) _getMountPath(pathKey model.PathKey, pid uint32, cache map[uint32]bool) (string, model.MountSource, model.MountOrigin, error) {
+	if _, err := mr.IsMountIDValid(pathKey.MountID); err != nil {
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	mount, source, origin := mr.lookupMount(mountID)
+	mount, source, origin := mr.lookupMount(pathKey)
 	if mount == nil {
-		return "", source, origin, &ErrMountNotFound{MountID: mountID}
+		return "", source, origin, &ErrMountNotFound{MountID: pathKey.MountID}
 	}
 
 	if len(mount.Path) > 0 {
@@ -434,10 +434,10 @@ func (mr *Resolver) _getMountPath(mountID uint32, pid uint32, cache map[uint32]b
 	}
 
 	// avoid infinite loop
-	if _, exists := cache[mountID]; exists {
+	if _, exists := cache[pathKey.MountID]; exists {
 		return "", source, mount.Origin, ErrMountLoop
 	}
-	cache[mountID] = true
+	cache[pathKey.MountID] = true
 
 	if mount.Detached {
 		return "/", source, mount.Origin, nil
@@ -447,7 +447,7 @@ func (mr *Resolver) _getMountPath(mountID uint32, pid uint32, cache map[uint32]b
 		return "", source, mount.Origin, ErrParentMountUndefined
 	}
 
-	parentMountPath, parentSource, parentOrigin, err := mr._getMountPath(mount.ParentPathKey.MountID, pid, cache)
+	parentMountPath, parentSource, parentOrigin, err := mr._getMountPath(mount.ParentPathKey, pid, cache)
 	if err != nil {
 		return "", parentSource, parentOrigin, err
 	}
@@ -470,20 +470,20 @@ func (mr *Resolver) _getMountPath(mountID uint32, pid uint32, cache map[uint32]b
 	return mountPointStr, source, origin, nil
 }
 
-func (mr *Resolver) getMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
-	return mr._getMountPath(mountID, pid, map[uint32]bool{})
+func (mr *Resolver) getMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+	return mr._getMountPath(pathKey, pid, map[uint32]bool{})
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
-func (mr *Resolver) ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMountRoot(mountID, pid)
+	return mr.resolveMountRoot(pathKey, pid)
 }
 
-func (mr *Resolver) resolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
-	mount, source, origin, err := mr.resolveMount(mountID, pid)
+func (mr *Resolver) resolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+	mount, source, origin, err := mr.resolveMount(pathKey, pid)
 	if err != nil {
 		return "", source, origin, err
 	}
@@ -491,19 +491,19 @@ func (mr *Resolver) resolveMountRoot(mountID uint32, pid uint32) (string, model.
 }
 
 // ResolveMountPath returns the path of a mount identified by its mount ID.
-func (mr *Resolver) ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMountPath(mountID, pid)
+	return mr.resolveMountPath(pathKey, pid)
 }
 
-func (mr *Resolver) resolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
-	if _, err := mr.IsMountIDValid(mountID); err != nil {
+func (mr *Resolver) resolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+	if _, err := mr.IsMountIDValid(pathKey.MountID); err != nil {
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	path, source, origin, err := mr.getMountPath(mountID, pid)
+	path, source, origin, err := mr.getMountPath(pathKey, pid)
 	if err == nil {
 		mr.cacheHitsStats.Inc()
 		return path, source, origin, nil
@@ -511,14 +511,14 @@ func (mr *Resolver) resolveMountPath(mountID uint32, pid uint32) (string, model.
 	mr.cacheMissStats.Inc()
 
 	if !mr.opts.UseProcFS {
-		return "", model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: mountID}
+		return "", model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: pathKey.MountID}
 	}
 
 	if err := mr.syncPidNamespace(pid); err != nil {
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	path, source, origin, err = mr.getMountPath(mountID, pid)
+	path, source, origin, err = mr.getMountPath(pathKey, pid)
 	if err == nil {
 		mr.procHitsStats.Inc()
 		return path, source, origin, nil
@@ -529,20 +529,23 @@ func (mr *Resolver) resolveMountPath(mountID uint32, pid uint32) (string, model.
 }
 
 // ResolveMount returns the mount
-func (mr *Resolver) ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMount(mountID, pid)
+	return mr.resolveMount(pathKey, pid)
 }
 
-func (mr *Resolver) resolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
-	if _, err := mr.IsMountIDValid(mountID); err != nil {
+func (mr *Resolver) resolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+	if _, err := mr.IsMountIDValid(pathKey.MountID); err != nil {
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	mount, source, origin := mr.lookupMount(mountID)
-	if mount != nil {
+	mount, source, origin := mr.lookupMount(pathKey)
+	if mount != nil && pathKey.MountEquals(mount.RootPathKey) {
+		// update the path ID to the latest one
+		mount.RootPathKey.PathID = pathKey.PathID
+
 		mr.cacheHitsStats.Inc()
 		return mount, source, origin, nil
 	}
@@ -552,13 +555,16 @@ func (mr *Resolver) resolveMount(mountID uint32, pid uint32) (*model.Mount, mode
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	if mount, ok := mr.mounts.Get(mountID); mount != nil && ok {
+	if mount, ok := mr.mounts.Get(pathKey.MountID); ok && pathKey.MountEquals(mount.RootPathKey) {
+		// update the path ID to the latest one
+		mount.RootPathKey.PathID = pathKey.PathID
+
 		mr.procHitsStats.Inc()
 		return mount, model.MountSourceMountID, mount.Origin, nil
 	}
 	mr.procMissStats.Inc()
 
-	return nil, model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: mountID}
+	return nil, model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: pathKey.MountID}
 }
 
 // SendStats sends metrics about the current state of the mount resolver

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -393,6 +393,11 @@ func (mr *Resolver) insert(m *model.Mount) {
 		}
 	}
 
+	if m.RootPathKey.IsNull() {
+		// this should never happen
+		seclog.Warnf("root path key is null for mount %d", m.MountID)
+	}
+
 	mr.mounts.Add(m.MountID, m)
 }
 

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -10,8 +10,9 @@ package mount
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -348,7 +349,7 @@ func TestMountResolver(t *testing.T) {
 					mr.insert(&evt.mount.Mount)
 				}
 				if evt.umount != nil {
-					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid)
+					mount, _, _, err := mr.ResolveMount(model.PathKey{MountID: evt.umount.MountID}, pid)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -357,7 +358,7 @@ func TestMountResolver(t *testing.T) {
 			}
 
 			for _, testC := range tt.args.cases {
-				p, _, _, err := mr.ResolveMountPath(testC.mountID, pid)
+				p, _, _, err := mr.ResolveMountPath(model.PathKey{MountID: testC.mountID}, pid)
 				if err != nil {
 					if testC.expectedError != nil {
 						assert.Equal(t, testC.expectedError.Error(), err.Error())
@@ -408,7 +409,7 @@ func TestMountGetParentPath(t *testing.T) {
 		mr.mounts.Add(m.MountID, m)
 	}
 
-	parentPath, _, _, err := mr.getMountPath(4, 1)
+	parentPath, _, _, err := mr.getMountPath(model.PathKey{MountID: 4}, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "/a/b/c", parentPath)
 }
@@ -449,7 +450,7 @@ func TestMountLoop(t *testing.T) {
 		mr.mounts.Add(m.MountID, m)
 	}
 
-	parentPath, _, _, err := mr.getMountPath(3, 1)
+	parentPath, _, _, err := mr.getMountPath(model.PathKey{MountID: 3}, 1)
 	assert.Equal(t, ErrMountLoop, err)
 	assert.Equal(t, "", parentPath)
 }
@@ -476,6 +477,6 @@ func BenchmarkGetParentPath(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _, _ = mr.getMountPath(100, 1)
+		_, _, _, _ = mr.getMountPath(model.PathKey{MountID: 100}, 1)
 	}
 }

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -47,7 +47,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								Device:  1,
+								RootPathKey: model.PathKey{
+									MountID: 27,
+								},
+								Device: 1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -76,7 +79,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 127,
-								Device:  52,
+								RootPathKey: model.PathKey{
+									MountID: 127,
+								},
+								Device: 52,
 								ParentPathKey: model.PathKey{
 									MountID: 27,
 								},
@@ -137,7 +143,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								Device:  1,
+								RootPathKey: model.PathKey{
+									MountID: 27,
+								},
+								Device: 1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -206,7 +215,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								Device:  1,
+								RootPathKey: model.PathKey{
+									MountID: 27,
+								},
+								Device: 1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -234,7 +246,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 638,
-								Device:  53,
+								RootPathKey: model.PathKey{
+									MountID: 638,
+								},
+								Device: 53,
 								ParentPathKey: model.PathKey{
 									MountID: 635,
 								},
@@ -248,7 +263,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 639,
-								Device:  54,
+								RootPathKey: model.PathKey{
+									MountID: 639,
+								},
+								Device: 54,
 								ParentPathKey: model.PathKey{
 									MountID: 638,
 								},
@@ -277,7 +295,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 32,
-								Device:  97,
+								RootPathKey: model.PathKey{
+									MountID: 32,
+								},
+								Device: 97,
 								ParentPathKey: model.PathKey{
 									MountID: 638,
 								},
@@ -289,7 +310,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 41,
-								Device:  98,
+								RootPathKey: model.PathKey{
+									MountID: 41,
+								},
+								Device: 98,
 								ParentPathKey: model.PathKey{
 									MountID: 32,
 								},
@@ -301,7 +325,10 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 42,
-								Device:  99,
+								RootPathKey: model.PathKey{
+									MountID: 42,
+								},
+								Device: 99,
 								ParentPathKey: model.PathKey{
 									MountID: 41,
 								},

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -53,7 +53,7 @@ func (r *Resolver) ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDC
 		return nil
 	}
 
-	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid)
+	mnt, _, _, err := r.mountResolver.ResolveMount(e.PathKey, pidCtx.Pid)
 	if err != nil {
 		return fmt.Errorf("attribute resolution error: %w", err)
 	}
@@ -77,7 +77,7 @@ func (r *Resolver) ResolveFullFilePath(e *model.FileFields, pidCtx *model.PIDCon
 		return pathStr, "", model.MountSourceMountID, model.MountOriginEvent, nil
 	}
 
-	mountPath, source, origin, err := r.mountResolver.ResolveMountPath(e.MountID, pidCtx.Pid)
+	mountPath, source, origin, err := r.mountResolver.ResolveMountPath(e.PathKey, pidCtx.Pid)
 	if err != nil {
 		if _, err := r.mountResolver.IsMountIDValid(e.MountID); errors.Is(err, mount.ErrMountKernelID) {
 			return pathStr, "", origin, source, &ErrPathResolutionNotCritical{Err: fmt.Errorf("mount ID(%d) invalid: %w", e.MountID, err)}
@@ -85,7 +85,7 @@ func (r *Resolver) ResolveFullFilePath(e *model.FileFields, pidCtx *model.PIDCon
 		return pathStr, "", source, origin, &ErrPathResolution{Err: err}
 	}
 
-	rootPath, source, origin, err := r.mountResolver.ResolveMountRoot(e.MountID, pidCtx.Pid)
+	rootPath, source, origin, err := r.mountResolver.ResolveMountRoot(e.PathKey, pidCtx.Pid)
 	if err != nil {
 		if _, err := r.mountResolver.IsMountIDValid(e.MountID); errors.Is(err, mount.ErrMountKernelID) {
 			return pathStr, "", source, origin, &ErrPathResolutionNotCritical{Err: fmt.Errorf("mount ID(%d) invalid: %w", e.MountID, err)}

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -415,7 +415,7 @@ func (p *EBPFResolver) enrichEventFromProcfs(entry *model.ProcessCacheEntry, pro
 		entry.FileEvent.MountVisible = true
 		entry.FileEvent.MountDetached = false
 		// resolve container path with the MountEBPFResolver
-		entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.MountID, entry.Process.Pid)
+		entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.PathKey, entry.Process.Pid)
 		if err != nil {
 			seclog.Debugf("snapshot failed for mount %d with pid %d : couldn't get the filesystem: %s", entry.Process.FileEvent.MountID, proc.Pid, err)
 		}
@@ -811,7 +811,7 @@ func (p *EBPFResolver) SetProcessSymlink(entry *model.ProcessCacheEntry) {
 // SetProcessFilesystem resolves process file system
 func (p *EBPFResolver) SetProcessFilesystem(entry *model.ProcessCacheEntry) (string, error) {
 	if entry.FileEvent.MountID != 0 {
-		fs, err := p.mountResolver.ResolveFilesystem(entry.FileEvent.MountID, entry.Pid)
+		fs, err := p.mountResolver.ResolveFilesystem(entry.FileEvent.PathKey, entry.Pid)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -12,6 +12,7 @@
 package model
 
 import (
+	"math"
 	"net"
 	"net/netip"
 	"runtime"
@@ -903,6 +904,22 @@ type PathKey struct {
 	Inode   uint64 `field:"inode"`    // SECLDoc[inode] Definition:`Inode of the file`
 	MountID uint32 `field:"mount_id"` // SECLDoc[mount_id] Definition:`Mount ID of the file`
 	PathID  uint32 `field:"-"`
+}
+
+// MountEquals returns true if the mount ID is the same as the other mount ID taking the path ID into account
+// See the increment of the path ID when the mount is updated kernel side
+func (p *PathKey) MountEquals(other PathKey) bool {
+	pathID, otherPathID := uint16(p.PathID&math.MaxUint16), uint16(other.PathID&math.MaxUint16)
+
+	diff := pathID - otherPathID // unsigned wrap-around
+	if diff > 0x8000 {
+		diff = ^diff + 1 // equivalent to 65536 - diff
+	}
+
+	// see kernel side definition of MOUNT_REVISION_BUMP_VALUE
+	const mountRevisionBumpValue = 30
+
+	return p.MountID == other.MountID && (p.PathID == 0 || other.PathID == 0 || diff < mountRevisionBumpValue)
 }
 
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -12,7 +12,6 @@
 package model
 
 import (
-	"math"
 	"net"
 	"net/netip"
 	"runtime"
@@ -909,7 +908,12 @@ type PathKey struct {
 // MountEquals returns true if the mount ID is the same as the other mount ID taking the path ID into account
 // See the increment of the path ID when the mount is updated kernel side
 func (p *PathKey) MountEquals(other PathKey) bool {
-	pathID, otherPathID := uint16(p.PathID&math.MaxUint16), uint16(other.PathID&math.MaxUint16)
+	// PathID encodes as PATH_ID(high, low) = (high << 16) | (low & 0xFFFF).
+	// The high 16 bits are the mount revision counter (bumped by MOUNT_REVISION_BUMP_VALUE on
+	// global invalidations such as directory renames/unlinks affecting the mount namespace).
+	// The low 16 bits are a per-inode counter and are unrelated between different files,
+	// so we must compare the high bits here.
+	pathID, otherPathID := uint16(p.PathID>>16), uint16(other.PathID>>16)
 
 	diff := pathID - otherPathID // unsigned wrap-around
 	if diff > 0x8000 {
@@ -917,7 +921,7 @@ func (p *PathKey) MountEquals(other PathKey) bool {
 	}
 
 	// see kernel side definition of MOUNT_REVISION_BUMP_VALUE
-	const mountRevisionBumpValue = 30
+	const mountRevisionBumpValue = 64
 
 	return p.MountID == other.MountID && (p.PathID == 0 || other.PathID == 0 || diff < mountRevisionBumpValue)
 }

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -364,7 +364,7 @@ func testMountSnapshot(t *testing.T) {
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
 		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
 
-		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid)
+		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(model.PathKey{MountID: uint32(mntInfo.ID)}, pid)
 		if err != nil {
 			t.Error(err)
 			return
@@ -377,7 +377,7 @@ func testMountSnapshot(t *testing.T) {
 		assert.Equal(t, mntInfo.FSType, mount.FSType, "snapshot and model fstype mismatch")
 		assert.Equal(t, mntInfo.Root, mount.RootStr, "snapshot and model root mismatch")
 
-		mountPointPath, mountSource, mountOrigin, err := mountResolver.ResolveMountPath(mount.MountID, pid)
+		mountPointPath, mountSource, mountOrigin, err := mountResolver.ResolveMountPath(model.PathKey{MountID: mount.MountID}, pid)
 		if err != nil {
 			t.Errorf("failed to resolve mountpoint path of mountpoint with id %d", mount.MountID)
 		}

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -92,7 +92,7 @@ func TestMoveMount(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.RootPathKey, 0)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, submountDir, mountPtr.Path, "Wrong mountpoint path")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
@@ -253,13 +253,13 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
+			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.RootPathKey, 0)
 			assert.Equal(t, err, nil, "Error resolving mount")
 			assert.Equal(t, 2, len(mount.Children), "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {
-				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0)
+				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: childMountID}, 0)
 				assert.Equal(t, err, nil, "Error resolving child mount")
 				assert.True(t, strings.HasPrefix(child.Path, te.submountDirDst), "Path wasn't updated")
 			}
@@ -338,7 +338,7 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 
 		p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
 		for i := range allMounts {
-			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(i, 0)
+			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(model.PathKey{MountID: i}, 0)
 
 			if len(path) == 0 || !strings.Contains(path, "tmp1") && !strings.Contains(path, "tmp2") {
 				// Some paths aren't being fully resolved due to missing mounts in the chain

--- a/pkg/security/tests/umount_test.go
+++ b/pkg/security/tests/umount_test.go
@@ -9,12 +9,14 @@
 package tests
 
 import (
-	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 	"syscall"
 	"testing"
 	"time"
+
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 func TmpMountAtLegacyAPI(dir string) error {
@@ -48,7 +50,7 @@ func TestUmount(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0)
+	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: mountID}, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +68,7 @@ func TestUmount(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Resolve the mount after detaching, without using redemption or reloading. Should return nil
-	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0)
+	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: mountID}, 0)
 	if err == nil {
 		t.Fatal("No error")
 	}


### PR DESCRIPTION
### What does this PR do?

  Introduce `PathKey`-based mount resolution across the mount resolver to                                                                
  leverage the path ID as a revision counter, allowing detection of stale                                                                
  or recycled mount IDs.                                                                                                                 
                  
  Key changes:
  - Add `MountEquals` on `PathKey` which compares mount IDs while
    tolerating small path ID deltas (< `MOUNT_REVISION_BUMP_VALUE=30`),
    enabling the kernel-side revision bump to signal mount recycling
  - Change `bump_high_path_id` to increment by `MOUNT_REVISION_BUMP_VALUE`
    instead of 1 so that a recycled mount ID produces a path ID outside
    the equality window
  - Update `ResolveMount`, `ResolveMountPath`, `ResolveMountRoot`,
    `ResolveFilesystem`, and their internal helpers to accept `model.PathKey`
    instead of a bare `uint32` mount ID, threading the path ID through
    the entire resolution chain
  - On a successful lookup, update the stored `RootPathKey.PathID` to the
    latest observed value so subsequent lookups stay current
  - Initialise `RootPathKey` in `newMountFromMountInfo` (procfs) and
    `newMountFromStatmount` (statmount) lister paths
  - Add a warning log when a mount is inserted with a null `RootPathKey`
  - Update all call sites (field handlers, path resolver, process resolver,
    probe, and tests) to pass a full `PathKey` rather than a raw mount ID

### Motivation

### Describe how you validated your changes

### Additional Notes
