### PR TITLE
[BARX-1597] Backport artifact-gateway support to 7.75.x

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -249,7 +249,6 @@ variables:
   DDA_FEATURE_FLAGS_CI_VAULT_KEY: token
   DDA_FEATURE_FLAGS_CI_VAULT_PATH: k8s/gitlab-runner-datadog-agent/datadog-agent/$DDA_CLIENT_TOKEN
 
-  DD_PKG_VERSION: "0.6.0-beta.4"
   DD_PKG_VERSION: "latest"
   DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -250,6 +250,7 @@ variables:
   DDA_FEATURE_FLAGS_CI_VAULT_PATH: k8s/gitlab-runner-datadog-agent/datadog-agent/$DDA_CLIENT_TOKEN
 
   DD_PKG_VERSION: "0.6.0-beta.4"
+  DD_PKG_VERSION: "latest"
   DD_PKG_GITLAB_URL: "https://artifact-gateway.us1.ddbuild.io/internal/artifact-gateway/api/v4"
   PIPELINE_KEY_ALIAS: "alias/ci_datadog-agent_pipeline-key"
 


### PR DESCRIPTION
## Summary
Updates `DD_PKG_VERSION` from `0.6.0-beta.4` to `latest` to ensure CI uses the most recent version of dd-pkg tooling.

## Changes
- Updated `DD_PKG_VERSION` in `.gitlab-ci.yml`

## Test plan
- CI should pass with the latest dd-pkg version