### PR TITLE
[BARX-1587] Backport artifact-gateway support to 7.68.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -250,6 +250,7 @@ variables:
   # End vault variables
 
   DD_PKG_VERSION: "latest"
+  DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job stage attempts (see https://docs.gitlab.com/ee/ci/runners/configure_runners.html#job-stages-attempts)

--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -17,6 +17,8 @@
     - !reference [.setup_dd_pkg]
     - RELEASE_VERSION="$(dda inv agent.version --url-safe --omnibus-format)-1" || exit $?; export RELEASE_VERSION
     - GITLAB_TOKEN="$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api)" || exit $?; export GITLAB_TOKEN
+    - |
+      echo "Using artifact gateway: $DD_PKG_GITLAB_URL"
     - |-
       dd-pkg promote \
         --build-pipeline-id $CI_PIPELINE_ID \

--- a/.gitlab/trigger_release/installer.yml
+++ b/.gitlab/trigger_release/installer.yml
@@ -19,6 +19,8 @@
     - !reference [.setup_dd_pkg]
     - RELEASE_VERSION="$(dda inv agent.version --url-safe --omnibus-format)-1" || exit $?; export RELEASE_VERSION
     - GITLAB_TOKEN="$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api)" || exit $?; export GITLAB_TOKEN
+    - |
+      echo "Using artifact gateway: $DD_PKG_GITLAB_URL"
     - |-
       dd-pkg promote \
         --build-pipeline-id $CI_PIPELINE_ID \


### PR DESCRIPTION
### What does this PR do?

Backports artifact-gateway support to the 7.68.x release branch by adding the `DD_PKG_GITLAB_URL` environment variable.

### Changes

- Add `DD_PKG_GITLAB_URL` variable to `.gitlab-ci.yml` pointing to prod artifact gateway
- Update trigger_release scripts to log the artifact gateway URL being used

### Additional Notes

This is a minimal backport that only adds the URL configuration without other unrelated changes from main.