### PR TITLE
Extend the basic type validator to allow basic types masked by an empty interface

### DIFF
--- a/pkg/config/viperconfig/validate_basic.go
+++ b/pkg/config/viperconfig/validate_basic.go
@@ -23,9 +23,6 @@ var allowlistCaller = []string{
 	"comp/core/profiler/impl/profiler_test.go",
 	"comp/core/workloadfilter/catalog/filter_config_test.go",
 	"comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver_test.go",
-	"comp/logs/agent/config/config_keys_test.go",
-	"comp/logs/agent/config/config_test.go",
-	"comp/logs/agent/config/endpoints_test.go",
 	"comp/metadata/host/hostimpl/host_test.go",
 	"comp/metadata/resources/resourcesimpl/resources_test.go",
 	"comp/networkpath/npcollector/npcollectorimpl/config_test.go",
@@ -63,7 +60,7 @@ func validate(v reflect.Value) bool {
 	if v.Interface() == nil {
 		return true
 	}
-	if v.Kind() == reflect.Pointer {
+	if v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 	switch v.Kind() {


### PR DESCRIPTION
### What does this PR do?
Viper's validate basic types function is designed to allow the passing of values like 
```
[]map[string]string{
    "host": "helloworld",
    "port": "42"
```
but will invalidate mixed basic types, like
```
[]map[string]interface{}{
    "host": "helloworld",
    "port": 42
}
```

A number of tests make use of mixed-type maps like this, and have exceptions carved out by hand for each offending file. It doesn't seem like allowing mixed types goes against the spirit of the validator, as long as every one of the component types is itself a basic type.
This MR allows extra inspection on interfaces to confirm whether the underlying implementation is a basic type, allowing for the removal of at least a few special exemptions in the code.

### Motivation

### Describe how you validated your changes
CI validation was relied on, as was a quick check to make sure nil interface{} entities were still treated appropriately.

### Additional Notes
