### PR TITLE
bazel: rust: add size_optimized_rust_binary target and transition

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,5 +62,8 @@ build:ci --output_groups=+clippy_checks
 build:ci --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect
 build:ci --output_groups=+rustfmt_checks
 
+# Release build configuration ------------------------------------------------------------------------------------------
+build:release --//bazel/toolchains/rust:rust_size_optimized=true  # Enables size optimizations for Rust binaries built with size_optimized_rust_binary
+
 # Local development options --------------------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/bazel/toolchains/rust/BUILD.bazel
+++ b/bazel/toolchains/rust/BUILD.bazel
@@ -1,0 +1,64 @@
+"""Build settings for Rust size optimization configuration.
+
+These build settings control size optimization parameters for Rust binaries
+when rust_size_optimized=true. They can be set via command line or .bazelrc.
+
+The settings work in combination with the size_optimized_rust_binary wrapper
+rule and the size_optimized_transition to apply aggressive size optimizations
+to specific Rust binaries without affecting others.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+# Master toggle for size optimization mode
+# Set to true to enable size optimizations for binaries wrapped with size_optimized_rust_binary
+bool_flag(
+    name = "rust_size_optimized",
+    build_setting_default = False,
+)
+
+# Optimization level for size-optimized builds
+# "z" = optimize aggressively for size (recommended)
+# "s" = optimize for size
+# "3" = optimize for speed (not recommended for size optimization)
+string_flag(
+    name = "rust_opt_level",
+    build_setting_default = "z",
+)
+
+# Number of codegen units for size-optimized builds
+# "1" = maximum optimization (slower compilation, smaller binary)
+# Higher values = faster compilation, potentially larger binary
+string_flag(
+    name = "rust_codegen_units",
+    build_setting_default = "1",
+)
+
+# Panic strategy for size-optimized builds
+# "abort" = panic immediately without unwinding (smaller binary)
+# "unwind" = support stack unwinding (larger binary, better debugging)
+string_flag(
+    name = "rust_panic",
+    build_setting_default = "abort",
+)
+
+# Symbol stripping for size-optimized builds
+# "symbols" = strip debug symbols (recommended)
+# "debuginfo" = strip debug info but keep function symbols
+# "none" = no stripping
+string_flag(
+    name = "rust_strip",
+    build_setting_default = "symbols",
+)
+
+# Link-Time Optimization mode for size-optimized builds
+# "fat" = full LTO across all crates (slowest, smallest)
+# "thin" = thin LTO (faster, slightly larger)
+# "off" = no LTO
+# Note: rules_rust automatically configures the linker (lld/mold) for LTO
+string_flag(
+    name = "rust_lto",
+    build_setting_default = "fat",
+)

--- a/bazel/toolchains/rust/defs.bzl
+++ b/bazel/toolchains/rust/defs.bzl
@@ -20,6 +20,7 @@ def _size_optimized_rust_binary_impl(ctx):
     Returns:
         Providers from the wrapped rust_binary target
     """
+
     # Transitions produce a list of targets (one per configuration)
     # In our case, we always have exactly one configuration, so we take the first element
     actual = ctx.attr.actual[0] if type(ctx.attr.actual) == type([]) else ctx.attr.actual

