### PR TITLE
chore(ssi): update e2e test app registry

### DIFF
--- a/test/new-e2e/tests/ssi/local_sdk_injection_test.go
+++ b/test/new-e2e/tests/ssi/local_sdk_injection_test.go
@@ -40,8 +40,8 @@ func TestLocalSDKInjectionSuite(t *testing.T) {
 						Apps: []singlestep.App{
 							{
 								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 								PodLabels: map[string]string{
 									"admission.datadoghq.com/enabled": "true",
@@ -53,8 +53,8 @@ func TestLocalSDKInjectionSuite(t *testing.T) {
 							},
 							{
 								Name:    "expect-no-injection",
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 							},
 						},

--- a/test/new-e2e/tests/ssi/namespace_selection_test.go
+++ b/test/new-e2e/tests/ssi/namespace_selection_test.go
@@ -41,8 +41,8 @@ func TestNamespaceSelectionSuite(t *testing.T) {
 						Apps: []singlestep.App{
 							{
 								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 							},
 						},
@@ -52,8 +52,8 @@ func TestNamespaceSelectionSuite(t *testing.T) {
 						Apps: []singlestep.App{
 							{
 								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 							},
 						},

--- a/test/new-e2e/tests/ssi/workload_selection_test.go
+++ b/test/new-e2e/tests/ssi/workload_selection_test.go
@@ -44,8 +44,8 @@ func TestWorkloadSelectionSuite(t *testing.T) {
 						Apps: []singlestep.App{
 							{
 								Name:    DefaultAppName,
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 								PodLabels: map[string]string{
 									"language": "python",
@@ -53,8 +53,8 @@ func TestWorkloadSelectionSuite(t *testing.T) {
 							},
 							{
 								Name:    "expect-no-injection",
-								Image:   "gcr.io/datadoghq/injector-dev/python",
-								Version: "d425e7df",
+								Image:   "registry.datadoghq.com/injector-dev/python",
+								Version: "16ad9d4b",
 								Port:    8080,
 							},
 						},


### PR DESCRIPTION
### What does this PR do?
This commit updates the registry we use for our test apps to use the dev registries.

### Motivation
See [this thread](https://dd.slack.com/archives/C06UEUW9A75/p1770038534256929)

We were publishing to gcr instead of our dev registries.

### Describe how you validated your changes
The e2e tests should pass attached to this change.

### Additional Notes
Registry change:
https://github.com/DataDog/injector-dev/pull/156
