### PR TITLE
[SNMP] Collect `type` and `is_physical` from interfaces

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metadata.go
@@ -75,6 +75,12 @@ var LegacyMetadataConfig = profiledefinition.MetadataConfig{
 					Format: "mac_address",
 				},
 			},
+			"type": {
+				Symbol: profiledefinition.SymbolConfig{
+					OID:  "1.3.6.1.2.1.2.2.1.3",
+					Name: "ifType",
+				},
+			},
 		},
 		IDTags: profiledefinition.MetricTagConfigList{
 			{

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -1041,6 +1041,7 @@ collect_topology: false
 	}, deviceCk.profileCache.scalarOIDs)
 	assert.Equal(t, []string{
 		"1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.3",
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
 		"1.3.6.1.2.1.2.2.1.8",
@@ -1111,6 +1112,7 @@ collect_topology: false
 	}, deviceCk.profileCache.scalarOIDs)
 	assert.Equal(t, []string{
 		"1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.3",
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
 		"1.3.6.1.2.1.2.2.1.8",

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -296,6 +296,16 @@ func buildNetworkInterfacesMetadata(deviceID string, store *metadata.Store) []de
 		ifIDTags := store.GetIDTags("interface", strIndex)
 
 		name := store.GetColumnAsString("interface.name", strIndex)
+		ifType := int32(store.GetColumnAsFloat("interface.type", strIndex))
+
+		// Compute is_physical based on ifType
+		// Physical ethernet types: 6 (ethernetCsmacd), 62 (fastEther), 69 (fastEtherFX), 117 (gigabitEthernet)
+		var isPhysical *bool
+		if ifType != 0 {
+			physical := ifType == 6 || ifType == 62 || ifType == 69 || ifType == 117
+			isPhysical = &physical
+		}
+
 		networkInterface := devicemetadata.InterfaceMetadata{
 			DeviceID:    deviceID,
 			Index:       int32(index),
@@ -305,6 +315,8 @@ func buildNetworkInterfacesMetadata(deviceID string, store *metadata.Store) []de
 			MacAddress:  store.GetColumnAsString("interface.mac_address", strIndex),
 			AdminStatus: devicemetadata.IfAdminStatus(store.GetColumnAsFloat("interface.admin_status", strIndex)),
 			OperStatus:  devicemetadata.IfOperStatus(store.GetColumnAsFloat("interface.oper_status", strIndex)),
+			Type:        ifType,
+			IsPhysical:  isPhysical,
 			IDTags:      ifIDTags,
 		}
 		interfaces = append(interfaces, networkInterface)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -1357,3 +1357,317 @@ func Test_buildInterfaceIndexByIDType(t *testing.T) {
 	}
 	assert.Equal(t, expectedInterfaceIndexByIDType, interfaceIndexByIDType)
 }
+
+func Test_metricSender_reportNetworkDeviceMetadata_withInterfaceTypeAndIsPhysical(t *testing.T) {
+	// Test various ifType values and their corresponding is_physical values
+	// Physical types: 6 (ethernetCsmacd), 62 (fastEther), 69 (fastEtherFX), 117 (gigabitEthernet)
+	// Non-physical type: 24 (softwareLoopback)
+	// Type 0 (not collected) should have is_physical = nil
+	var storeWithIfType = &valuestore.ResultValueStore{
+		ColumnValues: valuestore.ColumnResultValuesType{
+			"1.3.6.1.2.1.31.1.1.1.1": { // ifName
+				"1": valuestore.ResultValue{Value: "eth0"},
+				"2": valuestore.ResultValue{Value: "eth1"},
+				"3": valuestore.ResultValue{Value: "lo"},
+				"4": valuestore.ResultValue{Value: "eth2"},
+			},
+			"1.3.6.1.2.1.2.2.1.3": { // ifType
+				"1": valuestore.ResultValue{Value: float64(6)},   // ethernetCsmacd - physical
+				"2": valuestore.ResultValue{Value: float64(62)},  // fastEther - physical
+				"3": valuestore.ResultValue{Value: float64(24)},  // softwareLoopback - not physical
+				"4": valuestore.ResultValue{Value: float64(117)}, // gigabitEthernet - physical
+			},
+			"1.3.6.1.2.1.2.2.1.7": { // ifAdminStatus
+				"1": valuestore.ResultValue{Value: float64(1)},
+				"2": valuestore.ResultValue{Value: float64(1)},
+				"3": valuestore.ResultValue{Value: float64(1)},
+				"4": valuestore.ResultValue{Value: float64(1)},
+			},
+			"1.3.6.1.2.1.2.2.1.8": { // ifOperStatus
+				"1": valuestore.ResultValue{Value: float64(1)},
+				"2": valuestore.ResultValue{Value: float64(1)},
+				"3": valuestore.ResultValue{Value: float64(1)},
+				"4": valuestore.ResultValue{Value: float64(1)},
+			},
+		},
+	}
+	sender := mocksender.NewMockSender("testID")
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	ms := &MetricSender{
+		hostname: "test",
+		sender:   sender,
+	}
+
+	config := &checkconfig.CheckConfig{
+		IPAddress:          "1.2.3.4",
+		DeviceID:           "1234",
+		DeviceIDTags:       []string{"device_name:127.0.0.1"},
+		ResolvedSubnetName: "127.0.0.0/29",
+		Namespace:          "my-ns",
+	}
+	profile := profiledefinition.ProfileDefinition{
+		Metadata: profiledefinition.MetadataConfig{
+			"device": {
+				Fields: map[string]profiledefinition.MetadataField{
+					"type": {
+						Value: "switch",
+					},
+				},
+			},
+			"interface": {
+				Fields: map[string]profiledefinition.MetadataField{
+					"name": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.31.1.1.1.1",
+							Name: "ifName",
+						},
+					},
+					"type": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.3",
+							Name: "ifType",
+						},
+					},
+					"admin_status": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.7",
+							Name: "ifAdminStatus",
+						},
+					},
+					"oper_status": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.8",
+							Name: "ifOperStatus",
+						},
+					},
+				},
+				IDTags: profiledefinition.MetricTagConfigList{
+					profiledefinition.MetricTagConfig{
+						Symbol: profiledefinition.SymbolConfigCompat{
+							OID:  "1.3.6.1.2.1.31.1.1.1.1",
+							Name: "interface",
+						},
+						Tag: "interface",
+					},
+				},
+			},
+		},
+	}
+
+	layout := "2006-01-02 15:04:05"
+	str := "2014-11-12 11:45:26"
+	collectTime, err := time.Parse(layout, str)
+	assert.NoError(t, err)
+	ms.ReportNetworkDeviceMetadata(config, profile, storeWithIfType, []string{"tag1", "tag2"}, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
+
+	// language=json
+	event := []byte(`
+{
+    "subnet": "127.0.0.0/29",
+    "namespace": "my-ns",
+	"integration": "snmp",
+    "devices": [
+        {
+            "id": "1234",
+            "id_tags": [
+                "device_name:127.0.0.1"
+            ],
+            "tags": [
+                "tag1",
+                "tag2"
+            ],
+            "ip_address": "1.2.3.4",
+            "status":1,
+			"ping_status":1,
+            "subnet": "127.0.0.0/29",
+			"integration": "snmp",
+			"device_type": "switch"
+        }
+    ],
+    "interfaces": [
+        {
+            "device_id": "1234",
+            "id_tags": [
+                "interface:eth0"
+            ],
+            "index": 1,
+			"name": "eth0",
+			"admin_status": 1,
+			"oper_status": 1,
+			"type": 6,
+			"is_physical": true
+        },
+        {
+            "device_id": "1234",
+            "id_tags": [
+                "interface:eth1"
+            ],
+            "index": 2,
+            "name": "eth1",
+			"admin_status": 1,
+			"oper_status": 1,
+			"type": 62,
+			"is_physical": true
+        },
+        {
+            "device_id": "1234",
+            "id_tags": [
+                "interface:lo"
+            ],
+            "index": 3,
+            "name": "lo",
+			"admin_status": 1,
+			"oper_status": 1,
+			"type": 24,
+			"is_physical": false
+        },
+        {
+            "device_id": "1234",
+            "id_tags": [
+                "interface:eth2"
+            ],
+            "index": 4,
+            "name": "eth2",
+			"admin_status": 1,
+			"oper_status": 1,
+			"type": 117,
+			"is_physical": true
+        }
+    ],
+    "collect_timestamp":1415792726
+}
+`)
+	compactEvent := new(bytes.Buffer)
+	err = json.Compact(compactEvent, event)
+	assert.NoError(t, err)
+
+	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
+}
+
+func Test_metricSender_reportNetworkDeviceMetadata_withInterfaceTypeZero(t *testing.T) {
+	// Test case when ifType is not collected (0) - is_physical should be nil (omitted from JSON)
+	var storeWithoutIfType = &valuestore.ResultValueStore{
+		ColumnValues: valuestore.ColumnResultValuesType{
+			"1.3.6.1.2.1.31.1.1.1.1": { // ifName
+				"1": valuestore.ResultValue{Value: "eth0"},
+			},
+			// No ifType values - simulating when type is not collected
+			"1.3.6.1.2.1.2.2.1.7": { // ifAdminStatus
+				"1": valuestore.ResultValue{Value: float64(1)},
+			},
+			"1.3.6.1.2.1.2.2.1.8": { // ifOperStatus
+				"1": valuestore.ResultValue{Value: float64(1)},
+			},
+		},
+	}
+	sender := mocksender.NewMockSender("testID")
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	ms := &MetricSender{
+		hostname: "test",
+		sender:   sender,
+	}
+
+	config := &checkconfig.CheckConfig{
+		IPAddress:          "1.2.3.4",
+		DeviceID:           "1234",
+		DeviceIDTags:       []string{"device_name:127.0.0.1"},
+		ResolvedSubnetName: "127.0.0.0/29",
+		Namespace:          "my-ns",
+	}
+	profile := profiledefinition.ProfileDefinition{
+		Metadata: profiledefinition.MetadataConfig{
+			"device": {
+				Fields: map[string]profiledefinition.MetadataField{
+					"type": {
+						Value: "switch",
+					},
+				},
+			},
+			"interface": {
+				Fields: map[string]profiledefinition.MetadataField{
+					"name": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.31.1.1.1.1",
+							Name: "ifName",
+						},
+					},
+					"admin_status": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.7",
+							Name: "ifAdminStatus",
+						},
+					},
+					"oper_status": {
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.2.2.1.8",
+							Name: "ifOperStatus",
+						},
+					},
+				},
+				IDTags: profiledefinition.MetricTagConfigList{
+					profiledefinition.MetricTagConfig{
+						Symbol: profiledefinition.SymbolConfigCompat{
+							OID:  "1.3.6.1.2.1.31.1.1.1.1",
+							Name: "interface",
+						},
+						Tag: "interface",
+					},
+				},
+			},
+		},
+	}
+
+	layout := "2006-01-02 15:04:05"
+	str := "2014-11-12 11:45:26"
+	collectTime, err := time.Parse(layout, str)
+	assert.NoError(t, err)
+	ms.ReportNetworkDeviceMetadata(config, profile, storeWithoutIfType, []string{"tag1", "tag2"}, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
+
+	// language=json
+	// Note: type and is_physical should be omitted when ifType is 0
+	event := []byte(`
+{
+    "subnet": "127.0.0.0/29",
+    "namespace": "my-ns",
+	"integration": "snmp",
+    "devices": [
+        {
+            "id": "1234",
+            "id_tags": [
+                "device_name:127.0.0.1"
+            ],
+            "tags": [
+                "tag1",
+                "tag2"
+            ],
+            "ip_address": "1.2.3.4",
+            "status":1,
+			"ping_status":1,
+            "subnet": "127.0.0.0/29",
+			"integration": "snmp",
+			"device_type": "switch"
+        }
+    ],
+    "interfaces": [
+        {
+            "device_id": "1234",
+            "id_tags": [
+                "interface:eth0"
+            ],
+            "index": 1,
+			"name": "eth0",
+			"admin_status": 1,
+			"oper_status": 1
+        }
+    ],
+    "collect_timestamp":1415792726
+}
+`)
+	compactEvent := new(bytes.Buffer)
+	err = json.Compact(compactEvent, event)
+	assert.NoError(t, err)
+
+	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
+}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -164,14 +164,14 @@ tags:
 				Value: 201,
 			},
 			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.1",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