--- a/bazel/toolchains/rust/defs.bzl
+++ b/bazel/toolchains/rust/defs.bzl
@@ -1,0 +1,132 @@
+"""Wrapper rules for size-optimized Rust binaries.
+
+This module provides the size_optimized_rust_binary rule, which applies
+size optimization transitions to Rust binaries when enabled via the
+rust_size_optimized build setting.
+"""
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//bazel/toolchains/rust:transitions.bzl", "size_optimized_transition")
+
+def _size_optimized_rust_binary_impl(ctx):
+    """Implementation for size_optimized_rust_binary wrapper rule.
+
+    This rule simply forwards the actual rust_binary target built with
+    the size optimization transition applied.
+
+    Args:
+        ctx: Rule context
+
+    Returns:
+        Providers from the wrapped rust_binary target
+    """
+    # Transitions produce a list of targets (one per configuration)
+    # In our case, we always have exactly one configuration, so we take the first element
+    actual = ctx.attr.actual[0] if type(ctx.attr.actual) == type([]) else ctx.attr.actual
+
+    # Create a symlink to the actual executable
+    output_file = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(
+        output = output_file,
+        target_file = actual[DefaultInfo].files_to_run.executable,
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output_file]),
+            runfiles = actual[DefaultInfo].default_runfiles,
+            executable = output_file,
+        ),
+        actual[OutputGroupInfo],
+    ]
+
+_size_optimized_rust_binary = rule(
+    implementation = _size_optimized_rust_binary_impl,
+    attrs = {
+        "actual": attr.label(
+            doc = "The actual rust_binary target to wrap with size optimization",
+            cfg = size_optimized_transition,
+            mandatory = True,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            doc = "Allowlist for Bazel configuration transitions",
+        ),
+    },
+    doc = """Internal rule that applies size optimization transition to a rust_binary.
+
+    This rule wraps a rust_binary target and applies the size_optimized_transition
+    to it, which modifies rules_rust settings to enable aggressive size optimizations
+    when the rust_size_optimized flag is enabled.
+    """,
+    executable = True,
+)
+
+def size_optimized_rust_binary(name, **kwargs):
+    """Creates a Rust binary with size optimization transition support.
+
+    This macro creates two targets:
+    1. A private rust_binary target (name + "_actual")
+    2. A wrapper target (name) that applies size optimization transition
+
+    When rust_size_optimized=true (e.g., via --config=release), the binary
+    is built with aggressive size optimizations:
+    - LTO (Link-Time Optimization) with proper linker configuration
+    - Optimization level 'z' (optimize for size)
+    - Single codegen unit for maximum optimization
+    - Symbol stripping
+    - Panic abort strategy
+
+    Args:
+        name: Name of the target
+        **kwargs: All arguments forwarded to rust_binary
+            Common arguments:
+            - srcs: Source files
+            - deps: Dependencies
+            - edition: Rust edition (e.g., "2021")
+            - visibility: Target visibility
+            - tags: Target tags
+            - And all other rust_binary attributes
+
+    Example:
+        ```python
+        size_optimized_rust_binary(
+            name = "my_binary",
+            srcs = ["main.rs"],
+            deps = ["//some:dep"],
+            edition = "2021",
+        )
+        ```
+
+        Build with size optimization:
+        ```bash
+        bazel build //:my_binary --config=release
+        ```
+
+        Build without optimization (faster compilation):
+        ```bash
+        bazel build //:my_binary
+        ```
+    """
+    actual_name = name + "_actual"
+
+    # Extract visibility and tags to handle them separately
+    visibility = kwargs.pop("visibility", None)
+    tags = kwargs.get("tags", [])
+
+    # Create the actual rust_binary target with private visibility
+    # The internal target should not be directly accessible
+    rust_binary(
+        name = actual_name,
+        visibility = ["//visibility:private"],
+        **kwargs
+    )
+
+    # Create the wrapper with transition, forwarding visibility and tags
+    _size_optimized_rust_binary(
+        name = name,
+        actual = ":" + actual_name,
+        visibility = visibility,
+        tags = tags,
+    )

