### PR TITLE
Clean up openssl exporting on Bazel

### DIFF
--- a/bazel/rules/cc_shared_library_wrapper.bzl
+++ b/bazel/rules/cc_shared_library_wrapper.bzl
@@ -1,0 +1,35 @@
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
+
+def _cc_shared_library_wrapper_impl(ctx):
+    cc_info = ctx.attr.input[CcInfo]
+
+    # We're only interested in the linker input owned by the target, and ignore those coming from deps.
+    # This is what makes most sense for the motivating use case.
+    selected_input = None
+    for linker_input in cc_info.linking_context.linker_inputs.to_list():
+        if linker_input.owner == ctx.attr.input.label:
+            selected_input = linker_input
+
+    return [
+        # We could make this configurable by allowing the rule caller to control exports and dynamic_deps
+        # for now we don't seem to have this need, so we're defaulting to the most reasonable thing possible.
+        CcSharedLibraryInfo(
+            exports = [ctx.attr.input.label],
+            linker_input = selected_input,
+            link_once_static_libs = [],
+            dynamic_deps = depset([], order = "topological"),
+        ),
+    ]
+
+cc_shared_library_wrapper = rule(
+    implementation = _cc_shared_library_wrapper_impl,
+    attrs = {
+        "input": attr.label(),
+    },
+    doc = """
+    Creates a `CcSharedLibraryInfo` provider out of a `CcInfo` one.
+    It's use case comes from wanting to wire a rules_foreign_cc target to a cc_shared_library's
+    dynamic_deps, particularly when said target produces several libraries.
+    """,
+)

--- a/bazel/rules/cc_shared_library_wrapper.bzl
+++ b/bazel/rules/cc_shared_library_wrapper.bzl
@@ -10,6 +10,10 @@ def _cc_shared_library_wrapper_impl(ctx):
     for linker_input in cc_info.linking_context.linker_inputs.to_list():
         if linker_input.owner == ctx.attr.input.label:
             selected_input = linker_input
