### PR TITLE
[CWS] fix enablement check in security agent (related to direct sender)

### DIFF
--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -278,7 +278,12 @@ func RunAgent(log log.Component, config config.Component, secrets secrets.Compon
 	complianceRunInSystemProbe := config.GetBool("compliance_config.run_in_system_probe")
 	securityAgentShouldRunCompliance := complianceEnabled && !complianceRunInSystemProbe
 
-	if !securityAgentShouldRunCompliance && !config.GetBool("runtime_security_config.enabled") {
+	// Check if security-agent should run CWS (runtime security)
+	cwsEnabled := config.GetBool("runtime_security_config.enabled")
+	cwsDirectSendFromSystemProbe := config.GetBool("runtime_security_config.direct_send_from_system_probe")
+	securityAgentShouldRunCWS := cwsEnabled && !cwsDirectSendFromSystemProbe
+
+	if !securityAgentShouldRunCompliance && !securityAgentShouldRunCWS {
 		log.Infof("All security-agent components are deactivated, exiting")
 
 		// A sleep is necessary so that sysV doesn't think the agent has failed


### PR DESCRIPTION
### What does this PR do?

From the point of view of the security agent, CWS being enabled but in direct sender mode is equivalent to CWS being disabled. As such we should not run the security agent in this mode. This PR fixes the enablement check to respect this fact.

### Motivation

### Describe how you validated your changes

### Additional Notes
