### PR TITLE
[snmp] Fallback to unconnected UDP session automatically

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -40,9 +40,8 @@ import (
 )
 
 const (
-	defaultTimeout                 = 10 // Timeout better suited to walking
-	defaultRetries                 = 3
-	defaultUseUnconnectedUDPSocket = false
+	defaultTimeout = 10 // Timeout better suited to walking
+	defaultRetries = 3
 )
 
 // argsType is an alias so we can inject the args via fx.
@@ -73,7 +72,10 @@ func confErrf(msg string, args ...any) configErr {
 
 // Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	connParams := &snmpparse.SNMPConfig{}
+	connParams := &snmpparse.SNMPConfig{
+		// Similar to the snmpwalk command, we accept responses from a different IP address
+		UseUnconnectedUDPSocket: true,
+	}
 	snmpCmd := &cobra.Command{
 		Use:   "snmp",
 		Short: "Snmp tools",
@@ -137,7 +139,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	// general communication options
 	snmpWalkCmd.Flags().IntVarP(&connParams.Retries, "retries", "r", defaultRetries, "Set the number of retries")
 	snmpWalkCmd.Flags().IntVarP(&connParams.Timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
-	snmpWalkCmd.Flags().BoolVar(&connParams.UseUnconnectedUDPSocket, "use-unconnected-udp-socket", defaultUseUnconnectedUDPSocket, "If specified, changes net connection to be unconnected UDP socket")
 
 	snmpCmd.AddCommand(snmpWalkCmd)
 
@@ -205,7 +206,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	// general communication options
 	snmpScanCmd.Flags().IntVarP(&connParams.Retries, "retries", "r", defaultRetries, "Set the number of retries")
 	snmpScanCmd.Flags().IntVarP(&connParams.Timeout, "timeout", "t", defaultTimeout, "Set the request timeout (in seconds)")
-	snmpScanCmd.Flags().BoolVar(&connParams.UseUnconnectedUDPSocket, "use-unconnected-udp-socket", defaultUseUnconnectedUDPSocket, "If specified, changes net connection to be unconnected UDP socket")
 
 	// This command does nothing until the backend supports it, so it isn't enabled yet.
 	snmpCmd.AddCommand(snmpScanCmd)

--- a/cmd/agent/subcommands/snmp/command_test.go
+++ b/cmd/agent/subcommands/snmp/command_test.go
@@ -26,15 +26,6 @@ func TestWalkCommand(t *testing.T) {
 			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
-			require.False(t, cliParams.UseUnconnectedUDPSocket)
-		})
-
-	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
-		[]string{"snmp", "walk", "1.2.3.4", "10.9.8.7", "--use-unconnected-udp-socket"},
-		snmpWalk,
-		func(cliParams *snmpparse.SNMPConfig, args argsType) {
-			require.Equal(t, argsType{"1.2.3.4", "10.9.8.7"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})
 }
@@ -49,15 +40,6 @@ func TestScanCommand(t *testing.T) {
 			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.Equal(t, "3", cliParams.Version)
 			require.Equal(t, 10, cliParams.Retries)
-			require.False(t, cliParams.UseUnconnectedUDPSocket)
-		})
-
-	fxutil.TestOneShotSubcommand(t,
-		Commands(&command.GlobalParams{}),
-		[]string{"snmp", "scan", "1.2.3.4", "--use-unconnected-udp-socket"},
-		scanDevice,
-		func(cliParams *snmpparse.SNMPConfig, args argsType) {
-			require.Equal(t, argsType{"1.2.3.4"}, args)
 			require.True(t, cliParams.UseUnconnectedUDPSocket)
 		})
 }

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -206,6 +206,8 @@ type CheckConfig struct {
 
 	PingEnabled bool
 	PingConfig  pinger.Config
+
+	UseUnconnectedUDPSocket bool
 }
 
 // UpdateDeviceIDAndTags updates DeviceID and DeviceIDTags
@@ -649,6 +651,8 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.PingConfig.Timeout = c.PingConfig.Timeout
 	newConfig.PingConfig.Count = c.PingConfig.Count
 	newConfig.PingConfig.UseRawSocket = c.PingConfig.UseRawSocket
