### PR TITLE
Change how Windows `dll.a` files from openssl's build are treated

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -44,11 +44,6 @@ copy_to_directory(
         "openssl/lib",
         "openssl",
     ],
-    replace_prefixes = {
-        # We need to rename the .dll.a's into .lib files as the Python build expects
-        "libcrypto.dll.a": "libcrypto.lib",
-        "libssl.dll.a": "libssl.lib",
-    },
 )
 
 run_binary(

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -1,6 +1,7 @@
 load("@//bazel/rules:cc_shared_library_wrapper.bzl", "cc_shared_library_wrapper")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
+load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
@@ -119,10 +120,10 @@ configure_make(
     }),
     lib_source = ":all_srcs",
     out_include_dir = "include",
-    out_static_libs = select({
+    out_interface_libs = select({
         "@platforms//os:windows": [
-            "libssl.dll.a",
-            "libcrypto.dll.a",
+            "libssl.lib",
+            "libcrypto.lib",
         ],
         "//conditions:default": [],
     }),
@@ -177,6 +178,11 @@ configure_make(
         """ + FIX_OPENSSL_PATHS + """
         codesign -s - -f $$INSTALLDIR/lib/libcrypto.dylib $$INSTALLDIR/lib/libssl.dylib
         """,
+        # Rename .dll.a files into the appropriate extension for import libraries (.lib)
+        "@platforms//os:windows": """
+        mv $$INSTALLDIR/lib/libcrypto.dll.a $$INSTALLDIR/lib/libcrypto.lib
+        mv $$INSTALLDIR/lib/libssl.dll.a $$INSTALLDIR/lib/libssl.lib
+        """,
         "//conditions:default": """
             LIBS="$$INSTALLDIR/lib/libcrypto.so $$INSTALLDIR/lib/libssl.so"
         """ + FIX_OPENSSL_PATHS,
@@ -187,8 +193,6 @@ cc_shared_library_wrapper(
     name = "openssl_shared",
     input = ":openssl",
 )
-
-########################################################################
 
 filegroup(
     name = "headers",
@@ -266,27 +270,31 @@ filegroup(
     output_group = "pkgconfig",
 )
 
-filegroup(
-    name = "libcrypto_dll_a",
-    srcs = [":openssl"],
-    output_group = "libcrypto.dll.a",
+# "interface libs" are not exposed as output groups, therefore we use a more versatile rule to get these
+select_file(
+    name = "libcrypto_import_lib",
+    srcs = ":openssl",
+    subpath = "openssl/lib/libcrypto.lib",
     target_compatible_with = ["@platforms//os:windows"],
 )
 
-filegroup(
-    name = "libssl_dll_a",
-    srcs = [":openssl"],
-    output_group = "libssl.dll.a",
+select_file(
+    name = "libssl_import_lib",
+    srcs = ":openssl",
+    subpath = "openssl/lib/libssl.lib",
     target_compatible_with = ["@platforms//os:windows"],
 )
 
 pkg_files(
-    name = "dll_a",
+    name = "import_lib_files",
     srcs = [
-        ":libcrypto_dll_a",
-        ":libssl_dll_a",
+        ":libcrypto_import_lib",
+        ":libssl_import_lib",
     ],
-    prefix = "lib",
+    # Putting these in this folder is a "tactical" choice. The main reason we need these at all
+    # is to be able to build Python native extensions against the Agent's embedded OpenSSL.
+    # Since the OpenSSL DLLs will end up in that place (due to Python's expected installation layout)
+    prefix = "DLLs",
     target_compatible_with = ["@platforms//os:windows"],
 )
 
@@ -324,7 +332,7 @@ pkg_install(
         ":libcrypto_with_symlink",
     ] + select({
         "@platforms//os:windows": [
-            ":dll_a",
+            ":import_lib_files",
             ":openssl_exe_file",
         ],
         "//conditions:default": [

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -291,10 +291,7 @@ pkg_files(
         ":libcrypto_import_lib",
         ":libssl_import_lib",
     ],
-    # Putting these in this folder is a "tactical" choice. The main reason we need these at all
-    # is to be able to build Python native extensions against the Agent's embedded OpenSSL.
-    # Since the OpenSSL DLLs will end up in that place (due to Python's expected installation layout)
-    prefix = "DLLs",
+    prefix = "lib",
     target_compatible_with = ["@platforms//os:windows"],
 )
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -294,12 +294,6 @@ build do
       dll_folder = File.join(install_dir, "embedded3", "DLLS")
       include_folder = File.join(install_dir, "embedded3", "include")
 
-      # We first need create links to some files around such that cryptography finds .lib files
-      link File.join(lib_folder, "libssl.dll.a"),
-           File.join(dll_folder, "libssl-3-x64.lib")
-      link File.join(lib_folder, "libcrypto.dll.a"),
-           File.join(dll_folder, "libcrypto-3-x64.lib")
-
       block "Build cryptography library against Agent's OpenSSL" do
         cryptography_requirement = (shellout! "#{python} -m pip list --format=freeze").stdout[/cryptography==.*?$/]
 
@@ -307,7 +301,6 @@ build do
                 env: {
                   "OPENSSL_LIB_DIR" => dll_folder,
                   "OPENSSL_INCLUDE_DIR" => include_folder,
-                  "OPENSSL_LIBS" => "libssl-3-x64:libcrypto-3-x64",
                 }
       end
       # Python extensions on windows require this to find their DLL dependencies,

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -291,7 +291,6 @@ build do
     elsif windows_target?
       # Build the cryptography library in this case so that it gets linked to Agent's OpenSSL
       lib_folder = File.join(install_dir, "embedded3", "lib")
-      dll_folder = File.join(install_dir, "embedded3", "DLLS")
       include_folder = File.join(install_dir, "embedded3", "include")
 
       block "Build cryptography library against Agent's OpenSSL" do
@@ -299,7 +298,7 @@ build do
 
         shellout! "#{python} -m pip install --force-reinstall --no-deps --no-binary cryptography #{cryptography_requirement}",
                 env: {
-                  "OPENSSL_LIB_DIR" => dll_folder,
+                  "OPENSSL_LIB_DIR" => lib_folder,
                   "OPENSSL_INCLUDE_DIR" => include_folder,
                 }
       end

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -120,12 +120,9 @@ build do
 
     delete "#{install_dir}/embedded/bin/c_rehash"
     if windows?
-      # Putting these in this folder is a "tactical" choice. The main reason we need these at all
-      # is to be able to build Python native extensions against the Agent's embedded OpenSSL.
-      # Since the OpenSSL DLLs will end up in that place (due to Python's expected installation layout)
-      mkdir "#{install_dir}/embedded3/DLLs"
-      move "#{install_dir}/embedded3/lib/libcrypto.dll.a", "#{install_dir}/embedded3/DLLs/libcrypto.lib"
-      move "#{install_dir}/embedded3/lib/libssl.dll.a", "#{install_dir}/embedded3/DLLs/libssl.lib"
+      # Rename to more standard .lib suffix for windows import libraries
+      move "#{install_dir}/embedded3/lib/libcrypto.dll.a", "#{install_dir}/embedded3/lib/libcrypto.lib"
+      move "#{install_dir}/embedded3/lib/libssl.dll.a", "#{install_dir}/embedded3/lib/libssl.lib"
     else
       # Remove openssl static libraries here as we can't disable those at build time
       delete "#{install_dir}/embedded/lib/libcrypto.a"

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -119,11 +119,17 @@ build do
     command "make install_sw install_ssldirs", env: env
 
     delete "#{install_dir}/embedded/bin/c_rehash"
-    unless windows?
+    if windows?
+      # Putting these in this folder is a "tactical" choice. The main reason we need these at all
+      # is to be able to build Python native extensions against the Agent's embedded OpenSSL.
+      # Since the OpenSSL DLLs will end up in that place (due to Python's expected installation layout)
+      mkdir "#{install_dir}/embedded3/DLLs"
+      move "#{install_dir}/embedded3/lib/libcrypto.dll.a", "#{install_dir}/embedded3/DLLs/libcrypto.lib"
+      move "#{install_dir}/embedded3/lib/libssl.dll.a", "#{install_dir}/embedded3/DLLs/libssl.lib"
+    else
       # Remove openssl static libraries here as we can't disable those at build time
       delete "#{install_dir}/embedded/lib/libcrypto.a"
       delete "#{install_dir}/embedded/lib/libssl.a"
-    else
-    end
     end
   end
+end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -45,8 +45,8 @@ build do
     mkdir "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include"
     # Link the import library to have them point at our own built versions, regardless of
     # their names in usual python builds
-    link "#{install_dir}\\embedded3\\DLLs\\libcrypto.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto.lib"
-    link "#{install_dir}\\embedded3\\DLLs\\libssl.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
+    link "#{install_dir}\\embedded3\\lib\\libcrypto.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto.lib"
+    link "#{install_dir}\\embedded3\\lib\\libssl.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
     copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.dll"
     # Create empty PDBs since python's build system require those to be present

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -43,10 +43,10 @@ build do
     python_arch = "amd64"
 
     mkdir "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include"
-    # Copy the import library to have them point at our own built versions, regardless of
+    # Link the import library to have them point at our own built versions, regardless of
     # their names in usual python builds
-    copy "#{install_dir}\\embedded3\\lib\\libcrypto.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto.lib"
-    copy "#{install_dir}\\embedded3\\lib\\libssl.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
+    link "#{install_dir}\\embedded3\\DLLs\\libcrypto.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto.lib"
+    link "#{install_dir}\\embedded3\\DLLs\\libssl.lib", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
     copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.dll"
     # Create empty PDBs since python's build system require those to be present


### PR DESCRIPTION
### What does this PR do?

- Rename them to .lib extension before outputting with Bazel rule, also moving them from static to interface libs, which is semantically more correct. The .lib extension is the extension most tools expect for "import libraries".
- Reduce the number of moving around of these files by putting them in the right place and the right extension from the start.

### Motivation

- Use the semantically correct field in `configure_make` rule, moving these files out of the misleading _static libs_ category.
- Reduce the amount of renames and moving around of these files all around.

### Describe how you validated your changes

Passing CI.

I did some additional checks to make sure that cryptography's linking to openssl is not broken.

### Additional Notes

As I was doing these manipulations, I also realized that at least the cryptography build doesn't need the actual DLL at build time, and that the lib file doesn't need to match the DLL's name in any way (i.e. the `-3-x64` suffixes). This allowed further simplification there.