### PR TITLE
[CXP-2930] [agent] fix wlm process collection with cmdline detection

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -293,8 +293,7 @@ func processCacheDifference(procCacheA map[int32]*procutil.Process, procCacheB m
 			continue
 		}
 
-		// Same PID exists, but identity differs (different creation time or cmdline)
-		if procutil.ProcessIdentity(procA.Pid, procA.Stats.CreateTime, procA.Cmdline) != procutil.ProcessIdentity(procB.Pid, procB.Stats.CreateTime, procB.Cmdline) {
+		if !procutil.IsSameProcess(procA, procB) {
 			newProcs = append(newProcs, procA)
 		}
 	}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -293,7 +293,7 @@ func processCacheDifference(procCacheA map[int32]*procutil.Process, procCacheB m
 			continue
 		}
 
-		// Same PID exists, but identity differs (different creation time or exec'd to new cmdline)
+		// Same PID exists, but identity differs (different creation time or cmdline)
 		if procutil.ProcessIdentity(procA.Pid, procA.Stats.CreateTime, procA.Cmdline) != procutil.ProcessIdentity(procB.Pid, procB.Stats.CreateTime, procB.Cmdline) {
 			newProcs = append(newProcs, procA)
 		}

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -325,6 +325,9 @@ func TestProcessLifecycleCollection(t *testing.T) {
 	creationTime3 := time.Now().Add(2 * time.Second).Unix()
 	proc4 := createTestUnknownProcess(pid2, creationTime3)
 
+	// same pid AND same creation time as proc1, but different cmdline (simulates exec)
+	proc1DiffCmdline := createTestJavaProcess(pid1, creationTime1)
+
 	for _, tc := range []struct {
 		description              string
 		processesToCollectA      map[int32]*procutil.Process
@@ -436,6 +439,25 @@ func TestProcessLifecycleCollection(t *testing.T) {
 				workloadmetaProcess(proc2, nil, nil),
 			},
 		},
+		{
+			description: "process exec: same pid, same createTime, different cmdline",
+			processesToCollectA: map[int32]*procutil.Process{
+				proc1.Pid: proc1, // python process
+			},
+			processesToCollectB: map[int32]*procutil.Process{
+				proc1DiffCmdline.Pid: proc1DiffCmdline, // java process with same pid and createTime
+			},
+			expectedLiveProcesses: []*workloadmeta.Process{
+				workloadmetaProcess(proc1DiffCmdline,
+					&languagemodels.Language{
+						Name: languagemodels.Java,
+					},
+					nil),
+			},
+			expectedDeletedProcesses: []*workloadmeta.Process{
+				workloadmetaProcess(proc1, nil, nil),
+			},
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			cfg := config.NewMock(t)
@@ -477,9 +499,12 @@ func TestProcessLifecycleCollection(t *testing.T) {
 				for _, expectedDeletedProc := range tc.expectedDeletedProcesses {
 					actualProc, exists := mapActualProcs[expectedDeletedProc.Pid]
 
-					// the same process pid can exist so we ensure it is a different process by checking the creation time
+					// the same process pid can exist so we ensure it is a different process using ProcessIdentity
+					// which compares pid, createTime, and cmdline hash (handles both PID reuse and exec scenarios)
 					if exists {
-						assert.NotEqual(cT, expectedDeletedProc.CreationTime, actualProc.CreationTime)
+						expectedIdentity := procutil.ProcessIdentity(expectedDeletedProc.Pid, expectedDeletedProc.CreationTime.UnixMilli(), expectedDeletedProc.Cmdline)
+						actualIdentity := procutil.ProcessIdentity(actualProc.Pid, actualProc.CreationTime.UnixMilli(), actualProc.Cmdline)
+						assert.NotEqual(cT, expectedIdentity, actualIdentity, "Expected process to be replaced")
 					}
 
 				}
@@ -606,6 +631,153 @@ func TestProcessCollectorIntervalConfig(t *testing.T) {
 	}
 }
 
+// TestProcessExecCmdlineChangeIntegration tests that the full collector flow correctly handles
+// the exec() scenario where a process replaces itself (same PID, same createTime, but different cmdline).
+// This is an integration test that validates the entire collection cycle detects cmdline changes.
+func TestProcessExecCmdlineChangeIntegration(t *testing.T) {
+	collectionInterval := time.Second * 10
+	createTime := time.Now().Unix()
+	pid := int32(1234)
+
+	// First collection: bash process
+	bashProc := &procutil.Process{
+		Pid:     pid,
+		Ppid:    6,
+		NsPid:   2,
+		Name:    "bash",
+		Cwd:     "/home/user",
+		Exe:     "/bin/bash",
+		Comm:    "bash",
+		Cmdline: []string{"bash"},
+		Uids:    []int32{1000},
+		Gids:    []int32{1000},
+		Stats:   &procutil.Stats{CreateTime: createTime},
+	}
+
+	// Second collection: htop (same PID and createTime, simulating exec)
+	htopProc := &procutil.Process{
+		Pid:     pid,
+		Ppid:    6,
+		NsPid:   2,
+		Name:    "htop",
+		Cwd:     "/home/user",
+		Exe:     "/usr/bin/htop",
+		Comm:    "htop",
+		Cmdline: []string{"htop"},
+		Uids:    []int32{1000},
+		Gids:    []int32{1000},
+		Stats:   &procutil.Stats{CreateTime: createTime}, // Same createTime!
+	}
+
+	cfg := config.NewMock(t)
+	cfg.SetWithoutSource("process_config.process_collection.enabled", true)
+	cfg.SetWithoutSource("process_config.intervals.process", 10)
+	cfg.SetWithoutSource("language_detection.enabled", true)
+
+	c := setUpCollectorTest(t, cfg, nil, nil)
+	defer c.cleanup()
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	// First collection returns bash
+	c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(map[int32]*procutil.Process{pid: bashProc}, nil).Times(1)
+	c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(nil).Times(1)
+
+	// Second collection returns htop (exec'd)
+	c.probe.On("ProcessesByPID", mock.Anything, mock.Anything).Return(map[int32]*procutil.Process{pid: htopProc}, nil).Times(1)
+	c.mockContainerProvider.EXPECT().GetPidToCid(cacheValidityNoRT).Return(nil).Times(1)
+
+	// Start collection
+	err := c.collector.Start(ctx, c.mockStore)
+	assert.NoError(t, err)
+
+	// Wait for first collection to complete
+	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
+		actualProc, err := c.mockStore.GetProcess(pid)
+		if !assert.NoError(cT, err) || !assert.NotNil(cT, actualProc) {
+			return
+		}
+		assert.Equal(cT, []string{"bash"}, actualProc.Cmdline)
+	}, time.Second, time.Millisecond*100)
+
+	// Trigger second collection
+	c.mockClock.Add(collectionInterval)
+
+	// After exec, the store should have htop, not bash
+	assert.EventuallyWithT(t, func(cT *assert.CollectT) {
+		actualProc, err := c.mockStore.GetProcess(pid)
+		if !assert.NoError(cT, err) || !assert.NotNil(cT, actualProc) {
+			return
+		}
+		// Critical assertion: cmdline should be updated to htop after exec
+		assert.Equal(cT, []string{"htop"}, actualProc.Cmdline, "Process cmdline should be updated after exec")
+		assert.Equal(cT, "htop", actualProc.Name, "Process name should be updated after exec")
+	}, time.Second, time.Millisecond*100)
+}
+
+// TestProcessCacheDifferentCmdline tests that processCacheDifference correctly detects
+// when a process has a different cmdline (same PID, same CreateTime, different Cmdline).
+func TestProcessCacheDifferentCmdline(t *testing.T) {
+	createTime := time.Now().Unix()
+	pid := int32(12345)
+
+	// Original bash process
+	bashProc := &procutil.Process{
+		Pid:     pid,
+		Cmdline: []string{"bash"},
+		Stats:   &procutil.Stats{CreateTime: createTime},
+	}
+
+	// Same PID and createTime, but exec'd into htop
+	htopProc := &procutil.Process{
+		Pid:     pid,
+		Cmdline: []string{"htop"},
+		Stats:   &procutil.Stats{CreateTime: createTime},
+	}
+
+	// Cache A has htop (current state after exec)
+	cacheA := map[int32]*procutil.Process{
+		pid: htopProc,
+	}
+
+	// Cache B has bash (previous state before exec)
+	cacheB := map[int32]*procutil.Process{
+		pid: bashProc,
+	}
+
+	// processCacheDifference(A, B) should return htop as a "new" process because cmdline changed
+	diff := processCacheDifference(cacheA, cacheB)
+
+	assert.Len(t, diff, 1, "Expected one process in diff after exec cmdline change")
+	assert.Equal(t, pid, diff[0].Pid)
+	assert.Equal(t, []string{"htop"}, diff[0].Cmdline)
+}
+
+// TestProcessCacheDifferenceNoChangeWhenCmdlineSame tests that processCacheDifference
+// does not report a process as new when the cmdline stays the same.
+func TestProcessCacheDifferenceNoChangeWhenCmdlineSame(t *testing.T) {
+	createTime := time.Now().Unix()
+	pid := int32(12345)
+
+	proc := &procutil.Process{
+		Pid:     pid,
+		Cmdline: []string{"bash"},
+		Stats:   &procutil.Stats{CreateTime: createTime},
+	}
+
+	cacheA := map[int32]*procutil.Process{
+		pid: proc,
+	}
+
+	cacheB := map[int32]*procutil.Process{
+		pid: proc,
+	}
+
+	diff := processCacheDifference(cacheA, cacheB)
+
+	assert.Len(t, diff, 0, "Expected no processes in diff when cmdline is the same")
+}
+
 func setUpCollectorTest(t *testing.T, cfg config.Component, sysProbeConfigOverrides map[string]interface{}, wlmConfigOverrides map[string]interface{}) collectorTest {
 	// mock workloadmeta store
 	mockStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
@@ -720,67 +892,4 @@ func workloadmetaProcess(proc *procutil.Process, language *languagemodels.Langua
 		Owner:        owner,
 	}
 	return wlmProc
-}
-
-// TestProcessCacheDifferentCmdline tests that processCacheDifference correctly detects
-// when a process has a different cmdline (same PID, same CreateTime, different Cmdline).
-func TestProcessCacheDifferentCmdline(t *testing.T) {
-	createTime := time.Now().Unix()
-	pid := int32(12345)
-
-	// Original bash process
-	bashProc := &procutil.Process{
-		Pid:     pid,
-		Cmdline: []string{"bash"},
-		Stats:   &procutil.Stats{CreateTime: createTime},
-	}
-
-	// Same PID and createTime, but exec'd into htop
-	htopProc := &procutil.Process{
-		Pid:     pid,
-		Cmdline: []string{"htop"},
-		Stats:   &procutil.Stats{CreateTime: createTime},
-	}
-
-	// Cache A has htop (current state after exec)
-	cacheA := map[int32]*procutil.Process{
-		pid: htopProc,
-	}
-
-	// Cache B has bash (previous state before exec)
-	cacheB := map[int32]*procutil.Process{
-		pid: bashProc,
-	}
-
-	// processCacheDifference(A, B) should return htop as a "new" process because cmdline changed
-	diff := processCacheDifference(cacheA, cacheB)
-
-	assert.Len(t, diff, 1, "Expected one process in diff after exec cmdline change")
-	assert.Equal(t, pid, diff[0].Pid)
-	assert.Equal(t, []string{"htop"}, diff[0].Cmdline)
-}
-
-// TestProcessCacheDifferenceNoChangeWhenCmdlineSame tests that processCacheDifference
-// does not report a process as new when the cmdline stays the same.
-func TestProcessCacheDifferenceNoChangeWhenCmdlineSame(t *testing.T) {
-	createTime := time.Now().Unix()
-	pid := int32(12345)
-
-	proc := &procutil.Process{
-		Pid:     pid,
-		Cmdline: []string{"bash"},
-		Stats:   &procutil.Stats{CreateTime: createTime},
-	}
-
-	cacheA := map[int32]*procutil.Process{
-		pid: proc,
-	}
-
-	cacheB := map[int32]*procutil.Process{
-		pid: proc,
-	}
-
-	diff := processCacheDifference(cacheA, cacheB)
-
-	assert.Len(t, diff, 0, "Expected no processes in diff when cmdline is the same")
 }

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -722,7 +722,7 @@ func workloadmetaProcess(proc *procutil.Process, language *languagemodels.Langua
 	return wlmProc
 }
 
