### PR TITLE
chore: Remove KubeAPIServer Build Tag from Trace Agent

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -230,7 +230,6 @@ TRACE_AGENT_TAGS = {
     "docker",
     "containerd",
     "datadog.no_waf",
-    "kubeapiserver",
     "kubelet",
     "otlp",
     "netcgo",


### PR DESCRIPTION
### What does this PR do?

Removes the `kubeapiserver` build tag from the trace-agent build

### Motivation

In order to use the `kubeapiserver` build tag effectively, the tag must be removed from the trace-agent to avoid all of the k8s related dependencies from being pulled in. Any k8s related feature should be abstract away through remote implementations of workloadmeta/tagger that get processed in the core agent.

### Describe how you validated your changes

CI

### Additional Notes

Determine to reasoning behind the Kube API Server build tag in the trace-agent.