### PR TITLE
Store copies of necessary dependencies in S3

### DIFF
--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -296,7 +296,10 @@ http_archive(
     },
     sha256 = "03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b",
     strip_prefix = "libxml2-2.14.5",
-    url = "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libxml2-2.14.5.tar.xz",
+        "https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.5.tar.xz",
+    ],
 )
 
 http_archive(
@@ -308,7 +311,10 @@ http_archive(
     },
     sha256 = "5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a",
     strip_prefix = "libxslt-1.1.43",
-    url = "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/libxslt-1.1.43.tar.xz",
+        "https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz",
+    ],
 )
 
 http_archive(
@@ -322,7 +328,10 @@ http_archive(
     },
     sha256 = "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2",
     strip_prefix = "dbus-1.16.2",
-    url = "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/dbus-1.16.2.tar.xz",
+        "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
+    ],
 )
 
 http_archive(
@@ -333,7 +342,10 @@ http_archive(
     },
     sha256 = "7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88",
     strip_prefix = "lua-5.4.6",
-    url = "https://www.lua.org/ftp/lua-5.4.6.tar.gz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/lua-5.4.6.tar.gz",
+        "https://www.lua.org/ftp/lua-5.4.6.tar.gz",
+    ],
 )
 
 http_archive(
@@ -345,7 +357,10 @@ http_archive(
     },
     sha256 = "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea",
     strip_prefix = "xmlsec1-1.3.7",
-    url = "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/xmlsec1-1.3.7.tar.gz",
+        "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz",
+    ],
 )
 
 http_archive(
@@ -357,7 +372,10 @@ http_archive(
     },
     sha256 = "7d51e808138bd8f2ea59bd016f74c69497476eb8faada1067fcb8618ff813817",
     strip_prefix = "rpm-rpm-4.18.1-release",
-    url = "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/rpm-rpm-4.18.1-release.tar.gz",
+        "https://github.com/rpm-software-management/rpm/archive/refs/tags/rpm-4.18.1-release.tar.gz",
+    ],
 )
 
 http_archive(
@@ -367,5 +385,8 @@ http_archive(
     },
     sha256 = "b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35",
     strip_prefix = "krb5-1.21.3",
-    url = "https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz",
+    urls = [
+        "https://dd-agent-omnibus.s3.amazonaws.com/bazel/krb5-1.21.3.tar.gz",
+        "https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz",
+    ],
 )


### PR DESCRIPTION
### What does this PR do?
Puts external dependencies to our S3 bucket. Since we enabled ADMS in CI we see that bazel is failing to download some of the external dependencies as their source wasn't whitelisted. To mitigate the issue we store all necessary deps in our S3 bucket