### PR TITLE
[PROF-13470] Add metadata tags to resource attributes

### DIFF
--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -30,7 +30,8 @@ processors:
           enabled: false
 
 exporters:
-  debug: {}
+  debug:
+    verbosity: detailed
   otlphttp/metrics:
     metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
     headers:

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -30,8 +30,7 @@ processors:
           enabled: false
 
 exporters:
-  debug:
-    verbosity: detailed
+  debug: {}
   otlphttp/metrics:
     metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
     headers:

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -330,6 +330,11 @@ func TestConverterWithAgentErrors(t *testing.T) {
 			provided:      "agent/nonstr-proc-pipeline/in.yaml",
 			expectedError: "processor name must be a string",
 		},
+		{
+			name:          "reserved-processor-already-exists",
+			provided:      "agent/reserved-proc-exists/in.yaml",
+			expectedError: "reserved resource processor name",
+		},
 	}
 
 	mockCfg := newMockConfig()
@@ -480,6 +485,11 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 			name:          "converter-error-propagation-from-ensure",
 			provided:      "no_agent/conv-err-from-ensure/in.yaml",
 			expectedError: "path element \"pipelines\" is not a map",
+		},
+		{
+			name:          "reserved-processor-already-exists",
+			provided:      "no_agent/reserved-proc-exists/in.yaml",
+			expectedError: "reserved resource processor name",
 		},
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v3"
@@ -53,6 +54,13 @@ func (m *mockConfig) GetStringMapStringSlice(key string) map[string][]string {
 		}
 	}
 	return map[string][]string{}
+}
+
+const testVersion = "7.0.0-test"
+
+func init() {
+	// Override version for tests to ensure golden files are version-independent
+	version.AgentVersion = testVersion
 }
 
 // converter is an interface that both converterWithAgent and converterWithoutAgent implement

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -335,6 +335,16 @@ func TestConverterWithAgentErrors(t *testing.T) {
 			provided:      "agent/reserved-proc-exists/in.yaml",
 			expectedError: "reserved resource processor name",
 		},
+		{
+			name:          "reserved-processor-in-pipeline-not-defined",
+			provided:      "agent/reserved-proc-in-pipeline/in.yaml",
+			expectedError: "reserved resource processor name",
+		},
+		{
+			name:          "reserved-processor-empty",
+			provided:      "agent/reserved-proc-empty/in.yaml",
+			expectedError: "reserved resource processor name",
+		},
 	}
 
 	mockCfg := newMockConfig()
@@ -489,6 +499,16 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 		{
 			name:          "reserved-processor-already-exists",
 			provided:      "no_agent/reserved-proc-exists/in.yaml",
+			expectedError: "reserved resource processor name",
+		},
+		{
+			name:          "reserved-processor-in-pipeline-not-defined",
+			provided:      "no_agent/reserved-proc-in-pipeline/in.yaml",
+			expectedError: "reserved resource processor name",
+		},
+		{
+			name:          "reserved-processor-empty",
+			provided:      "no_agent/reserved-proc-empty/in.yaml",
 			expectedError: "reserved resource processor name",
 		},
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v3"
@@ -60,7 +60,7 @@ const testVersion = "7.0.0-test"
 
 func init() {
 	// Override version for tests to ensure golden files are version-independent
-	version.AgentVersion = testVersion
+	version.ProfilerVersion = testVersion
 }
 
 // converter is an interface that both converterWithAgent and converterWithoutAgent implement

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -162,6 +162,10 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 		return err
 	}
 
+	if err := addProfilerMetadataTags(confStringMap); err != nil {
+		return err
+	}
+
 	*conf = *confmap.NewFromStringMap(confStringMap)
 	return nil
 }

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -146,6 +146,11 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 	if err != nil {
 		return err
 	}
+	newProcessorNames, err = addProfilerMetadataTags(confStringMap, newProcessorNames)
+	if err != nil {
+		return err
+	}
+
 	profilesPipeline["processors"] = newProcessorNames
 
 	// Ensures at least one hostprofiler is used & configured