+			},
+			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
 				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.7.1",
-				Type:  gosnmp.Integer,
-				Value: 1,
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.14.2",
@@ -189,14 +189,14 @@ tags:
 				Value: 202,
 			},
 			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.2",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
+			},
+			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
 				Type:  gosnmp.OctetString,
 				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o2},
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.7.2",
-				Type:  gosnmp.Integer,
-				Value: 3,
 			},
 		},
 	}
@@ -219,11 +219,20 @@ tags:
 				Name: "999",
 				Type: gosnmp.NoSuchObject,
 			},
+			{
+				Name: "999",
+				Type: gosnmp.NoSuchObject,
+			},
 		},
 	}
 
 	bulkBatch2Packet1 := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.2.2.1.7.1",
+				Type:  gosnmp.Integer,
+				Value: 1,
+			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.8.1",
 				Type:  gosnmp.Integer,
@@ -244,12 +253,12 @@ tags:
 				Type:  gosnmp.Integer,
 				Value: 1,
 			},
-			{
-				Name:  "1.3.6.1.2.1.4.20.1.3.10.0.0.1",
-				Type:  gosnmp.IPAddress,
-				Value: "255.255.255.0",
-			},
 
+			{
+				Name:  "1.3.6.1.2.1.2.2.1.7.2",
+				Type:  gosnmp.Integer,
+				Value: 3,
+			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.8.2",
 				Type:  gosnmp.Integer,
@@ -269,11 +278,6 @@ tags:
 				Name:  "1.3.6.1.2.1.4.20.1.2.10.0.0.2",
 				Type:  gosnmp.Integer,
 				Value: 1,
-			},
-			{
-				Name:  "1.3.6.1.2.1.4.20.1.3.10.0.0.2",
-				Type:  gosnmp.IPAddress,
-				Value: "255.255.255.0",
 			},
 		},
 	}
