### PR TITLE
[CWS] Report `field` field of hash action in `ruleset_loaded` event

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -219,7 +219,8 @@ type RuleAction struct {
 // HashAction is used to report 'hash' action
 // easyjson:json
 type HashAction struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+	Field   string `json:"field,omitempty"`
 }
 
 // RuleSetAction is used to report 'set' action
@@ -357,6 +358,7 @@ func RuleStateFromRule(rule *rules.PolicyRule, policy *rules.PolicyInfo, status 
 		case action.Def.Hash != nil:
 			ruleAction.Hash = &HashAction{
 				Enabled: true,
+				Field:   action.Def.Hash.Field,
 			}
 		case action.Def.CoreDump != nil:
 			ruleAction.CoreDump = &CoreDumpAction{

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -2320,6 +2320,12 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10
 			} else {
 				out.Enabled = bool(in.Bool())
 			}
+		case "field":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Field = string(in.String())
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2339,6 +2345,16 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor10
 		first = false
 		out.RawString(prefix[1:])
 		out.Bool(bool(in.Enabled))
+	}
+	if in.Field != "" {
+		const prefix string = ",\"field\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Field))
 	}
 	out.RawByte('}')
 }


### PR DESCRIPTION
### What does this PR do?

Make it so the field named `field` of hash actions is reported in `ruleset_loaded` events.

### Motivation

Keep `ruleset_loaded` event up to date with rule and policy data model. 

### Describe how you validated your changes

### Additional Notes