+
+	newConfig.UseUnconnectedUDPSocket = c.UseUnconnectedUDPSocket
 
 	return &newConfig
 }

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/cmd/wrong_source_ip_simulator/main.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/cmd/wrong_source_ip_simulator/main.go
@@ -1,9 +1,9 @@
-//go:build ignore
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
+//go:build ignore
 
 // Wrong Source IP Simulator
 //

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/cmd/wrong_source_ip_simulator/main.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/cmd/wrong_source_ip_simulator/main.go
@@ -1,0 +1,486 @@
+//go:build ignore
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Wrong Source IP Simulator
+//
+// This program simulates unexpected network behavior where a device responds to
+// SNMP requests from a different IP than the one it was queried on.
+//
+// This can occur in certain network configurations (load balancers, NAT devices,
+// devices with multiple interfaces and asymmetric routing, etc.).
+//
+// When you query IP A, the device responds from IP B. This breaks standard
+// "connected" UDP sockets (which expect responses from the same IP they sent to)
+// but works with "unconnected" UDP sockets.
+//
+// Usage:
+//
+//	go run main.go -listen 127.0.0.1:1161 -respond 127.0.0.2:0 -community public
+//
+// Then configure your SNMP check to query 127.0.0.1:1161.
+// The response will come from 127.0.0.2, which will cause a timeout with
+// connected sockets but succeed with unconnected sockets.
+//
+// Prerequisites:
+//   - You need two IPs on your machine. On macOS, you can add a loopback alias:
+//     sudo ifconfig lo0 alias 127.0.0.2
+//   - On Linux:
+//     sudo ip addr add 127.0.0.2/8 dev lo
+package main
+
+import (
+	"encoding/asn1"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// SNMP constants
+const (
+	snmpVersion2c = 1 // SNMPv2c version number in the packet
+
+	// PDU types
+	pduGetRequest     = 0
+	pduGetNextRequest = 1
+	pduGetResponse    = 2
+
+	// sysObjectID OID: 1.3.6.1.2.1.1.2.0
+	sysObjectIDOID = "1.3.6.1.2.1.1.2.0"
+	// sysDescr OID: 1.3.6.1.2.1.1.1.0
+	sysDescrOID = "1.3.6.1.2.1.1.1.0"
+	// Device reachability check OID used by the agent
+	deviceReachableOID = "1.3.6.1.2.1.1.3.0" // sysUpTime
+)
+
+// Simulated device values
+var deviceValues = map[string]interface{}{
+	sysObjectIDOID:     asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 9, 1, 1}, // Cisco
+	sysDescrOID:        "Wrong Source IP Simulator - Tests unconnected UDP socket fallback",
+	deviceReachableOID: 123456, // sysUpTime in ticks
+}
+
+func main() {
+	listenAddr := flag.String("listen", "127.0.0.1:1161", "Address to listen for SNMP requests (IP:port)")
+	respondAddr := flag.String("respond", "127.0.0.2:0", "Address to send responses FROM (IP:port, use port 0 for ephemeral)")
+	community := flag.String("community", "public", "SNMP community string to accept")
+	flag.Parse()
+
+	fmt.Println("=== Wrong Source IP Simulator ===")
+	fmt.Printf("Listening on:      %s\n", *listenAddr)
+	fmt.Printf("Responding from:   %s\n", *respondAddr)
+	fmt.Printf("Community string:  %s\n", *community)
+	fmt.Println()
+	fmt.Println("This simulates unexpected network behavior where a device responds")
+	fmt.Println("from a different IP than the one queried.")
+	fmt.Println("Connected UDP sockets will timeout; unconnected sockets will work.")
+	fmt.Println()
+	fmt.Println("To add loopback alias (if needed):")
+	fmt.Println("  macOS: sudo ifconfig lo0 alias 127.0.0.2")
+	fmt.Println("  Linux: sudo ip addr add 127.0.0.2/8 dev lo")
+	fmt.Println()
+	fmt.Println("Press Ctrl+C to stop.")
+	fmt.Println()
+
+	// Parse addresses
+	listenUDPAddr, err := net.ResolveUDPAddr("udp", *listenAddr)
+	if err != nil {
+		log.Fatalf("Invalid listen address: %v", err)
+	}
+
+	respondUDPAddr, err := net.ResolveUDPAddr("udp", *respondAddr)
+	if err != nil {
+		log.Fatalf("Invalid respond address: %v", err)
+	}
+
+	// Create listening socket
+	listenConn, err := net.ListenUDP("udp", listenUDPAddr)
+	if err != nil {
+		log.Fatalf("Failed to listen on %s: %v", *listenAddr, err)
+	}
+	defer listenConn.Close()
+
+	// Handle graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		fmt.Println("\nShutting down...")
+		listenConn.Close()
+		os.Exit(0)
+	}()
+
+	buf := make([]byte, 4096)
+	for {
+		n, clientAddr, err := listenConn.ReadFromUDP(buf)
+		if err != nil {
+			log.Printf("Read error: %v", err)
+			continue
+		}
+
+		log.Printf("Received %d bytes from %s", n, clientAddr)
+
+		// Parse SNMP request
+		response, err := handleSNMPRequest(buf[:n], *community)
+		if err != nil {
+			log.Printf("Failed to handle request: %v", err)
+			continue
+		}
+
+		// Send response from DIFFERENT IP
+		err = sendFromDifferentIP(respondUDPAddr, clientAddr, response)
+		if err != nil {
+			log.Printf("Failed to send response: %v", err)
+			continue
+		}
+
+		log.Printf("Sent %d byte response from %s to %s", len(response), respondUDPAddr.IP, clientAddr)
+	}
+}
+
+// sendFromDifferentIP sends a UDP packet from a specific source IP to the client
+func sendFromDifferentIP(sourceAddr, destAddr *net.UDPAddr, data []byte) error {
+	// Create a new socket bound to the "wrong" IP
+	conn, err := net.DialUDP("udp", sourceAddr, destAddr)
+	if err != nil {
+		return fmt.Errorf("failed to dial from %s: %w", sourceAddr, err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Write(data)
+	return err
+}
+
+// handleSNMPRequest parses an SNMP request and generates a response
+func handleSNMPRequest(data []byte, expectedCommunity string) ([]byte, error) {
+	// Parse the SNMP message (simplified BER/DER parsing)
+	msg, err := parseSNMPMessage(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse error: %w", err)
+	}
+
+	// Verify community string
+	if msg.Community != expectedCommunity {
+		return nil, fmt.Errorf("wrong community: got %q, expected %q", msg.Community, expectedCommunity)
+	}
+
+	// Build response
+	return buildSNMPResponse(msg)
+}
+
+// SNMPMessage represents a simplified SNMP message
+type SNMPMessage struct {
+	Version   int
+	Community string
+	PDUType   int
+	RequestID int
+	OIDs      []string
+}
+
+// parseSNMPMessage does basic SNMP message parsing
+func parseSNMPMessage(data []byte) (*SNMPMessage, error) {
+	// SNMP message is a SEQUENCE
+	if len(data) < 2 || data[0] != 0x30 {
+		return nil, fmt.Errorf("not an SNMP message")
+	}
+
+	// Skip SEQUENCE header
+	pos := 2
+	if data[1] > 0x80 {
+		// Long form length
+		lenBytes := int(data[1] & 0x7f)
+		pos += lenBytes
+	}
+
+	msg := &SNMPMessage{}
+
+	// Parse version (INTEGER)
+	if data[pos] != 0x02 {
+		return nil, fmt.Errorf("expected INTEGER for version")
+	}
+	pos++
+	verLen := int(data[pos])
+	pos++
+	msg.Version = int(data[pos])
+	pos += verLen
+
+	// Parse community (OCTET STRING)
+	if data[pos] != 0x04 {
+		return nil, fmt.Errorf("expected OCTET STRING for community")
+	}
+	pos++
+	commLen := int(data[pos])
+	pos++
+	msg.Community = string(data[pos : pos+commLen])
+	pos += commLen
+
+	// Parse PDU (CONTEXT-SPECIFIC)
+	msg.PDUType = int(data[pos] & 0x1f)
+	pos++
+
+	// Skip PDU length
+	if data[pos] > 0x80 {
+		lenBytes := int(data[pos] & 0x7f)
+		pos += 1 + lenBytes
+	} else {
+		pos++
+	}
+
+	// Parse request-id (INTEGER)
+	if data[pos] != 0x02 {
+		return nil, fmt.Errorf("expected INTEGER for request-id")
+	}
+	pos++
+	reqIDLen := int(data[pos])
+	pos++
+	for i := 0; i < reqIDLen; i++ {
+		msg.RequestID = (msg.RequestID << 8) | int(data[pos+i])
+	}
+	pos += reqIDLen
+
+	// Skip error-status and error-index
+	// error-status (INTEGER)
+	pos++
+	errStatusLen := int(data[pos])
+	pos += 1 + errStatusLen
+	// error-index (INTEGER)
+	pos++
+	errIndexLen := int(data[pos])
+	pos += 1 + errIndexLen
+
+	// Parse varbind list
+	msg.OIDs = parseVarbindList(data[pos:])
+
+	return msg, nil
+}
+
+// parseVarbindList extracts OIDs from the varbind list
+func parseVarbindList(data []byte) []string {
+	var oids []string
+
+	if len(data) < 2 || data[0] != 0x30 {
+		return oids
+	}
+
+	pos := 2
+	if data[1] > 0x80 {
+		lenBytes := int(data[1] & 0x7f)
+		pos += lenBytes
+	}
+
+	// Iterate through varbinds
+	for pos < len(data) {
+		if data[pos] != 0x30 {
+			break
+		}
+		pos++
+		varbindLen := int(data[pos])
+		pos++
+
+		// Parse OID
+		if data[pos] == 0x06 {
+			pos++
+			oidLen := int(data[pos])
+			pos++
+			oid := decodeOID(data[pos : pos+oidLen])
+			oids = append(oids, oid)
+			pos += varbindLen - 2 - oidLen
+		} else {
+			pos += varbindLen
+		}
+	}
+
+	return oids
+}
+
+// decodeOID converts BER-encoded OID to string
+func decodeOID(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
+	// First byte encodes first two components
+	oid := fmt.Sprintf("%d.%d", data[0]/40, data[0]%40)
+
+	var val int
+	for i := 1; i < len(data); i++ {
+		val = (val << 7) | int(data[i]&0x7f)
+		if data[i]&0x80 == 0 {
+			oid += fmt.Sprintf(".%d", val)
+			val = 0
+		}
+	}
+
+	return oid
+}
+
+// buildSNMPResponse creates an SNMP response packet
+func buildSNMPResponse(req *SNMPMessage) ([]byte, error) {
+	// Build varbind list based on request
+	var varbinds []byte
+
+	for _, oid := range req.OIDs {
+		var responseOID string
+		var value interface{}
+
+		if req.PDUType == pduGetNextRequest {
+			// For GetNext, return the next OID
+			responseOID, value = getNextOID(oid)
+		} else {
+			// For Get, return the exact OID
+			responseOID = oid
+			var ok bool
+			value, ok = deviceValues[oid]
+			if !ok {
+				value = nil // noSuchObject
+			}
+		}
+
+		varbind := encodeVarbind(responseOID, value)
+		varbinds = append(varbinds, varbind...)
+	}
+
+	// Build varbind list SEQUENCE
+	varbindList := encodeSequence(varbinds)
+
+	// Build PDU
+	pdu := encodeInteger(req.RequestID)    // request-id
+	pdu = append(pdu, encodeInteger(0)...) // error-status
+	pdu = append(pdu, encodeInteger(0)...) // error-index
+	pdu = append(pdu, varbindList...)
+
+	// Wrap PDU with GetResponse tag (0xa2)
+	pduData := append([]byte{0xa2}, encodeLength(len(pdu))...)
+	pduData = append(pduData, pdu...)
+
+	// Build message
+	message := encodeInteger(req.Version)
+	message = append(message, encodeOctetString(req.Community)...)
+	message = append(message, pduData...)
+
+	return encodeSequence(message), nil
+}
+
+// getNextOID returns the next OID and its value (for GetNext requests)
+func getNextOID(oid string) (string, interface{}) {
+	// Simple implementation - return sysUpTime for any GetNext
+	// This is enough to pass the reachability check
+	return deviceReachableOID, deviceValues[deviceReachableOID]
+}
+
+// encodeSequence wraps data in a SEQUENCE
+func encodeSequence(data []byte) []byte {
+	return append(append([]byte{0x30}, encodeLength(len(data))...), data...)
+}
+
+// encodeLength encodes length in BER format
+func encodeLength(length int) []byte {
+	if length < 128 {
+		return []byte{byte(length)}
+	}
+	if length < 256 {
+		return []byte{0x81, byte(length)}
+	}
+	return []byte{0x82, byte(length >> 8), byte(length)}
+}
+
+// encodeInteger encodes an integer in BER format
+func encodeInteger(val int) []byte {
+	if val == 0 {
+		return []byte{0x02, 0x01, 0x00}
+	}
+
+	var bytes []byte
+	v := val
+	for v > 0 {
+		bytes = append([]byte{byte(v & 0xff)}, bytes...)
+		v >>= 8
+	}
+	// Add leading zero if high bit is set (to keep it positive)
+	if bytes[0]&0x80 != 0 {
+		bytes = append([]byte{0x00}, bytes...)
+	}
+
+	return append([]byte{0x02, byte(len(bytes))}, bytes...)
+}
+
+// encodeOctetString encodes a string as OCTET STRING
+func encodeOctetString(s string) []byte {
+	return append(append([]byte{0x04}, encodeLength(len(s))...), []byte(s)...)
+}
+
+// encodeOID encodes an OID string to BER format
+func encodeOID(oid string) []byte {
+	var components []int
+	var val int
+	for _, c := range oid + "." {
+		if c >= '0' && c <= '9' {
+			val = val*10 + int(c-'0')
+		} else if c == '.' {
+			components = append(components, val)
+			val = 0
+		}
+	}
+
+	if len(components) < 2 {
+		return []byte{0x06, 0x00}
+	}
+
+	// First two components combined
+	encoded := []byte{byte(components[0]*40 + components[1])}
+
+	// Remaining components
+	for i := 2; i < len(components); i++ {
+		v := components[i]
+		if v < 128 {
+			encoded = append(encoded, byte(v))
+		} else {
+			var octets []byte
+			for v > 0 {
+				octets = append([]byte{byte(v&0x7f) | 0x80}, octets...)
+				v >>= 7
+			}
+			octets[len(octets)-1] &= 0x7f // Clear high bit on last byte
+			encoded = append(encoded, octets...)
+		}
+	}
+
+	return append([]byte{0x06, byte(len(encoded))}, encoded...)
+}
+
+// encodeVarbind encodes an OID-value pair
+func encodeVarbind(oid string, value interface{}) []byte {
+	oidBytes := encodeOID(oid)
+
+	var valueBytes []byte
+	switch v := value.(type) {
+	case nil:
+		// noSuchObject
+		valueBytes = []byte{0x80, 0x00}
+	case int:
+		valueBytes = encodeInteger(v)
+	case string:
+		valueBytes = encodeOctetString(v)
+	case asn1.ObjectIdentifier:
+		oidStr := ""
+		for i, n := range v {
+			if i > 0 {
+				oidStr += "."
+			}
+			oidStr += fmt.Sprintf("%d", n)
+		}
+		valueBytes = encodeOID(oidStr)
+	default:
+		valueBytes = []byte{0x05, 0x00} // NULL
+	}
+
+	varbind := append(oidBytes, valueBytes...)
+	return encodeSequence(varbind)
+}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager.go
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package devicecheck
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
+	coresnmp "github.com/DataDog/datadog-agent/pkg/snmp"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// ConnectionManager handles SNMP session creation and connection management.
+type ConnectionManager interface {
+	// Connect establishes a connection and returns (session, deviceReachable, error).
+	// Returns:
+	//   - (nil, false, error): Cannot connect at all (socket failure)
+	//   - (session, false, nil): Connected but device is unreachable
+	//   - (session, true, nil): Connected and device is reachable
+	Connect() (session.Session, bool, error)
+
+	// GetSession returns the current active session if initialized.
+	GetSession() (session.Session, error)
+
+	// Close closes the current session.
+	Close() error
+}
+
+// connectionMode represents the decided connection mode after the first run.
+type connectionMode int
+
+const (
+	// modeUndecided means we haven't attempted connection yet (first run pending).
+	modeUndecided connectionMode = iota
+	// modeConnected means connected sockets work and should always be used.
+	modeConnected
+	// modeUnconnected means connected sockets timed out but unconnected worked.
+	modeUnconnected
+)
+
+// snmpConnectionManager implements ConnectionManager with automatic fallback
+// to unconnected UDP sockets for unexpected network behavior.
+//
+// Some network configurations cause devices to respond from a different IP
+// than the one queried. Connected UDP sockets fail in this case because they
+// expect responses from the same IP. Unconnected sockets accept responses
+// from any IP and work as a fallback.
+//
+// On first Connect():
+//   - Tries connected socket first (normal case)
+//   - If timeout occurs, tests unconnected socket once
+//   - Permanently decides which mode to use based on test result
+//
+// On subsequent Connect() calls:
+//   - Uses the previously decided mode (no more testing)
+type snmpConnectionManager struct {
+	config         *checkconfig.CheckConfig
+	sessionFactory session.Factory
+	session        session.Session
+	mode           connectionMode
+}
+
+// NewConnectionManager creates a new SNMP connection manager.
+func NewConnectionManager(config *checkconfig.CheckConfig, sessionFactory session.Factory) ConnectionManager {
+	return &snmpConnectionManager{
+		config:         config.Copy(),
+		sessionFactory: sessionFactory,
+		mode:           modeUndecided,
+	}
+}
+
+// Connect establishes a connection and returns (session, deviceReachable, error).
+func (m *snmpConnectionManager) Connect() (session.Session, bool, error) {
+	log.Errorf("Connect called with mode: %d", m.mode)
+	if m.mode == modeUndecided {
+		return m.firstConnect()
+	}
+
+	useUnconnected := m.mode == modeUnconnected
+	sess, err := m.createSession(useUnconnected)
+	if err != nil {
+		return nil, false, err
+	}
+	m.session = sess
+
+	reachErr := m.checkReachability(sess)
+	return sess, reachErr == nil, nil
+}
+
+// GetSession returns the current active session.
+func (m *snmpConnectionManager) GetSession() (session.Session, error) {
+	if m.session == nil {
+		return nil, errors.New("session not initialized - call Connect() first")
+	}
+	return m.session, nil
+}
+
+// Close closes the current session.
+func (m *snmpConnectionManager) Close() error {
+	if m.session == nil {
+		return nil
+	}
+	err := m.session.Close()
+	m.session = nil
+	return err
+}
+
+// firstConnect handles the initial connection attempt and mode decision.
+// This is the only place where fallback testing occurs.
+func (m *snmpConnectionManager) firstConnect() (session.Session, bool, error) {
+	log.Errorf("First connect called")
+	// Always try connected socket first
+	connectedSession, err := m.createSession(false)
+	log.Errorf("Connected session created")
+	if err != nil {
+		log.Errorf("Failed to create connected session: %s", err)
+		// Socket creation failed entirely - no point testing fallback
+		// Because this is UDP, this is not influenced by the state of the remote device
+		return nil, false, err
+	}
+
+	log.Errorf("Connected session created")
+	reachErr := m.checkReachability(connectedSession)
+	if reachErr == nil {
+		log.Errorf("Connected socket works perfectly")
+		// Connected socket works perfectly - use it permanently
+		m.mode = modeConnected
+		m.session = connectedSession
+		return connectedSession, true, nil
+	}
+
+	log.Errorf("Connected socket does not work: %s", reachErr)
+	// Device unreachable - should we test unconnected mode?
+	if !isTimeoutError(reachErr) {
+		log.Errorf("Not a timeout (e.g., auth error) - fallback won't help")
+		log.Errorf("%+v", reachErr)
+		// Not a timeout (e.g., auth error) - fallback won't help
+		m.mode = modeConnected
+		m.session = connectedSession
+		return connectedSession, false, nil
+	}
+
+	// Network timeout occurred - test unconnected socket
+	log.Infof("[%s] Connected socket timed out, testing unconnected socket", m.config.IPAddress)
+
+	unconnSess, unconnErr := m.createSession(true)
+	if unconnErr != nil {
+		// Unconnected socket failed to create - stick with connected
+		log.Infof("[%s] Unconnected socket creation failed, defaulting to connected mode", m.config.IPAddress)
+		m.mode = modeConnected
+		m.session = connectedSession
+		return connectedSession, false, nil
+	}
+
+	unconnReachErr := m.checkReachability(unconnSess)
+	if unconnReachErr == nil {
+		// Unconnected works - switch permanently
+		log.Infof("[%s] Unconnected socket succeeded, switching permanently", m.config.IPAddress)
+		m.mode = modeUnconnected
+		connectedSession.Close()
+		m.session = unconnSess
+		return unconnSess, true, nil
+	}
+
+	// Unconnected also failed - default to connected mode
+	log.Infof("[%s] Unconnected socket also failed, defaulting to connected mode", m.config.IPAddress)
+	m.mode = modeConnected
+	unconnSess.Close()
+	m.session = connectedSession
+	return connectedSession, false, nil
+}
+
+// createSession creates and connects an SNMP session.
+// Returns (session, nil) on success or (nil, error) on failure - never both.
+func (m *snmpConnectionManager) createSession(useUnconnected bool) (session.Session, error) {
+	cfg := m.config.Copy()
+	cfg.UseUnconnectedUDPSocket = useUnconnected
+
+	sess, err := m.sessionFactory(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session: %w", err)
+	}
+
+	if err := sess.Connect(); err != nil {
+		return nil, err
+	}
+
+	return sess, nil
+}
+
+// checkReachability verifies the device responds to SNMP queries.
+// Returns nil if reachable, or the error if not.
+func (m *snmpConnectionManager) checkReachability(sess session.Session) error {
+	_, err := sess.GetNext([]string{coresnmp.DeviceReachableGetNextOid})
+	return err
+}
+
+// isTimeoutError checks if the error is a network timeout.
+func isTimeoutError(err error) bool {
+	// gosnmp doesn't implement the net.Error interface, so we check the error string
+	// https://github.com/gosnmp/gosnmp/blob/e72026a86bb80209ed38f118892479e6b7177344/marshal.go#L210
+	return err != nil && strings.Contains(err.Error(), "timeout")
+}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager.go
@@ -77,7 +77,6 @@ func NewConnectionManager(config *checkconfig.CheckConfig, sessionFactory sessio
 
 // Connect establishes a connection and returns (session, deviceReachable, error).
 func (m *snmpConnectionManager) Connect() (session.Session, bool, error) {
-	log.Errorf("Connect called with mode: %d", m.mode)
 	if m.mode == modeUndecided {
 		return m.firstConnect()
 	}
@@ -114,10 +113,8 @@ func (m *snmpConnectionManager) Close() error {
 // firstConnect handles the initial connection attempt and mode decision.
 // This is the only place where fallback testing occurs.
 func (m *snmpConnectionManager) firstConnect() (session.Session, bool, error) {
-	log.Errorf("First connect called")
 	// Always try connected socket first
 	connectedSession, err := m.createSession(false)
-	log.Errorf("Connected session created")
 	if err != nil {
 		log.Errorf("Failed to create connected session: %s", err)
 		// Socket creation failed entirely - no point testing fallback
@@ -125,21 +122,16 @@ func (m *snmpConnectionManager) firstConnect() (session.Session, bool, error) {
 		return nil, false, err
 	}
 
-	log.Errorf("Connected session created")
 	reachErr := m.checkReachability(connectedSession)
 	if reachErr == nil {
-		log.Errorf("Connected socket works perfectly")
 		// Connected socket works perfectly - use it permanently
 		m.mode = modeConnected
 		m.session = connectedSession
 		return connectedSession, true, nil
 	}
 
-	log.Errorf("Connected socket does not work: %s", reachErr)
 	// Device unreachable - should we test unconnected mode?
 	if !isTimeoutError(reachErr) {
-		log.Errorf("Not a timeout (e.g., auth error) - fallback won't help")
-		log.Errorf("%+v", reachErr)
 		// Not a timeout (e.g., auth error) - fallback won't help
 		m.mode = modeConnected
 		m.session = connectedSession

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager_test.go
@@ -25,7 +25,7 @@ type mockSession struct {
 }
 
 func newMockTimeoutError() error {
-	return fmt.Errorf(".* timeout .*")
+	return errors.New(".* timeout .*")
 }
 
 func (m *mockSession) Connect() error {
@@ -97,7 +97,7 @@ func TestConnectionManager_ConnectSuccess(t *testing.T) {
 	mainSess.On("Connect").Return(nil).Once()
 	mainSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return mainSess, nil
 	}
 
@@ -175,7 +175,7 @@ func TestConnectionManager_NonTimeoutError(t *testing.T) {
 	mainSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
 		Return(nil, errors.New("authentication failed")).Once()
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return mainSess, nil
 	}
 
@@ -212,7 +212,7 @@ func TestConnectionManager_FallbackTestFails(t *testing.T) {
 	unconnectedSess.On("Close").Return(nil).Once()
 
 	callCount := 0
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		callCount++
 		if callCount == 1 {
 			return connectedSess, nil
@@ -244,7 +244,7 @@ func TestConnectionManager_Close(t *testing.T) {
 	sess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
 	sess.On("Close").Return(nil).Once()
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -271,7 +271,7 @@ func TestConnectionManager_GetSessionAfterClose(t *testing.T) {
 	sess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
 	sess.On("Close").Return(nil).Once()
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -429,7 +429,7 @@ func TestConnectionManager_SessionFactoryError(t *testing.T) {
 	}
 
 	factoryErr := errors.New("failed to create session")
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return nil, factoryErr
 	}
 
@@ -451,7 +451,7 @@ func TestConnectionManager_SessionConnectError(t *testing.T) {
 	mainSess := new(mockSession)
 	mainSess.On("Connect").Return(errors.New("connection refused")).Once()
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return mainSess, nil
 	}
 
@@ -481,7 +481,7 @@ func TestConnectionManager_UnconnectedSessionCreationFails(t *testing.T) {
 		Return(nil, newMockTimeoutError()).Once()
 
 	callCount := 0
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		callCount++
 		if callCount == 1 {
 			return connectedSess, nil
@@ -507,7 +507,7 @@ func TestConnectionManager_GetSessionBeforeConnect(t *testing.T) {
 		IPAddress: "10.0.0.1",
 	}
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return nil, nil
 	}
 
@@ -525,7 +525,7 @@ func TestConnectionManager_CloseWithoutSession(t *testing.T) {
 		IPAddress: "10.0.0.1",
 	}
 
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		return nil, nil
 	}
 
@@ -552,7 +552,7 @@ func TestConnectionManager_ReconnectAfterClose(t *testing.T) {
 	sess2.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
 
 	callCount := 0
-	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(_ *checkconfig.CheckConfig) (session.Session, error) {
 		callCount++
 		if callCount == 1 {
 			return sess1, nil

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/connection_manager_test.go
@@ -1,0 +1,634 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package devicecheck
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/session"
+	coresnmp "github.com/DataDog/datadog-agent/pkg/snmp"
+)
+
+// mockSession implements session.Session interface for testing
+type mockSession struct {
+	mock.Mock
+}
+
+// mockTimeoutError implements net.Error for testing timeout scenarios
+type mockTimeoutError struct {
+	msg string
+}
+
+func (e *mockTimeoutError) Error() string   { return e.msg }
+func (e *mockTimeoutError) Timeout() bool   { return true }
+func (e *mockTimeoutError) Temporary() bool { return false }
+
+func newMockTimeoutError(msg string) error {
+	return &mockTimeoutError{msg: msg}
+}
+
+func (m *mockSession) Connect() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSession) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSession) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	args := m.Called(oids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
+}
+
+func (m *mockSession) GetBulk(oids []string, bulkMaxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
+	args := m.Called(oids, bulkMaxRepetitions)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
+}
+
+func (m *mockSession) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	args := m.Called(oids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
+}
+
+func (m *mockSession) GetSnmpGetCount() uint32 {
+	args := m.Called()
+	return args.Get(0).(uint32)
+}
+
+func (m *mockSession) GetSnmpGetBulkCount() uint32 {
+	args := m.Called()
+	return args.Get(0).(uint32)
+}
+
+func (m *mockSession) GetSnmpGetNextCount() uint32 {
+	args := m.Called()
+	return args.Get(0).(uint32)
+}
+
+func (m *mockSession) GetVersion() gosnmp.SnmpVersion {
+	args := m.Called()
+	return args.Get(0).(gosnmp.SnmpVersion)
+}
+
+func (m *mockSession) IsUnconnectedUDP() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// TestConnectionManager_ConnectSuccess tests successful connection
+func TestConnectionManager_ConnectSuccess(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	mainSess := new(mockSession)
+	mainSess.On("Connect").Return(nil).Once()
+	mainSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return mainSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, mainSess, sess)
+
+	gotSess, err := connMgr.GetSession()
+	assert.NoError(t, err)
+	assert.Equal(t, mainSess, gotSess)
+
+	mainSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_TimeoutTriggersFallback tests that timeout triggers fallback
+func TestConnectionManager_TimeoutTriggersFallback(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	connectedSess := new(mockSession)
+	unconnectedSess := new(mockSession)
+
+	// Connected session fails with timeout on reachability check
+	connectedSess.On("Connect").Return(nil).Once()
+	connectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, newMockTimeoutError("timeout")).Once()
+	connectedSess.On("Close").Return(nil).Once()
+
+	// Unconnected session succeeds
+	unconnectedSess.On("Connect").Return(nil).Once()
+	unconnectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(&gosnmp.SnmpPacket{}, nil).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		if callCount == 1 {
+			// First call - connected session
+			assert.False(t, cfg.UseUnconnectedUDPSocket, "First session should use connected mode")
+			return connectedSess, nil
+		}
+		// Second call - unconnected session
+		assert.True(t, cfg.UseUnconnectedUDPSocket, "Second session should have UseUnconnectedUDPSocket enabled")
+		return unconnectedSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, unconnectedSess, sess)
+	// Note: Original config should NOT be modified (ConnectionManager makes a copy)
+
+	gotSess, err := connMgr.GetSession()
+	assert.NoError(t, err)
+	assert.Equal(t, unconnectedSess, gotSess)
+
+	connectedSess.AssertExpectations(t)
+	unconnectedSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_NonTimeoutError tests that non-timeout errors don't trigger fallback
+func TestConnectionManager_NonTimeoutError(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	mainSess := new(mockSession)
+	mainSess.On("Connect").Return(nil).Once()
+	mainSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, errors.New("authentication failed")).Once()
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return mainSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.NoError(t, err)
+	assert.False(t, reachable)
+	// Session should be returned even on reachability failure so caller can continue
+	assert.NotNil(t, sess)
+	assert.Equal(t, mainSess, sess)
+
+	mainSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_FallbackTestFails tests fallback when unconnected is also unreachable
+func TestConnectionManager_FallbackTestFails(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	connectedSess := new(mockSession)
+	unconnectedSess := new(mockSession)
+
+	// Connected session fails with timeout
+	connectedSess.On("Connect").Return(nil).Once()
+	connectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, newMockTimeoutError("timeout")).Once()
+
+	// Unconnected session connects but is also unreachable
+	unconnectedSess.On("Connect").Return(nil).Once()
+	unconnectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, errors.New("still fails")).Once()
+	unconnectedSess.On("Close").Return(nil).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		if callCount == 1 {
+			return connectedSess, nil
+		}
+		return unconnectedSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.NoError(t, err)
+	assert.False(t, reachable)
+	// When unconnected is also unreachable, fall back to connected session
+	assert.NotNil(t, sess)
+	assert.Equal(t, connectedSess, sess)
+
+	connectedSess.AssertExpectations(t)
+	unconnectedSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_Close tests connection closing
+func TestConnectionManager_Close(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	sess := new(mockSession)
+	sess.On("Connect").Return(nil).Once()
+	sess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+	sess.On("Close").Return(nil).Once()
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	gotSess, reachable, err := connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, sess, gotSess)
+
+	err = connMgr.Close()
+	assert.NoError(t, err)
+
+	sess.AssertExpectations(t)
+}
+
+// TestConnectionManager_GetSessionAfterClose tests that GetSession returns error after Close
+func TestConnectionManager_GetSessionAfterClose(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	sess := new(mockSession)
+	sess.On("Connect").Return(nil).Once()
+	sess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+	sess.On("Close").Return(nil).Once()
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+
+	// Connect should succeed
+	gotSess, reachable, err := connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, sess, gotSess)
+
+	// GetSession should work before Close
+	gotSess, err = connMgr.GetSession()
+	assert.NoError(t, err)
+	assert.Equal(t, sess, gotSess)
+
+	// Close the session
+	err = connMgr.Close()
+	assert.NoError(t, err)
+
+	// GetSession should now return an error
+	gotSess, err = connMgr.GetSession()
+	assert.Error(t, err)
+	assert.Nil(t, gotSess)
+	assert.Contains(t, err.Error(), "session not initialized")
+
+	sess.AssertExpectations(t)
+}
+
+// TestConnectionManager_SubsequentConnectUsesConnectedMode tests that after first success,
+// subsequent Connect() calls use connected mode without re-testing fallback
+func TestConnectionManager_SubsequentConnectUsesConnectedMode(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	firstSess := new(mockSession)
+	secondSess := new(mockSession)
+
+	// First session succeeds
+	firstSess.On("Connect").Return(nil).Once()
+	firstSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+	firstSess.On("Close").Return(nil).Once()
+
+	// Second session also succeeds (should use connected mode)
+	secondSess.On("Connect").Return(nil).Once()
+	secondSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		// Both calls should use connected mode (UseUnconnectedUDPSocket = false)
+		assert.False(t, cfg.UseUnconnectedUDPSocket, "Call %d should use connected mode", callCount)
+		if callCount == 1 {
+			return firstSess, nil
+		}
+		return secondSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+
+	// First connect
+	sess, reachable, err := connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, firstSess, sess)
+
+	// Close and reconnect
+	err = connMgr.Close()
+	assert.NoError(t, err)
+
+	// Second connect - should use connected mode, not test fallback
+	sess, reachable, err = connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, secondSess, sess)
+
+	firstSess.AssertExpectations(t)
+	secondSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_SubsequentConnectUsesUnconnectedMode tests that after fallback is chosen,
+// subsequent Connect() calls use unconnected mode
+func TestConnectionManager_SubsequentConnectUsesUnconnectedMode(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	connectedSess := new(mockSession)
+	unconnectedSess1 := new(mockSession)
+	unconnectedSess2 := new(mockSession)
+
+	// First: connected times out
+	connectedSess.On("Connect").Return(nil).Once()
+	connectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, newMockTimeoutError("timeout")).Once()
+	connectedSess.On("Close").Return(nil).Once()
+
+	// First: unconnected succeeds
+	unconnectedSess1.On("Connect").Return(nil).Once()
+	unconnectedSess1.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(&gosnmp.SnmpPacket{}, nil).Once()
+	unconnectedSess1.On("Close").Return(nil).Once()
+
+	// Second connect: should directly use unconnected mode
+	unconnectedSess2.On("Connect").Return(nil).Once()
+	unconnectedSess2.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(&gosnmp.SnmpPacket{}, nil).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		switch callCount {
+		case 1:
+			assert.False(t, cfg.UseUnconnectedUDPSocket, "First call should be connected")
+			return connectedSess, nil
+		case 2:
+			assert.True(t, cfg.UseUnconnectedUDPSocket, "Second call should be unconnected (fallback test)")
+			return unconnectedSess1, nil
+		case 3:
+			assert.True(t, cfg.UseUnconnectedUDPSocket, "Third call should be unconnected (mode decided)")
+			return unconnectedSess2, nil
+		}
+		t.Fatalf("Unexpected call count: %d", callCount)
+		return nil, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+
+	// First connect - triggers fallback
+	sess, reachable, err := connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, unconnectedSess1, sess)
+
+	// Close and reconnect
+	err = connMgr.Close()
+	assert.NoError(t, err)
+
+	// Second connect - should use unconnected mode directly
+	sess, reachable, err = connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, unconnectedSess2, sess)
+
+	connectedSess.AssertExpectations(t)
+	unconnectedSess1.AssertExpectations(t)
+	unconnectedSess2.AssertExpectations(t)
+}
+
+// TestConnectionManager_SessionFactoryError tests that factory errors are propagated
+func TestConnectionManager_SessionFactoryError(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	factoryErr := errors.New("failed to create session")
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return nil, factoryErr
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create session")
+	assert.False(t, reachable)
+	assert.Nil(t, sess)
+}
+
+// TestConnectionManager_SessionConnectError tests that Connect() errors are propagated
+func TestConnectionManager_SessionConnectError(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	mainSess := new(mockSession)
+	mainSess.On("Connect").Return(errors.New("connection refused")).Once()
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return mainSess, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.False(t, reachable)
+	assert.Nil(t, sess)
+
+	mainSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_UnconnectedSessionCreationFails tests that when unconnected session
+// creation fails during fallback, we stick with the connected session
+func TestConnectionManager_UnconnectedSessionCreationFails(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	connectedSess := new(mockSession)
+
+	// Connected session times out
+	connectedSess.On("Connect").Return(nil).Once()
+	connectedSess.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).
+		Return(nil, newMockTimeoutError("timeout")).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		if callCount == 1 {
+			return connectedSess, nil
+		}
+		// Unconnected session creation fails
+		return nil, errors.New("failed to create unconnected session")
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, reachable, err := connMgr.Connect()
+
+	// Should return connected session even though it's unreachable
+	assert.NoError(t, err)
+	assert.False(t, reachable)
+	assert.Equal(t, connectedSess, sess)
+
+	connectedSess.AssertExpectations(t)
+}
+
+// TestConnectionManager_GetSessionBeforeConnect tests GetSession before any Connect call
+func TestConnectionManager_GetSessionBeforeConnect(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return nil, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	sess, err := connMgr.GetSession()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "session not initialized")
+	assert.Nil(t, sess)
+}
+
+// TestConnectionManager_CloseWithoutSession tests Close when no session exists
+func TestConnectionManager_CloseWithoutSession(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		return nil, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	err := connMgr.Close()
+
+	assert.NoError(t, err)
+}
+
+// TestConnectionManager_ReconnectAfterClose tests that Connect works after Close
+func TestConnectionManager_ReconnectAfterClose(t *testing.T) {
+	config := &checkconfig.CheckConfig{
+		IPAddress: "10.0.0.1",
+	}
+
+	sess1 := new(mockSession)
+	sess2 := new(mockSession)
+
+	sess1.On("Connect").Return(nil).Once()
+	sess1.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+	sess1.On("Close").Return(nil).Once()
+
+	sess2.On("Connect").Return(nil).Once()
+	sess2.On("GetNext", []string{coresnmp.DeviceReachableGetNextOid}).Return(&gosnmp.SnmpPacket{}, nil).Once()
+
+	callCount := 0
+	sessionFactory := func(cfg *checkconfig.CheckConfig) (session.Session, error) {
+		callCount++
+		if callCount == 1 {
+			return sess1, nil
+		}
+		return sess2, nil
+	}
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+
+	// First connect
+	gotSess, reachable, err := connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, sess1, gotSess)
+
+	// Close
+	err = connMgr.Close()
+	assert.NoError(t, err)
+
+	// Verify session is cleared
+	gotSess, err = connMgr.GetSession()
+	assert.Error(t, err)
+	assert.Nil(t, gotSess)
+
+	// Reconnect
+	gotSess, reachable, err = connMgr.Connect()
+	assert.NoError(t, err)
+	assert.True(t, reachable)
+	assert.Equal(t, sess2, gotSess)
+
+	sess1.AssertExpectations(t)
+	sess2.AssertExpectations(t)
+}
+
+// TestIsTimeoutError tests timeout error detection
+func TestIsTimeoutError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "network timeout error",
+			err:      newMockTimeoutError("timeout"),
+			expected: true,
+		},
+		{
+			name:     "wrapped network timeout",
+			err:      fmt.Errorf("wrapped: %w", newMockTimeoutError("timeout")),
+			expected: true,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTimeoutError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -57,7 +57,8 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -197,7 +198,8 @@ global_metrics:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -246,7 +248,8 @@ community_string: public
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, session.NewMockSession)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -277,7 +280,8 @@ community_string: public
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, session.NewMockSession)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	hostname, err := deviceCk.GetDeviceHostname()
@@ -343,7 +347,8 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	snmpTags := []string{"snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "snmp_profile:f5-big-ip", "device_vendor:f5", "snmp_host:foo_sys_name",
@@ -648,7 +653,8 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -695,7 +701,8 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	// override pinger with mock pinger
@@ -846,7 +853,8 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	// override pinger with mock pinger
@@ -991,7 +999,8 @@ collect_topology: false
 	cfg := agentconfig.NewMock(t)
 	cfg.SetWithoutSource("tags", []string{"tag1:value1"})
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, cfg)
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, cfg)
 	assert.Nil(t, err)
 
 	// WHEN
