### PR TITLE
Check presence of `bazelisk` wrapper scripts

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -254,4 +254,4 @@ include("//deps/windows:drivers.MODULE.bazel")
 # to the build command to enable it.
 bazel_dep(name = "apple_support", version = "1.24.1")
 
-use_repo_rule("//bazel/tools:check_bazel_version.bzl", "check_bazel_version")(name = "check_bazel_version")
+use_repo_rule("//bazel/tools:bazelisk_check.bzl", "bazelisk_check")(name = "bazelisk_check")

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@check_bazel_version//:defs.bzl", "check_bazel_version")
+load("@bazelisk_check//:defs.bzl", "check_bazel_version")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 
 check_bazel_version()


### PR DESCRIPTION
### What does this PR do?
Rename `check_bazel_version` to `bazelisk_check` and extend it to verify at build time the presence of required files:
- `.bazelversion` (implicit before, now explicit),
- `tools/bazel` and `tools/bazel.bat` as well,
- their paths are expected to denote files, i.e. _not directories_.

### Motivation
This implements the promise from #45784:
> A _subsequent_ PR will ensure both `tools/bazel` and `tools/bazel.bat` are present.

After PR #43661 inadvertently moved `tools/bazel` into `tools/bazel/bazel` (`tools/bazel` became a _directory_), we need a defensive mechanism to prevent similar accidents.

### Additional Notes
The check uses `repository_ctx.watch()` to ensure proper cache invalidation when files appear/disappear.