### PR TITLE
[CWS] lock variables after calling the scoper

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -1100,13 +1100,14 @@ func (v *ScopedVariables) Len() int {
 // NewSECLVariable returns new variable of the type of the specified value
 func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName string, opts VariableOpts) (SECLVariable, error) {
 	getVariable := func(ctx *Context, noFollowInheritance bool) MutableSECLVariable {
-		v.varsLock.RLock()
-		defer v.varsLock.RUnlock()
 		scope := v.scoper(ctx)
 		if scope == nil {
 			return nil
 		}
 		key := scope.Hash()
+
+		v.varsLock.RLock()
+		defer v.varsLock.RUnlock()
 		vars := v.vars[key]
 		if (vars == nil || vars[name] == nil) && opts.Inherited && !noFollowInheritance {
 			var ok bool
@@ -1121,14 +1122,14 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 	}
 
 	setVariable := func(ctx *Context, value any) error {
-		v.varsLock.Lock()
-		defer v.varsLock.Unlock()
 		scope := v.scoper(ctx)
 		if scope == nil {
 			return fmt.Errorf("`%s` scoper failed to scope variable '%s'", v.scoperName, name)
 		}
-
 		key := scope.Hash()
+
+		v.varsLock.Lock()
+		defer v.varsLock.Unlock()
 		vars := v.vars[key]
 		varType := getVariableType(value)
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where we have 2 locks taken in a different order:
- when we run a set action:
  - we lock `v.varsLock`
  - we then lock the process resolver to get the scope used to set the variable
- when we list all the variables for the status output:
  - we lock the process resolver to walk it
  - we then lock `v.varsLock` when fetching the value of a variable

### Motivation

### Describe how you validated your changes

### Additional Notes
