### PR TITLE
Fix segfault due to race in fleet e2e tests

### DIFF
--- a/test/new-e2e/tests/fleet/suite/suite.go
+++ b/test/new-e2e/tests/fleet/suite/suite.go
@@ -8,6 +8,7 @@ package suite
 
 import (
 	"regexp"
+	"slices"
 	"testing"
 
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
@@ -69,7 +70,8 @@ func Run(t *testing.T, f func() e2e.Suite[environments.Host], platforms []e2eos.
 		t.Run(platform.String(), func(t *testing.T) {
 			t.Parallel()
 			name := regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString(t.Name(), "_")
-			opts = append(opts, awshost.WithRunOptions(ec2.WithEC2InstanceOptions(ec2.WithOS(platform)), ec2.WithoutAgent()))
+			// clone opts and shadow it to avoid race condition when running in parallel
+			opts := append(slices.Clone(opts), awshost.WithRunOptions(ec2.WithEC2InstanceOptions(ec2.WithOS(platform)), ec2.WithoutAgent()))
 			e2e.Run(t, s, e2e.WithProvisioner(awshost.Provisioner(opts...)), e2e.WithStackName(name))
 		})
 	}


### PR DESCRIPTION
### What does this PR do?
Fix a race in fleet e2e tests where the `opts` slice could be modified in parallel by multiple tests, resulting in a segfault (due to the slice becoming invalid).

### Motivation
Avoid segfaults.

### Describe how you validated your changes
CI

### Additional Notes
Example failure https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1391695404/raw