### PR TITLE
APM: Small v1 trace payload fixes

### DIFF
--- a/releasenotes/notes/apm-tracev1-filtering-support-4a5b9742bbff9f4c.yaml
+++ b/releasenotes/notes/apm-tracev1-filtering-support-4a5b9742bbff9f4c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Correctly mark traces as probability sampled when using the trace V1 format.
+    APM: Fix issue where v1 trace writer might not flush traces during an agent shutdown.


### PR DESCRIPTION
### What does this PR do?
Fix issue where v1 trace payloads won't be properly marked when using probability sampling
Call shutdown on the trace writer v1 and make sure the API key is updated

### Motivation
Make the big converting agent PR smaller by pulling some small fixes into main via a separate PR

### Describe how you validated your changes
Added unit tests where needed

### Additional Notes
