### PR TITLE
Add golden test files updater

### DIFF
--- a/tasks/full_host_profiler.py
+++ b/tasks/full_host_profiler.py
@@ -55,3 +55,16 @@ def build(ctx):
         "./cmd/host-profiler/dist/host-profiler-config.yaml",
         os.path.join(dist_folder, "full-host-profiler-config.yaml"),
     )
+
+
+@task
+def update_golden_tests(ctx):
+    """
+    Update golden test files for host-profiler converters
+    """
+    print("Updating golden test files...")
+
+    with ctx.cd("comp/host-profiler/collector/impl/converters"):
+        ctx.run("go test -tags test -update")
+
+    print("Golden test files updated successfully!")


### PR DESCRIPTION
### What does this PR do?

Adds a `update` task to dda in order to be able to easily enrich the expected output of every test.
From repo root:
```bash
dda inv full-host-profiler.update-golden-tests
```

### Motivation

Since the converter of the host profiler keeps changing, this allows for easily modifying every expected test output files to account for new converter features.
ie. https://github.com/DataDog/datadog-agent/pull/45441

### Describe how you validated your changes

### Additional Notes
This was the solution that made the most sense to me, but I would appreciate any suggestions!