### PR TITLE
[ABLD-317] Repair `modparser` tests

### DIFF
--- a/internal/tools/modparser/testdata/match/go.mod
+++ b/internal/tools/modparser/testdata/match/go.mod
@@ -1,3 +1,7 @@
 module github.com/DataDog/datadog-agent/internal/tools/modparser/testdata/match
 
-go 1.18
+go 1.25.0
+
+require (
+    github.com/DataDog/datadog-agent/pkg/test v0.65.3
+)

--- a/internal/tools/modparser/testdata/match/go.sum
+++ b/internal/tools/modparser/testdata/match/go.sum
@@ -1,8 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/tools/modparser/testdata/nomatch/go.mod
+++ b/internal/tools/modparser/testdata/nomatch/go.mod
@@ -1,3 +1,8 @@
 module github.com/DataDog/datadog-agent/internal/tools/modparser/testdata/nomatch
 
-go 1.18
+go 1.25.0
+
+require (
+    github.com/DataDog/datadog-not-agent/pkg/test v0.65.3
+    not/github.com/DataDog/datadog-agent/pkg/test v0.65.3
+)

--- a/internal/tools/modparser/testdata/nomatch/go.sum
+++ b/internal/tools/modparser/testdata/nomatch/go.sum
@@ -1,8 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/tools/modparser/testdata/patchgoversion/go.mod
+++ b/internal/tools/modparser/testdata/patchgoversion/go.mod
@@ -1,3 +1,3 @@
 module github.com/DataDog/datadog-agent/internal/tools/modparser/testdata/patchgoversion
 
-go 1.21.0
+go 1.25.6

--- a/internal/tools/modparser/testdata/patchgoversion/go.sum
+++ b/internal/tools/modparser/testdata/patchgoversion/go.sum
@@ -1,8 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### What does this PR do?
Repair, refresh and strengthen `modparser` tests that were inadvertently broken, and remove outdated/unused `testdata/*/go.sum` files.

### Motivation
Offload #45714 which aims at migrating `modparser` as first Go module to `bazel` (better have this change individually cherry-pickable/revertable).

The tests were broken since #30061 where `require` blocks were removed from `testdata/*/go.mod` files during a dependencies upgrade. As the tests are not yet (or no longer) running in CI, the breakage went unnoticed.

Contrarily to `go.mod` files in `testdata` sub-directories that are used by `modparser` test cases, the sibling `go.sum` files are not used and reflect outdated dependencies/checksums.

### Describe how you validated your changes
- test failure: `TestFilterMatch/With_matches` expected to find `["github.com/DataDog/datadog-agent/pkg/test"]` but got empty array.
  => all 7/7 test cases now pass.
- golangci-lint issues: 2 `perfsprint` violations (`fmt.Errorf` without format specifiers should use `errors.New`).

### Additional Notes
#45714, or a follow-up PR, will make sure the tests run in CI.