### PR TITLE
Add jsDelivr CDN mirror for SQLite license download

### DIFF
--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -20,6 +20,8 @@ allow golang.google.cn
 allow tukaani.org
 allow bcr.bazel.build
 allow dd-agent-omnibus.s3.amazonaws.com
+allow cdn.jsdelivr.net
+allow raw.githubusercontent.com
 
 # This list is temporary. It should be upstreamed to basic adms support.
 allow dbus.freedesktop.org
@@ -77,6 +79,8 @@ rewrite (fastdl.mongodb.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (get.helm.sh)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (git.kernel.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (github.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (raw.githubusercontent.com)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (cdn.jsdelivr.net)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 
 # Taken from https://blog.aspect.build/configuring-bazels-downloader
 # > For some reason the bazel team decided that mirror.bazel.build should be the source of truth for these 3 files, let

--- a/deps/repos.MODULE.bazel
+++ b/deps/repos.MODULE.bazel
@@ -22,7 +22,10 @@ http_file(
     name = "sqlite3_license",
     downloaded_file_path = "LICENSE.md",
     sha256 = "a7a58d6022c090c528e3167026167b3141d682efc6a3c188b473ba59f1788fc7",
-    url = "https://raw.githubusercontent.com/sqlite/sqlite/version-{}/LICENSE.md".format(".".join([v.lstrip("0") for v in sqlite_ver])),
+    urls = [url.format(".".join([v.lstrip("0") for v in sqlite_ver])) for url in (
+        "https://cdn.jsdelivr.net/gh/sqlite/sqlite@version-{}/LICENSE.md",
+        "https://raw.githubusercontent.com/sqlite/sqlite/version-{}/LICENSE.md",
+    )],
 )
 
 http_archive(


### PR DESCRIPTION
### What does this PR do?
Add [jsDelivr CDN](https://www.jsdelivr.com/) as primary download source for SQLite LICENSE.md, with original GitHub raw URL as fallback.

### Motivation
Tentative fix for newly observed CI failure where Bazel's URL rewriter blocks GitHub raw URLs:
```
INFO: Repository +_repo_rules4+sqlite3_license instantiated at:
  <builtin>: in <toplevel>
Repository rule http_file defined at:
  /data/bzl/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/bazel_tools/tools/build_defs/repo/http.bzl:522:28: in <toplevel>
ERROR: /data/bzl/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/bazel_tools/tools/build_defs/repo/http.bzl:205:33: An error occurred during the fetch of repository '+_repo_rules4+sqlite3_license':
   Traceback (most recent call last):
	File "/data/bzl/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/bazel_tools/tools/build_defs/repo/http.bzl", line 205, column 33, in _http_file_impl
		download_info = ctx.download(
Error in download: java.io.IOException: Cache miss and no url specified - Configured URL rewriter blocked all URLs: [https://raw.githubusercontent.com/sqlite/sqlite/version-3.50.4/LICENSE.md] - This blocking should only be happening in CI - reach out to Datadog#dependency-management
ERROR: no such package '@@+_repo_rules+sqlite3//': no such package '@@+_repo_rules4+sqlite3_license//file': java.io.IOException: Cache miss and no url specified - Configured URL rewriter blocked all URLs: [https://raw.githubusercontent.com/sqlite/sqlite/version-3.50.4/LICENSE.md] - This blocking should only be happening in CI - reach out to Datadog#dependency-management
ERROR: /go/src/github.com/DataDog/datadog-agent/deps/BUILD.bazel:8:10: no such package '@@+_repo_rules+sqlite3//': no such package '@@+_repo_rules4+sqlite3_license//file': java.io.IOException: Cache miss and no url specified - Configured URL rewriter blocked all URLs: [https://raw.githubusercontent.com/sqlite/sqlite/version-3.50.4/LICENSE.md] - This blocking should only be happening in CI - reach out to Datadog#dependency-management and referenced by '//deps:all_deps'
ERROR: Analysis of target '//deps:all_deps' failed; build aborted: Analysis failed
```

Using jsDelivr CDN (which mirrors GitHub repositories) as primary source might bypass this restriction while maintaining the same file content.

### Describe how you validated your changes
Verified jsDelivr CDN serves identical file, SHA256: a7a58d6022...

### Additional Notes
[JsDelivr is now part of the CDN Alliance](https://cdnalliance.org/jsdelivr-joins-the-cdn-alliance/).