### PR TITLE
[EBPF] kmt: run on CI when microVMs package in e2e-framework changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -563,6 +563,7 @@ workflow:
   - test/new-e2e/scenarios/system-probe/**/*
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
+  - test/e2e-framework/scenarios/aws/microVMs/**/*
   - test/new-e2e/go.mod
   - go.mod
   - tasks/security_agent.py
@@ -618,6 +619,7 @@ workflow:
   - test/new-e2e/scenarios/system-probe/**/*
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
+  - test/e2e-framework/scenarios/aws/microVMs/**/*
   - test/new-e2e/go.mod
   - go.mod
   - tasks/system_probe.py


### PR DESCRIPTION
### What does this PR do?

Updates the change paths for system-probe and security-agent KMT tests, so that they are executed when the e2e test used for provisioning changes.

### Motivation

Avoid incidents due to changing e2e code without running KMT tests.

### Describe how you validated your changes

CI passing

### Additional Notes