@@ -1020,7 +1029,8 @@ collect_topology: false
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -1136,4 +1146,40 @@ collect_topology: false
 		"1.3.6.1.2.1.31.1.1.1.18",
 		"1.3.6.1.2.1.4.20.1.2",
 	}, deviceCk.profileCache.columnOIDs)
+}
+
+// TestDeviceCheck_ConnectionManager_Initialized tests that ConnectionManager is initialized
+func TestDeviceCheck_ConnectionManager_Initialized(t *testing.T) {
+	profile.SetConfdPathAndCleanProfiles()
+	sess := session.CreateFakeSession()
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+collect_topology: false
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+profiles:
+  f5-big-ip:
+    definition_file: f5-big-ip.yaml
+`)
+
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+	assert.Nil(t, err)
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
+	assert.Nil(t, err)
+
+	// Verify ConnectionManager is initialized
+	assert.NotNil(t, deviceCk.connMgr, "ConnectionManager should be initialized in NewDeviceCheck")
+
+	// Verify it's the correct type (implementation detail, but good to check)
+	_, ok := deviceCk.connMgr.(*snmpConnectionManager)
+	assert.True(t, ok, "connMgr should be a *snmpConnectionManager")
 }

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -243,7 +243,9 @@ func (d *Discovery) getDevicesFound() []string {
 }
 
 func (d *Discovery) createDevice(deviceDigest checkconfig.DeviceDigest, subnet *snmpSubnet, deviceIP string, writeCache bool) {
-	deviceCk, err := devicecheck.NewDeviceCheck(subnet.config, deviceIP, d.sessionFactory, d.agentConfig)
+	deviceConfig := subnet.config.CopyWithNewIP(deviceIP)
+	connMgr := devicecheck.NewConnectionManager(deviceConfig, d.sessionFactory)
+	deviceCk, err := devicecheck.NewDeviceCheck(deviceConfig, connMgr, d.agentConfig)
 	if err != nil {
 		// should not happen since the deviceCheck is expected to be valid at this point
 		// and are only changing the device ip

--- a/pkg/collector/corechecks/snmp/internal/session/fake_session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/fake_session.go
@@ -148,6 +148,11 @@ func (fs *FakeSession) GetVersion() gosnmp.SnmpVersion {
 	return gosnmp.Version3
 }
 
+// IsUnconnectedUDP returns false for FakeSession
+func (fs *FakeSession) IsUnconnectedUDP() bool {
+	return false
+}
+
 // Get gets the values for the given OIDs. OIDs not in the session will return
 // PDUs of type NoSuchObject.
 func (fs *FakeSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) {

--- a/pkg/collector/corechecks/snmp/internal/session/session.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session.go
@@ -39,6 +39,7 @@ type Session interface {
 	GetSnmpGetBulkCount() uint32
 	GetSnmpGetNextCount() uint32
 	GetVersion() gosnmp.SnmpVersion
+	IsUnconnectedUDP() bool
 }
 
 // GosnmpSession is used to connect to a snmp device
@@ -95,6 +96,11 @@ func (s *GosnmpSession) GetSnmpGetNextCount() uint32 {
 // GetVersion returns the snmp version used
 func (s *GosnmpSession) GetVersion() gosnmp.SnmpVersion {
 	return s.gosnmpInst.Version
+}
+
+// IsUnconnectedUDP returns whether the session uses unconnected UDP socket mode
+func (s *GosnmpSession) IsUnconnectedUDP() bool {
+	return s.gosnmpInst.UseUnconnectedUDPSocket
 }
 
 // NewGosnmpSession creates a new session
@@ -162,6 +168,7 @@ func NewGosnmpSession(config *checkconfig.CheckConfig) (Session, error) {
 	s.gosnmpInst.Port = config.Port
 	s.gosnmpInst.Timeout = time.Duration(config.Timeout) * time.Second
 	s.gosnmpInst.Retries = config.Retries
+	s.gosnmpInst.UseUnconnectedUDPSocket = config.UseUnconnectedUDPSocket
 
 	lvl, err := log.GetLogLevel()
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -453,3 +453,61 @@ func TestFetchAllOIDsUsingGetNext_invalidZeroVariable(t *testing.T) {
 	resultOIDs := FetchAllOIDsUsingGetNext(sess) // no packet created if variables != 1
 	assert.Equal(t, []string(nil), resultOIDs)
 }
+
+// mockTimeoutError implements net.Error with Timeout() returning true
+type mockTimeoutError struct {
+	msg string
+}
+
+func (e *mockTimeoutError) Error() string   { return e.msg }
+func (e *mockTimeoutError) Timeout() bool   { return true }
+func (e *mockTimeoutError) Temporary() bool { return true }
+
+// mockNonTimeoutError is a regular error that doesn't implement net.Error
+type mockNonTimeoutError struct {
+	msg string
+}
+
+func (e *mockNonTimeoutError) Error() string { return e.msg }
+
+// TestUseUnconnectedUDPSocketPropagation tests that UseUnconnectedUDPSocket config is applied to gosnmp
+func TestUseUnconnectedUDPSocketPropagation(t *testing.T) {
+	tests := []struct {
+		name                     string
+		useUnconnectedUDPSocket  bool
+		expectedGosnmpValue      bool
+	}{
+		{
+			name:                    "UseUnconnectedUDPSocket true is propagated",
+			useUnconnectedUDPSocket: true,
+			expectedGosnmpValue:     true,
+		},
+		{
+			name:                    "UseUnconnectedUDPSocket false is propagated",
+			useUnconnectedUDPSocket: false,
+			expectedGosnmpValue:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &checkconfig.CheckConfig{
+				IPAddress:               "127.0.0.1",
+				Port:                    161,
+				CommunityString:         "public",
+				SnmpVersion:             "2c",
+				UseUnconnectedUDPSocket: tt.useUnconnectedUDPSocket,
+			}
+
+			sess, err := NewGosnmpSession(config)
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+
+			gosnmpSess, ok := sess.(*GosnmpSession)
+			require.True(t, ok, "Expected *GosnmpSession type")
+
+			assert.Equal(t, tt.expectedGosnmpValue, gosnmpSess.gosnmpInst.UseUnconnectedUDPSocket,
+				"UseUnconnectedUDPSocket should be propagated to gosnmp instance")
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/internal/session/session_test.go
+++ b/pkg/collector/corechecks/snmp/internal/session/session_test.go
@@ -454,28 +454,12 @@ func TestFetchAllOIDsUsingGetNext_invalidZeroVariable(t *testing.T) {
 	assert.Equal(t, []string(nil), resultOIDs)
 }
 
-// mockTimeoutError implements net.Error with Timeout() returning true
-type mockTimeoutError struct {
-	msg string
-}
-
-func (e *mockTimeoutError) Error() string   { return e.msg }
-func (e *mockTimeoutError) Timeout() bool   { return true }
-func (e *mockTimeoutError) Temporary() bool { return true }
-
-// mockNonTimeoutError is a regular error that doesn't implement net.Error
-type mockNonTimeoutError struct {
-	msg string
-}
-
-func (e *mockNonTimeoutError) Error() string { return e.msg }
-
 // TestUseUnconnectedUDPSocketPropagation tests that UseUnconnectedUDPSocket config is applied to gosnmp
 func TestUseUnconnectedUDPSocketPropagation(t *testing.T) {
 	tests := []struct {
-		name                     string
-		useUnconnectedUDPSocket  bool
-		expectedGosnmpValue      bool
+		name                    string
+		useUnconnectedUDPSocket bool
+		expectedGosnmpValue     bool
 	}{
 		{
 			name:                    "UseUnconnectedUDPSocket true is propagated",

--- a/pkg/collector/corechecks/snmp/internal/session/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/session/testing_utils.go
@@ -89,9 +89,8 @@ func (s *MockSession) GetVersion() gosnmp.SnmpVersion {
 func (s *MockSession) IsUnconnectedUDP() bool {
 	// If no mock expectation is set, return false by default
 	defer func() {
-		if r := recover(); r != nil {
-			// Swallow panics from unexpected calls
-		}
+		// Swallow panics from unexpected calls
+		_ = recover()
 	}()
 
 	// Check if there's an expectation set

--- a/pkg/collector/corechecks/snmp/internal/session/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/session/testing_utils.go
@@ -85,6 +85,27 @@ func (s *MockSession) GetVersion() gosnmp.SnmpVersion {
 	return s.Version
 }
 
+// IsUnconnectedUDP returns whether the session uses unconnected UDP socket mode
+func (s *MockSession) IsUnconnectedUDP() bool {
+	// If no mock expectation is set, return false by default
+	defer func() {
+		if r := recover(); r != nil {
+			// Swallow panics from unexpected calls
+		}
+	}()
+
+	// Check if there's an expectation set
+	for _, call := range s.ExpectedCalls {
+		if call.Method == "IsUnconnectedUDP" {
+			args := s.Mock.Called()
+			return args.Bool(0)
+		}
+	}
+
+	// No expectation set, return false by default
+	return false
+}
+
 // CreateMockSession creates a mock session
 func CreateMockSession() *MockSession {
 	session := &MockSession{

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -162,7 +162,8 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 		c.discovery = discovery.NewDiscovery(c.config, c.sessionFactory, c.agentConfig, c.scanManager)
 		c.discovery.Start()
 	} else {
-		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress, c.sessionFactory, c.agentConfig)
+		connMgr := devicecheck.NewConnectionManager(c.config, c.sessionFactory)
+		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, connMgr, c.agentConfig)
 		if err != nil {
 			return fmt.Errorf("failed to create device check: %s", err)
 		}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1634,6 +1634,7 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	mockConfig := configmock.New(t)
 	testDir := t.TempDir()
 	mockConfig.SetWithoutSource("run_path", testDir)
+	mockConfig.SetWithoutSource("hostname", "my-hostname")
 	timeNow = common.MockTimeNow
 	deps := createDeps(t)
 	senderManager := deps.Demultiplexer

--- a/releasenotes/notes/snmp-unconnected-udp-820a61fc63385d38.yaml
+++ b/releasenotes/notes/snmp-unconnected-udp-820a61fc63385d38.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add support for unconnected UDP sockets in the SNMP corecheck.
+    Automatically fallback to unconnected UDP sockets if the connected UDP socket times out.


### PR DESCRIPTION
## What does this PR do?

Introduces a `ConnectionManager` to handle SNMP session creation with automatic fallback to unconnected UDP sockets for devices that respond from different IP addresses than the one queried.

## Motivation

Some network configurations cause devices to respond to SNMP queries from a different IP address. The official snmpwalk command allows this behavior by default while the Datadog Agent doesn't.

Standard "connected" UDP sockets fail in these scenarios because they expect responses from the same IP they sent to. This results in timeouts even though the device is responding.

## Solution

The `ConnectionManager` implements a smart connection strategy:

1. **First connection attempt:**
   - Try connected socket first (normal/optimal case)
   - If timeout occurs, test unconnected socket once
   - Permanently decide which mode to use based on test result

2. **Subsequent connections:**
   - Always use the previously decided mode
   - No more testing overhead

## Changes

### Core Changes
- **ConnectionManager interface** - Encapsulates connection logic and mode selection
- **snmpConnectionManager implementation** - Smart fallback logic with permanent mode decision
- **DeviceCheck refactor** - Uses ConnectionManager instead of direct session access

### Testing & Debugging
- Comprehensive unit tests covering all connection scenarios
- `wrong_source_ip_simulator` - Tool to simulate devices responding from different IPs

### Configuration
- Added `UseUnconnectedUDPSocket` field to `CheckConfig`
- CLI tools (`snmpwalk`, `snmpscan`) now default to unconnected mode (matches standard SNMP tools)

## Test Plan

1. ✅ Unit tests for all connection scenarios
2. ✅ Tests for mode persistence across reconnections
3. ✅ Tests for proper error handling and edge cases
4. Manual testing with `wrong_source_ip_simulator`

## Telemetry

Added `snmp.devices.using_unconnected_socket` metric to track devices requiring fallback mode.

## Risks & Considerations

- Low risk: fallback only triggers on timeout, not on auth errors or other failures
- Mode decision is permanent per device to avoid testing overhead
- Unconnected sockets are standard SNMP behavior (used by `snmpwalk`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)