@@ -304,13 +308,40 @@ tags:
 		},
 	}
 
+	bulkBatch3Packet1 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.4.20.1.3.10.0.0.1",
+				Type:  gosnmp.IPAddress,
+				Value: "255.255.255.0",
+			},
+			{
+				Name:  "1.3.6.1.2.1.4.20.1.3.10.0.0.2",
+				Type:  gosnmp.IPAddress,
+				Value: "255.255.255.0",
+			},
+		},
+	}
+
+	bulkBatch3Packet2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			// no more matching oids for batch 3
+			{
+				Name: "999",
+				Type: gosnmp.NoSuchObject,
+			},
+		},
+	}
+
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet1, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2", "1.3.6.1.2.1.2.2.1.6.2", "1.3.6.1.2.1.2.2.1.7.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet2, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18", "1.3.6.1.2.1.4.20.1.2", "1.3.6.1.2.1.4.20.1.3"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch2Packet1, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.31.1.1.1.1.2", "1.3.6.1.2.1.31.1.1.1.18.2", "1.3.6.1.2.1.4.20.1.2.10.0.0.2", "1.3.6.1.2.1.4.20.1.3.10.0.0.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch2Packe2, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20", "1.3.6.1.2.1.2.2.1.3", "1.3.6.1.2.1.2.2.1.6"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet1, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2", "1.3.6.1.2.1.2.2.1.3.2", "1.3.6.1.2.1.2.2.1.6.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch1Packet2, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18", "1.3.6.1.2.1.4.20.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch2Packet1, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.7.2", "1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.31.1.1.1.1.2", "1.3.6.1.2.1.31.1.1.1.18.2", "1.3.6.1.2.1.4.20.1.2.10.0.0.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch2Packe2, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.4.20.1.3"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch3Packet1, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.4.20.1.3.10.0.0.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkBatch3Packet2, nil)
 
 	err = chk.Run()
 	assert.Nil(t, err)