--- a/bazel/toolchains/rust/transitions.bzl
+++ b/bazel/toolchains/rust/transitions.bzl
@@ -1,0 +1,65 @@
+"""Bazel transitions for Rust size optimization.
+
+This module implements configuration transitions that apply size optimization
+flags specifically to Rust binaries without affecting the entire build graph.
+"""
+
+def _size_optimized_transition_impl(settings, attr):
+    """Transition implementation for size-optimized Rust binaries.
+
+    This transition modifies rules_rust build settings to apply aggressive
+    size optimization flags (LTO, opt-level=z, strip, etc.) when the
+    rust_size_optimized flag is enabled.
+
+    Args:
+        settings: Dict of current build setting values
+        attr: Attributes of the rule invoking the transition
+
+    Returns:
+        Dict mapping build settings to their new values
+    """
+    # Read custom build settings
+    size_optimized = settings["//bazel/toolchains/rust:rust_size_optimized"]
+
+    # If size optimization is not enabled, return unchanged settings
+    if not size_optimized:
+        return {}
+
+    # Read optimization parameter settings
+    opt_level = settings["//bazel/toolchains/rust:rust_opt_level"]
+    codegen_units = settings["//bazel/toolchains/rust:rust_codegen_units"]
+    panic = settings["//bazel/toolchains/rust:rust_panic"]
+    strip = settings["//bazel/toolchains/rust:rust_strip"]
+    lto = settings["//bazel/toolchains/rust:rust_lto"]
+
+    # Build rustc flags for size optimization
+    rustc_flags = [
+        "-Copt-level={}".format(opt_level),
+        "-Ccodegen-units={}".format(codegen_units),
+        "-Cpanic={}".format(panic),
+        "-Cstrip={}".format(strip),
+    ]
+
+    # Return modified rules_rust settings
+    # Note: LTO is handled separately via rules_rust's dedicated setting,
+    # which properly configures the linker (lld/mold) with LTO support
+    return {
+        "@rules_rust//rust/settings:lto": lto,
+        "@rules_rust//rust/settings:extra_rustc_flags": rustc_flags,
+    }
+
+size_optimized_transition = transition(
+    implementation = _size_optimized_transition_impl,
+    inputs = [
+        "//bazel/toolchains/rust:rust_size_optimized",
+        "//bazel/toolchains/rust:rust_opt_level",
+        "//bazel/toolchains/rust:rust_codegen_units",
+        "//bazel/toolchains/rust:rust_panic",
+        "//bazel/toolchains/rust:rust_strip",
+        "//bazel/toolchains/rust:rust_lto",
+    ],
+    outputs = [
+        "@rules_rust//rust/settings:lto",
+        "@rules_rust//rust/settings:extra_rustc_flags",
+    ],
+)

--- a/bazel/toolchains/rust/transitions.bzl
+++ b/bazel/toolchains/rust/transitions.bzl
@@ -4,7 +4,7 @@ This module implements configuration transitions that apply size optimization
 flags specifically to Rust binaries without affecting the entire build graph.
 """
 
-def _size_optimized_transition_impl(settings, attr):
+def _size_optimized_transition_impl(settings, _attr):
     """Transition implementation for size-optimized Rust binaries.
 
     This transition modifies rules_rust build settings to apply aggressive
@@ -18,6 +18,7 @@ def _size_optimized_transition_impl(settings, attr):
     Returns:
         Dict mapping build settings to their new values
     """
+
     # Read custom build settings
     size_optimized = settings["//bazel/toolchains/rust:rust_size_optimized"]
 

--- a/bazel/toolchains/rust/transitions.bzl
+++ b/bazel/toolchains/rust/transitions.bzl
@@ -13,7 +13,7 @@ def _size_optimized_transition_impl(settings, _attr):
 
     Args:
         settings: Dict of current build setting values
-        attr: Attributes of the rule invoking the transition
+        _attr: Attributes of the rule invoking the transition (unused)
 
     Returns:
         Dict mapping build settings to their new values

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_shared_library", "rust_test")
+load("//bazel/toolchains/rust:defs.bzl", "size_optimized_rust_binary")
 
 # ============================================================================
 # Library Targets (rlib + cdylib)
@@ -102,7 +103,7 @@ rust_shared_library(
 # ============================================================================
 
 # Main sd-agent service binary
-rust_binary(
+size_optimized_rust_binary(
     name = "sd-agent",
     srcs = [
         "src/cli.rs",


### PR DESCRIPTION
### What does this PR do?

Add Bazel transition infrastructure for per-target Rust size optimization.

Introduces `size_optimized_rust_binary` wrapper rule that applies aggressive size optimizations (LTO=fat, opt-level=z, strip=symbols) when `--config=release` is used, without affecting other Rust binaries in the same build.

Uses incoming edge transitions to modify `@rules_rust` settings only for wrapped targets.

The PR also changes `sd-agent` build target to use `size_optimized_rust_binary`.

### Motivation

Allow use of Rust size optimization options without applying them to every Rust binaries.

### Describe how you validated your changes

Built sd-agent and disco binaries with & without `--config=release`. `sd-agent` goes from 12MiB to 1.3MiB with the release config. `disco` is unchanged as expected.

### Additional Notes
