### PR TITLE
[CWS] insert process even if stat perm denied

### DIFF
--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -25,4 +25,5 @@ type ResolverInterface interface {
 	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	ToJSON() ([]byte, error)
+	Iterate(cb func(*model.Mount))
 }

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -82,3 +82,7 @@ func (mr *NoOpResolver) ToJSON() ([]byte, error) {
 func (mr *NoOpResolver) InsertMoved(_ model.Mount) error {
 	return nil
 }
+
+// Iterate iterates over all the mounts in the cache and calls the callback function for each mount
+func (mr *NoOpResolver) Iterate(_ func(*model.Mount)) {
+}

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -593,6 +593,16 @@ func (mr *Resolver) ToJSON() ([]byte, error) {
 	return json.Marshal(dump)
 }
 
+// Iterate iterates over all the mounts in the cache and calls the callback function for each mount
+func (mr *Resolver) Iterate(cb func(*model.Mount)) {
+	mr.lock.RLock()
+	defer mr.lock.RUnlock()
+
+	for mount := range mr.mounts.ValuesIter() {
+		cb(mount)
+	}
+}
+
 // NewResolver instantiates a new mount resolver
 func NewResolver(statsdClient statsd.ClientInterface, cgroupsResolver *cgroup.Resolver, dentryResolver *dentry.Resolver, opts ResolverOpts) (*Resolver, error) {
 	mounts, err := simplelru.NewLRU[uint32, *model.Mount](mountsLimit, nil)

--- a/pkg/security/seclog/logger.go
+++ b/pkg/security/seclog/logger.go
@@ -141,6 +141,14 @@ func (l *PatternLogger) IsTracing() bool {
 	return true
 }
 
+// IsDebugging returns true if the debug level is enabled
+func (l *PatternLogger) IsDebugging() bool {
+	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != log.DebugLvl {
+		return false
+	}
+	return true
+}
+
 // Debugf is used to print a trace level log
 func (l *PatternLogger) Debugf(format string, params ...interface{}) {
 	log.DebugStackDepth(depth-1, fmt.Sprintf(format, params...))


### PR DESCRIPTION
### What does this PR do?

Insert process entry from procfs even if the stat of the binary failed. This will avoid having broken lineage. 

This PR also add more debug info in that case.

### Motivation

### Describe how you validated your changes

### Additional Notes
