### PR TITLE
[BARX-1592] Backport artifact-gateway support to 7.73.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,6 +242,7 @@ variables:
   # End vault variables
 
   DD_PKG_VERSION: "latest"
+  DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 
   # Job cloning strategy

--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -16,6 +16,9 @@
   script:
     - !reference [.setup_dd_pkg]
     - RELEASE_VERSION="$(dda inv agent.version --url-safe --omnibus-format --pipeline-id $PARENT_PIPELINE_ID)-1" || exit $?; export RELEASE_VERSION
+
+    - |
+      echo "Using artifact gateway: $DD_PKG_GITLAB_URL"
     - |-
       dd-pkg promote \
         --build-pipeline-id $PARENT_PIPELINE_ID \

--- a/.gitlab/trigger_release/installer.yml
+++ b/.gitlab/trigger_release/installer.yml
@@ -18,6 +18,9 @@
   script:
     - !reference [.setup_dd_pkg]
     - RELEASE_VERSION="$(dda inv agent.version --url-safe --omnibus-format --pipeline-id $PARENT_PIPELINE_ID)-1" || exit $?; export RELEASE_VERSION
+
+    - |
+      echo "Using artifact gateway: $DD_PKG_GITLAB_URL"
     - |-
       dd-pkg promote \
         --build-pipeline-id $PARENT_PIPELINE_ID \


### PR DESCRIPTION
### What does this PR do?

Backports artifact-gateway support to the 7.73.x release branch by adding the `DD_PKG_GITLAB_URL` environment variable.

### Changes

- Add `DD_PKG_GITLAB_URL` variable to `.gitlab-ci.yml` pointing to prod artifact gateway
- Update trigger_release scripts to log the artifact gateway URL being used

### Additional Notes

This is a minimal backport that only adds the URL configuration without other unrelated changes from main.