### PR TITLE
Fix GitHub Actions output issue

### DIFF
--- a/.github/workflows/update-kubernetes-versions.yml
+++ b/.github/workflows/update-kubernetes-versions.yml
@@ -117,7 +117,8 @@ jobs:
             [ -n "$digest" ] || { echo "Error: Could not get digest for $tag"; exit 1; }
 
             # Append the digest into the new versions JSON
-            new_versions=$(jq --arg tag "$tag" --arg digest "$digest" '.[$tag].digest = $digest' <<< "$new_versions")
+            # Must use the -c option (compact) to keep the jq output to a single-line
+            new_versions=$(jq -c --arg tag "$tag" --arg digest "$digest" '.[$tag].digest = $digest' <<< "$new_versions")
           done
 
           echo "new_versions=$new_versions" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What does this PR do?
Fixes `Error: Unable to process file command 'output' successfully.` error by compacting the `jq` output to one-line.

### Motivation
[Setting output parameters](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-output-parameter) only supports single lines. 

### Describe how you validated your changes
```bash
❯ digest=sha256:ba87b83a00fbbef5bbba3b438e2a6f1f144dded48d43c45c7499829d100a242e
❯ new_versions='{"v1.35.0-rc.1": {"tag": "v1.35.0-rc.1", "rc": true}}'
❯ tag=v1.35.0-rc.1
❯ new_versions=$(jq -c --arg tag "$tag" --arg digest "$digest" '.[$tag].digest = $digest' <<< "$new_versions")
❯ echo $new_versions
{"v1.35.0-rc.1":{"tag":"v1.35.0-rc.1","rc":true,"digest":"sha256:ba87b83a00fbbef5bbba3b438e2a6f1f144dded48d43c45c7499829d100a242e"}}
```

### Additional Notes
Alternatively, [multiline strings are supported](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#multiline-strings).
