### PR TITLE
[backport 7.75.x][SBOM] use `sbom.cache_directory` when creating cache (#45092)

### DIFF
--- a/pkg/util/trivy/cache.go
+++ b/pkg/util/trivy/cache.go
@@ -12,8 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -33,21 +31,9 @@ const cacheSize = 1600
 // telemetryTick is the frequency at which the cache usage metrics are collected.
 var telemetryTick = 1 * time.Minute
 
-// defaultCacheDir returns/creates the default cache-dir to be used for trivy operations
-func defaultCacheDir() string {
-	tmpDir, err := os.UserCacheDir()
-	if err != nil {
-		tmpDir = os.TempDir()
-	}
-	return filepath.Join(tmpDir, "trivy")
-}
-
 // NewCustomBoltCache returns a BoltDB cache using an LRU algorithm with a
 // maximum disk size and garbage collection of unused images with its custom cleaner.
 func NewCustomBoltCache(wmeta option.Option[workloadmeta.Component], cacheDir string, maxDiskSize int) (CacheWithCleaner, error) {
-	if cacheDir == "" {
-		cacheDir = defaultCacheDir()
-	}
 	db, err := NewBoltDB(cacheDir)
 	if err != nil {
 		return nil, err

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -57,6 +57,7 @@ const (
 
 // collectorConfig allows to pass configuration
 type collectorConfig struct {
+	cacheDir            string
 	clearCacheOnClose   bool
 	maxCacheSize        int
 	computeDependencies bool
@@ -221,6 +222,7 @@ func DefaultDisabledHandlers() []ftypes.HandlerType {
 func NewCollector(cfg config.Component, wmeta option.Option[workloadmeta.Component]) (*Collector, error) {
 	return &Collector{
 		config: collectorConfig{
+			cacheDir:            cfg.GetString("sbom.cache_directory"),
 			clearCacheOnClose:   cfg.GetBool("sbom.clear_cache_on_exit"),
 			maxCacheSize:        cfg.GetInt("sbom.cache.max_disk_size"),
 			computeDependencies: cfg.GetBool("sbom.compute_dependencies"),
@@ -294,7 +296,7 @@ func (c *Collector) GetCache() (CacheWithCleaner, error) {
 	c.cacheInitialized.Do(func() {
 		c.persistentCache, c.persistentCacheErr = NewCustomBoltCache(
 			c.wmeta,
-			defaultCacheDir(),
+			c.config.cacheDir,
 			c.config.maxCacheSize,
 		)
 	})


### PR DESCRIPTION
backport of #45092

### What does this PR do?

This PR removes the usage of `UserCacheDir` (or `TempDir`) that can return paths to non-writable locations (especially now that helm charts configure the root fs of the agent to be read-only, and `UserCacheDir` returns `/root/.cache` which is not writable by default).

Instead we use the already existing `sbom.cache_directory` (that was not used, a bug) that defaults to a folder in the run folder which is writable.

### Motivation

### Describe how you validated your changes

### Additional Notes


(cherry picked from commit f46eb0e2a75b6269c064d0bd417c9e752f85e544)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
