### PR TITLE
Run go list commands in parallel to speed up go-deps.diff task

### DIFF
--- a/.gitlab/build/source_test/golang_deps_diff.yml
+++ b/.gitlab/build/source_test/golang_deps_diff.yml
@@ -10,8 +10,10 @@ golang_deps_diff:
     - when: on_success
   needs: ["go_deps"]
   variables:
-    KUBERNETES_CPU_REQUEST: 4
+    KUBERNETES_CPU_REQUEST: 8
     OVERRIDE_GIT_STRATEGY: "clone" # needed because this job uses `git merge-base`
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -147,6 +147,8 @@ def diff(
                 if branch_ref:
                     ctx.run(f"git checkout -q {branch_ref}")
 
+                # Run all go list commands in parallel for this branch
+                promises = []
                 for binary, details in BINARIES.items():
                     with ctx.cd(details.get("entrypoint")):
                         for combo in details["platforms"]:
@@ -165,7 +167,16 @@ def diff(
                                 "CGO_ENABLED": "1",
                                 "GOTOOLCHAIN": f"go{dot_go_version(ctx)}",
                             }
-                            ctx.run(f"{dep_cmd} -tags \"{' '.join(build_tags)}\" > {depsfile}", env=env)
+                            promise = ctx.run(
+                                f"{dep_cmd} -tags \"{' '.join(build_tags)}\" > {depsfile}",
+                                env=env,
+                                asynchronous=True,
+                            )
+                            promises.append(promise)
+
+                # Wait for all commands to complete
+                for promise in promises:
+                    promise.join()
         finally:
             ctx.run(f"git checkout -q {current_branch}")
 


### PR DESCRIPTION
### What does this PR do?
Run go list commands in parallel in `go-deps.diff` invoke task

### Motivation
Speed up the task.

### Describe how you validated your changes
Manual testing.

### Additional Notes
Reduces the duration from ~5min to ~1min locally. Also reduces the duration in CI from ~15min to ~2min.

I often run this task locally when working on removing dependencies, a 5x duration improvement is significant for me.