-// TestProcessCacheDifferentCmdlinetests that processCacheDifference correctly detects
+// TestProcessCacheDifferentCmdline tests that processCacheDifference correctly detects
 // when a process has a different cmdline (same PID, same CreateTime, different Cmdline).
 func TestProcessCacheDifferentCmdline(t *testing.T) {
 	createTime := time.Now().Unix()

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector_test.go
@@ -722,10 +722,9 @@ func workloadmetaProcess(proc *procutil.Process, language *languagemodels.Langua
 	return wlmProc
 }
 
-// TestProcessCacheDifferenceExecScenario tests that processCacheDifference correctly detects
-// when a process has been replaced via exec (same PID, same CreateTime, different Cmdline).
-// This is a regression test for https://github.com/DataDog/datadog-agent/issues/43137
-func TestProcessCacheDifferenceExecScenario(t *testing.T) {
+// TestProcessCacheDifferentCmdlinetests that processCacheDifference correctly detects
+// when a process has a different cmdline (same PID, same CreateTime, different Cmdline).
+func TestProcessCacheDifferentCmdline(t *testing.T) {
 	createTime := time.Now().Unix()
 	pid := int32(12345)
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -353,7 +353,7 @@ func TestServiceStoreLifetimeProcessCollectionDisabled(t *testing.T) {
 
 				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Process{
 					Pid:     process.Pid,
-					Cmdline: []string{"python3", "--version"}, // Must match makeProcess cmdline for identity comparison
+					Cmdline: []string{"python3", "--version"},
 					Stats:   &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()},
 				}
 			}
@@ -569,9 +569,9 @@ func TestServiceStoreLifetime(t *testing.T) {
 					},
 				})
 