@@ -1387,6 +1418,11 @@ tags:
 				Value: []byte("ifDescRow1"),
 			},
 			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.1",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
+			},
+			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
 				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
@@ -1426,6 +1462,11 @@ tags:
 				Name:  "1.3.6.1.2.1.2.2.1.2.2",
 				Type:  gosnmp.OctetString,
 				Value: []byte("ifDescRow2"),
+			},
+			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.2",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
@@ -1503,6 +1544,11 @@ tags:
 				Type:  gosnmp.Integer,
 				Value: 999,
 			},
+			{
+				Name:  "9", // exit table
+				Type:  gosnmp.Integer,
+				Value: 999,
+			},
 		},
 	}
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
@@ -1519,6 +1565,7 @@ tags:
 		// "1.3.6.1.2.1.2.2.1.13",
 		// "1.3.6.1.2.1.2.2.1.14",
 		"1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.3", // ifType
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
 		"1.3.6.1.2.1.2.2.1.8",
@@ -1579,7 +1626,9 @@ tags:
       "description": "ifDescRow1",
       "mac_address": "00:00:00:00:00:01",
       "admin_status": 1,
-      "oper_status": 1
+      "oper_status": 1,
+      "type": 6,
+      "is_physical": true
     },
     {
       "device_id": "default:1.2.3.4",
@@ -1590,7 +1639,9 @@ tags:
       "description": "ifDescRow2",
       "mac_address": "00:00:00:00:00:02",
       "admin_status": 1,
-      "oper_status": 1
+      "oper_status": 1,
+      "type": 6,
+      "is_physical": true
     }
   ],
   "ip_addresses": [
@@ -1753,6 +1804,7 @@ tags:
 }
 
 func TestDiscovery(t *testing.T) {
+	setupHostname(t)
 	mockConfig := configmock.New(t)
 	testDir := t.TempDir()
 	mockConfig.SetWithoutSource("run_path", testDir)
@@ -1843,6 +1895,11 @@ metric_tags:
 				Value: []byte("ifDescRow1"),
 			},
 			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.1",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
