### PR TITLE
[ABLD-280] Add back missing license files for freedts and nfsiostat

### DIFF
--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -260,6 +260,7 @@ pkg_filegroup(
         ":lib_file",
         ":so_link",
     ],
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -7,9 +7,11 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_filegroup(
     name = "embedded",
     srcs = [
+        "@freetds//:all_files",
         "//deps/gstatus:bin_files",
         # have to include this explicitly because it is not hooked up with package_metadata
         "//deps/gstatus:license_file",
+        "//deps/nfsiostat:all_files",
     ] + select({
         "@platforms//os:linux": [
             "//deps/compile_policy:bin_files",

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -7,11 +7,9 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_filegroup(
     name = "embedded",
     srcs = [
-        "@freetds//:all_files",
         "//deps/gstatus:bin_files",
         # have to include this explicitly because it is not hooked up with package_metadata
         "//deps/gstatus:license_file",
-        "//deps/nfsiostat:all_files",
     ] + select({
         "@platforms//os:linux": [
             "//deps/compile_policy:bin_files",
@@ -31,7 +29,9 @@ filegroup(
     ] + select({
         "//packages/agent:linux_heroku": [],
         "//packages/agent:linux_default": [
+            "//deps/nfsiostat:all_files",
             "//deps/openscap:all_deps",
+            "@freetds//:all_files",
         ],
         "//conditions:default": [
             # This will become "//deps/openscap:all_deps" in the future


### PR DESCRIPTION
These were dropped in https://github.com/DataDog/datadog-agent/pull/45578

## verification
Take a recent .deb build. Take the new deb build. Compare content.
```
From:
  [file] opt/datadog-agent/LICENSES/freetds-COPYING
  [file] opt/datadog-agent/LICENSES/nfsiostat-GPL-2.0
To:
  [file] opt/datadog-agent/LICENSES/freetds-COPYING.LIB
  [file] opt/datadog-agent/LICENSES/nfsiostat-COPYING
```
The change in name is what I expected. It reflects correct specification of the license files. The omnibus scripts had it wrong.