-				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Process{
+				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Processe{
 					Pid:     process.Pid,
-					Cmdline: []string{"python3", "--version"}, // Must match makeProcess cmdline for identity comparison
+					Cmdline: []string{"python3", "--version"},
 					Stats:   &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()},
 				}
 

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -352,8 +352,9 @@ func TestServiceStoreLifetimeProcessCollectionDisabled(t *testing.T) {
 				})
 
 				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Process{
-					Pid:   process.Pid,
-					Stats: &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()}, // Use actual creation time from process entity
+					Pid:     process.Pid,
+					Cmdline: []string{"python3", "--version"}, // Must match makeProcess cmdline for identity comparison
+					Stats:   &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()},
 				}
 			}
 
@@ -569,8 +570,9 @@ func TestServiceStoreLifetime(t *testing.T) {
 				})
 
 				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Process{
-					Pid:   process.Pid,
-					Stats: &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()}, // Use actual creation time from process entity
+					Pid:     process.Pid,
+					Cmdline: []string{"python3", "--version"}, // Must match makeProcess cmdline for identity comparison
+					Stats:   &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()},
 				}
 
 				// If this is a process whose injection status we've reported (but has no service), add to tracking

--- a/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_service_collector_test.go
@@ -569,7 +569,7 @@ func TestServiceStoreLifetime(t *testing.T) {
 					},
 				})
 
