### PR TITLE
[Backport 7.76.x] bump tmpl versions to update datadog-vault-secrets

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -36,18 +36,18 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
-  IMAGE_VERSION: tmpl-v20
+  IMAGE_VERSION: tmpl-v22
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 
 .cluster_agent_variables: &cluster_agent_variables
-  IMAGE_VERSION: tmpl-v10
+  IMAGE_VERSION: tmpl-v12
   IMAGE_NAME: datadog-cluster-agent
   TMPL_SRC_REPO: ci/datadog-agent/cluster-agent
   RELEASE_PROD: "true"
 
 .ot_standalone_variables: &ot_standalone_variables
-  IMAGE_VERSION: tmpl-v5
+  IMAGE_VERSION: tmpl-v7
   IMAGE_NAME: otel-agent
   TMPL_SRC_REPO: ci/datadog-agent/otel-agent
 


### PR DESCRIPTION
### What does this PR do?
Backport #45842 to 7.76.x 
Bump tmpl versions to update datadog-vault-secrets

### Motivation
[BARX-1600](https://datadoghq.atlassian.net/browse/BARX-1600)
Bump datadog-vault-secrets to get latest go runtime version. The changes need to be in by end of February so that is why we are backporting it to 7.76.x


### Describe how you validated your changes
N/A

### Additional Notes


[BARX-1600]: https://datadoghq.atlassian.net/browse/BARX-1600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