### PR TITLE
feat(chainguard): Add new policy for label addition

### DIFF
--- a/.github/chainguard/self.add-labels-pr.label-pr.sts.yaml
+++ b/.github/chainguard/self.add-labels-pr.label-pr.sts.yaml
@@ -1,0 +1,13 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:pull_request
+
+claim_pattern:
+  event_name: (pull_request|pull_request_target)
+  ref: refs/(pull/[0-9]+/merge|heads/main)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/(add-label-pr|add-label-community-pr)\.yml@refs/(pull/[0-9]+/merge|heads/main)
+
+permissions:
+  contents: read
+  pull_requests: write


### PR DESCRIPTION
### What does this PR do?
Add a new chainguard for label addition, cf PR #45330 

### Motivation
Use a token for label-addition action. As a consequence the actions triggering on `labeled` event can trigger without the need of `workflow_run`

### Describe how you validated your change
Need to merge before triggering the workflow

### Additional Notes