-				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Processe{
+				c.collector.lastCollectedProcesses[process.Pid] = &procutil.Process{
 					Pid:     process.Pid,
 					Cmdline: []string{"python3", "--version"},
 					Stats:   &procutil.Stats{CreateTime: process.CreationTime.UnixMilli()},

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -72,14 +72,14 @@ func TestExtractor(t *testing.T) {
 	procs, cacheVersion := extractor.GetAllProcessEntities()
 	assert.Equal(t, int32(1), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
-		hashProcess(Pid1, proc1.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid1, proc1.Stats.CreateTime, proc1.Cmdline): {
 			Pid:          proc1.Pid,
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
 			ContainerId:  ctrId1,
 		},
-		hashProcess(Pid2, proc2.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid2, proc2.Stats.CreateTime, proc2.Cmdline): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
@@ -119,14 +119,14 @@ func TestExtractor(t *testing.T) {
 	procs, cacheVersion = extractor.GetAllProcessEntities()
 	assert.Equal(t, int32(1), cacheVersion) // cache version doesn't change
 	assert.Equal(t, map[string]*ProcessEntity{
-		hashProcess(Pid1, proc1.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid1, proc1.Stats.CreateTime, proc1.Cmdline): {
 			Pid:          proc1.Pid,
 			NsPid:        proc1.NsPid,
 			CreationTime: proc1.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Java},
 			ContainerId:  ctrId1,
 		},
-		hashProcess(Pid2, proc2.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid2, proc2.Stats.CreateTime, proc2.Cmdline): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
@@ -145,7 +145,7 @@ func TestExtractor(t *testing.T) {
 	procs, cacheVersion = extractor.GetAllProcessEntities()
 	assert.Equal(t, int32(2), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
-		hashProcess(Pid2, proc2.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid2, proc2.Stats.CreateTime, proc2.Cmdline): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
@@ -176,14 +176,14 @@ func TestExtractor(t *testing.T) {
 	procs, cacheVersion = extractor.GetAllProcessEntities()
 	assert.Equal(t, int32(3), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
-		hashProcess(Pid2, proc2.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid2, proc2.Stats.CreateTime, proc2.Cmdline): {
 			Pid:          proc2.Pid,
 			NsPid:        proc2.NsPid,
 			CreationTime: proc2.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Python},
 			ContainerId:  ctrId1,
 		},
-		hashProcess(Pid3, proc3.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid3, proc3.Stats.CreateTime, proc3.Cmdline): {
 			Pid:          proc3.Pid,
 			NsPid:        proc3.NsPid,
 			CreationTime: proc3.Stats.CreateTime,
@@ -214,14 +214,14 @@ func TestExtractor(t *testing.T) {
 	procs, cacheVersion = extractor.GetAllProcessEntities()
 	assert.Equal(t, int32(4), cacheVersion)
 	assert.Equal(t, map[string]*ProcessEntity{
-		hashProcess(Pid3, proc3.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid3, proc3.Stats.CreateTime, proc3.Cmdline): {
 			Pid:          proc3.Pid,
 			NsPid:        proc3.NsPid,
 			CreationTime: proc3.Stats.CreateTime,
 			Language:     &languagemodels.Language{Name: languagemodels.Unknown},
 			ContainerId:  ctrId1,
 		},
-		hashProcess(Pid4, proc4.Stats.CreateTime): {
+		procutil.ProcessIdentity(Pid4, proc4.Stats.CreateTime, proc4.Cmdline): {
 			Pid:          proc4.Pid,
 			NsPid:        proc4.NsPid,
 			CreationTime: proc4.Stats.CreateTime,
@@ -252,19 +252,20 @@ func TestExtractor(t *testing.T) {
 	}, diff.Deletion)
 }
 
-func BenchmarkHashProcess(b *testing.B) {
-	b.Run("itoa", func(b *testing.B) {
+func BenchmarkProcessIdentity(b *testing.B) {
+	cmdline := []string{"python", "myprogram.py", "--flag"}
+	b.Run("strconv", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			hashProcess(0, 0)
+			procutil.ProcessIdentity(0, 0, cmdline)
 		}
 	})
 	b.Run("sprintf", func(b *testing.B) {
-		hashProcess := func(pid int32, createTime int64) string {
-			return fmt.Sprintf("pid:%v|createTime:%v", pid, createTime)
+		processIdentity := func(pid int32, createTime int64, cmdline []string) string {
+			return fmt.Sprintf("%v|%v|%x", pid, createTime, 0) // simplified for benchmark
 		}
 
 		for i := 0; i < b.N; i++ {
-			hashProcess(0, 0)
+			processIdentity(0, 0, cmdline)
 		}
 	})
 }
@@ -322,4 +323,67 @@ func TestLateContainerId(t *testing.T) {
 		},
 		Deletion: []*ProcessEntity{},
 	}, <-extractor.ProcessCacheDiff())
+}
+
+// TestExecCmdlineChange tests that when a process uses exec() to replace itself with a different
+// executable (same PID, same createTime, but different cmdline), the extractor treats it as a
+// new process and generates creation/deletion events accordingly.
+func TestExecCmdlineChange(t *testing.T) {
+	fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule()).Reset()
+
+	extractor := NewWorkloadMetaExtractor(configmock.New(t))
+
+	// Create a process with a specific createTime
+	createTime := time.Now().Unix()
+	proc1 := &procutil.Process{
+		Pid:     Pid1,
+		NsPid:   1,
+		Cmdline: []string{"bash"},
+		Stats:   &procutil.Stats{CreateTime: createTime},
+	}
+
+	// First extraction: bash process
+	extractor.Extract(map[int32]*procutil.Process{
+		Pid1: proc1,
+	})
+
+	procs, cacheVersion := extractor.GetAllProcessEntities()
+	assert.Equal(t, int32(1), cacheVersion)
+	assert.Len(t, procs, 1)
+
+	diff := <-extractor.ProcessCacheDiff()
+	assert.Equal(t, int32(1), diff.cacheVersion)
+	assert.Len(t, diff.Creation, 1)
+	assert.Equal(t, proc1.Pid, diff.Creation[0].Pid)
+	assert.Len(t, diff.Deletion, 0)
+
+	// Simulate exec: same PID and createTime but different cmdline (bash -> htop)
+	proc1Exec := &procutil.Process{
+		Pid:     Pid1,
+		NsPid:   1,
+		Cmdline: []string{"htop"},
+		Stats:   &procutil.Stats{CreateTime: createTime}, // Same createTime as before!
+	}
+
+	extractor.Extract(map[int32]*procutil.Process{
+		Pid1: proc1Exec,
+	})
+
+	procs, cacheVersion = extractor.GetAllProcessEntities()
+	assert.Equal(t, int32(2), cacheVersion)
+	assert.Len(t, procs, 1) // Still 1 process, but it should be the new one
+
+	diff = <-extractor.ProcessCacheDiff()
+	assert.Equal(t, int32(2), diff.cacheVersion)
+
+	// The exec should generate a creation event for the new process (htop)
+	// and a deletion event for the old process (bash)
+	assert.Len(t, diff.Creation, 1, "Expected creation event for exec'd process")
+	assert.Len(t, diff.Deletion, 1, "Expected deletion event for original process")
+
+	// Verify the creation is for the new cmdline
+	assert.Equal(t, int32(Pid1), diff.Creation[0].Pid)
+
+	// Verify the deletion is for the old cmdline
+	assert.Equal(t, int32(Pid1), diff.Deletion[0].Pid)
 }

--- a/pkg/process/metadata/workloadmeta/extractor_test.go
+++ b/pkg/process/metadata/workloadmeta/extractor_test.go
@@ -6,7 +6,6 @@
 package workloadmeta
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -250,24 +249,6 @@ func TestExtractor(t *testing.T) {
 			ContainerId:  ctrId1,
 		},
 	}, diff.Deletion)
-}
-
-func BenchmarkProcessIdentity(b *testing.B) {
-	cmdline := []string{"python", "myprogram.py", "--flag"}
-	b.Run("strconv", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			procutil.ProcessIdentity(0, 0, cmdline)
-		}
-	})
-	b.Run("sprintf", func(b *testing.B) {
-		processIdentity := func(pid int32, createTime int64, cmdline []string) string {
-			return fmt.Sprintf("%v|%v|%x", pid, createTime, 0) // simplified for benchmark
-		}
-
-		for i := 0; i < b.N; i++ {
-			processIdentity(0, 0, cmdline)
-		}
-	})
 }
 
 // Occasionally, WorkloadMeta will not have the ContainerID by the first time a process collection is executed. This test

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -76,7 +76,7 @@ func (p *Process) GetCmdline() []string {
 // and command line hash. This allows detection of exec scenarios where the PID and creation time
 // remain the same but the command line changes.
 func ProcessIdentity(pid int32, createTime int64, cmdline []string) string {
-	return "pid:" + strconv.Itoa(int(pid)) + "|createTime:" + strconv.FormatInt(createTime, 10) + "|cmdHash:" + strconv.FormatUint(hashCmdline(cmdline), 16)
+	return "pid:" + strconv.FormatInt(int64(pid), 10) + "|createTime:" + strconv.FormatInt(createTime, 10) + "|cmdHash:" + strconv.FormatUint(hashCmdline(cmdline), 16)
 }
 
 // hashCmdline computes a fast FNV-1a hash of the command line arguments.

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -75,7 +75,6 @@ func (p *Process) GetCmdline() []string {
 // ProcessIdentity generates a unique identity string for a process based on PID, creation time,
 // and command line hash. This allows detection of exec scenarios where the PID and creation time
 // remain the same but the command line changes.
-// See https://github.com/DataDog/datadog-agent/issues/43137
 func ProcessIdentity(pid int32, createTime int64, cmdline []string) string {
 	return "pid:" + strconv.Itoa(int(pid)) + "|createTime:" + strconv.FormatInt(createTime, 10) + "|cmdHash:" + strconv.FormatUint(hashCmdline(cmdline), 16)
 }

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -94,7 +94,7 @@ func IsSameProcess(a, b *Process) bool {
 
 // hashCmdline computes a fast FNV-1a hash of the command line arguments.
 // Only hashes first 100 args to bound work for processes with huge cmdlines (some have 70K+ args).
-// 100 args covers ~p99.9 of real-world processes (per process_discovery.command_args_per_process metric).
+// 100 args covers ~p99.9 of real-world processes
 func hashCmdline(cmdline []string) uint64 {
 	const maxArgs = 100
 	if len(cmdline) > maxArgs {

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -7,6 +7,7 @@ package procutil
 
 import (
 	"hash/fnv"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -77,6 +78,18 @@ func (p *Process) GetCmdline() []string {
 // remain the same but the command line changes.
 func ProcessIdentity(pid int32, createTime int64, cmdline []string) string {
 	return "pid:" + strconv.FormatInt(int64(pid), 10) + "|createTime:" + strconv.FormatInt(createTime, 10) + "|cmdHash:" + strconv.FormatUint(hashCmdline(cmdline), 16)
+}
+
+// IsSameProcess returns true if two processes have the same identity (PID, create time, and cmdline).
+// Returns false if either process is nil.
+func IsSameProcess(a, b *Process) bool {
+	if a.Pid != b.Pid {
+		return false
+	}
+	if a.Stats.CreateTime != b.Stats.CreateTime {
+		return false
+	}
+	return slices.Equal(a.Cmdline, b.Cmdline)
 }
 
 // hashCmdline computes a fast FNV-1a hash of the command line arguments.

--- a/pkg/process/procutil/process_model_test.go
+++ b/pkg/process/procutil/process_model_test.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessIdentity(t *testing.T) {
+	// Basic identity generation
+	identity := ProcessIdentity(1234, 1000000, []string{"bash", "-c", "echo hello"})
+	assert.Contains(t, identity, "pid:1234")
+	assert.Contains(t, identity, "createTime:1000000")
+	assert.Contains(t, identity, "cmdHash:")
+}
+
+func TestProcessIdentityDifferentCmdline(t *testing.T) {
+	// Same PID and createTime, different cmdline should produce different identity
+	identity1 := ProcessIdentity(1234, 1000000, []string{"bash"})
+	identity2 := ProcessIdentity(1234, 1000000, []string{"htop"})
+
+	assert.NotEqual(t, identity1, identity2, "Different cmdlines should produce different identities")
+}
+
+func TestProcessIdentitySameCmdline(t *testing.T) {
+	// Same PID, createTime, and cmdline should produce same identity
+	identity1 := ProcessIdentity(1234, 1000000, []string{"bash", "-c", "echo"})
+	identity2 := ProcessIdentity(1234, 1000000, []string{"bash", "-c", "echo"})
+
+	assert.Equal(t, identity1, identity2, "Same inputs should produce same identity")
+}
+
+func TestProcessIdentityArgOrderMatters(t *testing.T) {
+	// Argument order should matter
+	identity1 := ProcessIdentity(1234, 1000000, []string{"cmd", "a", "b"})
+	identity2 := ProcessIdentity(1234, 1000000, []string{"cmd", "b", "a"})
+
+	assert.NotEqual(t, identity1, identity2, "Different arg order should produce different identities")
+}
+
+func TestProcessIdentityTruncatesAt100Args(t *testing.T) {
+	// Create cmdline with 150 args
+	cmdline150 := make([]string, 150)
+	for i := range cmdline150 {
+		cmdline150[i] = "arg"
+	}
+
+	// Same first 100 args, but different args after 100
+	cmdline150Different := make([]string, 150)
+	copy(cmdline150Different, cmdline150)
+	cmdline150Different[120] = "DIFFERENT" // Change arg at position 120
+
+	identity1 := ProcessIdentity(1234, 1000000, cmdline150)
+	identity2 := ProcessIdentity(1234, 1000000, cmdline150Different)
+
+	// Should be equal because we only hash first 100 args
+	assert.Equal(t, identity1, identity2, "Should only hash first 100 args, differences after should be ignored")
+}
+
+func TestProcessIdentityDifferenceWithin100Args(t *testing.T) {
+	// Create cmdline with 150 args
+	cmdline150 := make([]string, 150)
+	for i := range cmdline150 {
+		cmdline150[i] = "arg"
+	}
+
+	// Different arg within first 100
+	cmdline150Different := make([]string, 150)
+	copy(cmdline150Different, cmdline150)
+	cmdline150Different[50] = "DIFFERENT" // Change arg at position 50
+
+	identity1 := ProcessIdentity(1234, 1000000, cmdline150)
+	identity2 := ProcessIdentity(1234, 1000000, cmdline150Different)
+
+	// Should be different because change is within first 100 args
+	assert.NotEqual(t, identity1, identity2, "Differences within first 100 args should produce different identities")
+}
+
+func TestProcessIdentityEmptyCmdline(t *testing.T) {
+	// Empty cmdline should work
+	identity1 := ProcessIdentity(1234, 1000000, []string{})
+	identity2 := ProcessIdentity(1234, 1000000, nil)
+
+	// Both empty, should be equal
+	assert.Equal(t, identity1, identity2, "Empty and nil cmdlines should produce same identity")
+}
+
+func TestProcessIdentityArgBoundaryDistinction(t *testing.T) {
+	// Ensure ["ab", "c"] and ["a", "bc"] hash differently (null separator works)
+	identity1 := ProcessIdentity(1234, 1000000, []string{"ab", "c"})
+	identity2 := ProcessIdentity(1234, 1000000, []string{"a", "bc"})
+
+	assert.NotEqual(t, identity1, identity2, "Different arg boundaries should produce different identities")
+}

--- a/releasenotes/notes/process-collection-cmdline-hashing-fdbb3734e094590c.yaml
+++ b/releasenotes/notes/process-collection-cmdline-hashing-fdbb3734e094590c.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 fixes:
   - |

--- a/releasenotes/notes/process-collection-cmdline-hashing-fdbb3734e094590c.yaml
+++ b/releasenotes/notes/process-collection-cmdline-hashing-fdbb3734e094590c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix process collection to detect command line changes for processes with the 
+    same PID and creation time by hashing the command line.


### PR DESCRIPTION
### What does this PR do?
- Fixes a bug where all process collection on all platforms did not detect process changes when a process had the same PID and creation time but a different command line (e.g., after an exec() syscall).
    - github community issue https://github.com/DataDog/datadog-agent/issues/43137 (author mentions this behaviour is no longer seen in 7.73)
    - support cases
        - https://datadoghq.atlassian.net/browse/PRMS-3121
- Introduces a `ProcessIdentity` function that generates a unique identity string based on PID, creation time, and a hash of the command line for windows
    - Set a 100 argument limit for hashing based off metric `process_discovery.command_args_per_process`, which showed this covers ~p99.9 of real-world processes while protecting against anomlous cases with 15K-74K cli args. If there is a collision somehow (would be unlikely) we would not be introducing any regression as we would fallback to the same behaviour without this change (process command line change would not be emitted)
- introduces a `IsSameProcess` function to compare if 2 processes are the same (this is used in the WLM process collector for linux)

[dashboard widget](https://app.datadoghq.com/s/yB5yjZ/nht-kzs-dug)
<img width="1507" height="810" alt="image" src="https://github.com/user-attachments/assets/a40b1bdf-69c8-49c9-9691-ed9ed9022dca" />
    
### Replication of bug
- checkout tag `7.72.0` 
- started devcontainer and re-built agent from source
```
terminal 1      |  terminal 2
----------------|---------------------------------------------------------------------------------
$ bash          |
$ echo $$       |
6645            |  $ sudo datadog-agent processchecks process  | grep -A 5 'PID: 6645'
                | > PID: 6645 NSPID: 6645 PPID: 0
                |  Container ID: 
                |  Exe: 
                |  Command Name: bash
                |  Args: '/run/rosetta/rosetta' '/usr/bin/bash' 'bash'
                |  Cwd: 
                | --
                |   Args: '/run/rosetta/rosetta' '/usr/bin/grep' 'grep' '--color=auto' '-A' '5' 'PID: 6645'
                |   Cwd: 
                |   User: datadog Uid: 503 Gid: 20 Euid: 0 Egid: 0 Suid: 0 Sgid: 0
                |   Create Time: 2026-02-04T04:07:21Z
                |   State: S
                |   Memory:
$ exec top     |
                | $ sudo datadog-agent processchecks process  | grep -A 5 'PID: 6645'
                | > PID: 6645 NSPID: 6645 PPID: 0
                |   Container ID: 
                |   Exe: 
                |   Command Name: bash
                |   Args: '/run/rosetta/rosetta' '/usr/bin/bash' 'bash'
                |   Cwd: 
                | --
                |   Args: '/run/rosetta/rosetta' '/usr/bin/grep' 'grep' '--color=auto' '-A' '5' 'PID: 6645'
                |   Cwd: 
                |   User: datadog Uid: 503 Gid: 20 Euid: 0 Egid: 0 Suid: 0 Sgid: 0
                |   Create Time: 2026-02-04T04:07:55Z
                |   State: S
                |   Memory:
```

### Testing on agent version 7.73.0 shows the issue is "fixed" with the `processchecks` command which https://github.com/DataDog/datadog-agent/issues/43137 says

```
terminal 1      |  terminal 2
----------------|---------------------------------------------------------------------------------
$ bash          |
$ echo $$       |
75978            |  $ sudo datadog-agent processchecks process  | grep -A 5 'PID: 75978'
                | > PID: 75978 NSPID: 75978 PPID: 0
                |  Container ID: 
                |  Exe: /run/rosetta/rosetta
                |  Command Name: bash
                |  Args: 'bash'
                |  Cwd: /workspaces/datadog-agent
                |--
                |  Args: 'grep' '--color=auto' '-A' '5' 'PID: 75978'
                |  Cwd: /workspaces/datadog-agent
                |  User: datadog Uid: 503 Gid: 20 Euid: 0 Egid: 0 Suid: 0 Sgid: 0
                |  Create Time: 2026-02-04T04:42:32Z
                |  State: S
                |  Memory:
$ exec top     |
                | $ sudo datadog-agent processchecks process  | grep -A 5 'PID: 75978'
                | > PID: 75978 NSPID: 75978 PPID: 0
                |   Container ID: 
                |   Exe: /run/rosetta/rosetta
                |   Command Name: top
                |   Args: 'top'
                |   Cwd: /workspaces/datadog-agent
                | --
                |   Args: 'grep' '--color=auto' '-A' '5' 'PID: 75978'
                |   Cwd: /workspaces/datadog-agent
                |   User: datadog Uid: 503 Gid: 20 Euid: 0 Egid: 0 Suid: 0 Sgid: 0
                |   Create Time: 2026-02-04T04:43:46Z
                |   State: S
                |   Memory:
```

However, in 7.73 the `processchecks` command creates a fresh wlm store each time so this issue is not visible with that invocation.

Using the `workload-list` command instead which queries the active WLM store, we can see the issue still present.

```
terminal 1      |  terminal 2
----------------|---------------------------------------------------------------------------------
$ bash          |
$ echo $$       |
4520            |  $ sudo datadog-agent workload-list  | grep -A 5 'PID: 4520'
                | PID: 4520
                | Name: bash
                | Exe: 
                | Cmdline: /run/rosetta/rosetta /usr/bin/bash bash
                | Namespace PID: 4520
                | Container ID: 
                | Creation time: 2026-02-04 05:17:37 +0000 UTC
                | Language: 
                | APM Injection Status: unknown
                | ===
$ exec top     |
                | $ sudo datadog-agent workload-list  | grep -A 5 'PID: 4520'
                | PID: 4520
                | Name: bash
                | Exe: 
                | Cmdline: /run/rosetta/rosetta /usr/bin/bash bash
                | Namespace PID: 4520
                | Container ID: 
                | Creation time: 2026-02-04 05:17:37 +0000 UTC
                | Language: 
                | APM Injection Status: unknown
                | ===
```

### Bug no longer seen with new changes using WLM command
```
terminal 1      |  terminal 2
----------------|---------------------------------------------------------------------------------
$ bash          |
$ echo $$       | 
4973           | $ sudo datadog-agent workload-list  | grep -A 5 'PID: 4973'
                | PID: 4973
                | Name: bash
                | Exe: 
                | Cmdline: /run/rosetta/rosetta /usr/bin/bash bash
                | Namespace PID: 4973
                | Container ID: 
                | Creation time: 2026-02-04 05:22:44 +0000 UTC
                | Language: 
                | APM Injection Status: unknown
                |===
$ exec top      |
                |   $ sudo datadog-agent workload-list  | grep -A 5 'PID: 4973'
                | PID: 4973
                | Name: top
                | Exe: 
                | Cmdline: /run/rosetta/rosetta /usr/bin/top top
                | Namespace PID: 4973
                | Container ID: 
                | Creation time: 2026-02-04 05:22:44 +0000 UTC
                | Language: 
                | APM Injection Status: unknown
                | ===
```

HOWEVER! the processes page still shows the old command line https://dddev.datadoghq.com/process?query=host%3Amatthew.geng-devcontainer&cols=proc%2Cuser%2Chost%2CpodStatus%2CcontStatus%2Cpid%2Ccpu%2Cmem%2Cstart&inspect=650500001be2ea89c058227b9748ee5eb73d74ed&selectedTopGraph=timeseries

<img width="1068" height="687" alt="image" src="https://github.com/user-attachments/assets/6cc08d03-0113-45bd-9d78-9a9a3acff3fb" />

This is due to https://github.com/DataDog/dd-go/blob/65e64ba539529f9d841af3060ff33e981099c49c/process/apps/process-resolver/resolver.go#L457 since the key we use to write unique process data does not include the command line. This is something we will have to change on the backend in the future.

After the TTL we can eventually see the cmdline change

<img width="1051" height="823" alt="image" src="https://github.com/user-attachments/assets/ab6b4ebe-c5bb-44ac-a4b9-86c661189493" />


### Motivation
- it is possible for a process to run a new command but still retain the same PID and create time as seen with the `exec` command from https://github.com/DataDog/datadog-agent/issues/43137
- there was also a support case due to this https://datadoghq.atlassian.net/browse/PRMS-3121

### Describe how you validated your changes
- Unit tests for ProcessIdentity hashing function 
- Unit tests for processCacheDifference exec scenario
- Added entry to Integration test case added to TestProcessLifecycleCollection
Integration test TestExecCmdlineChange in extractor_test.go
Manual testing in devcontainer with actual exec scenario

### Additional Notes
- `FNV-1a` was chosen since it is already being used in https://github.com/DataDog/datadog-agent/blob/5b5453ba885032eda6867c02fd2d2e54ef724e43/pkg/process/runner/submitter.go#L413 and for hashing speed
- The fix applies to both Linux (process_collector.go) and macOS/Windows (extractor.go) code paths.
