### PR TITLE
fix(gitlab): Use wildcard for include keyword

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,6 @@
 ---
 include:
-  - local: .adms/npm/gitlab.yaml
-  - local: .adms/go/gitlab.yaml
-  - local: .adms/python/gitlab.yaml
+  - local: .adms/**/*.yaml
   - local: .gitlab/.pre/**.yml
   - local: .gitlab/build/**.yml
   - local: .gitlab/deploy/**.yml


### PR DESCRIPTION
### What does this PR do?
Follow-up of #44764.

### Motivation
We prefer to use wildcards to be sure all the files which need to be included are correctly included in the configuration

### Describe how you validated your changes
CI execution

### Additional Notes
