### PR TITLE
e2e: bump agent helm version to 3.164.1

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	HelmVersion = "3.155.1"
+	HelmVersion = "3.164.1"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
