### PR TITLE
fix `test/regression/**/*` path when detecting SMP needing changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,7 +357,7 @@ variables:
     - MODULE.bazel
     - release.json
     # SMP regression detector experiments
-    - test/regression/**
+    - test/regression/**/*
 
 .if_coverage_pipeline: &if_coverage_pipeline
   if: $E2E_COVERAGE_PIPELINE == "true"


### PR DESCRIPTION
### What does this PR do?

`test/regression/**` doesn't work, and is not consistent with the other paths in the same detection list. Let's use `**/*` instead.

### Motivation

### Describe how you validated your changes

### Additional Notes
