### PR TITLE
feat(cla): Prevent PR locking

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -39,3 +39,4 @@ jobs:
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
           allowlist: "*[bot]"
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
### What does this PR do?
Prevent the lock of PRs by the CLA action. Waiting for a fine-graine lock on a future version of the contributor-assistant action

### Motivation
Locked PR is preventing comments by backport workflow and cross PR reference

### Describe how you validated your changes
n/a this is a pure configuration change. The option is referenced [here](https://github.com/contributor-assistant/github-action/blob/master/README.md?plain=1#L140) 

### Additional Notes
