### PR TITLE
[BARX-1605] Unpin dd_pkg version to latest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ variables:
   DDA_FEATURE_FLAGS_CI_VAULT_KEY: token
   DDA_FEATURE_FLAGS_CI_VAULT_PATH: k8s/gitlab-runner-datadog-agent/datadog-agent/$DDA_CLIENT_TOKEN
 
-  DD_PKG_VERSION: "0.6.0-beta.4"
+  DD_PKG_VERSION: "latest"
   DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 

--- a/tasks/unit_tests/testdata/variables.yml
+++ b/tasks/unit_tests/testdata/variables.yml
@@ -171,7 +171,7 @@ variables:
   SLACK_AGENT: slack-agent-ci  # agent-devx
   # End vault variables
 
-  DD_PKG_VERSION: "0.6.0-beta.4"
+  DD_PKG_VERSION: "latest"
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)
   ARTIFACT_DOWNLOAD_ATTEMPTS: 2


### PR DESCRIPTION
## Summary
Updates `DD_PKG_VERSION` from `0.6.0-beta.4` to `latest` to ensure CI uses the most recent version of dd-pkg tooling.

## Changes
- Updated `DD_PKG_VERSION` in `.gitlab-ci.yml`
- Updated `DD_PKG_VERSION` in `tasks/unit_tests/testdata/variables.yml`

## Test plan
- CI should pass with the latest dd-pkg version