### PR TITLE
host-profiler: update the opentelemetry-ebpf-profiler to pull fixes

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -97,6 +97,9 @@ func defaultConfig() component.Config {
 	cfg.Tracers = getDefaultTracersString()
 	// 60s batches more samples per report, improving compression and reducing upload bandwidth
 	cfg.ReporterInterval = 60 * time.Second
+	// Default jitter is 20%, which makes sense for 5s intervals (~1s variation).
+	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
+	cfg.ReporterJitter = 0.05
 
 	return Config{
 		EbpfCollectorConfig: cfg,

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace (
 	// To update the Datadog/opentelemetry-ebpf-profiler dependency on latest commit on datadog branch, change the following line to:
 	// replace go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler datadog
 	// and run `go mod tidy`
-	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20251209111023-a403a55f78da
+	go.opentelemetry.io/ebpf-profiler => github.com/DataDog/opentelemetry-ebpf-profiler v0.0.202602-0.20260130121113-9fabd54fb605
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/DataDog/nikos v1.12.12 h1:72YrdzMeQT3wcXIDgiS1ClU53SzUdR7uAbp5FSSpo5k
 github.com/DataDog/nikos v1.12.12/go.mod h1:kZGOhfE76+nXS7V5PAlIw3MRxWKM70ynET4VeuZ4U4k=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816 h1:8diKw2aLYE6LsjWfYxDEqx0ZmcyMMmqB+qapRJrGtys=
 github.com/DataDog/opa v0.0.0-20251126100856-d2e1e78e0816/go.mod h1:7cPuErOAt7k/oVWAVJnxqAC6mwArrAazkvk0RXiih2A=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20251209111023-a403a55f78da h1:ZBmMIv7/Xqdmw6WSs4lRXF75TOQCrnQdvnL5k8uk/t8=
-github.com/DataDog/opentelemetry-ebpf-profiler v0.0.0-20251209111023-a403a55f78da/go.mod h1:6Y2/ixrHEY2qmt0eJVdG6pP7CPb9p5ypxnKj2t3kPJU=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.202602-0.20260130121113-9fabd54fb605 h1:C3c2EoKJ9cl6r4vka0LBC9pSSHUOE28dvFSlaQIC5qs=
+github.com/DataDog/opentelemetry-ebpf-profiler v0.0.202602-0.20260130121113-9fabd54fb605/go.mod h1:6Y2/ixrHEY2qmt0eJVdG6pP7CPb9p5ypxnKj2t3kPJU=
 github.com/DataDog/sketches-go v1.4.7 h1:eHs5/0i2Sdf20Zkj0udVFWuCrXGRFig2Dcfm5rtcTxc=
 github.com/DataDog/sketches-go v1.4.7/go.mod h1:eAmQ/EBmtSO+nQp7IZMZVRPT4BQTmIc5RZQ+deGlTPM=
 github.com/DataDog/trivy v0.0.0-20251216175138-81422df93657 h1:UuMA1oxXCY6cVoVIGLYNU18YDchvxS3n57PjGysxxPg=


### PR DESCRIPTION
### What does this PR do?

update the version used of the opentelemetry-ebpf-profiler to pull fixes

### Motivation

this should fix:
- the reporter jitter should be 5% instead of 20%
- the profile durations should align with wall clock time and report interval instead of the timestamps of the samples

### Describe how you validated your changes

Tested locally everything works as expected.

### Additional Notes
