### PR TITLE
Add E2E_DEV_LOCAL support for local Kind provisioner in SSI tests

### DIFF
--- a/test/e2e-framework/testing/provisioners/local/kubernetes/kind.go
+++ b/test/e2e-framework/testing/provisioners/local/kubernetes/kind.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	provisionerBaseID = "aws-kind-"
+	provisionerBaseID = "local-kind-"
 	defaultVMName     = "kind"
 )
 

--- a/test/e2e-framework/testing/runner/parameters/const.go
+++ b/test/e2e-framework/testing/runner/parameters/const.go
@@ -67,6 +67,8 @@ const (
 	PulumiVerboseProgressStreams StoreKey = "pulumi_verbose_progress_streams"
 	// DevMode allows to keep the stack after the test completes
 	DevMode StoreKey = "dev_mode"
+	// DevLocal uses local Kind cluster instead of AWS for faster development
+	DevLocal StoreKey = "dev_local"
 	// InitOnly config flag parameter name
 	InitOnly StoreKey = "init_only"
 	// TeardownOnly config flag parameter name

--- a/test/e2e-framework/testing/runner/parameters/store_config_file.go
+++ b/test/e2e-framework/testing/runner/parameters/store_config_file.go
@@ -44,6 +44,7 @@ type ConfigParams struct {
 	OutputDir string `yaml:"outputDir"`
 	Pulumi    Pulumi `yaml:"pulumi"`
 	DevMode   string `yaml:"devMode"`
+	DevLocal  string `yaml:"devLocal"`
 }
 
 // AWS instance contains AWS related parameters
@@ -200,6 +201,8 @@ func (s configFileValueStore) get(key StoreKey) (string, error) {
 		value = s.config.ConfigParams.Pulumi.VerboseProgressStreams
 	case DevMode:
 		value = s.config.ConfigParams.DevMode
+	case DevLocal:
+		value = s.config.ConfigParams.DevLocal
 	}
 
 	if value == "" {

--- a/test/e2e-framework/testing/runner/parameters/store_env.go
+++ b/test/e2e-framework/testing/runner/parameters/store_env.go
@@ -41,6 +41,7 @@ var envVariablesByStoreKey = map[StoreKey]string{
 	PulumiLogToStdErr:            "E2E_PULUMI_LOG_TO_STDERR",
 	PulumiVerboseProgressStreams: "E2E_PULUMI_VERBOSE_PROGRESS_STREAMS",
 	DevMode:                      "E2E_DEV_MODE",
+	DevLocal:                     "E2E_DEV_LOCAL",
 	InitOnly:                     "E2E_INIT_ONLY",
 	TeardownOnly:                 "E2E_TEARDOWN_ONLY",
 	MajorVersion:                 "E2E_MAJOR_VERSION",

--- a/test/new-e2e/tests/ssi/local_sdk_injection_test.go
+++ b/test/new-e2e/tests/ssi/local_sdk_injection_test.go
@@ -18,10 +18,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/singlestep"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	compkube "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 )
 
 type localSDKInjectionSuite struct {
@@ -31,39 +29,39 @@ type localSDKInjectionSuite struct {
 func TestLocalSDKInjectionSuite(t *testing.T) {
 	helmValues, err := os.ReadFile("testdata/local_sdk_injection.yaml")
 	require.NoError(t, err, "Could not open helm values file for test")
-	e2e.Run(t, &localSDKInjectionSuite{}, e2e.WithProvisioner(provkindvm.Provisioner(
-		provkindvm.WithRunOptions(
-			kindvm.WithAgentDependentWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
-				return singlestep.Scenario(e, kubeProvider, "local-sdk-injection", []singlestep.Namespace{
-					{
-						Name: "application",
-						Apps: []singlestep.App{
-							{
-								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
-								PodLabels: map[string]string{
-									"admission.datadoghq.com/enabled": "true",
-									"tags.datadoghq.com/service":      DefaultAppName,
-								},
-								PodAnnotations: map[string]string{
-									"admission.datadoghq.com/python-lib.version": "v3.18.1",
-								},
+	e2e.Run(t, &localSDKInjectionSuite{}, e2e.WithProvisioner(Provisioner(ProvisionerOptions{
+		AgentOptions: []kubernetesagentparams.Option{
+			kubernetesagentparams.WithHelmValues(string(helmValues)),
+		},
+		AgentDependentWorkloadAppFunc: func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
+			return singlestep.Scenario(e, kubeProvider, "local-sdk-injection", []singlestep.Namespace{
+				{
+					Name: "application",
+					Apps: []singlestep.App{
+						{
+							Name:    DefaultAppName,
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
+							PodLabels: map[string]string{
+								"admission.datadoghq.com/enabled": "true",
+								"tags.datadoghq.com/service":      DefaultAppName,
 							},
-							{
-								Name:    "expect-no-injection",
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
+							PodAnnotations: map[string]string{
+								"admission.datadoghq.com/python-lib.version": "v3.18.1",
 							},
 						},
+						{
+							Name:    "expect-no-injection",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
+						},
 					},
-				}, dependsOnAgent)
-			}),
-			kindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(string(helmValues))),
-		),
-	)))
+				},
+			}, dependsOnAgent)
+		},
+	})))
 }
 
 func (v *localSDKInjectionSuite) TestClusterAgentInstalled() {

--- a/test/new-e2e/tests/ssi/namespace_selection_test.go
+++ b/test/new-e2e/tests/ssi/namespace_selection_test.go
@@ -19,10 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/singlestep"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	compkube "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 )
 
 type namespaceSelectionSuite struct {
@@ -32,37 +30,37 @@ type namespaceSelectionSuite struct {
 func TestNamespaceSelectionSuite(t *testing.T) {
 	helmValues, err := os.ReadFile("testdata/namespace_selection.yaml")
 	require.NoError(t, err, "Could not open helm values file for test")
-	e2e.Run(t, &namespaceSelectionSuite{}, e2e.WithProvisioner(provkindvm.Provisioner(
-		provkindvm.WithRunOptions(
-			kindvm.WithAgentDependentWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
-				return singlestep.Scenario(e, kubeProvider, "namespace-selection", []singlestep.Namespace{
-					{
-						Name: "expect-injection",
-						Apps: []singlestep.App{
-							{
-								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
-							},
+	e2e.Run(t, &namespaceSelectionSuite{}, e2e.WithProvisioner(Provisioner(ProvisionerOptions{
+		AgentOptions: []kubernetesagentparams.Option{
+			kubernetesagentparams.WithHelmValues(string(helmValues)),
+		},
+		AgentDependentWorkloadAppFunc: func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
+			return singlestep.Scenario(e, kubeProvider, "namespace-selection", []singlestep.Namespace{
+				{
+					Name: "expect-injection",
+					Apps: []singlestep.App{
+						{
+							Name:    DefaultAppName,
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
 						},
 					},
-					{
-						Name: "expect-no-injection",
-						Apps: []singlestep.App{
-							{
-								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
-							},
+				},
+				{
+					Name: "expect-no-injection",
+					Apps: []singlestep.App{
+						{
+							Name:    DefaultAppName,
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
 						},
 					},
-				}, dependsOnAgent)
-			}),
-			kindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(string(helmValues))),
-		),
-	)))
+				},
+			}, dependsOnAgent)
+		},
+	})))
 }
 
 func (v *namespaceSelectionSuite) TestClusterAgentInstalled() {

--- a/test/new-e2e/tests/ssi/provisioner.go
+++ b/test/new-e2e/tests/ssi/provisioner.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ssi
+
+import (
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	localkind "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
+)
+
+// ProvisionerOptions contains the common options for Kubernetes provisioners
+type ProvisionerOptions struct {
+	AgentOptions                  []kubernetesagentparams.Option
+	WorkloadAppFunc               kubeComp.WorkloadAppFunc
+	AgentDependentWorkloadAppFunc kubeComp.AgentDependentWorkloadAppFunc
+}
+
+// Provisioner returns a Kubernetes provisioner based on E2E_DEV_LOCAL parameter.
+// If E2E_DEV_LOCAL=true, returns a local Kind provisioner for faster development.
+// Otherwise, returns an AWS Kind VM provisioner.
+func Provisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
+	if isLocalMode() {
+		return localKindProvisioner(opts)
+	}
+	return awsKindProvisioner(opts)
+}
+
+// isLocalMode returns true if E2E_DEV_LOCAL is set to "true" (via env var or config file)
+func isLocalMode() bool {
+	devLocal, err := runner.GetProfile().ParamStore().GetBoolWithDefault(parameters.DevLocal, false)
+	if err != nil {
+		return false
+	}
+	return devLocal
+}
+
+// localKindProvisioner returns a local Kind provisioner
+func localKindProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
+	var localOpts []localkind.ProvisionerOption
+	if len(opts.AgentOptions) > 0 {
+		localOpts = append(localOpts, localkind.WithAgentOptions(opts.AgentOptions...))
+	}
+	if opts.WorkloadAppFunc != nil {
+		localOpts = append(localOpts, localkind.WithWorkloadApp(opts.WorkloadAppFunc))
+	}
+	if opts.AgentDependentWorkloadAppFunc != nil {
+		localOpts = append(localOpts, localkind.WithAgentDependentWorkloadApp(opts.AgentDependentWorkloadAppFunc))
+	}
+	return localkind.Provisioner(localOpts...)
+}
+
+// awsKindProvisioner returns an AWS Kind VM provisioner
+func awsKindProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
+	var runOpts []kindvm.RunOption
+	if len(opts.AgentOptions) > 0 {
+		runOpts = append(runOpts, kindvm.WithAgentOptions(opts.AgentOptions...))
+	}
+	if opts.WorkloadAppFunc != nil {
+		runOpts = append(runOpts, kindvm.WithWorkloadApp(opts.WorkloadAppFunc))
+	}
+	if opts.AgentDependentWorkloadAppFunc != nil {
+		runOpts = append(runOpts, kindvm.WithAgentDependentWorkloadApp(opts.AgentDependentWorkloadAppFunc))
+	}
+	return provkindvm.Provisioner(provkindvm.WithRunOptions(runOpts...))
+}

--- a/test/new-e2e/tests/ssi/workload_selection_test.go
+++ b/test/new-e2e/tests/ssi/workload_selection_test.go
@@ -19,10 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/apps/singlestep"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
 	compkube "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
-	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
 )
 
 type workloadSelectionSuite struct {
@@ -32,38 +30,38 @@ type workloadSelectionSuite struct {
 func TestWorkloadSelectionSuite(t *testing.T) {
 	helmValues, err := os.ReadFile("testdata/workload_selection.yaml")
 	require.NoError(t, err, "Could not open helm values file for test")
-	e2e.Run(t, &workloadSelectionSuite{}, e2e.WithProvisioner(provkindvm.Provisioner(
-		provkindvm.WithRunOptions(
-			kindvm.WithAgentDependentWorkloadApp(func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
-				return singlestep.Scenario(e, kubeProvider, "workload-selection", []singlestep.Namespace{
-					{
-						Name: "targeted-namespace",
-						Labels: map[string]string{
-							"injection": "yes",
+	e2e.Run(t, &workloadSelectionSuite{}, e2e.WithProvisioner(Provisioner(ProvisionerOptions{
+		AgentOptions: []kubernetesagentparams.Option{
+			kubernetesagentparams.WithHelmValues(string(helmValues)),
+		},
+		AgentDependentWorkloadAppFunc: func(e config.Env, kubeProvider *kubernetes.Provider, dependsOnAgent pulumi.ResourceOption) (*compkube.Workload, error) {
+			return singlestep.Scenario(e, kubeProvider, "workload-selection", []singlestep.Namespace{
+				{
+					Name: "targeted-namespace",
+					Labels: map[string]string{
+						"injection": "yes",
+					},
+					Apps: []singlestep.App{
+						{
+							Name:    DefaultAppName,
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
+							PodLabels: map[string]string{
+								"language": "python",
+							},
 						},
-						Apps: []singlestep.App{
-							{
-								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
-								PodLabels: map[string]string{
-									"language": "python",
-								},
-							},
-							{
-								Name:    "expect-no-injection",
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
-								Port:    8080,
-							},
+						{
+							Name:    "expect-no-injection",
+							Image:   "gcr.io/datadoghq/injector-dev/python",
+							Version: "d425e7df",
+							Port:    8080,
 						},
 					},
-				}, dependsOnAgent)
-			}),
-			kindvm.WithAgentOptions(kubernetesagentparams.WithHelmValues(string(helmValues))),
-		),
-	)))
+				},
+			}, dependsOnAgent)
+		},
+	})))
 }
 
 func (v *workloadSelectionSuite) TestClusterAgentInstalled() {


### PR DESCRIPTION
### What does this PR do?

Adds `E2E_DEV_LOCAL` parameter to run SSI e2e tests on a local Kind cluster instead of AWS. 
Refactors SSI tests to use a unified `Provisioner()` helper.

### Motivation

Faster development iteration - local Kind takes ~3 min vs ~15 min on AWS.

### Describe how you validated your changes

- Ran SSI tests with `E2E_DEV_LOCAL=true` - uses local Kind provisioner
- Ran SSI tests without the flag - uses AWS provisioner

### Additional Notes

Usage:
```
E2E_DEV_LOCAL=true inv new-e2e-tests.run --targets=./tests/ssi --run=TestWorkloadSelectionSuite
```