### PR TITLE
fix(AdmissionController): Unify Caching for Secrets within DCA

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 
 	admicommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
@@ -70,14 +71,16 @@ type WebhookFunc func(request *Request) *admiv1.AdmissionResponse
 
 // Server TODO <container-integrations>
 type Server struct {
-	decoder runtime.Decoder
-	mux     *http.ServeMux
+	decoder       runtime.Decoder
+	mux           *http.ServeMux
+	secretsLister corelisters.SecretLister
 }
 
 // NewServer creates an admission webhook server.
-func NewServer() *Server {
+func NewServer(secretsLister corelisters.SecretLister) *Server {
 	s := &Server{
-		mux: http.NewServeMux(),
+		mux:           http.NewServeMux(),
+		secretsLister: secretsLister,
 	}
 
 	s.initDecoder()
@@ -110,7 +113,7 @@ func (s *Server) Register(uri string, webhookName string, webhookType admicommon
 }
 
 // Run starts the kubernetes admission webhook server.
-func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error {
+func (s *Server) Run(mainCtx context.Context) error {
 	var tlsMinVersion uint16 = tls.VersionTLS13
 	if pkgconfigsetup.Datadog().GetBool("cluster_agent.allow_legacy_tls") {
 		tlsMinVersion = tls.VersionTLS10
@@ -125,7 +128,7 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 			GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 				secretNs := namespace.GetResourcesNamespace()
 				secretName := pkgconfigsetup.Datadog().GetString("admission_controller.certificate.secret_name")
-				cert, err := certificate.GetCertificateFromSecret(secretNs, secretName, client)
+				cert, err := certificate.GetCertificateFromLister(s.secretsLister.Secrets(secretNs), secretName)
 				if err != nil {
 					log.Errorf("Couldn't fetch certificate: %v", err)
 				}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -585,7 +585,8 @@ func start(log log.Component,
 			}
 			// Webhook and secret controllers are started successfully
 			// Set up the k8s admission webhook server
-			server := admissioncmd.NewServer()
+			secretsLister := apiCl.CertificateSecretInformerFactory.Core().V1().Secrets().Lister()
+			server := admissioncmd.NewServer(secretsLister)
 
 			for _, webhookConf := range webhooks {
 				server.Register(webhookConf.Endpoint(), webhookConf.Name(), webhookConf.WebhookType(), webhookConf.WebhookFunc(), apiCl.DynamicCl, apiCl.Cl)
@@ -596,7 +597,7 @@ func start(log log.Component,
 			go func() {
 				defer wg.Done()
 
-				errServ := server.Run(mainCtx, apiCl.Cl)
+				errServ := server.Run(mainCtx)
 				if errServ != nil {
 					pkglog.Errorf("Error in the Admission Controller Webhook Server: %v", errServ)
 				}

--- a/releasenotes-dca/notes/admission-controller-ca-expire-13bd88888d0f0085.yaml
+++ b/releasenotes-dca/notes/admission-controller-ca-expire-13bd88888d0f0085.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduce admission controller downtime during certificate rotation.


### PR DESCRIPTION
### What does this PR do?

Eliminates the 5-minute certificate cache in the admission webhook HTTP server by using the shared Secret informer cache instead. Using multiple independent caches produced problems whenever the Secret value updated in informer cache but not the HTTP server's cache (5 min delay).

### Motivation

During certificate rotation, there was a potential 5-minute downtime window where:
1. Secret Controller updates the certificate Secret (detects soon expiration)
2. Webhook Controller updates the MutatingWebhookConfiguration with the new CA bundle 
3. HTTP Server continues serving the old certificate from cache (up to 5 minutes)
4. Kubernetes API server rejects the webhook call because the old cert doesn't match the new CA bundle

By using the same informer cache that the Webhook Controller uses, both components stay synchronized.

CONTP-1219

### Describe how you validated your changes

**Unit Tests**: Existing secret controller tests verify that secret rotations/refreshes still propagate smoothly.

**Manual**:  Deploy the admission controller with `mutateUnlabelled:true` and `failurePolicy:fail`.

Before the patch, when you delete the secret (to trigger a rotation), you will see `FailedCreate` events like the following for 5 minutes: 
```
k delete secret webhook-certificate -n datadog-agent
### Deploy some workloads (CronJob)
kubectl get events --field-selector reason=FailedCreate -A

NAMESPACE   LAST SEEN   TYPE      REASON         OBJECT                           MESSAGE
default     4m         Warning   FailedCreate   job/webhook-load-test-29495340   Error creating: Internal error occurred: failed calling webhook "datadog.webhook.agent.config": failed to call webhook: Post "https://datadog-agent-linux-cluster-agent-admission-controller.datadog-agent.svc:443/injectconfig?timeout=10s": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2026-01-29T21:00:00Z is after 2026-01-29T20:57:55Z
```

Now, deleting the secret and deploying new workloads will cause no errors!
```
k delete secret webhook-certificate -n datadog-agent
###  Deploy some workloads (CronJob)
kubectl get events --field-selector reason=FailedCreate -A
No resources found
```

### Additional Notes

Original implementation considered storing 2 certificates within the CA Bundle with overlapping lifetimes. For example C1 is valid from T1-T10 and C2 is valid from T5-T15.  Both the certificates are stored in the secret. When we hit a time like T8 when we want to transition to the next valid certificate, it is already present throughout all the relevant clients.

Before this change, the admission controller went uncertified for worst case 5 minutes. Now, the worst case is simply how long the API request to update the mutatingwebhook controller with the new configuration takes. The shared informed on the cluster agent is notified of a change to the secret cert. It's possible a request comes in to the HTTP server and the new cert is used, however, under a race, the mutating webhook configuration has not been updated yet with the new cert.

From an initial search online, API Server requests can operate on the order of 100ms. Our cache had a lifetime of 300,000ms and so this would be a 3000x increase in availability of the admission controller which can land us a quick easy win.