### PR TITLE
[Backport 7.75.x] bump SGC to v1.5.1 to address [VULN-13320] CVE-2025-58181

### DIFF
--- a/deps/secret_connector/secret_connector.MODULE.bazel
+++ b/deps/secret_connector/secret_connector.MODULE.bazel
@@ -2,7 +2,7 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -24,16 +24,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
     "linux": {
-        "x86_64": "932d78686207f4d428e266c7afcea0fe4cba26fbad9f3b5e6686ef510bcc985c",
-        "arm64": "f20c043af96d8982283ee065e3fe5eca527656916d5e2e79e308a51e959fba10",
+        "x86_64": "eb17a21c4aa543737c34597a67815f273de9240629a03d91643e3e8d40019e48",
+        "arm64": "1987a766917a119c15cdcce7ef9e1d1a19289b26c1bf304427ea329c9a2c16f1",
     },
     "windows": {
-        "x86_64": "2b1fc0523cb9e5ff48f70a779b4cdc3d0b5d58ef929e41a0935e35dd01c6b636",
-        "arm64": "5d28d6db8663e3e428a702608caf4e5ac4008ed901f46d0feb2965e7f7603146",
+        "x86_64": "e370fb7953de604d39a7ecb05ba03be3477d923445f2d8ceddf172a3474325d8",
+        "arm64": "2a93ebe2d7468afb7f657cb90702f1e66d8006405b31db254d0c5194f2019fe2",
     },
     "macos": {
-        "x86_64": "583fac3054ba1630fc115bda45dd3aceb93f3c4bcebf366dcad17f39320b2d91",
-        "arm64": "1bc6998789553aa26d2b248d1b2aac5b6a1807d51865eca495065fb44be047f6",
+        "x86_64": "5e3318786f168f15ac02db144132a044ea981edded45def8aa1c763c568ce388",
+        "arm64": "f75de28244a2282858a3e9ae7222ad668ddab92e7a13009c26b3f7c84c642229",
     },
 }
 


### PR DESCRIPTION
### What does this PR do?
bumps SGC to `1.5.1` which addresses [[VULN-13320]](https://datadoghq.atlassian.net/browse/VULN-13320) CVE-2025-58181 due to `golang.org/x/crypto` version < `v0.44.0`

### Motivation
CVE

### Describe how you validated your changes
CI

### Additional Notes
This should be handled in Agent 7.76+ as we have migrated SGC from an external repo to within the datadog-agent, so we have inherited its security benefits. 


[VULN-13320]: https://datadoghq.atlassian.net/browse/VULN-13320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