### PR TITLE
Explicitly disable collecting vcs info in go list commands to speed up

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -363,7 +363,9 @@ def go_fix(ctx, fix=None):
 def get_deps(ctx, path):
     with ctx.cd(path):
         # Might fail if no mod tidy
-        deps: list[str] = ctx.run("go list -deps ./...", hide=True, warn=True).stdout.strip().splitlines()
+        deps: list[str] = (
+            ctx.run("go list -buildvcs=false -deps ./...", hide=True, warn=True).stdout.strip().splitlines()
+        )
         prefix = 'github.com/DataDog/datadog-agent/'
         deps = [
             dep.removeprefix(prefix)

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -141,7 +141,7 @@ def diff(
         baseline_ref = get_common_ancestor(ctx, commit_sha, base_branch)
 
     diffs = {}
-    dep_cmd = "go list -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"
+    dep_cmd = "go list -buildvcs=false -f '{{ range .Deps }}{{ printf \"%s\\n\" . }}{{end}}'"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         try:
@@ -307,7 +307,7 @@ def compute_count_metric(
 
     # need to explicitly enable CGO to also include CGO-only deps when checking different platforms
     env = {"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "1"}
-    cmd = "go list -f '{{ join .Deps \"\\n\"}}'"
+    cmd = "go list -buildvcs=false -f '{{ join .Deps \"\\n\"}}'"
     with ctx.cd(entrypoint):
         res = ctx.run(
             f"{cmd} -tags \"{','.join(build_tags)}\"",
@@ -372,7 +372,7 @@ def compute_binary_dependencies_list(
     build_tags = get_default_build_tags(build=build, flavor=flavor, platform=platform)
 
     env = {"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "1"}
-    cmd = "go list -f '{{ join .Deps \"\\n\"}}'"
+    cmd = "go list -buildvcs=false -f '{{ join .Deps \"\\n\"}}'"
 
     res = ctx.run(
         f"{cmd} -tags \"{','.join(build_tags)}\"",

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -695,7 +695,7 @@ def create_dependencies(ctx, build_tags=None):
         for module in batch_modules:
             with ctx.cd(module):
                 cmd = (
-                    'go list '
+                    'go list -buildvcs=false'
                     + f'-tags "{" ".join(build_tags)}" '
                     + '-f "{{.ImportPath}} {{.Imports}} {{.TestImports}}" ./...'
                 )
@@ -807,7 +807,7 @@ def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[
     for module in modules_to_test:
         with ctx.cd(module):
             res = ctx.run(
-                f'go list -tags "{" ".join(build_tags)}" {" ".join([normpath(os.path.join("github.com/DataDog/datadog-agent", module, target)) for target in modules_to_test[module].test_targets])}',
+                f'go list -buildvcs=false -tags "{" ".join(build_tags)}" {" ".join([normpath(os.path.join("github.com/DataDog/datadog-agent", module, target)) for target in modules_to_test[module].test_targets])}',
                 hide=True,
                 warn=True,
             )

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -695,7 +695,7 @@ def create_dependencies(ctx, build_tags=None):
         for module in batch_modules:
             with ctx.cd(module):
                 cmd = (
-                    'go list -buildvcs=false'
+                    'go list -buildvcs=false '
                     + f'-tags "{" ".join(build_tags)}" '
                     + '-f "{{.ImportPath}} {{.Imports}} {{.TestImports}}" ./...'
                 )

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -1057,7 +1057,7 @@ def compute_package_dependencies(ctx: Context, packages: list[str], build_tags: 
 
     packages_list = " ".join(packages)
     list_format = "{{ .ImportPath }}: {{ join .Deps \" \" }}"
-    res = ctx.run(f"go list -test -f '{list_format}' -tags \"{build_tags}\" {packages_list}", hide=True)
+    res = ctx.run(f"go list -buildvcs=false -test -f '{list_format}' -tags \"{build_tags}\" {packages_list}", hide=True)
     if res is None or not res.ok:
         raise Exit("Failed to get dependencies for system-probe")
 


### PR DESCRIPTION
### What does this PR do?
Explicitly disable collecting VCS info in `go list`.

### Motivation
Speed up the commands.

For `inv go-deps.diff` specifically, which runs around ~40 `go list` commands, this change reduces duration from 1m50s to 35s on my laptop.

### Describe how you validated your changes
No expected change, CI is enough.

### Additional Notes
This is really only useful when running many `go list` commands, eg. one per artifact or one per module.

In some cases, go is able to determine that VCS info is not needed, but not here.

Relates to https://github.com/golang/go/issues/77419.

Follow-up of https://github.com/DataDog/datadog-agent/pull/45733 which already significantly reduced the duration of `inv go-deps.diff`.