+			},
+			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
 				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
@@ -1882,6 +1939,11 @@ metric_tags:
 				Name:  "1.3.6.1.2.1.2.2.1.2.2",
 				Type:  gosnmp.OctetString,
 				Value: []byte("ifDescRow2"),
+			},
+			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.2",
+				Type:  gosnmp.Integer,
+				Value: 6, // ethernetCsmacd
 			},
 			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.2",
@@ -1964,17 +2026,13 @@ metric_tags:
 				Type:  gosnmp.Integer,
 				Value: 999,
 			},
-			{
-				Name:  "9", // exit table
-				Type:  gosnmp.Integer,
-				Value: 999,
-			},
 		},
 	}
 
 	sess.On("GetBulk", []string{
 		// "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1"
 		"1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.3", // ifType
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
 		"1.3.6.1.2.1.2.2.1.8",
@@ -2052,7 +2110,9 @@ metric_tags:
       "description": "ifDescRow1",
       "mac_address": "00:00:00:00:00:01",
       "admin_status": 1,
-      "oper_status": 1
+      "oper_status": 1,
+      "type": 6,
+      "is_physical": true
     },
     {
       "device_id": "%s",
@@ -2063,7 +2123,9 @@ metric_tags:
       "description": "ifDescRow2",
       "mac_address": "00:00:00:00:00:02",
       "admin_status": 1,
-      "oper_status": 1
+      "oper_status": 1,
+      "type": 6,
+      "is_physical": true
     }
   ],
   "ip_addresses": [
@@ -2250,6 +2312,11 @@ use_device_id_as_hostname: true
 					Value: []byte("ifDescRow1"),
 				},
 				{
+					Name:  "1.3.6.1.2.1.2.2.1.3.1",
+					Type:  gosnmp.Integer,
+					Value: 6, // ethernetCsmacd
+				},
+				{
 					Name:  "1.3.6.1.2.1.2.2.1.6.1",
 					Type:  gosnmp.OctetString,
 					Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
@@ -2263,11 +2330,6 @@ use_device_id_as_hostname: true
 					Name:  "1.3.6.1.2.1.2.2.1.8.1",
 					Type:  gosnmp.Integer,
 					Value: 1,
-				},
-				{
-					Name:  "1.3.6.1.2.1.31.1.1.1.1.1",
-					Type:  gosnmp.OctetString,
-					Value: []byte("nameRow1"),
 				},
 				{
 					Name:  "9", // exit table
@@ -2297,6 +2359,11 @@ use_device_id_as_hostname: true
 			},
 		}, {
 			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.1.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("nameRow1"),
+				},
 				{
 					Name:  "1.3.6.1.2.1.31.1.1.1.18.1",
 					Type:  gosnmp.OctetString,
@@ -2328,13 +2395,19 @@ use_device_id_as_hostname: true
 					Type:  gosnmp.Integer,
 					Value: 999,
 				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
 			},
 		},
 	}
 	sess.On("GetBulk", []string{
-		"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1",
+		"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.3", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8",
 	}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[0], nil)
 	sess.On("GetBulk", []string{
+		"1.3.6.1.2.1.31.1.1.1.1",
 		"1.3.6.1.2.1.31.1.1.1.18",
 		"1.3.6.1.2.1.4.20.1.2",
 		"1.3.6.1.2.1.4.20.1.3",
@@ -2464,6 +2537,11 @@ metrics:
 				Value: []byte("ifDescRow1"),
 			},
 			{
+				Name:  "1.3.6.1.2.1.2.2.1.3.1",
+				Type:  gosnmp.Integer,
+				Value: 6,
+			},
+			{
 				Name:  "1.3.6.1.2.1.2.2.1.6.1",
 				Type:  gosnmp.OctetString,
 				Value: []byte{0o0, 0o0, 0o0, 0o0, 0o0, 0o1},
@@ -2539,10 +2617,16 @@ metrics:
 				Type:  gosnmp.Integer,
 				Value: 999,
 			},
+			{
+				Name:  "9", // exit table
+				Type:  gosnmp.Integer,
+				Value: 999,
+			},
 		},
 	}
 	sess.On("GetBulk", []string{
 		"1.3.6.1.2.1.2.2.1.2",
+		"1.3.6.1.2.1.2.2.1.3",
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
 		"1.3.6.1.2.1.2.2.1.8",

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -130,6 +130,8 @@ type InterfaceMetadata struct {
 	MacAddress    string        `json:"mac_address,omitempty"`
 	AdminStatus   IfAdminStatus `json:"admin_status,omitempty"`   // IF-MIB ifAdminStatus type is INTEGER
 	OperStatus    IfOperStatus  `json:"oper_status,omitempty"`    // IF-MIB ifOperStatus type is INTEGER
+	Type          int32         `json:"type,omitempty"`           // IF-MIB ifType (RFC7224 IANAifType)
+	IsPhysical    *bool         `json:"is_physical,omitempty"`    // true for physical ethernet interface types (6, 62, 69, 117)
 	MerakiEnabled *bool         `json:"meraki_enabled,omitempty"` // enabled bool for Meraki devices, use a pointer to determine if the value was actually sent
 	MerakiStatus  string        `json:"meraki_status,omitempty"`  // status for Meraki devices
 }

--- a/pkg/networkdevice/profile/profiledefinition/validation.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation.go
@@ -33,6 +33,7 @@ var validMetadataResources = map[string]map[string]bool{
 		"mac_address":  true,
 		"admin_status": true,
 		"oper_status":  true,
+		"type":         true,
 	},
 }
 

--- a/releasenotes/notes/snmp-collect-type-and-is-physical-965950f836d25e5e.yaml
+++ b/releasenotes/notes/snmp-collect-type-and-is-physical-965950f836d25e5e.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    SNMP interface metadata now includes ``type`` (IF-MIB ifType) and ``is_physical`` fields.
+    The ``is_physical`` field is set to true for physical ethernet interface types
+    (ethernetCsmacd, fastEther, fastEtherFX, gigabitEthernet).


### PR DESCRIPTION
### Summary
Add `type` and `is_physical` fields to SNMP interface metadata.

  - `type`: IF-MIB ifType value (OID 1.3.6.1.2.1.2.2.1.3)
  - `is_physical`: true for physical ethernet types (6, 62, 69, 117), false otherwise, nil if type not collected

NDMC-191