@@ -159,10 +164,6 @@ func (c *converterWithAgent) Convert(_ context.Context, conf *confmap.Conf) erro
 	// Go through every configured processors to make sure there are no resourcedetections declared that were not in the
 	// pipeline
 	if err := c.ensureGlobalProcessors(confStringMap); err != nil {
-		return err
-	}
-
-	if err := addProfilerMetadataTags(confStringMap); err != nil {
 		return err
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -117,6 +117,10 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
+	if err := addProfilerMetadataTags(confStringMap); err != nil {
+		return err
+	}
+
 	*conf = *confmap.NewFromStringMap(confStringMap)
 	return nil
 }

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -91,6 +91,10 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 	if err != nil {
 		return err
 	}
+	newProcessorNames, err = addProfilerMetadataTags(confStringMap, newProcessorNames)
+	if err != nil {
+		return err
+	}
 	profilesPipeline["processors"] = newProcessorNames
 
 	// Ensures at least one hostprofiler is used & configured
@@ -114,10 +118,6 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 
 	// infraattributes processor can also be used in metrics pipeline
 	if err := c.ensureMetricsPipeline(confStringMap); err != nil {
-		return err
-	}
-
-	if err := addProfilerMetadataTags(confStringMap); err != nil {
 		return err
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -314,7 +314,7 @@ func addProfilerMetadataTags(conf confMap) error {
 
 	profilerNameElement := confMap{
 		"key":    "profiler_name",
-		"value":  "host_profiler",
+		"value":  "host-profiler",
 		"action": "upsert",
 	}
 	profilerVersionElement := confMap{

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -9,11 +9,13 @@
 package converters
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -190,4 +192,150 @@ func ensureKeyStringValue(config confMap, key string) bool {
 		log.Warnf("API key %s has unexpected type %T, cannot convert", key, val)
 		return false
 	}
+}
+
+// fixReceiversPipeline ensures at least one hostprofiler receiver is configured in the pipeline
+// If none exists, it adds a minimal hostprofiler receiver with symbol_uploader disabled
+// warnFunc is called if a default hostprofiler is added
+func fixReceiversPipeline(conf confMap, receiverNames []any, warnFunc func(...any)) ([]any, error) {
+	// Check if hostprofiler is in the pipeline
+	hasHostProfiler := false
+	for _, nameAny := range receiverNames {
+		name, ok := nameAny.(string)
+		if !ok {
+			return nil, fmt.Errorf("receiver name must be a string, got %T", nameAny)
+		}
+
+		if !isComponentType(name, componentTypeHostProfiler) {
+			continue
+		}
+
+		hasHostProfiler = true
+
+		if hostProfilerConfig, ok := Get[confMap](conf, "receivers::"+name); ok {
+			if err := checkHostProfilerReceiverConfig(hostProfilerConfig); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if hasHostProfiler {
+		return receiverNames, nil
+	}
+
+	// Ensure default config exists if hostprofiler receiver is not configured
+	if err := Set(conf, "receivers::"+defaultHostProfilerName+"::"+pathSymbolUploaderEnabled, false); err != nil {
+		return nil, err
+	}
+
+	warnFunc("Added minimal hostprofiler receiver to user configuration")
+	return append(receiverNames, defaultHostProfilerName), nil
+}
+
+// checkHostProfilerReceiverConfig validates and normalizes hostprofiler receiver configuration
+// It ensures that if symbol_uploader is enabled, symbol_endpoints is properly configured
+// and all api_key/app_key values are strings
+func checkHostProfilerReceiverConfig(hostProfiler confMap) error {
+	if isEnabled, ok := Get[bool](hostProfiler, pathSymbolUploaderEnabled); !ok || !isEnabled {
+		return nil
+	}
+
+	endpoints, ok := Get[[]any](hostProfiler, pathSymbolEndpoints)
+
+	if !ok {
+		return errors.New("symbol_endpoints must be a list")
+	}
+
+	if len(endpoints) == 0 {
+		return errors.New("symbol_endpoints cannot be empty when symbol_uploader is enabled")
+	}
+
+	for _, epAny := range endpoints {
+		if ep, ok := epAny.(confMap); ok {
+			ensureKeyStringValue(ep, fieldAPIKey)
+			ensureKeyStringValue(ep, fieldAppKey)
+		}
+	}
+	return nil
+}
+
+func ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
+	// for each otlphttpexporter used, check if necessary api key is present
+	hasOtlpHTTP := false
+	for _, nameAny := range exporterNames {
+		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
+			hasOtlpHTTP = true
+
+			headers, err := Ensure[confMap](conf, "exporters::"+name+"::headers")
+			if err != nil {
+				return err
+			}
+
+			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
+				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
+			}
+		}
+	}
+
+	if !hasOtlpHTTP {
+		return errors.New("no otlphttp exporter configured in profiles pipeline")
+	}
+
+	return nil
+}
+
+var (
+	profilerNameResourceProcessorElement = confMap{
+		"key":    "profiler_name",
+		"value":  "host_profiler",
+		"action": "upsert",
+	}
+	profilerVersionResourceProcessorElement = confMap{
+		"key":    "profiler_version",
+		"value":  version.AgentPackageVersion,
+		"action": "upsert",
+	}
+)
+
+func addProfilerMetadataTags(conf confMap) error {
+	processors, err := Ensure[[]any](conf, "service::pipelines::profiles::processors")
+	if err != nil {
+		return err
+	}
+
+	resourceProcessorName := "resource/default"
+	isResourceProcessorInPipeline := false
+	for _, processorAny := range processors {
+		// by that point, processors pipeline has been verified to be only strings
+		processor := processorAny.(string)
+		if isComponentType(processor, "resource") {
+			resourceProcessorName = processor
+			isResourceProcessorInPipeline = true
+			break
+		}
+	}
+
+	resourceProcessor, err := Ensure[confMap](conf, "processors::"+resourceProcessorName)
+	if err != nil {
+		return err
+	}
+
+	attributes, err := Ensure[[]any](resourceProcessor, "attributes")
+	if err != nil {
+		return err
+	}
+	attributes = append(attributes, profilerNameResourceProcessorElement)
+	attributes = append(attributes, profilerVersionResourceProcessorElement)
+	if err := Set(resourceProcessor, "attributes", attributes); err != nil {
+		return err
+	}
+
+	if !isResourceProcessorInPipeline {
+		processors = append(processors, resourceProcessorName)
+		if err := Set(conf, "service::pipelines::profiles::processors", processors); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -196,7 +196,7 @@ func ensureKeyStringValue(config confMap, key string) bool {
 // addProfilerMetadataTags always creates a dedicated resource/profiler-metadata processor
 // without searching for existing resource processors.
 func addProfilerMetadataTags(conf confMap) error {
-	const resourceProcessorName = "resource/profiler-metadata"
+	const resourceProcessorName = "resource/dd-profiler-internal-metadata"
 
 	resourceProcessor, err := Ensure[confMap](conf, "processors::"+resourceProcessorName)
 	if err != nil {
@@ -224,7 +224,6 @@ func addProfilerMetadataTags(conf confMap) error {
 
 	attributes = append(attributes, profilerNameElement)
 	attributes = append(attributes, profilerVersionElement)
-	resourceProcessor["attributes"] = attributes
 	if err := Set(resourceProcessor, "attributes", attributes); err != nil {
 		return err
 	}

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -284,19 +284,6 @@ func ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
 	return nil
 }
 
-var (
-	profilerNameResourceProcessorElement = confMap{
-		"key":    "profiler_name",
-		"value":  "host_profiler",
-		"action": "upsert",
-	}
-	profilerVersionResourceProcessorElement = confMap{
-		"key":    "profiler_version",
-		"value":  version.AgentPackageVersion,
-		"action": "upsert",
-	}
-)
-
 func addProfilerMetadataTags(conf confMap) error {
 	processors, err := Ensure[[]any](conf, "service::pipelines::profiles::processors")
 	if err != nil {
@@ -324,8 +311,20 @@ func addProfilerMetadataTags(conf confMap) error {
 	if err != nil {
 		return err
 	}
-	attributes = append(attributes, profilerNameResourceProcessorElement)
-	attributes = append(attributes, profilerVersionResourceProcessorElement)
+
+	profilerNameElement := confMap{
+		"key":    "profiler_name",
+		"value":  "host_profiler",
+		"action": "upsert",
+	}
+	profilerVersionElement := confMap{
+		"key":    "profiler_version",
+		"value":  version.AgentPackageVersion,
+		"action": "upsert",
+	}
+
+	attributes = append(attributes, profilerNameElement)
+	attributes = append(attributes, profilerVersionElement)
 	if err := Set(resourceProcessor, "attributes", attributes); err != nil {
 		return err
 	}

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -203,12 +203,12 @@ func addProfilerMetadataTags(conf confMap) error {
 		return err
 	}
 
+	if len(resourceProcessor) != 0 {
+		return fmt.Errorf("%s is a reserved resource processor name. Please change it in your configuration file", resourceProcessorName)
+	}
 	attributes, err := Ensure[[]any](resourceProcessor, "attributes")
 	if err != nil {
 		return err
-	}
-	if len(attributes) != 0 {
-		log.Warnf("%s already exists! appending profiler_name and profiler_version", resourceProcessorName)
 	}
 
 	profilerNameElement := confMap{

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -290,7 +290,7 @@ func addProfilerMetadataTags(conf confMap) error {
 		return err
 	}
 
-	resourceProcessorName := "resource/default"
+	resourceProcessorName := "resource/host-profiler-default"
 	isResourceProcessorInPipeline := false
 	for _, processorAny := range processors {
 		// by that point, processors pipeline has been verified to be only strings

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -319,7 +319,7 @@ func addProfilerMetadataTags(conf confMap) error {
 	}
 	profilerVersionElement := confMap{
 		"key":    "profiler_version",
-		"value":  version.AgentPackageVersion,
+		"value":  version.AgentVersion,
 		"action": "upsert",
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -9,13 +9,12 @@
 package converters
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -194,96 +193,6 @@ func ensureKeyStringValue(config confMap, key string) bool {
 	}
 }
 
-// fixReceiversPipeline ensures at least one hostprofiler receiver is configured in the pipeline
-// If none exists, it adds a minimal hostprofiler receiver with symbol_uploader disabled
-// warnFunc is called if a default hostprofiler is added
-func fixReceiversPipeline(conf confMap, receiverNames []any, warnFunc func(...any)) ([]any, error) {
-	// Check if hostprofiler is in the pipeline
-	hasHostProfiler := false
-	for _, nameAny := range receiverNames {
-		name, ok := nameAny.(string)
-		if !ok {
-			return nil, fmt.Errorf("receiver name must be a string, got %T", nameAny)
-		}
-
-		if !isComponentType(name, componentTypeHostProfiler) {
-			continue
-		}
-
-		hasHostProfiler = true
-
-		if hostProfilerConfig, ok := Get[confMap](conf, "receivers::"+name); ok {
-			if err := checkHostProfilerReceiverConfig(hostProfilerConfig); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	if hasHostProfiler {
-		return receiverNames, nil
-	}
-
-	// Ensure default config exists if hostprofiler receiver is not configured
-	if err := Set(conf, "receivers::"+defaultHostProfilerName+"::"+pathSymbolUploaderEnabled, false); err != nil {
-		return nil, err
-	}
-
-	warnFunc("Added minimal hostprofiler receiver to user configuration")
-	return append(receiverNames, defaultHostProfilerName), nil
-}
-
-// checkHostProfilerReceiverConfig validates and normalizes hostprofiler receiver configuration
-// It ensures that if symbol_uploader is enabled, symbol_endpoints is properly configured
-// and all api_key/app_key values are strings
-func checkHostProfilerReceiverConfig(hostProfiler confMap) error {
-	if isEnabled, ok := Get[bool](hostProfiler, pathSymbolUploaderEnabled); !ok || !isEnabled {
-		return nil
-	}
-
-	endpoints, ok := Get[[]any](hostProfiler, pathSymbolEndpoints)
-
-	if !ok {
-		return errors.New("symbol_endpoints must be a list")
-	}
-
-	if len(endpoints) == 0 {
-		return errors.New("symbol_endpoints cannot be empty when symbol_uploader is enabled")
-	}
-
-	for _, epAny := range endpoints {
-		if ep, ok := epAny.(confMap); ok {
-			ensureKeyStringValue(ep, fieldAPIKey)
-			ensureKeyStringValue(ep, fieldAppKey)
-		}
-	}
-	return nil
-}
-
-func ensureOtlpHTTPExporterConfig(conf confMap, exporterNames []any) error {
-	// for each otlphttpexporter used, check if necessary api key is present
-	hasOtlpHTTP := false
-	for _, nameAny := range exporterNames {
-		if name, ok := nameAny.(string); ok && isComponentType(name, componentTypeOtlpHTTP) {
-			hasOtlpHTTP = true
-
-			headers, err := Ensure[confMap](conf, "exporters::"+name+"::headers")
-			if err != nil {
-				return err
-			}
-
-			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
-				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
-			}
-		}
-	}
-
-	if !hasOtlpHTTP {
-		return errors.New("no otlphttp exporter configured in profiles pipeline")
-	}
-
-	return nil
-}
-
 // addProfilerMetadataTags always creates a dedicated resource/profiler-metadata processor
 // without searching for existing resource processors.
 func addProfilerMetadataTags(conf confMap) error {
@@ -304,12 +213,12 @@ func addProfilerMetadataTags(conf confMap) error {
 
 	profilerNameElement := confMap{
 		"key":    "profiler_name",
-		"value":  "host-profiler",
+		"value":  version.ProfilerName,
 		"action": "upsert",
 	}
 	profilerVersionElement := confMap{
 		"key":    "profiler_version",
-		"value":  version.AgentVersion,
+		"value":  version.ProfilerVersion,
 		"action": "upsert",
 	}
 

--- a/comp/host-profiler/collector/impl/converters/td/adds_resource_processor.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/adds_resource_processor.yaml
@@ -1,0 +1,19 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [batch, infraattributes]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  batch:
+    timeout: 10s
+  infraattributes:
+    allow_hostname_override: true
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -7,7 +7,7 @@ processors:
         timeout: 10s
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -30,6 +30,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -7,6 +7,14 @@ processors:
         timeout: 10s
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -22,5 +30,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -7,11 +7,11 @@ processors:
         timeout: 10s
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -20,8 +20,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -30,6 +30,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-default-no-infra/out.yaml
@@ -7,7 +7,7 @@ processors:
         timeout: 10s
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -30,6 +30,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
     otlp: {}
 service:
     pipelines:
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -20,6 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-missing/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
     otlp: {}
 service:
     pipelines:
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -20,6 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/add-prof-to-pipe/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,7 +28,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-apikey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/conv-nonstr-appkey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/create-default-prof/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -7,7 +7,7 @@ processors:
         allow_hostname_override: true
     infraattributes/custom:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -30,6 +30,6 @@ service:
             processors:
                 - infraattributes
                 - infraattributes/custom
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -7,11 +7,11 @@ processors:
         allow_hostname_override: true
     infraattributes/custom:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -20,8 +20,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -30,6 +30,6 @@ service:
             processors:
                 - infraattributes
                 - infraattributes/custom
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -7,7 +7,7 @@ processors:
         allow_hostname_override: true
     infraattributes/custom:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -30,6 +30,6 @@ service:
             processors:
                 - infraattributes
                 - infraattributes/custom
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -7,6 +7,14 @@ processors:
         allow_hostname_override: true
     infraattributes/custom:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -22,5 +30,6 @@ service:
             processors:
                 - infraattributes
                 - infraattributes/custom
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/default-custom-infra/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
@@ -7,7 +7,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - otlphttp/datadoghq.com_0
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
@@ -1,25 +1,34 @@
 exporters:
-  otlphttp/datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/profiler-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: test_api_key_123
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp/datadoghq.com_0
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/profiler-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-pipeline/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -29,6 +29,6 @@ service:
                 - ""
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -21,5 +29,6 @@ service:
                 - ""
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - ""
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/empty-proc-name/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - ""
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -6,11 +6,11 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_other_config: value
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -19,8 +19,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -6,7 +6,7 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_other_config: value
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -6,7 +6,7 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_other_config: value
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -6,6 +6,14 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_other_config: value
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -20,5 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensure-infraattr-cfg/out.yaml
@@ -10,7 +10,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ensures-headers/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
@@ -13,7 +13,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
@@ -9,7 +9,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,6 +33,6 @@ service:
                 - otlphttp/datadoghq.com_0
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/error-no-otlp/out.yaml
@@ -1,29 +1,38 @@
 exporters:
-  debug: {}
-  logging: {}
-  otlphttp/datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    debug: {}
+    logging: {}
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/profiler-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: test_api_key_123
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - logging
-      - debug
-      - otlphttp/datadoghq.com_0
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - logging
+                - debug
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/profiler-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -20,5 +28,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/global-procs-notmap/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -28,6 +28,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/headers-wrong-type/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -7,11 +7,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -20,8 +20,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -7,7 +7,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -7,7 +7,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/ignore-non-otlp/out.yaml
@@ -7,6 +7,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -23,5 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/custom:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/custom
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/custom:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/custom
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/custom:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/custom
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infraattr-custom/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/custom:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/custom
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,7 +33,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -25,6 +33,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,7 +33,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-hostprof-recv/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -33,7 +33,7 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -9,6 +9,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -25,5 +33,6 @@ service:
                 - logging
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -9,7 +9,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,6 +33,6 @@ service:
                 - logging
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -13,7 +13,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -9,11 +9,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -22,8 +22,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -33,6 +33,6 @@ service:
                 - logging
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-otlp-exp/out.yaml
@@ -9,7 +9,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,6 +33,6 @@ service:
                 - logging
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -6,11 +6,11 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -19,8 +19,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -6,7 +6,7 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -6,6 +6,14 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -21,5 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -6,7 +6,7 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-resdetect-proc/out.yaml
@@ -10,7 +10,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -21,5 +29,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/multi-symbol-ep/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -29,6 +29,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-conv-nonstr-key/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/otlp-str-apikey/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -6,6 +6,14 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_config: value
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -20,5 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -6,11 +6,11 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_config: value
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -19,8 +19,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -6,7 +6,7 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_config: value
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -6,7 +6,7 @@ processors:
     infraattributes:
         allow_hostname_override: true
         some_config: value
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -28,6 +28,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -10,7 +10,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -23,5 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
     otlp:
         protocols:
             grpc:
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/preserve-otlp-proto/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -31,6 +31,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -12,7 +12,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -8,7 +8,7 @@ processors:
         allow_hostname_override: true
     infraattributes_custom: {}
     myresourcedetection: {}
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,6 +33,6 @@ service:
                 - myresourcedetection
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -8,7 +8,7 @@ processors:
         allow_hostname_override: true
     infraattributes_custom: {}
     myresourcedetection: {}
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -33,6 +33,6 @@ service:
                 - myresourcedetection
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -8,11 +8,11 @@ processors:
         allow_hostname_override: true
     infraattributes_custom: {}
     myresourcedetection: {}
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -21,8 +21,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -33,6 +33,6 @@ service:
                 - myresourcedetection
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proc-name-similar/out.yaml
@@ -8,6 +8,14 @@ processors:
         allow_hostname_override: true
     infraattributes_custom: {}
     myresourcedetection: {}
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -25,5 +33,6 @@ service:
                 - myresourcedetection
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-empty/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-empty/in.yaml
@@ -1,0 +1,16 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resource/dd-profiler-internal-metadata: {}
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-exists/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-exists/in.yaml
@@ -1,0 +1,20 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resource/dd-profiler-internal-metadata:
+    attributes:
+      - key: some_key
+        value: some_value
+        action: upsert
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-in-pipeline/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/reserved-proc-in-pipeline/in.yaml
@@ -1,0 +1,14 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect-custom/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -18,8 +18,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -6,11 +6,11 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -19,8 +19,8 @@ receivers:
         symbol_uploader:
             enabled: true
             symbol_endpoints:
-            - api_key: test_api_key_123
-              site: datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
     pipelines:
         profiles:
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -6,7 +6,7 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -6,6 +6,14 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -21,5 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -6,7 +6,7 @@ processors:
     batch: {}
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
             processors:
                 - batch
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/rm-resdetect/out.yaml
@@ -10,7 +10,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
@@ -1,25 +1,34 @@
 exporters:
-  otlphttp:
-    headers:
-      dd-api-key: test-api-key
+    otlphttp:
+        headers:
+            dd-api-key: test-api-key
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/profiler-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: custom-api-key-eu
-        site: datadoghq.eu
-      - api_key: custom-api-key-us
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: custom-api-key-eu
+                  site: datadoghq.eu
+                - api_key: custom-api-key-us
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - infraattributes/default
+                - resource/profiler-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-ep-no-inference/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -29,6 +29,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -24,6 +24,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -16,5 +24,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -24,6 +24,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-disabled/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -24,6 +24,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
@@ -1,23 +1,32 @@
 exporters:
-  otlphttp:
-    headers:
-      dd-api-key: test-api-key
+    otlphttp:
+        headers:
+            dd-api-key: test-api-key
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/profiler-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: test_api_key_123
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - infraattributes/default
+                - resource/profiler-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-empty-ep/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
     hostprofiler:
         symbol_uploader:
@@ -19,5 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/symbol-up-str-keys/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     infraattributes/default:
         allow_hostname_override: true
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -27,6 +27,6 @@ service:
                 - otlphttp
             processors:
                 - infraattributes/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -28,6 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -28,6 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,7 +36,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -30,5 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -30,5 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: "12345"
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: "12345"
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: "12345"
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: "12345"
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,6 +36,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -36,6 +36,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -28,5 +36,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -36,6 +36,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -5,7 +5,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -5,7 +5,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -5,11 +5,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -5,6 +5,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -31,5 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -44,7 +44,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -36,6 +44,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -44,7 +44,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -44,7 +44,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler
                 - hostprofiler/custom

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -7,6 +7,14 @@ exporters:
         headers:
             dd-api-key: staging-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -33,5 +41,6 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -7,11 +7,11 @@ exporters:
         headers:
             dd-api-key: staging-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -41,6 +41,6 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -7,7 +7,7 @@ exporters:
         headers:
             dd-api-key: staging-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -41,6 +41,6 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -7,7 +7,7 @@ exporters:
         headers:
             dd-api-key: staging-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -41,6 +41,6 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -40,6 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -32,5 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -40,6 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -40,6 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -31,5 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -39,6 +39,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -9,7 +9,7 @@ processors:
         other_config: value
     myinfraat tributes:
         some_config: value
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -44,6 +44,6 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -13,7 +13,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -9,6 +9,14 @@ processors:
         other_config: value
     myinfraat tributes:
         some_config: value
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -36,5 +44,6 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -9,7 +9,7 @@ processors:
         other_config: value
     myinfraat tributes:
         some_config: value
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -44,6 +44,6 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -9,11 +9,11 @@ processors:
         other_config: value
     myinfraat tributes:
         some_config: value
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -44,6 +44,6 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-empty/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-empty/in.yaml
@@ -1,0 +1,16 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resource/dd-profiler-internal-metadata: {}
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-exists/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-exists/in.yaml
@@ -1,0 +1,20 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resource/dd-profiler-internal-metadata:
+    attributes:
+      - key: some_key
+        value: some_value
+        action: upsert
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-in-pipeline/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/reserved-proc-in-pipeline/in.yaml
@@ -1,0 +1,14 @@
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resource/dd-profiler-internal-metadata]
+      exporters: [otlphttp]
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-key

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -11,7 +11,7 @@ extensions:
 processors:
     batch:
         timeout: 10s
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -47,6 +47,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -11,6 +11,14 @@ extensions:
 processors:
     batch:
         timeout: 10s
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -39,5 +47,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -11,11 +11,11 @@ extensions:
 processors:
     batch:
         timeout: 10s
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -47,6 +47,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -11,7 +11,7 @@ extensions:
 processors:
     batch:
         timeout: 10s
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -47,6 +47,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -5,11 +5,11 @@ exporters:
 processors:
     batch:
         timeout: 10s
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -41,6 +41,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -5,6 +5,14 @@ exporters:
 processors:
     batch:
         timeout: 10s
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -33,5 +41,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     batch:
         timeout: 10s
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -41,6 +41,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -5,7 +5,7 @@ exporters:
 processors:
     batch:
         timeout: 10s
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -41,6 +41,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -35,6 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -3,11 +3,11 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/host-profiler-default:
+    resource/profiler-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host_profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/host-profiler-default
+                - resource/profiler-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
+    resource/default:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: host_profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection/default:
         detectors:
             - system
@@ -30,5 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - resource/default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/profiler-metadata:
+    resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/profiler-metadata
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -3,7 +3,7 @@ exporters:
         headers:
             dd-api-key: test-api-key
 processors:
-    resource/default:
+    resource/host-profiler-default:
         attributes:
             - action: upsert
               key: profiler_name
@@ -38,6 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - resource/default
+                - resource/host-profiler-default
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/otel_col_factories.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor"
 
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/debugexporter"
@@ -83,6 +84,7 @@ func (e extraFactoriesWithAgentCore) GetExtensions() []extension.Factory {
 func (e extraFactoriesWithAgentCore) GetProcessors() []processor.Factory {
 	return []processor.Factory{
 		infraattributesprocessor.NewFactoryForAgent(e.tagger, e.hostname.Get),
+		resourceprocessor.NewFactory(),
 	}
 }
 
@@ -112,6 +114,7 @@ func (e extraFactoriesWithoutAgentCore) GetProcessors() []processor.Factory {
 	return []processor.Factory{
 		k8sattributesprocessor.NewFactory(),
 		resourcedetectionprocessor.NewFactory(),
+		resourceprocessor.NewFactory(),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent
 
-go 1.25.5
+go 1.25.6
 
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
@@ -747,7 +747,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.145.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.145.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.145.0 // indirect

--- a/tools/host-profiler/build_and_launch.sh
+++ b/tools/host-profiler/build_and_launch.sh
@@ -8,7 +8,8 @@ if [ "${DO_NOT_START_PROFILER}" = "1" ]; then
 else
     # Build full-host-profiler
     mkdir -p bin/full-host-profiler
-    go build -o bin/full-host-profiler/full-host-profiler ./cmd/host-profiler
+    go build -ldflags="-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=docker-dev" \
+      -o bin/full-host-profiler/full-host-profiler ./cmd/host-profiler
 
     # Launch the profiler
     exec ./tools/host-profiler/launch.sh


### PR DESCRIPTION
### What does this PR do?

Adds 2 tags:
- `profiler_version` (taken from `version.AgentVersion`)
- `profiler_name`

The code tries to hook itself into an existing `resource` processor found in `services::pipelines::profiles::processors` to inject these two tags.
If no such processor exists, a new `host-profiler-default` one is declared and added to the pipeline.

### Motivation

### Describe how you validated your changes

Tested by running the profiler & added a test.

### Additional Notes

Another simpler approach would be to always add a new `resource` processor called something like `resource/profiler-metadata`. This has the benefit of being more straightforward in the code, but could overwrite user defined configuration if there ever was a `resource/profiler-metadata` declared. I'm not sure how much of an issue that is.
