### PR TITLE
[CWS] allow system-probe config to be re-adjusted when reloading config

### DIFF
--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -883,6 +883,12 @@ func genTestConfigs(t testing.TB, cfgDir string, opts testOpts) (*emconfig.Confi
 		return nil, nil, fmt.Errorf("unable to set up datadog.yaml configuration: %s", err)
 	}
 
+	// reset the system-probe config to not be adjusted yet
+	// necessary because the config object is a global, and we want the adjustment
+	// to happen again
+	cfg := pkgconfigsetup.GlobalSystemProbeConfigBuilder()
+	cfg.Set("system_probe_config.adjusted", false, pkgconfigmodel.SourceAgentRuntime)
+
 	_, err = spconfig.New(sysprobeConfigName, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load config: %w", err)


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
