### PR TITLE
Replace `copy_file` workaround with `pkg_files`' `renames`

### DIFF
--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -36,7 +36,6 @@
 """Agent specific BUILD file for zlib."""
 
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
@@ -141,18 +140,11 @@ pkg_files(
     prefix = "embedded/include",
 )
 
-copy_file(
-    name = "renamed_license",
-    src = ":LICENSE",
-    out = "zlib-zlib.license",
-)
-
 pkg_files(
     name = "license_files",
-    srcs = [
-        ":renamed_license",
-    ],
+    srcs = [":LICENSE"],
     prefix = "LICENSES",
+    renames = {"LICENSE": "zlib-zlib.license"},
 )
 
 pkg_install(


### PR DESCRIPTION
### What does this PR do?
Removes unnecessary `copy_file` workaround by instead setting the `renames` built-in attribute of `pkg_files`.

### Motivation
Less workarounds.

### Describe how you validated your changes
```
bazel run @zlib//:install -- --destdir=/tmp/xxx
```
Output files are identical before and after changes.