+            break
+
+    if selected_input == None:
+        fail("No linker inputs found for input label `{}`".format(ctx.attr.input.label))
 
     return [
         # We could make this configurable by allowing the rule caller to control exports and dynamic_deps

--- a/bazel/rules/cc_shared_library_wrapper.bzl
+++ b/bazel/rules/cc_shared_library_wrapper.bzl
@@ -25,7 +25,7 @@ def _cc_shared_library_wrapper_impl(ctx):
 cc_shared_library_wrapper = rule(
     implementation = _cc_shared_library_wrapper_impl,
     attrs = {
-        "input": attr.label(),
+        "input": attr.label(providers=[CcInfo]),
     },
     doc = """
     Creates a `CcSharedLibraryInfo` provider out of a `CcInfo` one.

--- a/bazel/rules/cc_shared_library_wrapper.bzl
+++ b/bazel/rules/cc_shared_library_wrapper.bzl
@@ -29,11 +29,13 @@ def _cc_shared_library_wrapper_impl(ctx):
 cc_shared_library_wrapper = rule(
     implementation = _cc_shared_library_wrapper_impl,
     attrs = {
-        "input": attr.label(providers=[CcInfo]),
+        "input": attr.label(
+            mandatory = True,
+            providers = [CcInfo],
+            doc = "Input label from which to generate a `CcSharedLibraryInfo`",
+        ),
     },
-    doc = """
-    Creates a `CcSharedLibraryInfo` provider out of a `CcInfo` one.
-    It's use case comes from wanting to wire a rules_foreign_cc target to a cc_shared_library's
-    dynamic_deps, particularly when said target produces several libraries.
-    """,
+    doc = """Creates a `CcSharedLibraryInfo` provider out of a `CcInfo` one.
+It's use case comes from wanting to wire a rules_foreign_cc target to a cc_shared_library's
+dynamic_deps, particularly when said target produces several libraries.""",
 )

--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -92,7 +92,7 @@ _PUBLIC_HEADERS = [
 ]
 
 cc_library(
-    name = "tdsodbc_static",
+    name = "libtdsodbc",
     srcs = [
         ":gen_sysdep_h",
         ":gen_version_h",
@@ -206,15 +206,13 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "@unixodbc//:odbc",
-        "@openssl//:crypto",
-        "@openssl//:ssl",
-        "@openssl//:imported_ssl_headers",
+        "@openssl",
     ],
 )
 
 cc_shared_library(
     name = "tdsodbc_so",
-    deps = [":tdsodbc_static"],
+    deps = [":libtdsodbc"],
     shared_lib_name = "libtdsodbc.so",
     dynamic_deps = [
         "@unixodbc//:libodbc_so",

--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -216,8 +216,7 @@ cc_shared_library(
     shared_lib_name = "libtdsodbc.so",
     dynamic_deps = [
         "@unixodbc//:libodbc_so",
-        "@openssl//:crypto_shared",
-        "@openssl//:ssl_shared",
+        "@openssl//:openssl_shared",
     ],
     user_link_flags = select({
         "@platforms//os:linux": [

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -1,6 +1,5 @@
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
-load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
 load("@rules_cc//cc:cc_import.bzl", "cc_import")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
@@ -126,10 +125,7 @@ configure_make(
             "libssl.dll.a",
             "libcrypto.dll.a",
         ],
-        "//conditions:default": [
-            "libssl.a",
-            "libcrypto.a",
-        ],
+        "//conditions:default": [],
     }),
     out_shared_libs = select({
         "@platforms//os:linux": [
@@ -198,29 +194,7 @@ filegroup(
     output_group = "include",
 )
 
-copy_directory(
-    name = "copy_headers",
-    src = ":headers",
-    out = "copied_headers",
-)
-
-cc_library(
-    name = "imported_ssl_headers",
-    hdrs = [":copy_headers"],
-    includes = ["copied_headers"],
-)
-
-# The static library built with configure/make
-filegroup(
-    name = "libssl_static",
-    srcs = [":openssl"],
-    output_group = select({
-        "@platforms//os:windows": "libssl.dll.a",
-        "//conditions:default": "libssl.a",
-    }),
-)
-
-# The dynmamic library built with configure/make. Even though the name
+# The dynamic library built with configure/make. Even though the name
 # is libssl.so, it is not actually the same folder, so we can have our
 # own libssl.so shadow it.
 filegroup(
@@ -230,43 +204,6 @@ filegroup(
         "@platforms//os:windows": WIN_LIBSSL,
         "@platforms//os:macos": MACOS_LIBSSL,
         "@platforms//os:linux": LINUX_LIBSSL,
-    }),
-)
-
-# If you need to depend on openssl to build, you want this target.
-# If you depend on this, you must also depend on ":imported_ssl_headers".
-cc_import(
-    name = "ssl",
-    # hrs seems to have no effect in practice, but we have it here because
-    # the docs say this should work
-    hdrs = [":imported_ssl_headers"],
-    static_library = ":libssl_static",
-    shared_library = ":libssl_shared_file",
-)
-
-cc_shared_library(
-    name = "ssl_shared",
-    shared_lib_name = select({
-        "@platforms//os:windows": WIN_LIBSSL,
-        "@platforms//os:macos": MACOS_LIBSSL,
-        "@platforms//os:linux": LINUX_LIBSSL,
-    }),
-    deps = [
-        ":ssl",
-        ":imported_ssl_headers",
-    ],
-    dynamic_deps = [
-        ":crypto_shared",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "libcrypto_static",
-    srcs = [":openssl"],
-    output_group = select({
-        "@platforms//os:windows": "libcrypto.dll.a",
-        "//conditions:default": "libcrypto.a",
     }),
 )
 
@@ -280,15 +217,34 @@ filegroup(
     }),
 )
 
-# Do not depend both on this and imported_ssl
-# If you depend on this, you must also depend on ":imported_ssl_headers".
+cc_import(
+    name = "ssl",
+    shared_library = ":libssl_shared_file",
+)
+
+cc_library(
+    name = "ssl_library",
+    deps = [":ssl"],
+)
+
+cc_shared_library(
+    name = "ssl_shared",
+    shared_lib_name = select({
+        "@platforms//os:windows": WIN_LIBSSL,
+        "@platforms//os:macos": MACOS_LIBSSL,
+        "@platforms//os:linux": LINUX_LIBSSL,
+    }),
+    deps = [":ssl_library"],
+)
+
 cc_import(
     name = "crypto",
-    # hrs seems to have no effect in practice, but we have it here because
-    # the docs say this should work
-    # hdrs = [":imported_ssl_headers"],
-    static_library = ":libcrypto_static",
     shared_library = ":libcrypto_shared_file",
+)
+
+cc_library(
+    name = "crypto_library",
+    deps = [":crypto"],
 )
 
 cc_shared_library(
@@ -298,8 +254,7 @@ cc_shared_library(
         "@platforms//os:macos": MACOS_LIBCRYPTO,
         "@platforms//os:linux": LINUX_LIBCRYPTO,
     }),
-    deps = [":crypto"],
-    visibility = ["//visibility:public"],
+    deps = [":crypto_library"],
 )
 
 #####

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -1,7 +1,6 @@
+load("@//bazel/rules:cc_shared_library_wrapper.bzl", "cc_shared_library_wrapper")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
-load("@rules_cc//cc:cc_import.bzl", "cc_import")
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
@@ -184,9 +183,12 @@ configure_make(
     }),
 )
 
-########################################################################
+cc_shared_library_wrapper(
+    name = "openssl_shared",
+    input = ":openssl",
+)
 
-# Now we have to use filegroups to pull the outputs of configure_make into targets.
+########################################################################
 
 filegroup(
     name = "headers",
@@ -215,46 +217,6 @@ filegroup(
         "@platforms//os:macos": MACOS_LIBCRYPTO,
         "@platforms//os:linux": LINUX_LIBCRYPTO,
     }),
-)
-
-cc_import(
-    name = "ssl",
-    shared_library = ":libssl_shared_file",
-)
-
-cc_library(
-    name = "ssl_library",
-    deps = [":ssl"],
-)
-
-cc_shared_library(
-    name = "ssl_shared",
-    shared_lib_name = select({
-        "@platforms//os:windows": WIN_LIBSSL,
-        "@platforms//os:macos": MACOS_LIBSSL,
-        "@platforms//os:linux": LINUX_LIBSSL,
-    }),
-    deps = [":ssl_library"],
-)
-
-cc_import(
-    name = "crypto",
-    shared_library = ":libcrypto_shared_file",
-)
-
-cc_library(
-    name = "crypto_library",
-    deps = [":crypto"],
-)
-
-cc_shared_library(
-    name = "crypto_shared",
-    shared_lib_name = select({
-        "@platforms//os:windows": WIN_LIBCRYPTO,
-        "@platforms//os:macos": MACOS_LIBCRYPTO,
-        "@platforms//os:linux": LINUX_LIBCRYPTO,
-    }),
-    deps = [":crypto_library"],
 )
 
 #####

--- a/deps/rpm/rpm.BUILD.bazel
+++ b/deps/rpm/rpm.BUILD.bazel
@@ -129,8 +129,7 @@ cc_shared_library(
         "@zlib//:z",
         "@xz//:lzma",
         "@bzip2//:bz2",
-        "@openssl//:crypto_shared",
-        "@openssl//:ssl_shared",
+        "@openssl//:openssl_shared",
     ],
     user_link_flags = select({
         "@platforms//os:linux": [

--- a/deps/rpm/rpm.BUILD.bazel
+++ b/deps/rpm/rpm.BUILD.bazel
@@ -106,9 +106,7 @@ cc_library(
     ],
     deps = [
         ":misc",
-        "@openssl//:crypto",
-        "@openssl//:ssl",
-        "@openssl//:imported_ssl_headers",
+        "@openssl",
         "@zstd//:libzstd",
         "@popt//:libpopt",
         "@lua//:liblua",

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -172,8 +172,7 @@ cc_shared_library(
     dynamic_deps = [
         "@libxslt//:xslt",
         "@libxml2//:xml2",
-        "@openssl//:crypto_shared",
-        "@openssl//:ssl_shared",
+        "@openssl//:openssl_shared",
         ":xmlsec1",
     ],
     user_link_flags = select({

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -142,9 +142,7 @@ cc_library(
     deps = [
         "@libxslt//:libxslt",
         "@libxml2//:libxml2",
-        "@openssl//:crypto",
-        "@openssl//:ssl",
-        "@openssl//:imported_ssl_headers",
+        "@openssl",
         ":libxmlsec1",
     ],
     defines = [


### PR DESCRIPTION
### What does this PR do?

It makes it simpler and clearer to consume `rules_foreign_cc`-built openssl by adding a wrapper that forwards the data out of a `rules_foreign_cc`-created `CcInfo` in the shape of a `CcSharedLibraryInfo`. This bypasses the need for a chain of wrapping rules trying to do the same using a `cc_shared_library` at the end, and makes the flow of information more explicit and easier to understand – so that it looks at least that we're more in control by comparison to the initial approach.

In doing so, it also restores the original `NEEDED` from the importing binaries to use the (major-)versioned reference of the imported library (i.e. its SONAME).

### Motivation

As I was working on #43852, https://github.com/DataDog/datadog-agent/pull/45578, the PR that implemented the initial "wrapping", landed, and interfered with how I was building up the layout for the different possible combinations of platform and flavors. Partly, because of how we're incorrectly treating `dll.a` files as static libs.

Digging further led me to a better understanding of how the different elements work together, ultimately leading to this PR.

### Describe how you validated your changes

- CI green, and no changes in deliverable sizes based on SQGs.
- Confirming with `du` that file sizes don't change for libraries depending on openssl, and using `ldd` and `readelf` to confirm the references to libcrypto and libssl are correct.

### Additional Notes

`cc_shared_library` uses its `dynamic_deps` attribute to compute what gets statically linked and what gets dynamically linked. Without passing any information about `openssl` to a `cc_shared_library` wanting to link dynamically against it (like we do), all of openssl gets linked statically in the output of the `cc_shared_library`.

An important catch in this is that labels passed as `dynamic_deps` must include a [`CcSharedLibraryInfo`](https://github.com/bazelbuild/rules_cc/blob/6f0ade9d4d0cef4c41e48b115f719f65dd851026/cc/common/cc_shared_library_info.bzl#L18) provider – and it's the only provider from the `dynamic_deps` that `cc_shared_library` looks at. `rules_foreign_cc`'s rules doesn't return such a provider, and the only rule to return this kind of provider is [`cc_shared_library`](https://bazel.build/reference/be/c-cpp#cc_shared_library).

However `cc_shared_library` is a rule with a linking action which we don't need, which creates an impedance mismatch when trying to use it to connect the output of the `configure_make` to the consuming `cc_shared_library`. I think this is at the heart of what made our previous attempts confusing, combined with the fact that `openssl` actually produces two libraries (`libssl` and `libcrypto`).

The proposed solution creates a wrapper with no action involved, which simply forwards the information about the libraries produced (from the `CcInfo` provider) repackaged in a `CcSharedLibraryInfo` provider. This can be provided to the consuming `cc_shared_library` such that it correctly figures out that it should link dynamically against `libssl` and `libcrypto`, and not statically.

Useful reference to understand `cc_shared_library`: https://pikachuhya.github.io/posts/bazel-cc-shared-library/

The move of `dll.a` libraries (one of the original motivators) out of static libs to be treated as an "interface library" can be done as a follow-up.