### PR TITLE
[PROF-13649] host-profiler: remove dependency on dd-otel-host-profiler

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -162,17 +162,6 @@ core,github.com/DataDog/datadog-traceroute/tcp,Apache-2.0,"Copyright 2016-presen
 core,github.com/DataDog/datadog-traceroute/traceroute,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/udp,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-traceroute/winconn,Apache-2.0,"Copyright 2016-present Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/config,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/containermetadata,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/pclntab,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/cgroup,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/oom,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/pipeline,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/pprof,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/samples,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/reporter/symbol,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
-core,github.com/DataDog/dd-otel-host-profiler/version,Apache-2.0,"Copyright 2017 Datadog, Inc | Copyright 2024 Datadog, Inc"
 core,github.com/DataDog/ddtrivy,Apache-2.0,"Copyright 2025-Present Datadog, Inc"
 core,github.com/DataDog/ddtrivy/walker,Apache-2.0,"Copyright 2025-Present Datadog, Inc"
 core,github.com/DataDog/ebpf-manager,MIT,Copyright (c) 2021 Authors of Datadog
@@ -2302,7 +2291,6 @@ core,github.com/uptrace/bun/internal/tagparser,BSD-2-Clause,Copyright (c) 2021 V
 core,github.com/uptrace/bun/migrate,BSD-2-Clause,Copyright (c) 2021 Vladimir Mihailenco. All rights reserved
 core,github.com/uptrace/bun/migrate/sqlschema,BSD-2-Clause,Copyright (c) 2021 Vladimir Mihailenco. All rights reserved
 core,github.com/uptrace/bun/schema,BSD-2-Clause,Copyright (c) 2021 Vladimir Mihailenco. All rights reserved
-core,github.com/urfave/cli/v3,MIT,Copyright (c) 2023 urfave/cli maintainers
 core,github.com/urfave/negroni,MIT,Copyright (c) 2014 Jeremy Saenz
 core,github.com/valyala/fastjson,MIT,Copyright (c) 2018 Aliaksandr Valialkin
 core,github.com/valyala/fastjson/fastfloat,MIT,Copyright (c) 2018 Aliaksandr Valialkin

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/tracer/types"
 
 	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // Config is the configuration for the profiles receiver.
@@ -33,8 +32,6 @@ type Config struct {
 // ServiceNameEnvVars is the list of environment variables used to determine the service name.
 // The order indicates which environment variable takes precedence.
 var serviceNameEnvVars = []string{"DD_SERVICE", "OTEL_SERVICE_NAME"}
-
-const profilerName = "full-host-profiler"
 
 var _ xconfmap.Validator = (*Config)(nil)
 
@@ -97,9 +94,6 @@ func defaultConfig() component.Config {
 	cfg.ReporterJitter = 0.05
 
 	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig()
-	symbolUploaderConfig.Version = version.AgentVersion
-	symbolUploaderConfig.Name = profilerName
-
 	return Config{
 		EbpfCollectorConfig:  cfg,
 		SymbolUploader:       symbolUploaderConfig,

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -12,28 +12,29 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/dd-otel-host-profiler/config"
-	"github.com/DataDog/dd-otel-host-profiler/reporter"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	ebpfcollector "go.opentelemetry.io/ebpf-profiler/collector"
 	ebpfconfig "go.opentelemetry.io/ebpf-profiler/collector/config"
 	"go.opentelemetry.io/ebpf-profiler/tracer/types"
-)
 
-// ReporterConfig is the configuration for the reporter.
-type ReporterConfig struct {
-	CollectContext bool `mapstructure:"collect_context"`
-}
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
 
 // Config is the configuration for the profiles receiver.
 type Config struct {
-	EbpfCollectorConfig  *ebpfconfig.Config            `mapstructure:"ebpf_collector"`
-	SymbolUploader       reporter.SymbolUploaderConfig `mapstructure:"symbol_uploader"`
-	ReporterConfig       ReporterConfig                `mapstructure:"reporter"`
-	EnableSplitByService bool                          `mapstructure:"enable_split_by_service"`
+	EbpfCollectorConfig  *ebpfconfig.Config                  `mapstructure:"ebpf_collector"`
+	SymbolUploader       symboluploader.SymbolUploaderConfig `mapstructure:"symbol_uploader"`
+	CollectContext       bool                                `mapstructure:"collect_context"`
+	EnableSplitByService bool                                `mapstructure:"enable_split_by_service"`
 }
+
+// ServiceNameEnvVars is the list of environment variables used to determine the service name.
+// The order indicates which environment variable takes precedence.
+var serviceNameEnvVars = []string{"DD_SERVICE", "OTEL_SERVICE_NAME"}
+
+const profilerName = "full-host-profiler"
 
 var _ xconfmap.Validator = (*Config)(nil)
 
@@ -53,7 +54,7 @@ func (c *Config) Validate() error {
 	if err := c.EbpfCollectorConfig.Validate(); err != nil {
 		return err
 	}
-	if c.ReporterConfig.CollectContext {
+	if c.CollectContext {
 		includeTracers, err := types.Parse(c.EbpfCollectorConfig.Tracers)
 		if err != nil {
 			return err
@@ -62,7 +63,7 @@ func (c *Config) Validate() error {
 		c.EbpfCollectorConfig.Tracers = includeTracers.String()
 	}
 	if c.EnableSplitByService {
-		includeEnvVars := reporter.ServiceNameEnvVars
+		includeEnvVars := append([]string{}, serviceNameEnvVars...)
 		if c.EbpfCollectorConfig.IncludeEnvVars != "" {
 			includeEnvVars = append(includeEnvVars, c.EbpfCollectorConfig.IncludeEnvVars)
 		}
@@ -95,26 +96,15 @@ func defaultConfig() component.Config {
 	// With 60s intervals, 20% would mean ~12s variation, so we reduce to 5% (~3s).
 	cfg.ReporterJitter = 0.05
 
-	return Config{
-		EbpfCollectorConfig: cfg,
-		SymbolUploader: reporter.SymbolUploaderConfig{
-			SymbolUploaderOptions: reporter.SymbolUploaderOptions{
-				Enabled:              config.DefaultUploadSymbols,
-				UploadDynamicSymbols: config.DefaultUploadDynamicSymbols,
-				UploadGoPCLnTab:      config.DefaultUploadGoPCLnTab,
-				UseHTTP2:             config.DefaultUploadSymbolsHTTP2,
-				SymbolQueryInterval:  config.DefaultSymbolQueryInterval,
-				DryRun:               config.DefaultUploadSymbolsDryRun,
-				SymbolEndpoints:      nil,
-			},
-			Version:                        version.AgentVersion,
-			DisableDebugSectionCompression: false,
-		},
+	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig()
+	symbolUploaderConfig.Version = version.AgentVersion
+	symbolUploaderConfig.Name = profilerName
 
-		EnableSplitByService: config.DefaultSplitByService,
-		ReporterConfig: ReporterConfig{
-			CollectContext: config.DefaultCollectContext,
-		},
+	return Config{
+		EbpfCollectorConfig:  cfg,
+		SymbolUploader:       symbolUploaderConfig,
+		EnableSplitByService: true,
+		CollectContext:       false,
 	}
 }
 

--- a/comp/host-profiler/collector/impl/receiver/config_test.go
+++ b/comp/host-profiler/collector/impl/receiver/config_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/dd-otel-host-profiler/reporter"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,12 +30,12 @@ func TestTracers(t *testing.T) {
 	require.NotContains(t, cfg.EbpfCollectorConfig.Tracers, "go")
 	require.NotContains(t, cfg.EbpfCollectorConfig.Tracers, "labels")
 
-	cfg.ReporterConfig.CollectContext = false
+	cfg.CollectContext = false
 	cfg.SymbolUploader.Enabled = false
 	require.NoError(t, cfg.Validate())
 	require.NotContains(t, cfg.EbpfCollectorConfig.Tracers, "labels")
 
-	cfg.ReporterConfig.CollectContext = true
+	cfg.CollectContext = true
 	require.NoError(t, cfg.Validate())
 	require.Contains(t, cfg.EbpfCollectorConfig.Tracers, "labels")
 }
@@ -50,7 +50,7 @@ func TestServiceNameEnvVars(t *testing.T) {
 
 	cfg.EnableSplitByService = true
 	require.NoError(t, cfg.Validate())
-	require.Equal(t, strings.Join(reporter.ServiceNameEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
+	require.Equal(t, strings.Join(serviceNameEnvVars, ","), cfg.EbpfCollectorConfig.IncludeEnvVars)
 }
 
 func TestSymbolUploader(t *testing.T) {
@@ -62,7 +62,7 @@ func TestSymbolUploader(t *testing.T) {
 	cfg.SymbolUploader.Enabled = true
 	require.Error(t, errSymbolEndpointsRequired(), cfg.Validate())
 
-	cfg.SymbolUploader.SymbolEndpoints = []reporter.SymbolEndpoint{{}}
+	cfg.SymbolUploader.SymbolEndpoints = []symboluploader.SymbolEndpoint{{}}
 	require.Error(t, errSymbolEndpointsSiteRequired(), cfg.Validate())
 	cfg.SymbolUploader.SymbolEndpoints[0].Site = "datadoghq.com"
 	require.Error(t, errSymbolEndpointsAPIKeyRequired(), cfg.Validate())

--- a/comp/host-profiler/collector/impl/receiver/executable_reporter.go
+++ b/comp/host-profiler/collector/impl/receiver/executable_reporter.go
@@ -13,20 +13,20 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/DataDog/dd-otel-host-profiler/reporter"
-
 	ebpfreporter "go.opentelemetry.io/ebpf-profiler/reporter"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader"
 )
 
 var _ ebpfreporter.ExecutableReporter = (*executableReporter)(nil)
 
 type executableReporter struct {
-	symbolUploader *reporter.DatadogSymbolUploader
+	symbolUploader *symboluploader.DatadogSymbolUploader
 }
 
-func newExecutableReporter(config *reporter.SymbolUploaderConfig, _ *zap.Logger) (*executableReporter, error) {
+func newExecutableReporter(config *symboluploader.SymbolUploaderConfig, _ *zap.Logger) (*executableReporter, error) {
 	ctx := context.Background()
-	symbolUploader, err := reporter.NewDatadogSymbolUploader(ctx, config)
+	symbolUploader, err := symboluploader.NewDatadogSymbolUploader(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/host-profiler/symboluploader/cgroup/cgroup.go
+++ b/comp/host-profiler/symboluploader/cgroup/cgroup.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+// Package cgroup provides utilities for returning usable memory from cgroups.
+package cgroup
+
+import (
+	"path/filepath"
+	"strconv"
+)
+
+const (
+	cgroupRoot     = "/sys/fs/cgroup"
+	v1MaxMemory    = "memory.limit_in_bytes"
+	v2MaxMemory    = "memory.max"
+	memoryMaxUnset = 0x7FFFFFFFFFFFF000
+	budgetRatio    = 8
+)
+
+func v1GetMaxUsableMemory() (int64, error) {
+	cgroupPath, err := v1GetCurrentCgroupPath()
+	if err != nil {
+		return -1, err
+	}
+
+	str, err := readFromFile(filepath.Join(cgroupPath, v1MaxMemory))
+	if err != nil {
+		return -1, err
+	}
+
+	limit, err := strconv.ParseInt(str, 10, 64)
+
+	if err != nil {
+		return -1, err
+	}
+
+	if limit < 0 || limit == memoryMaxUnset {
+		return -1, nil
+	}
+
+	return limit, nil
+}
+
+func v2GetMaxUsableMemory() (int64, error) {
+	currCgroupPath, err := v2GetCurrentCgroupPath()
+	if err != nil {
+		return -1, err
+	}
+
+	str, err := readFromFile(filepath.Join(currCgroupPath, v2MaxMemory))
+
+	if err != nil {
+		return -1, err
+	}
+
+	// not error -> no memory constraints
+	if str == "max" {
+		return -1, nil
+	}
+
+	limit, err := strconv.ParseInt(str, 10, 64)
+
+	if err != nil {
+		return -1, err
+	}
+
+	return limit, nil
+}
+
+func GetMaxUsableMemory() (int64, error) {
+	if !isCgroup2UnifiedMode() {
+		return v1GetMaxUsableMemory()
+	}
+	return v2GetMaxUsableMemory()
+}
+
+// GetMemoryBudget returns a percentage of the overall memory limit found in
+// cgroup. If there are no limits, it returns -1.
+func GetMemoryBudget() (int64, error) {
+	maxMemory, err := GetMaxUsableMemory()
+	if err != nil {
+		return -1, err
+	}
+	if maxMemory == -1 {
+		return maxMemory, nil
+	}
+
+	return maxMemory * budgetRatio / 10, nil
+}

--- a/comp/host-profiler/symboluploader/cgroup/helpers.go
+++ b/comp/host-profiler/symboluploader/cgroup/helpers.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package cgroup
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func isCgroup2UnifiedMode() bool {
+	var st unix.Statfs_t
+	err := unix.Statfs(cgroupRoot, &st)
+	if err != nil {
+		return false
+	}
+	return st.Type == unix.CGROUP2_SUPER_MAGIC
+}
+
+func readFromFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func v1GetCurrentCgroupPath() (string, error) {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		// hierarchy:controller(s):path
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) < 3 {
+			continue
+		}
+
+		for controller := range strings.SplitSeq(parts[1], ",") {
+			if controller == "memory" {
+				return filepath.Join(cgroupRoot, "memory", parts[2]), nil
+			}
+		}
+	}
+
+	return "", errors.New("cgroup path not found in /proc/self/cgroup")
+}
+
+func v2GetCurrentCgroupPath() (string, error) {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if path, ok := strings.CutPrefix(line, "0::"); ok {
+			return filepath.Join(cgroupRoot, path), nil
+		}
+	}
+
+	return "", errors.New("cgroup path not found in /proc/self/cgroup")
+}

--- a/comp/host-profiler/symboluploader/config.go
+++ b/comp/host-profiler/symboluploader/config.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+import (
+	"time"
+)
+
+// Default configuration values
+const (
+	DefaultSymbolQueryInterval  = 5 * time.Second
+	DefaultUploadSymbolsDryRun  = false
+	DefaultUploadSymbolsHTTP2   = false
+	DefaultUploadSymbols        = true
+	DefaultUploadDynamicSymbols = false
+	DefaultUploadGoPCLnTab      = true
+)
+
+type SymbolUploaderOptions struct {
+	// Enabled defines whether the agent should upload debug symbols to the backend.
+	Enabled bool `mapstructure:"enabled"`
+	// UploadDynamicSymbols defines whether the agent should upload dynamic symbols to the backend.
+	UploadDynamicSymbols bool `mapstructure:"upload_dynamic_symbols"`
+	// UploadGoPCLnTab defines whether the agent should upload GoPCLnTab section for Go binaries to the backend.
+	UploadGoPCLnTab bool `mapstructure:"upload_go_pcln_tab"`
+	// UseHTTP2 defines whether the agent should use HTTP/2 when uploading symbols.
+	UseHTTP2 bool `mapstructure:"use_http2"`
+	// SymbolQueryInterval defines the interval at which the agent should query the backend for symbols. A value of 0 disables batching.
+	SymbolQueryInterval time.Duration `mapstructure:"symbol_query_interval"`
+	// DryRun defines whether the agent should upload debug symbols to the backend in dry-run mode.
+	DryRun bool `mapstructure:"dry_run"`
+	// Sites to upload symbols to.
+	SymbolEndpoints []SymbolEndpoint `mapstructure:"symbol_endpoints"`
+}
+
+type SymbolUploaderConfig struct {
+	// Options defines the options for the symbol uploader.
+	SymbolUploaderOptions `mapstructure:",squash"`
+
+	// DisableDebugSectionCompression defines whether the uploader should disable debug section compression whatever objcopy supports.
+	// This is only used for testing purposes.
+	DisableDebugSectionCompression bool `mapstructure:"disable_debug_section_compression"`
+	// Version is the version of the profiler.
+	Version string `mapstructure:"-"`
+	// Name is the name of the profiler.
+	Name string `mapstructure:"-"`
+}
+
+func DefaultSymbolUploaderConfig() SymbolUploaderConfig {
+	return SymbolUploaderConfig{
+		SymbolUploaderOptions: SymbolUploaderOptions{
+			Enabled:              DefaultUploadSymbols,
+			UploadDynamicSymbols: DefaultUploadDynamicSymbols,
+			UploadGoPCLnTab:      DefaultUploadGoPCLnTab,
+			UseHTTP2:             DefaultUploadSymbolsHTTP2,
+			SymbolQueryInterval:  DefaultSymbolQueryInterval,
+			DryRun:               DefaultUploadSymbolsDryRun,
+		},
+	}
+}

--- a/comp/host-profiler/symboluploader/config.go
+++ b/comp/host-profiler/symboluploader/config.go
@@ -9,6 +9,8 @@ package symboluploader
 
 import (
 	"time"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 )
 
 // Default configuration values
@@ -61,5 +63,7 @@ func DefaultSymbolUploaderConfig() SymbolUploaderConfig {
 			SymbolQueryInterval:  DefaultSymbolQueryInterval,
 			DryRun:               DefaultUploadSymbolsDryRun,
 		},
+		Name:    version.ProfilerName,
+		Version: version.ProfilerVersion,
 	}
 }

--- a/comp/host-profiler/symboluploader/oom/oom.go
+++ b/comp/host-profiler/symboluploader/oom/oom.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+// Package oom provides utilities for getting and setting OOM (Out of Memory) score adjustments for processes.
+package oom
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// GetOOMScoreAdj returns the OOM score adjustment for the given process, or for the current process if pid is 0.
+func GetOOMScoreAdj(pid int) (int, error) {
+	pidString := "self"
+	if pid != 0 {
+		pidString = strconv.Itoa(pid)
+	}
+
+	procPath := fmt.Sprintf("/proc/%s/oom_score_adj", pidString)
+	data, err := os.ReadFile(procPath)
+	if err != nil {
+		return -1, fmt.Errorf("failed to read oom_score_adj to %s for PID %d: %w", procPath, pid, err)
+	}
+
+	// trim the trailing newline
+	data = bytes.TrimSuffix(data, []byte("\n"))
+	score, err := strconv.Atoi(string(data))
+
+	if err != nil {
+		return -1, fmt.Errorf("oom_score_adj is not a number from %s for PID %d: %w", procPath, pid, err)
+	}
+
+	return score, nil
+}
+
+// SetOOMScoreAdj sets the OOM score adjustment for the given process, or for the current process if pid is 0.
+func SetOOMScoreAdj(pid, score int) error {
+	if score < -1000 || score > 1000 {
+		return fmt.Errorf("oom_score_adj must be between -1000 and 1000, got %d", score)
+	}
+
+	pidString := "self"
+	if pid != 0 {
+		pidString = strconv.Itoa(pid)
+	}
+
+	procPath := fmt.Sprintf("/proc/%s/oom_score_adj", pidString)
+
+	if err := os.WriteFile(procPath, []byte(strconv.Itoa(score)), 0); err != nil {
+		return fmt.Errorf("failed to write oom_score_adj to %s for PID %d: %w", procPath, pid, err)
+	}
+
+	return nil
+}

--- a/comp/host-profiler/symboluploader/pclntab/pclntab.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab.go
@@ -1,0 +1,837 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+// Package pclntab provides utilities for parsing and extracting Go pclntab data.
+package pclntab
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+
+	elf "github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+type HeaderVersion int
+
+const (
+	verUnknown HeaderVersion = iota
+	ver12
+	ver116
+	ver118
+	ver120
+)
+
+const (
+	ptrSize           = 8
+	maxBytesGoPclntab = 128 * 1024 * 1024
+	maxGoFuncID       = 22
+
+	funcdataInlTree = 3
+
+	// pclntabHeader magic identifying Go version
+	magicGo1_2  = 0xfffffffb
+	magicGo1_16 = 0xfffffffa
+	magicGo1_18 = 0xfffffff0
+	magicGo1_20 = 0xfffffff1
+)
+
+var (
+	disableRecover = false
+)
+
+type GoPCLnTabInfo struct {
+	Address    uint64        // goPCLnTab address
+	Data       []byte        // goPCLnTab data
+	Version    HeaderVersion // gopclntab header version
+	Offsets    TableOffsets
+	TextStart  TextStartInfo // text start information
+	GoFuncAddr uint64        // goFunc address
+	GoFuncData []byte        // goFunc data
+
+	numFuncs            int
+	funcSize            int
+	fieldSize           int
+	funcNpcdataOffset   int
+	funcNfuncdataOffset int
+	functab             []byte
+	funcdata            []byte
+}
+
+type TableOffsets struct {
+	FuncNameTabOffset uint64
+	CuTabOffset       uint64
+	FileTabOffset     uint64
+	PcTabOffset       uint64
+	FuncTabOffset     uint64
+}
+
+type pclntabHeader struct {
+	// magic is one of the magicGo1_xx constants identifying the version
+	magic uint32
+	// pad is unused and is needed for alignment
+	pad uint16
+	// quantum is the CPU instruction size alignment (e.g. 1 for x86, 4 for arm)
+	quantum uint8
+	// ptrSize is the CPU pointer size in bytes
+	ptrSize uint8
+	// numFuncs is the number of function definitions to follow
+	numFuncs uint64
+}
+
+type pclntabHeader116 struct {
+	pclntabHeader
+
+	nfiles         uint
+	funcnameOffset uintptr
+	cuOffset       uintptr
+	filetabOffset  uintptr
+	pctabOffset    uintptr
+	pclnOffset     uintptr
+}
+
+// pclntabHeader118 is the Golang pclntab header structure starting Go 1.18
+// structural definition of this is found in go/src/runtime/symtab.go as pcHeader
+type pclntabHeader118 struct {
+	pclntabHeader
+
+	nfiles         uint
+	textStart      uintptr
+	funcnameOffset uintptr
+	cuOffset       uintptr
+	filetabOffset  uintptr
+	pctabOffset    uintptr
+	pclnOffset     uintptr
+}
+
+type rawInlinedCall112 struct {
+	Parent   int16 // index of parent in the inltree, or < 0
+	FuncID   uint8 // type of the called function
+	padding  byte
+	File     int32 // perCU file index for inlined call. See cmd/link:pcln.go
+	Line     int32 // line number of the call site
+	Func     int32 // offset into pclntab for name of called function
+	ParentPC int32 // position of an instruction whose source position is the call site (offset from entry)
+}
+
+// rawInlinedCall120 is the encoding of entries in the FUNCDATA_InlTree table
+// from Go 1.20. It is equivalent to runtime.inlinedCall.
+type rawInlinedCall120 struct {
+	FuncID    uint8 // type of the called function
+	padding   [3]byte
+	NameOff   int32 // offset into pclntab for name of called function
+	ParentPC  int32 // position of an instruction whose source position is the call site (offset from entry)
+	StartLine int32 // line number of start of function (func keyword/TEXT directive)
+}
+
+type TextStartOrigin int
+
+const (
+	TextStartOriginPCLnTab TextStartOrigin = iota
+	TextStartOriginModuleData
+	TextStartOriginRuntimeTextSymbol
+)
+
+type TextStartInfo struct {
+	Origin             TextStartOrigin
+	Address            uint64
+	TextSectionAddress uint64
+}
+
+func (h HeaderVersion) String() string {
+	switch h {
+	case ver12:
+		return "1.2"
+	case ver116:
+		return "1.16"
+	case ver118:
+		return "1.18"
+	case ver120:
+		return "1.20"
+	default:
+		return "unknown"
+	}
+}
+
+// getInt32 gets a 32-bit integer from the data slice at offset with bounds checking
+func getInt32(data []byte, offset int) int {
+	if offset < 0 || offset+4 > len(data) {
+		return -1
+	}
+	return int(*(*int32)(unsafe.Pointer(&data[offset])))
+}
+
+func getUInt32(data []byte, offset int) int {
+	if offset < 0 || offset+4 > len(data) {
+		return -1
+	}
+	return int(*(*uint32)(unsafe.Pointer(&data[offset])))
+}
+
+func getUint8(data []byte, offset int) int {
+	if offset < 0 || offset+1 > len(data) {
+		return -1
+	}
+	return int(*(*uint8)(unsafe.Pointer(&data[offset])))
+}
+
+// pclntabHeaderSize returns the minimal pclntab header size.
+func pclntabHeaderSize() int {
+	return int(unsafe.Sizeof(pclntabHeader{}))
+}
+
+func sectionContaining(elfFile *pfelf.File, addr uint64) *pfelf.Section {
+	for _, s := range elfFile.Sections {
+		if s.Type != elf.SHT_NOBITS && addr >= s.Addr && addr < s.Addr+s.Size {
+			return &s
+		}
+	}
+	return nil
+}
+
+// goFuncOffset returns the offset of the goFunc field in moduledata.
+func goFuncOffset(v HeaderVersion) (uint32, error) {
+	if v < ver118 {
+		return 0, fmt.Errorf("unsupported pclntab version: %v", v.String())
+	}
+	if v < ver120 {
+		return 38 * ptrSize, nil
+	}
+	return 40 * ptrSize, nil
+}
+
+func FindModuleData(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (data []byte, address uint64, returnedErr error) {
+	// First: try to use the 'go.module' section introduced in Go 1.26.
+	moduleSection := ef.Section(".go.module")
+	if moduleSection != nil {
+		data, err := moduleSection.Data(maxBytesGoPclntab)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not read .go.module section: %w", err)
+		}
+		return data, moduleSection.Addr, nil
+	}
+
+	// Second: try to locate module data by looking for runtime.firstmoduledata symbol.
+	if runtimeFirstModuleDataSymbolValue != 0 {
+		addr := uint64(runtimeFirstModuleDataSymbolValue)
+		section := sectionContaining(ef, addr)
+		if section == nil {
+			return nil, 0, errors.New("could not find section containing runtime.firstmoduledata")
+		}
+		data, err := section.Data(maxBytesGoPclntab)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not read section containing runtime.firstmoduledata: %w", err)
+		}
+		return data[addr-section.Addr:], addr, nil
+	}
+
+	// If runtime.firstmoduledata is missing, heuristically search for gopclntab address in .noptrdata section.
+	// https://www.mandiant.com/resources/blog/golang-internals-symbol-recovery
+	noPtrSection := ef.Section(".noptrdata")
+	noPtrSectionData, err := noPtrSection.Data(maxBytesGoPclntab)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not read .noptrdata section: %w", err)
+	}
+
+	var buf [2 * ptrSize]byte
+	binary.NativeEndian.PutUint64(buf[:], goPCLnTabInfo.Address)
+	binary.NativeEndian.PutUint64(buf[ptrSize:], goPCLnTabInfo.Address+goPCLnTabInfo.Offsets.FuncNameTabOffset)
+	for i := 0; i < len(noPtrSectionData)-19*ptrSize; i += ptrSize {
+		n := bytes.Index(noPtrSectionData[i:], buf[:])
+		if n < 0 {
+			break
+		}
+		i += n
+
+		off := i + 4*ptrSize
+		cuTabAddr := binary.NativeEndian.Uint64(noPtrSectionData[off:])
+		off += 3 * ptrSize
+		fileTabAddr := binary.NativeEndian.Uint64(noPtrSectionData[off:])
+		off += 3 * ptrSize
+		pcTabAddr := binary.NativeEndian.Uint64(noPtrSectionData[off:])
+		off += 6 * ptrSize
+		funcTabAddr := binary.NativeEndian.Uint64(noPtrSectionData[off:])
+
+		// Check if the offsets are valid.
+		if cuTabAddr != goPCLnTabInfo.Address+goPCLnTabInfo.Offsets.CuTabOffset ||
+			fileTabAddr != goPCLnTabInfo.Address+goPCLnTabInfo.Offsets.FileTabOffset ||
+			pcTabAddr != goPCLnTabInfo.Address+goPCLnTabInfo.Offsets.PcTabOffset ||
+			funcTabAddr != goPCLnTabInfo.Address+goPCLnTabInfo.Offsets.FuncTabOffset {
+			continue
+		}
+		return noPtrSectionData[n:], noPtrSection.Addr + uint64(n), nil
+	}
+
+	return nil, 0, errors.New("could not find moduledata")
+}
+
+func findGoFuncEnd112(data []byte) int {
+	elemSize := int(unsafe.Sizeof(rawInlinedCall112{}))
+	nbElem := len(data) / elemSize
+	inlineCalls := unsafe.Slice((*rawInlinedCall112)(unsafe.Pointer(&data[0])), nbElem)
+	for i, ic := range inlineCalls {
+		// all inlined functions FuncID seem to be 0, but to be safe we just check that it is not greater than maxGoFuncID
+		if ic.padding != 0 || ic.FuncID > maxGoFuncID || ic.Line < 0 || ic.ParentPC < 0 || ic.Func < 0 {
+			return i * elemSize
+		}
+	}
+	return nbElem * elemSize
+}
+
+func findGoFuncEnd120(data []byte) int {
+	elemSize := int(unsafe.Sizeof(rawInlinedCall120{}))
+	nbElem := len(data) / elemSize
+	inlineCalls := unsafe.Slice((*rawInlinedCall120)(unsafe.Pointer(&data[0])), nbElem)
+	for i, ic := range inlineCalls {
+		// all inlined functions FuncID seem to be 0, but to be safe we just check that it is not greater than maxGoFuncID
+		if ic.padding[0] != 0 || ic.padding[1] != 0 || ic.padding[2] != 0 || ic.FuncID > maxGoFuncID || ic.StartLine < 0 || ic.ParentPC < 0 || ic.NameOff < 0 {
+			return i * elemSize
+		}
+	}
+	return nbElem * elemSize
+}
+
+// Determine heuristically the end of go func data.
+func findGoFuncEnd(data []byte, version HeaderVersion) int {
+	if version < ver120 {
+		return findGoFuncEnd112(data)
+	}
+	return findGoFuncEnd120(data)
+}
+
+func findGoFuncVal(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue libpf.SymbolValue) (uint64, error) {
+	moduleData, _, err := FindModuleData(ef, goPCLnTabInfo, runtimeFirstModuleDataSymbolValue)
+	if err != nil {
+		return 0, fmt.Errorf("could not find module data: %w", err)
+	}
+	goFuncOff, err := goFuncOffset(goPCLnTabInfo.Version)
+	if err != nil {
+		return 0, fmt.Errorf("could not get go func offset: %w", err)
+	}
+	if goFuncOff+ptrSize >= uint32(len(moduleData)) {
+		return 0, fmt.Errorf("invalid go func offset: %v", goFuncOff)
+	}
+	goFuncVal := binary.NativeEndian.Uint64(moduleData[goFuncOff:])
+
+	return goFuncVal, nil
+}
+
+func FindGoFunc(ef *pfelf.File, goPCLnTabInfo *GoPCLnTabInfo, runtimeFirstModuleDataSymbolValue, goFuncSymbolValue libpf.SymbolValue) (data []byte, goFuncVal uint64, err error) {
+	if goFuncSymbolValue == 0 {
+		goFuncVal, err = findGoFuncVal(ef, goPCLnTabInfo, runtimeFirstModuleDataSymbolValue)
+		if err != nil {
+			return nil, 0, fmt.Errorf("could not find go func value: %w", err)
+		}
+	} else {
+		// Symbol go:func.* or go.func.* is present, use it to get the goFunc value.
+		goFuncVal = uint64(goFuncSymbolValue)
+	}
+	sec := sectionContaining(ef, goFuncVal)
+	if sec == nil {
+		return nil, 0, errors.New("could not find section containing gofunc")
+	}
+	secData, err := sec.Data(maxBytesGoPclntab)
+	if err != nil {
+		return nil, 0, fmt.Errorf("could not read section containing gofunc: %w", err)
+	}
+	return secData[goFuncVal-sec.Addr:], goFuncVal, nil
+}
+
+func pclntabHeaderSignature(arch elf.Machine) []byte {
+	var quantum byte
+
+	switch arch {
+	case elf.EM_X86_64:
+		quantum = 0x1
+	case elf.EM_AARCH64:
+		quantum = 0x4
+	}
+
+	//  - the first byte is ignored and not included in this signature
+	//    as it is different per Go version (see magicGo1_XX)
+	//  - next three bytes are 0xff (shared on magicGo1_XX)
+	//  - pad is zero (two bytes)
+	//  - quantum depends on the architecture
+	//  - ptrSize is 8 for 64 bit systems (arm64 and amd64)
+
+	return []byte{0xff, 0xff, 0xff, 0x00, 0x00, quantum, 0x08}
+}
+
+func SearchGoPclntab(ef *pfelf.File) (data []byte, address uint64, err error) {
+	signature := pclntabHeaderSignature(ef.Machine)
+
+	for i := range ef.Progs {
+		p := ef.Progs[i]
+		// Search for the .rodata (read-only) and .data.rel.ro (read-write which gets
+		// turned into read-only after relocations handling via GNU_RELRO header).
+		if p.Type != elf.PT_LOAD || p.Flags&elf.PF_X == elf.PF_X || p.Flags&elf.PF_R != elf.PF_R {
+			continue
+		}
+
+		// Skip segments that are too small anyway.
+		if p.Filesz < uint64(pclntabHeaderSize()) {
+			continue
+		}
+
+		data, err = p.Data(maxBytesGoPclntab)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		for i := 1; i < len(data)-pclntabHeaderSize(); i += 8 {
+			// Search for something looking like a valid pclntabHeader header
+			// Ignore the first byte on bytes.Index (differs on magicGo1_XXX)
+			n := bytes.Index(data[i:], signature)
+			if n < 0 {
+				break
+			}
+			i += n - 1
+
+			// Check the 'magic' against supported list, and if valid, use this
+			// location as the .gopclntab base. Otherwise, continue just search
+			// for next candidate location.
+			magic := binary.NativeEndian.Uint32(data[i:])
+			switch magic {
+			case magicGo1_2, magicGo1_16, magicGo1_18, magicGo1_20:
+				return data[i:], uint64(i) + p.Vaddr, nil
+			}
+		}
+	}
+
+	return nil, 0, errors.New("could not find .gopclntab with signature search")
+}
+
+func (g *GoPCLnTabInfo) findMaxInlineTreeOffset() int {
+	maxInlineTreeOffset := -1
+	for i := range g.numFuncs {
+		funcIdx := (2*i + 1) * g.fieldSize
+		funcOff := getUInt32(g.functab, funcIdx)
+		if funcOff == -1 {
+			continue
+		}
+		nfuncdata := getUint8(g.funcdata, funcOff+g.funcNfuncdataOffset)
+		npcdata := getUInt32(g.funcdata, funcOff+g.funcNpcdataOffset)
+		if nfuncdata != -1 && npcdata != -1 && nfuncdata > funcdataInlTree {
+			off := funcOff + g.funcSize + (npcdata+funcdataInlTree)*4
+			inlineTreeOffset := getUInt32(g.funcdata, off)
+			if inlineTreeOffset != int(^uint32(0)) && inlineTreeOffset > maxInlineTreeOffset {
+				maxInlineTreeOffset = inlineTreeOffset
+			}
+		}
+	}
+
+	return maxInlineTreeOffset
+}
+
+func alignUp(v, align int) int {
+	return (v + align - 1) &^ (align - 1)
+}
+
+func (g *GoPCLnTabInfo) findFuncDataSize() int {
+	maxFuncOffset := -1
+	maxFuncOffsetIdx := -1
+	for i := range g.numFuncs {
+		funcIdx := (2*i + 1) * g.fieldSize
+		funcOff := getUInt32(g.functab, funcIdx)
+		if funcOff > maxFuncOffset {
+			maxFuncOffset = funcOff
+			maxFuncOffsetIdx = i
+		}
+	}
+
+	if maxFuncOffsetIdx == -1 {
+		return -1
+	}
+
+	nfuncdata := getUint8(g.funcdata, maxFuncOffset+g.funcNfuncdataOffset)
+	npcdata := getUInt32(g.funcdata, maxFuncOffset+g.funcNpcdataOffset)
+	return maxFuncOffset + g.funcSize + npcdata*4 + nfuncdata*g.fieldSize
+}
+
+func (g *GoPCLnTabInfo) computePCLnTabSize() int {
+	if g.Version < ver116 {
+		return -1
+	}
+
+	funcDataSize := g.findFuncDataSize()
+	if funcDataSize == -1 {
+		return -1
+	}
+	return alignUp(int(g.Offsets.FuncTabOffset)+funcDataSize, ptrSize)
+}
+
+func (g *GoPCLnTabInfo) trimGoFunc(goFuncData []byte, goFuncAddr uint64, runtimeGcbitsSymbolValue libpf.SymbolValue) ([]byte, error) {
+	if runtimeGcbitsSymbolValue != 0 {
+		// symbol runtime.gcbits.* follows goFunc, use it to determine the end of goFunc.
+		if uint64(runtimeGcbitsSymbolValue) > goFuncAddr {
+			dist := uint64(runtimeGcbitsSymbolValue) - goFuncAddr
+			if dist < uint64(len(goFuncData)) {
+				return goFuncData[:dist], nil
+			}
+		}
+	}
+
+	// Iterate over the functions to find the maximum offset of the inline tree.
+	maxInlineTreeOffset := g.findMaxInlineTreeOffset()
+
+	if maxInlineTreeOffset == -1 || maxInlineTreeOffset >= len(goFuncData) {
+		return nil, fmt.Errorf("invalid inline tree offset: %v", maxInlineTreeOffset)
+	}
+
+	// maxInlineTreeOffset is the base address of the inlined calls for a function
+	// find the end of the goFunc by finding heuristically the end of the last inlined call.
+	goFuncEndOffset := findGoFuncEnd(goFuncData[maxInlineTreeOffset:], g.Version)
+	goFuncSize := maxInlineTreeOffset + goFuncEndOffset
+
+	// Starting from Go 1.19, Go linker appears to align some symbols to ptrSize bytes.
+	// https://github.com/golang/go/commit/c2c76c6f198480f3c9aece4aa5d9b8de044d8457
+	// Cannot check explicitly for Go 1.19 as the version is not available in the pclntab header.
+	if g.Version >= ver118 {
+		goFuncSize = alignUp(goFuncSize, ptrSize)
+		// Just to be safe (and for Go 1.18)
+		goFuncSize = min(goFuncSize, len(goFuncData))
+	}
+
+	return goFuncData[:goFuncSize], nil
+}
+
+func parseGoPCLnTab(data []byte) (*GoPCLnTabInfo, error) {
+	var version HeaderVersion
+	var offsets TableOffsets
+	var funcSize, funcNpcdataOffset int
+	var textStart uint64
+	hdrSize := uintptr(pclntabHeaderSize())
+
+	dataLen := uintptr(len(data))
+	if dataLen < hdrSize {
+		return nil, fmt.Errorf(".gopclntab is too short (%v)", len(data))
+	}
+	var functab, funcdata []byte
+
+	hdr := (*pclntabHeader)(unsafe.Pointer(&data[0]))
+	fieldSize := int(hdr.ptrSize)
+	switch hdr.magic {
+	case magicGo1_2:
+		version = ver12
+		funcSize = ptrSize + 8*4
+		funcNpcdataOffset = ptrSize + 6*4
+		mapSize := uintptr(2 * ptrSize)
+		functabEnd := int(hdrSize + uintptr(hdr.numFuncs)*mapSize + uintptr(hdr.ptrSize))
+		filetabOffset := getInt32(data, functabEnd)
+		numSourceFiles := getInt32(data, filetabOffset)
+		if filetabOffset == 0 || numSourceFiles == 0 {
+			return nil, fmt.Errorf(".gopclntab corrupt (filetab 0x%x, nfiles %d)",
+				filetabOffset, numSourceFiles)
+		}
+		functab = data[hdrSize:filetabOffset]
+		funcdata = data
+		offsets = TableOffsets{
+			FuncTabOffset: uint64(hdrSize),
+			CuTabOffset:   uint64(filetabOffset),
+		}
+	case magicGo1_16:
+		version = ver116
+		hdrSize = unsafe.Sizeof(pclntabHeader116{})
+		funcSize = ptrSize + 9*4
+		funcNpcdataOffset = ptrSize + 6*4
+		if dataLen < hdrSize {
+			return nil, fmt.Errorf(".gopclntab is too short (%v)", len(data))
+		}
+		hdr116 := (*pclntabHeader116)(unsafe.Pointer(&data[0]))
+		if dataLen < hdr116.funcnameOffset || dataLen < hdr116.cuOffset ||
+			dataLen < hdr116.filetabOffset || dataLen < hdr116.pctabOffset ||
+			dataLen < hdr116.pclnOffset {
+			return nil, fmt.Errorf(".gopclntab is corrupt (%x, %x, %x, %x, %x)",
+				hdr116.funcnameOffset, hdr116.cuOffset,
+				hdr116.filetabOffset, hdr116.pctabOffset,
+				hdr116.pclnOffset)
+		}
+		functab = data[hdr116.pclnOffset:]
+		funcdata = functab
+		offsets = TableOffsets{
+			FuncNameTabOffset: uint64(hdr116.funcnameOffset),
+			CuTabOffset:       uint64(hdr116.cuOffset),
+			FileTabOffset:     uint64(hdr116.filetabOffset),
+			PcTabOffset:       uint64(hdr116.pctabOffset),
+			FuncTabOffset:     uint64(hdr116.pclnOffset),
+		}
+	case magicGo1_18, magicGo1_20:
+		if hdr.magic == magicGo1_20 {
+			version = ver120
+			funcSize = 11 * 4
+		} else {
+			version = ver118
+			funcSize = 10 * 4
+		}
+		funcNpcdataOffset = 7 * 4
+		hdrSize = unsafe.Sizeof(pclntabHeader118{})
+		if dataLen < hdrSize {
+			return nil, fmt.Errorf(".gopclntab is too short (%v)", dataLen)
+		}
+		hdr118 := (*pclntabHeader118)(unsafe.Pointer(&data[0]))
+		if dataLen < hdr118.funcnameOffset || dataLen < hdr118.cuOffset ||
+			dataLen < hdr118.filetabOffset || dataLen < hdr118.pctabOffset ||
+			dataLen < hdr118.pclnOffset {
+			return nil, fmt.Errorf(".gopclntab is corrupt (%x, %x, %x, %x, %x)",
+				hdr118.funcnameOffset, hdr118.cuOffset,
+				hdr118.filetabOffset, hdr118.pctabOffset,
+				hdr118.pclnOffset)
+		}
+		functab = data[hdr118.pclnOffset:]
+		funcdata = functab
+		fieldSize = 4
+		offsets = TableOffsets{
+			FuncNameTabOffset: uint64(hdr118.funcnameOffset),
+			CuTabOffset:       uint64(hdr118.cuOffset),
+			FileTabOffset:     uint64(hdr118.filetabOffset),
+			PcTabOffset:       uint64(hdr118.pctabOffset),
+			FuncTabOffset:     uint64(hdr118.pclnOffset),
+		}
+		textStart = uint64(hdr118.textStart)
+	default:
+		return nil, fmt.Errorf(".gopclntab format (0x%x) not supported", hdr.magic)
+	}
+	if hdr.pad != 0 || hdr.ptrSize != ptrSize {
+		return nil, fmt.Errorf(".gopclntab header: %x, %x", hdr.pad, hdr.ptrSize)
+	}
+
+	// nfuncdata is the last field in _func struct
+	funcNfuncdataOffset := funcSize - 1
+
+	return &GoPCLnTabInfo{
+		Data:    data,
+		Version: version,
+		Offsets: offsets,
+		TextStart: TextStartInfo{
+			Origin:  TextStartOriginPCLnTab,
+			Address: textStart,
+		},
+		numFuncs:            int(hdr.numFuncs),
+		funcSize:            funcSize,
+		fieldSize:           fieldSize,
+		funcNpcdataOffset:   funcNpcdataOffset,
+		funcNfuncdataOffset: funcNfuncdataOffset,
+		functab:             functab,
+		funcdata:            funcdata,
+	}, nil
+}
+
+func DisableRecoverFromPanic() {
+	disableRecover = true
+}
+
+func FindGoPCLnTab(ef *pfelf.File) (goPCLnTabInfo *GoPCLnTabInfo, err error) {
+	return findGoPCLnTab(ef, false)
+}
+
+func FindGoPCLnTabWithChecks(ef *pfelf.File) (goPCLnTabInfo *GoPCLnTabInfo, err error) {
+	return findGoPCLnTab(ef, true)
+}
+
+func findGoPCLnTab(ef *pfelf.File, additionalChecks bool) (goPCLnTabInfo *GoPCLnTabInfo, err error) {
+	if !disableRecover {
+		// gopclntab parsing code might panic if the data is corrupt.
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic while searching pclntab: %v", r)
+			}
+		}()
+	}
+
+	var data []byte
+	var goPCLnTabAddr uint64
+
+	goPCLnTabEndKnown := true
+	if s := ef.Section(".gopclntab"); s != nil {
+		if data, err = s.Data(maxBytesGoPclntab); err != nil {
+			return nil, fmt.Errorf("failed to load .gopclntab: %w", err)
+		}
+		goPCLnTabAddr = s.Addr
+	} else if s := ef.Section(".data.rel.ro.gopclntab"); s != nil {
+		if data, err = s.Data(maxBytesGoPclntab); err != nil {
+			return nil, fmt.Errorf("failed to load .data.rel.ro.gopclntab: %w", err)
+		}
+		goPCLnTabAddr = s.Addr
+	} else if s := ef.Section(".go.buildinfo"); s != nil {
+		var start, end libpf.SymbolValue
+		_ = ef.VisitSymbols(func(sym libpf.Symbol) bool {
+			if start == 0 && sym.Name == "runtime.pclntab" {
+				start = sym.Address
+			} else if end == 0 && sym.Name == "runtime.epclntab" {
+				end = sym.Address
+			}
+			return start == 0 || end == 0
+		})
+		if start == 0 || end == 0 {
+			// It seems the Go binary was stripped, use the heuristic approach to get find gopclntab.
+			// Note that `SearchGoPclntab` returns a slice starting from gopcltab header to the end of segment
+			// containing gopclntab. Therefore this slice might contain additional data after gopclntab.
+			// There does not seem to be an easy way to get the end of gopclntab segment without parsing the
+			// gopclntab itself.
+			if data, goPCLnTabAddr, err = SearchGoPclntab(ef); err != nil {
+				return nil, fmt.Errorf("failed to search .gopclntab: %w", err)
+			}
+			// Truncate the data to the end of the section containing gopclntab.
+			if sec := sectionContaining(ef, goPCLnTabAddr); sec != nil {
+				data = data[:sec.Addr+sec.Size-goPCLnTabAddr]
+			}
+			goPCLnTabEndKnown = false
+		} else {
+			if start >= end {
+				return nil, fmt.Errorf("invalid .gopclntab symbols: %v-%v", start, end)
+			}
+			data, err = ef.VirtualMemory(int64(start), int(end-start), maxBytesGoPclntab)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load .gopclntab via symbols: %w", err)
+			}
+			goPCLnTabAddr = uint64(start)
+		}
+	}
+
+	if data == nil {
+		return nil, errors.New("file does not contain any of the gopclntab expected sections")
+	}
+
+	goPCLnTabInfo, err = parseGoPCLnTab(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse .gopclntab: %w", err)
+	}
+
+	if goPCLnTabInfo.TextStart.Address == 0 && goPCLnTabInfo.Version >= ver118 {
+		// Starting from Go 1.26, textStart address in pclntab is always set to 0.
+		// Therefore we need to get it from either `runtime.text` symbol or moduledata.
+		// Note that it does not always match the address of `.text` section
+		// (for example with cgo binaries or when built with -linkmode=external).
+		textStartInfo, err := findTextStart(ef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find text start: %w", err)
+		}
+		textSection := ef.Section(".text")
+		if textSection != nil {
+			textStartInfo.TextSectionAddress = textSection.Addr
+		}
+		goPCLnTabInfo.TextStart = textStartInfo
+	}
+	goPCLnTabInfo.Address = goPCLnTabAddr
+
+	// Only search for goFunc if the version is 1.18 or later and heuristic search is enabled.
+	if goPCLnTabInfo.Version >= ver118 {
+		var runtimeFirstModuleDataSymbolValue, goFuncSymbolValue, runtimeGcbitsSymbolValue libpf.SymbolValue
+		// Retrieve the address of some symbols that can be used to find the goFunc start/end.
+		// Do it once here to avoid calling VisitSymbols multiple times for each symbol.
+		_ = ef.VisitSymbols(func(sym libpf.Symbol) bool {
+			switch {
+			case runtimeFirstModuleDataSymbolValue == 0 && sym.Name == "runtime.firstmoduledata":
+				runtimeFirstModuleDataSymbolValue = sym.Address
+			// Depending on the Go version, the symbol name may be "go:func.*" or "go.func.*".
+			case goFuncSymbolValue == 0 && (sym.Name == "go:func.*" || sym.Name == "go.func.*"):
+				goFuncSymbolValue = sym.Address
+			case runtimeGcbitsSymbolValue == 0 && sym.Name == "runtime.gcbits.*":
+				runtimeGcbitsSymbolValue = sym.Address
+			}
+			return runtimeFirstModuleDataSymbolValue == 0 || goFuncSymbolValue == 0 || runtimeGcbitsSymbolValue == 0
+		})
+
+		goFuncData, goFuncAddr, err := FindGoFunc(ef, goPCLnTabInfo, runtimeFirstModuleDataSymbolValue, goFuncSymbolValue)
+		if err == nil {
+			// Starting from Go 1.26, goFunc is stored in gopclntab, so if we know the end of gopclntab, we don't need to trim goFunc.
+			if goPCLnTabEndKnown && goFuncAddr > goPCLnTabInfo.Address && goFuncAddr < goPCLnTabInfo.Address+uint64(len(goPCLnTabInfo.Data)) {
+				goPCLnTabInfo.GoFuncAddr = goFuncAddr
+				// Do not set goPCLnTabInfo.GoFuncData since goFunc is already in gopclntab.
+				return goPCLnTabInfo, nil
+			}
+			goFuncData, err = goPCLnTabInfo.trimGoFunc(goFuncData, goFuncAddr, runtimeGcbitsSymbolValue)
+			if err == nil {
+				goPCLnTabInfo.GoFuncAddr = goFuncAddr
+				goPCLnTabInfo.GoFuncData = goFuncData
+			} else if additionalChecks {
+				// if we failed to trim goFunc, return an error only if additionalChecks is enabled
+				// otherwise discard goFunc and continue.
+				// goFunc in this case is discarded because goFunc is in .rodata section that may contain
+				// sensitive information past the end of the goFunc.
+				return nil, fmt.Errorf("failed to trim goFunc: %w", err)
+			}
+		}
+	}
+
+	if (!goPCLnTabEndKnown || additionalChecks) && goPCLnTabInfo.Version >= ver116 {
+		// Do not try to find the size of the .gopclntab for older versions because pclntab layout is different.
+		// Failure to find the size of the .gopclntab is not critical because when gopclntab does not have
+		// its own section, it is stored in .data.rel.ro  most likely does not contain sensitive information.
+		// This happens with buildmode=pie and cgo or external linkmode because in that case gopclntab is in
+		// .data.rel.ro.gopclntab which is then merged with .data.rel.ro section by system linker
+		// (that does not happen if there is no cgo or external linkmode because in that case Go uses its own
+		// internal linker which does not merge the .data.rel.ro* sections).
+		//
+		// Starting from Go 1.26, .gopclntab has no more relocation and therefore stays in its own .gopclntab section even with buildmode=pie.
+		goPCLnTabSize := goPCLnTabInfo.computePCLnTabSize()
+		if additionalChecks && goPCLnTabEndKnown {
+			// check that the computed size matches the known size
+			if len(goPCLnTabInfo.Data) != goPCLnTabSize {
+				return nil, fmt.Errorf("invalid computed .gopclntab size: %v (computed) vs %v (expected)", goPCLnTabSize, len(goPCLnTabInfo.Data))
+			}
+		}
+
+		if goPCLnTabSize != -1 && goPCLnTabSize < len(goPCLnTabInfo.Data) {
+			goPCLnTabInfo.Data = goPCLnTabInfo.Data[:goPCLnTabSize]
+		}
+	}
+
+	return goPCLnTabInfo, nil
+}
+
+func findTextStartFromModuleData(ef *pfelf.File) (uint64, error) {
+	// Starting from Go 1.26, moduledata has its own `.go.module` section.
+	moduleDataSection := ef.Section(".go.module")
+	if moduleDataSection == nil || moduleDataSection.Type == elf.SHT_NOBITS {
+		// Stop here and do not try to locate moduledata with other means because this function is expected to be called only for Go 1.26+ binaries
+		// and for those cases moduledata is always in .go.module section.
+		return 0, errors.New("could not find .go.module section")
+	}
+	const textStartOff = 22 * ptrSize
+	var textStartBytes [ptrSize]byte
+	_, err := moduleDataSection.ReadAt(textStartBytes[:], textStartOff)
+	if err != nil {
+		return 0, fmt.Errorf("could not read .go.module section at offset %v: %w", textStartOff, err)
+	}
+
+	return binary.NativeEndian.Uint64(textStartBytes[:]), nil
+}
+
+func findTextStart(ef *pfelf.File) (TextStartInfo, error) {
+	// Use moduledata to find textstart, since it's more efficient than iterating over symbols.
+	textStart, err := findTextStartFromModuleData(ef)
+	if err == nil {
+		return TextStartInfo{
+			Origin:  TextStartOriginModuleData,
+			Address: textStart,
+		}, nil
+	}
+
+	// Use `runtime.text` symbol to find textstart, this is only for tests where moduledata is not available.
+	_ = ef.VisitSymbols(func(sym libpf.Symbol) bool {
+		if sym.Name == "runtime.text" {
+			textStart = uint64(sym.Address)
+			return false
+		}
+		return true
+	})
+
+	if textStart != 0 {
+		return TextStartInfo{
+			Origin:  TextStartOriginRuntimeTextSymbol,
+			Address: textStart,
+		}, nil
+	}
+
+	return TextStartInfo{}, errors.New("could not find text start")
+}

--- a/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
+++ b/comp/host-profiler/symboluploader/pclntab/pclntab_test.go
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package pclntab_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbolcopier"
+)
+
+func getGoToolChain(goMinorVersion int) string {
+	suffix := ""
+	if goMinorVersion >= 21 {
+		suffix = ".0"
+	}
+	if goMinorVersion == 26 {
+		suffix = "rc2"
+	}
+	return fmt.Sprintf("GOTOOLCHAIN=go1.%v%v", goMinorVersion, suffix)
+}
+
+func findSymbol(ef *pfelf.File, name string) *libpf.Symbol {
+	var sym *libpf.Symbol
+	_ = ef.VisitSymbols(func(s libpf.Symbol) bool {
+		if string(s.Name) == name {
+			sym = &s
+			return false
+		}
+		return true
+	})
+	return sym
+}
+
+func getTextStart(ef *pfelf.File) uint64 {
+	sym := findSymbol(ef, "runtime.text")
+	if sym != nil {
+		return uint64(sym.Address)
+	}
+	return 0
+}
+
+func getPIEStr(pie bool) string {
+	if pie {
+		return ".pie"
+	}
+	return ".pde"
+}
+
+func getStripDebugInfoStr(stripDebugInfo bool) string {
+	if stripDebugInfo {
+		return ".sw"
+	}
+	return ""
+}
+
+func getLinkexternalStr(linkexternal bool) string {
+	if linkexternal {
+		return ".linkexternal"
+	}
+	return ""
+}
+
+func checkGoPCLnTab(t *testing.T, ef *pfelf.File, goPCLnTabInfoRef *pclntab.GoPCLnTabInfo) {
+	goPCLnTabInfo, err := pclntab.FindGoPCLnTabWithChecks(ef)
+	require.NoError(t, err)
+	assert.NotNil(t, goPCLnTabInfo)
+
+	require.Equal(t, goPCLnTabInfoRef.GoFuncAddr, goPCLnTabInfo.GoFuncAddr)
+	require.Equal(t, goPCLnTabInfoRef.Address, goPCLnTabInfo.Address)
+	require.Equal(t, goPCLnTabInfoRef.TextStart.Address, goPCLnTabInfo.TextStart.Address)
+	require.GreaterOrEqual(t, len(goPCLnTabInfo.Data), len(goPCLnTabInfoRef.Data))
+	require.GreaterOrEqual(t, len(goPCLnTabInfo.GoFuncData), len(goPCLnTabInfoRef.GoFuncData))
+}
+
+func checkGoPCLnTabExtraction(t *testing.T, exe string, goMinorVersion int) {
+	ef, err := pfelf.Open(exe)
+	require.NoError(t, err)
+	defer ef.Close()
+
+	goPCLnTabInfo, err := pclntab.FindGoPCLnTabWithChecks(ef)
+	require.NoError(t, err)
+	assert.NotNil(t, goPCLnTabInfo)
+
+	textStart := getTextStart(ef)
+
+	if goMinorVersion >= 18 {
+		require.NotNil(t, goPCLnTabInfo.GoFuncAddr)
+		if textStart != 0 {
+			require.Equal(t, textStart, goPCLnTabInfo.TextStart.Address)
+		}
+	}
+
+	symbolFile := exe + ".dbg"
+	err = symbolcopier.CopySymbols(t.Context(), exe, symbolFile, goPCLnTabInfo, nil, false)
+	require.NoError(t, err)
+	efSymbol, err := pfelf.Open(symbolFile)
+	require.NoError(t, err)
+	defer efSymbol.Close()
+
+	checkGoPCLnTab(t, efSymbol, goPCLnTabInfo)
+
+	exeStripped := exe + ".stripped"
+	out, err := exec.CommandContext(t.Context(), "objcopy", "-S", exe, exeStripped).CombinedOutput() // #nosec G204
+	require.NoError(t, err, "failed to rename section: %s\n%s", err, out)
+
+	ef2, err := pfelf.Open(exeStripped)
+	require.NoError(t, err)
+	defer ef2.Close()
+
+	goPCLnTabInfo2, err := pclntab.FindGoPCLnTabWithChecks(ef2)
+	require.NoError(t, err)
+	require.NotNil(t, goPCLnTabInfo2)
+
+	checkGoPCLnTab(t, ef2, goPCLnTabInfo2)
+
+	symbolFile2 := exeStripped + ".dbg"
+	err = symbolcopier.CopySymbols(t.Context(), exeStripped, symbolFile2, goPCLnTabInfo2, nil, false)
+	require.NoError(t, err)
+	efSymbol2, err := pfelf.Open(symbolFile2)
+	require.NoError(t, err)
+	defer efSymbol2.Close()
+
+	checkGoPCLnTab(t, efSymbol2, goPCLnTabInfo)
+}
+
+func TestGoPCLnTabExtraction(t *testing.T) {
+	t.Parallel()
+	pclntab.DisableRecoverFromPanic()
+	testDataDir := "../testdata"
+	srcFile := "helloworld.go"
+
+	tmpDir := t.TempDir()
+	goMinorVersions := []int{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
+	for _, goMinorVersion := range goMinorVersions {
+		for _, pie := range []bool{false, true} {
+			for _, linkexternal := range []bool{false, true} {
+				for _, stripDebugInfo := range []bool{false, true} {
+					if pie && goMinorVersion <= 12 {
+						continue
+					}
+					if runtime.GOARCH == "arm64" && goMinorVersion <= 8 {
+						continue
+					}
+					if linkexternal && goMinorVersion <= 3 {
+						continue
+					}
+					name := fmt.Sprintf("go1.%v%v%v%v",
+						goMinorVersion, getPIEStr(pie), getStripDebugInfoStr(stripDebugInfo), getLinkexternalStr(linkexternal))
+
+					t.Run(name, func(t *testing.T) {
+						t.Parallel()
+						exe := filepath.Join(tmpDir, "test."+name)
+						buildArgs := []string{"build", "-o", exe}
+						if pie {
+							buildArgs = append(buildArgs, "-buildmode=pie")
+						}
+						ldflags := []string{}
+						if stripDebugInfo {
+							ldflags = append(ldflags, "-s", "-w")
+						}
+						if linkexternal {
+							ldflags = append(ldflags, "-linkmode=external")
+						}
+						if len(ldflags) > 0 {
+							buildArgs = append(buildArgs, "-ldflags="+strings.Join(ldflags, " "))
+						}
+						cmd := exec.CommandContext(t.Context(), "go", buildArgs...) // #nosec G204
+						cmd.Args = append(cmd.Args, srcFile)
+						cmd.Dir = testDataDir
+						cmd.Env = append(cmd.Environ(), getGoToolChain(goMinorVersion), "GO111MODULE=off")
+						out, err := cmd.CombinedOutput()
+						require.NoError(t, err, "failed to build test binary with `%v`: %s\n%s", cmd.String(), err, out)
+
+						checkGoPCLnTabExtraction(t, exe, goMinorVersion)
+					})
+				}
+			}
+		}
+	}
+}

--- a/comp/host-profiler/symboluploader/pipeline/pipeline.go
+++ b/comp/host-profiler/symboluploader/pipeline/pipeline.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+// Package pipeline provides a concurrent processing pipeline for symbol upload operations.
+package pipeline
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/sync/semaphore"
+)
+
+type Stage interface {
+	Start(ctx context.Context)
+	Stop()
+}
+
+type ConsumerWorker[In any] struct {
+	wg             sync.WaitGroup
+	inputChan      <-chan In
+	concurrency    int
+	processingFunc func(context.Context, In)
+}
+
+type StageWorker[In any, Out any] struct {
+	ConsumerWorker[In]
+
+	outputChan chan Out
+}
+
+type BatchingStageWorker[In any] struct {
+	StageWorker[In, []In]
+
+	batchSize     int
+	batchInterval time.Duration
+	clock         clockwork.Clock
+}
+
+// NewBudgetedProcessingFunc wraps a processing function with memory budget management.
+// The wrapped function will automatically acquire budget before processing and release it after.
+func NewBudgetedProcessingFunc[In any](budget int64, costCalculator func(In) int64, fun func(context.Context, In)) func(context.Context, In) {
+	budgetSemaphore := semaphore.NewWeighted(budget)
+	return func(ctx context.Context, i In) {
+		cost := costCalculator(i)
+
+		err := budgetSemaphore.Acquire(ctx, cost)
+		if err != nil {
+			return // the context is done
+		}
+		defer budgetSemaphore.Release(cost)
+
+		fun(ctx, i)
+	}
+}
+
+func newConsumerWorker[In any](inputChan <-chan In, concurrency int, fun func(context.Context, In)) ConsumerWorker[In] {
+	return ConsumerWorker[In]{
+		inputChan:      inputChan,
+		concurrency:    concurrency,
+		processingFunc: fun,
+	}
+}
+
+func NewSinkStage[In any](inputChan <-chan In, fun func(context.Context, In), options ...StageOption) *ConsumerWorker[In] {
+	opts := NewStageOptions(options...)
+	w := newConsumerWorker(inputChan, opts.concurrency, fun)
+	return &w
+}
+
+func NewStage[In any, Out any](inputChan <-chan In, fun func(context.Context, In, chan<- Out), options ...StageOption) *StageWorker[In, Out] {
+	opts := NewStageOptions(options...)
+	output := make(chan Out, opts.outputChanSize)
+	return &StageWorker[In, Out]{
+		ConsumerWorker: newConsumerWorker(inputChan, opts.concurrency, func(ctx context.Context, i In) {
+			fun(ctx, i, output)
+		}),
+		outputChan: output,
+	}
+}
+
+func NewBatchingStage[In any](inputChan <-chan In, batchInterval time.Duration, batchSize int, options ...StageOption) *BatchingStageWorker[In] {
+	return NewBatchingStageWithClock[In](inputChan, batchInterval, batchSize, clockwork.NewRealClock(), options...)
+}
+
+func NewBatchingStageWithClock[In any](inputChan <-chan In, batchInterval time.Duration, batchSize int, clock clockwork.Clock, options ...StageOption) *BatchingStageWorker[In] {
+	opts := NewStageOptions(options...)
+	output := make(chan []In, opts.outputChanSize)
+	return &BatchingStageWorker[In]{
+		StageWorker: StageWorker[In, []In]{
+			ConsumerWorker: newConsumerWorker(inputChan, opts.concurrency, nil),
+			outputChan:     output,
+		},
+
+		batchSize:     batchSize,
+		batchInterval: batchInterval,
+		clock:         clock,
+	}
+}
+
+func (w *ConsumerWorker[In]) Start(ctx context.Context) {
+	for range w.concurrency {
+		w.wg.Go(func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case input, ok := <-w.inputChan:
+					if !ok {
+						return
+					}
+					w.processingFunc(ctx, input)
+				}
+			}
+		})
+	}
+}
+
+func (w *ConsumerWorker[In]) Stop() {
+	w.wg.Wait()
+}
+
+func (w *StageWorker[In, Out]) Stop() {
+	w.ConsumerWorker.Stop()
+	close(w.outputChan)
+}
+
+func (w *StageWorker[In, Out]) GetOutputChannel() <-chan Out {
+	return w.outputChan
+}
+
+func (w *BatchingStageWorker[In]) Start(ctx context.Context) {
+	for range w.concurrency {
+		w.wg.Go(func() {
+			var batch []In
+			var tickerChan <-chan time.Time
+			var ticker clockwork.Ticker
+			if w.batchInterval > 0 {
+				ticker = w.clock.NewTicker(w.batchInterval)
+				tickerChan = ticker.Chan()
+				defer ticker.Stop()
+			}
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case input, ok := <-w.inputChan:
+					if !ok {
+						if len(batch) > 0 {
+							w.outputChan <- batch
+						}
+						return
+					}
+					batch = append(batch, input)
+					if w.batchSize > 0 && len(batch) >= w.batchSize {
+						if ticker != nil {
+							ticker.Reset(w.batchInterval)
+						}
+						w.outputChan <- batch
+						batch = nil
+					}
+				case <-tickerChan:
+					if len(batch) > 0 {
+						w.outputChan <- batch
+						batch = nil
+					}
+				}
+			}
+		})
+	}
+}
+
+type Pipeline[In any] struct {
+	inputChan chan In
+	workers   []Stage
+}
+
+func (p *Pipeline[In]) GetInputChannel() chan In {
+	return p.inputChan
+}
+func (p *Pipeline[In]) Start(ctx context.Context) {
+	for _, worker := range p.workers {
+		worker.Start(ctx)
+	}
+}
+
+func (p *Pipeline[In]) Stop() {
+	close(p.inputChan)
+	for _, worker := range p.workers {
+		worker.Stop()
+	}
+}
+
+func NewPipeline[In any](inputChan chan In, workers ...Stage) Pipeline[In] {
+	return Pipeline[In]{
+		inputChan: inputChan,
+		workers:   workers,
+	}
+}
+
+type StageOptions struct {
+	concurrency    int
+	outputChanSize int
+}
+
+type StageOption func(*StageOptions)
+
+func WithConcurrency(concurrency int) StageOption {
+	return func(o *StageOptions) {
+		o.concurrency = concurrency
+	}
+}
+
+func WithOutputChanSize(size int) StageOption {
+	return func(o *StageOptions) {
+		o.outputChanSize = size
+	}
+}
+
+func NewStageOptions(options ...StageOption) StageOptions {
+	o := StageOptions{
+		concurrency:    1,
+		outputChanSize: 0,
+	}
+	for _, option := range options {
+		option(&o)
+	}
+	return o
+}

--- a/comp/host-profiler/symboluploader/pipeline/pipeline_test.go
+++ b/comp/host-profiler/symboluploader/pipeline/pipeline_test.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package pipeline
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeline(t *testing.T) {
+	t.Run("EmptyPipeline", func(_ *testing.T) {
+		input := make(chan int)
+		p := NewPipeline(input)
+		p.Start(t.Context())
+		p.Stop()
+	})
+
+	t.Run("PipelineWithOneSink", func(t *testing.T) {
+		input := make(chan int)
+		output := make(chan int)
+		p := NewPipeline(input, NewSinkStage(input,
+			func(_ context.Context, x int) {
+				output <- x * 2
+			}))
+		p.Start(t.Context())
+		input <- 1
+		require.Equal(t, 2, <-output)
+		p.Stop()
+	})
+
+	t.Run("PipelineWithMultipleStages", func(t *testing.T) {
+		input := make(chan int)
+		output := make(chan int)
+		stage1 := NewStage(input,
+			func(_ context.Context, x int, outputChan chan<- []int) {
+				outputChan <- []int{x * 2, x * 3}
+			})
+		stage2 := NewSinkStage(stage1.GetOutputChannel(),
+			func(_ context.Context, x []int) {
+				var sum int
+				for _, v := range x {
+					sum += v
+				}
+				output <- sum
+			})
+		p := NewPipeline(input, stage1, stage2)
+		p.Start(t.Context())
+		go func() {
+			input <- 1
+			input <- 2
+		}()
+		require.Equal(t, 5, <-output)
+		require.Equal(t, 10, <-output)
+		p.Stop()
+	})
+
+	t.Run("GracefulShutdown", func(t *testing.T) {
+		input := make(chan int, 1000)
+		for i := range 1000 {
+			input <- i
+		}
+		var output []int
+		var mut sync.Mutex
+		stage1 := NewStage(input,
+			func(_ context.Context, x int, outputChan chan<- int) {
+				outputChan <- x * 2
+			}, WithConcurrency(10))
+		stage2 := NewStage(stage1.GetOutputChannel(),
+			func(_ context.Context, x int, outputChan chan<- int) {
+				outputChan <- x + 1
+			}, WithConcurrency(10))
+		stage3 := NewSinkStage(stage2.GetOutputChannel(),
+			func(_ context.Context, x int) {
+				mut.Lock()
+				output = append(output, x)
+				mut.Unlock()
+			}, WithConcurrency(10))
+
+		p := NewPipeline(input, stage1, stage2, stage3)
+		p.Start(t.Context())
+		p.Stop()
+		require.Len(t, output, 1000)
+	})
+
+	t.Run("PipelineWithBatchingStageNoInterval", func(t *testing.T) {
+		input := make(chan int, 1000)
+		for i := range 999 {
+			input <- i
+		}
+		var output [][]int
+		stage1 := NewBatchingStage(input, 0, 10)
+		stage2 := NewSinkStage(stage1.GetOutputChannel(),
+			func(_ context.Context, x []int) {
+				output = append(output, x)
+			})
+		p := NewPipeline(input, stage1, stage2)
+		p.Start(t.Context())
+		p.Stop()
+		require.Len(t, output, 100)
+		require.Len(t, output[99], 9)
+	})
+
+	t.Run("PipelineWithBatchingStageWithInterval", func(t *testing.T) {
+		input := make(chan int)
+		clock := clockwork.NewFakeClock()
+		stage1 := NewBatchingStageWithClock(input, 1*time.Second, 10, clock,
+			WithOutputChanSize(1))
+		p := NewPipeline(input, stage1)
+		output := stage1.GetOutputChannel()
+		p.Start(t.Context())
+		for i := range 9 {
+			input <- i
+		}
+		clock.Advance(1 * time.Second)
+		require.Len(t, <-output, 9)
+		clock.Advance(999 * time.Millisecond)
+		for i := range 15 {
+			input <- i
+		}
+		require.Len(t, <-output, 10)
+		clock.Advance(1 * time.Millisecond)
+		require.Empty(t, output)
+		clock.Advance(999 * time.Millisecond)
+		require.Len(t, <-output, 5)
+		for i := range 5 {
+			input <- i
+		}
+		p.Stop()
+		require.Len(t, <-output, 5)
+	})
+
+	t.Run("PipelineWithBudgetedSinkStage", func(t *testing.T) {
+		input := make(chan int, 100)
+
+		const budgetCapacity int64 = 15
+		var inflightCost int64
+		var maxCost int64
+		processingFunction := func(_ context.Context, i int) {
+			atomic.AddInt64(&inflightCost, int64(i))
+
+			newCost := atomic.LoadInt64(&inflightCost)
+			for {
+				oldMax := atomic.LoadInt64(&maxCost)
+				if newCost <= oldMax || atomic.CompareAndSwapInt64(&maxCost, oldMax, newCost) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond * 2)
+			atomic.AddInt64(&inflightCost, -int64(i))
+		}
+
+		budgetedProcessingFunc := NewBudgetedProcessingFunc(budgetCapacity,
+			func(i int) int64 {
+				return int64(i)
+			},
+			processingFunction)
+		budgetedStage := NewSinkStage(input, budgetedProcessingFunc)
+		p := NewPipeline(input, budgetedStage)
+		p.Start(t.Context())
+		inputs := []int{5, 2, 3, 1, 1, 1, 1, 1, 1, 4, 10, 15, 11, 7, 8, 9}
+		for _, i := range inputs {
+			input <- i
+		}
+		time.Sleep(time.Millisecond * 40)
+		p.Stop()
+		if maxInFlight := atomic.LoadInt64(&maxCost); maxInFlight > budgetCapacity {
+			t.Fatal("the max in flight is higher than the overall budget!")
+		}
+	})
+}

--- a/comp/host-profiler/symboluploader/symbol/elf.go
+++ b/comp/host-profiler/symboluploader/symbol/elf.go
@@ -1,0 +1,266 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+// Package symbol provides utilities for working with ELF files and debug information.
+package symbol
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
+)
+
+type elfWrapperWithSource struct {
+	wrapper      *elfWrapper
+	symbolSource Source
+}
+
+type Elf struct {
+	elfWrapperWithSource
+
+	arch       string
+	isGolang   bool
+	goBuildID  string
+	gnuBuildID string
+	fileID     libpf.FileID
+
+	separateSymbols *elfWrapperWithSource
+
+	// Cached value set during the first call to getGoPCLnTab
+	goPCLnTabInfo    *pclntab.GoPCLnTabInfo
+	goPCLnTabInfoErr error
+
+	elfDataDump string
+}
+
+func NewElfFromMapping(m *process.Mapping, gnuBuildID, goBuildID string, fileID libpf.FileID, pr process.Process) (*Elf, error) {
+	wrapper, err := newElfWrapperFromMapping(m, pr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create elf wrapper from mapping: %w", err)
+	}
+	return newElf(wrapper, fileID, gnuBuildID, goBuildID)
+}
+
+func NewElfForTest(arch, gnuBuildID, goBuildID string, fileID libpf.FileID) *Elf {
+	return &Elf{
+		arch:       arch,
+		gnuBuildID: gnuBuildID,
+		goBuildID:  goBuildID,
+		fileID:     fileID,
+	}
+}
+
+func NewElfFromDisk(path string) (*Elf, error) {
+	fileID, err := libpf.FileIDFromExecutableFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file ID: %w", err)
+	}
+
+	wrapper, err := newElfWrapperFromFile(path, &diskHelper{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create elf wrapper for file %s from disk: %w", path, err)
+	}
+
+	goBuildID := ""
+	gnuBuildID, err := wrapper.elfFile.GetBuildID()
+	if err != nil {
+		slog.Debug("failed to get GNU build ID for file", slog.String("path", path), slog.String("error", err.Error()))
+	}
+
+	if wrapper.elfFile.IsGolang() {
+		goBuildID, err = wrapper.elfFile.GetGoBuildID()
+		if err != nil {
+			slog.Debug("failed to get Go build ID for file", slog.String("path", path), slog.String("error", err.Error()))
+		}
+	}
+
+	return newElf(wrapper, fileID, gnuBuildID, goBuildID)
+}
+
+func (e *Elf) FileHash() string {
+	return e.fileID.StringNoQuotes()
+}
+
+func (e *Elf) FileID() libpf.FileID {
+	return e.fileID
+}
+
+func (e *Elf) GnuBuildID() string {
+	return e.gnuBuildID
+}
+
+func (e *Elf) GoBuildID() string {
+	return e.goBuildID
+}
+
+func (e *Elf) IsGolang() bool {
+	return e.isGolang
+}
+
+func (e *Elf) Arch() string {
+	return e.arch
+}
+
+func (e *Elf) Path() string {
+	return e.wrapper.filePath
+}
+
+func (e *Elf) Close() {
+	e.wrapper.Close()
+
+	if e.separateSymbols != nil {
+		e.separateSymbols.wrapper.Close()
+	}
+	if e.elfDataDump != "" {
+		os.Remove(e.elfDataDump)
+	}
+}
+
+// GetSize returns the size of the elf file or data it contains.
+// It will return 0 if the size can't be retrieved.
+func (e *Elf) GetSize() int64 {
+	elfPath := e.SymbolPathOnDisk()
+	// vdso
+	if elfPath == "" {
+		data, err := e.wrapper.ElfData()
+		if err != nil {
+			slog.Warn("Failed to get elf data", slog.String("error", err.Error()))
+			return 0
+		}
+		return int64(len(data))
+	}
+
+	fi, err := os.Stat(elfPath)
+	if err != nil {
+		slog.Warn("Failed to get elf file", slog.String("error", err.Error()))
+		return 0
+	}
+	return fi.Size()
+}
+
+func (e *Elf) SymbolSource() Source {
+	source := e.symbolSource
+
+	if e.separateSymbols != nil {
+		source = max(source, e.separateSymbols.symbolSource)
+	}
+
+	return source
+}
+
+func (e *Elf) HasGoPCLnTabInfo() bool {
+	return e.goPCLnTabInfo != nil
+}
+
+func (e *Elf) GoPCLnTab() (*pclntab.GoPCLnTabInfo, error) {
+	if e.goPCLnTabInfoErr == nil && e.goPCLnTabInfo == nil {
+		e.goPCLnTabInfo, e.goPCLnTabInfoErr = e.goPCLnTab()
+	}
+	return e.goPCLnTabInfo, e.goPCLnTabInfoErr
+}
+
+func (e *Elf) SymbolPathOnDisk() string {
+	if e.separateSymbols != nil && e.separateSymbols.symbolSource > e.symbolSource {
+		return e.separateSymbols.wrapper.GetPersistentPath()
+	}
+
+	return e.wrapper.GetPersistentPath()
+}
+
+func (e *Elf) String() string {
+	hasPCLnTab := e.HasGoPCLnTabInfo()
+	symbolSource := e.SymbolSource()
+	if hasPCLnTab {
+		symbolSource = max(symbolSource, SourceGoPCLnTab)
+	}
+	return fmt.Sprintf("%s, arch=%s, gnu_build_id=%s, go_build_id=%s, file_hash=%s, symbol_source=%s, has_gopclntab=%t",
+		e.wrapper.filePath, e.arch, e.gnuBuildID, e.goBuildID, e.FileHash(), symbolSource, hasPCLnTab,
+	)
+}
+
+func (e *Elf) DumpElfData() (string, error) {
+	if e.elfDataDump != "" {
+		return e.elfDataDump, nil
+	}
+
+	elfData, err := e.wrapper.ElfData()
+	if err != nil {
+		return "", fmt.Errorf("failed to get elf data: %w", err)
+	}
+
+	tempFile, err := os.CreateTemp("", "elf")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file to dump elf data: %w", err)
+	}
+
+	defer tempFile.Close()
+
+	_, err = tempFile.Write(elfData)
+	if err != nil {
+		os.Remove(tempFile.Name())
+		return "", fmt.Errorf("failed to write elf data to temp file: %w", err)
+	}
+
+	e.elfDataDump = tempFile.Name()
+	return e.elfDataDump, nil
+}
+
+func (e *Elf) GetSectionsRequiredForDynamicSymbols() []SectionInfo {
+	return e.wrapper.GetSectionsRequiredForDynamicSymbols()
+}
+
+func (e *Elf) goPCLnTab() (*pclntab.GoPCLnTabInfo, error) {
+	if !e.isGolang {
+		return nil, errors.New("not a Go executable")
+	}
+
+	goPCLnTab, err := pclntab.FindGoPCLnTab(e.wrapper.elfFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return goPCLnTab, nil
+}
+
+func newElf(wrapper *elfWrapper, fileID libpf.FileID, gnuBuildID, goBuildID string) (*Elf, error) {
+	elf := &Elf{
+		elfWrapperWithSource: elfWrapperWithSource{
+			wrapper:      wrapper,
+			symbolSource: wrapper.symbolSource(),
+		},
+		arch:       runtime.GOARCH,
+		isGolang:   wrapper.elfFile.IsGolang(),
+		fileID:     fileID,
+		gnuBuildID: gnuBuildID,
+		goBuildID:  goBuildID,
+	}
+
+	if elf.symbolSource < SourceDebugInfo {
+		separateSymbols := wrapper.findSeparateSymbolsWithDebugInfo()
+		if separateSymbols != nil {
+			elf.separateSymbols = &elfWrapperWithSource{
+				wrapper:      separateSymbols,
+				symbolSource: SourceDebugInfo,
+			}
+		}
+	}
+
+	return elf, nil
+}
+
+type diskHelper struct{}
+
+func (o *diskHelper) ExtractAsFile(path string) (string, error) {
+	return path, nil
+}

--- a/comp/host-profiler/symboluploader/symbol/elf_wrapper.go
+++ b/comp/host-profiler/symboluploader/symbol/elf_wrapper.go
@@ -1,0 +1,345 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symbol
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strconv"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+
+	elf "github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+const buildIDSectionName = ".note.gnu.build-id"
+
+var debugStrSectionNames = []string{".debug_str", ".zdebug_str", ".debug_str.dwo"}
+var debugInfoSectionNames = []string{".debug_info", ".zdebug_info"}
+var globalDebugDirectories = []string{"/usr/lib/debug"}
+
+var sectionTypesToKeepForDynamicSymbols = []elf.SectionType{
+	elf.SHT_GNU_HASH,
+	elf.SHT_HASH,
+	elf.SHT_REL,
+	elf.SHT_RELA, //nolint:misspell
+	elf.SHT_DYNSYM,
+	elf.SHT_DYNAMIC,
+	elf.SHT_GNU_VERDEF,
+	elf.SHT_GNU_VERNEED,
+	elf.SHT_GNU_VERSYM,
+}
+
+var selfPid = os.Getpid()
+
+type FileHelper interface {
+	ExtractAsFile(string) (string, error)
+}
+
+type ProcessFileHelper struct {
+	pid libpf.PID
+}
+
+func (p *ProcessFileHelper) ExtractAsFile(filePath string) (string, error) {
+	return path.Join("/proc", strconv.Itoa(int(p.pid)), "root", filePath), nil
+}
+
+type elfWrapper struct {
+	elfFile  *pfelf.File
+	filePath string
+	// Data for non-file backed ELF files (eg. vdso)
+	data []byte
+	// Reader for file backed ELF files (nil for vdso)
+	reader *os.File
+	helper FileHelper
+}
+
+type SectionInfo struct {
+	Name  string
+	Flags elf.SectionFlag
+}
+
+func (e *elfWrapper) Close() error {
+	if e.reader != nil {
+		e.reader.Close()
+	}
+	return e.elfFile.Close()
+}
+
+func newElfWrapperFromVDSO(m *process.Mapping, pr process.Process) (ef *elfWrapper, err error) {
+	// vdso is not backed by a file
+	data := make([]byte, m.Length)
+	_, err = pr.GetRemoteMemory().ReadAt(data, int64(m.Vaddr))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vdso memory for PID %d: %w", pr.PID(), err)
+	}
+	r := bytes.NewReader(data)
+	elfFile, err := pfelf.NewFile(r, 0, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create elf file from vdso memory for PID %d: %w", pr.PID(), err)
+	}
+	return &elfWrapper{elfFile: elfFile, data: data, helper: &ProcessFileHelper{pid: pr.PID()}}, nil
+}
+
+func newElfWrapperFromMapping(m *process.Mapping, pr process.Process) (ef *elfWrapper, err error) {
+	if m.IsVDSO() {
+		return newElfWrapperFromVDSO(m, pr)
+	}
+
+	elfFile, err := pr.OpenELF(m.Path.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to open ELF file %s for PID %d: %w", m.Path.String(), pr.PID(), err)
+	}
+	defer func() {
+		if err != nil {
+			elfFile.Close()
+		}
+	}()
+
+	r, err := pr.OpenMappingFile(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mapping file %s for PID %d: %w", m.Path.String(), pr.PID(), err)
+	}
+	defer func() {
+		if err != nil {
+			r.Close()
+		}
+	}()
+
+	f, ok := r.(*os.File)
+	if !ok {
+		return nil, fmt.Errorf("failed to cast mapping file %s to *os.File for PID %d", m.Path.String(), pr.PID())
+	}
+
+	return newElfWrapper(elfFile, m.Path.String(), f, &ProcessFileHelper{pid: pr.PID()}, nil)
+}
+
+func newElfWrapperFromFile(filePath string, helper FileHelper) (ef *elfWrapper, err error) {
+	procFilePath, err := helper.ExtractAsFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	elfFile, err := pfelf.Open(procFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			elfFile.Close()
+		}
+	}()
+
+	f, err := os.Open(procFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil {
+			f.Close()
+		}
+	}()
+
+	return newElfWrapper(elfFile, filePath, f, helper, nil)
+}
+
+func newElfWrapper(elfFile *pfelf.File, filePath string, reader *os.File, helper FileHelper, data []byte) (*elfWrapper, error) {
+	err := elfFile.LoadSections()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sections for %s: %w", filePath, err)
+	}
+	return &elfWrapper{elfFile: elfFile, filePath: filePath, data: data, reader: reader, helper: helper}, nil
+}
+
+func (e *elfWrapper) GetPersistentPath() string {
+	if e.reader != nil {
+		return fmt.Sprintf("/proc/%v/fd/%v", selfPid, e.reader.Fd())
+	}
+	return ""
+}
+
+func (e *elfWrapper) ElfData() ([]byte, error) {
+	if e.reader != nil {
+		return nil, errors.New("elf data is not available for file backed ELF files")
+	}
+	return e.data, nil
+}
+
+func (e *elfWrapper) GetSectionsRequiredForDynamicSymbols() []SectionInfo {
+	var sections []SectionInfo
+	for _, section := range e.elfFile.Sections {
+		if slices.Contains(sectionTypesToKeepForDynamicSymbols, section.Type) {
+			sections = append(sections, SectionInfo{Name: section.Name, Flags: section.Flags})
+		}
+		if section.Type == elf.SHT_DYNSYM {
+			// Add STRTAB (usually .dynstr) section linked to the DYNSYM (usually .dynsym) section if it exists
+			if section.Link != 0 {
+				linkSection := e.elfFile.Sections[section.Link]
+				sections = append(sections, SectionInfo{Name: linkSection.Name, Flags: linkSection.Flags})
+			}
+		}
+	}
+
+	return sections
+}
+
+func (e *elfWrapper) openELF(filePath string) (*elfWrapper, error) {
+	return newElfWrapperFromFile(filePath, e.helper)
+}
+
+func (e *elfWrapper) symbolSource() Source {
+	if HasDWARFData(e.elfFile) {
+		return SourceDebugInfo
+	}
+
+	if e.elfFile.Section(".symtab") != nil {
+		return SourceSymbolTable
+	}
+
+	if e.elfFile.Section(".dynsym") != nil {
+		return SourceDynamicSymbolTable
+	}
+
+	return SourceNone
+}
+
+// findSeparateSymbolsWithDebugInfo attempts to find a separate symbol source for the elf file,
+// following the same order as GDB
+// https://sourceware.org/gdb/current/onlinedocs/gdb.html/Separate-Debug-Files.html
+func (e *elfWrapper) findSeparateSymbolsWithDebugInfo() *elfWrapper {
+	slog.Debug("No debug symbols found in file", slog.String("path", e.filePath))
+
+	// First, check based on the GNU build ID
+	debugElf := e.findDebugSymbolsWithBuildID()
+	if debugElf != nil {
+		if HasDWARFData(debugElf.elfFile) {
+			return debugElf
+		}
+		debugElf.Close()
+		slog.Debug("No debug symbols found in buildID link file", slog.String("path", debugElf.filePath))
+	}
+
+	// Then, check based on the debug link
+	debugElf = e.findDebugSymbolsWithDebugLink()
+	if debugElf != nil {
+		if HasDWARFData(debugElf.elfFile) {
+			return debugElf
+		}
+		slog.Debug("No debug symbols found in debug link file", slog.String("path", debugElf.filePath))
+		debugElf.Close()
+	}
+
+	return nil
+}
+
+func (e *elfWrapper) findDebugSymbolsWithBuildID() *elfWrapper {
+	buildID, err := e.elfFile.GetBuildID()
+	if err != nil || len(buildID) < 2 {
+		slog.Debug("Failed to get build ID for file", slog.String("path", e.filePath), slog.String("error", err.Error()))
+		return nil
+	}
+
+	// Try to find the debug file
+	for _, dir := range globalDebugDirectories {
+		debugFile := filepath.Join(dir, ".build-id", buildID[:2], buildID[2:]+".debug")
+		debugELF, err := e.openELF(debugFile)
+		if err != nil {
+			continue
+		}
+		debugBuildID, err := debugELF.elfFile.GetBuildID()
+		if err != nil || buildID != debugBuildID {
+			debugELF.Close()
+			continue
+		}
+		return debugELF
+	}
+	return nil
+}
+
+func (e *elfWrapper) findDebugSymbolsWithDebugLink() *elfWrapper {
+	linkName, linkCRC32, err := e.elfFile.GetDebugLink()
+	if err != nil {
+		return nil
+	}
+
+	// Try to find the debug file
+	executablePath := filepath.Dir(e.filePath)
+
+	debugDirectories := []string{
+		executablePath,
+		filepath.Join(executablePath, ".debug"),
+	}
+	for _, dir := range globalDebugDirectories {
+		debugDirectories = append(debugDirectories,
+			filepath.Join(dir, executablePath))
+	}
+
+	for _, debugPath := range debugDirectories {
+		debugFile := filepath.Join(debugPath, executablePath, linkName)
+		debugELF, err := e.openELF(debugFile)
+		if err != nil {
+			continue
+		}
+		fileCRC32, err := debugELF.elfFile.CRC32()
+		if err != nil || fileCRC32 != linkCRC32 {
+			debugELF.Close()
+			continue
+		}
+		return debugELF
+	}
+	return nil
+}
+
+// HasDWARFData is a copy of pfelf.HasDWARFData, but for the libpf.File interface.
+func HasDWARFData(f *pfelf.File) bool {
+	hasBuildID := false
+	hasDebugStr := false
+	for _, section := range f.Sections {
+		// NOBITS indicates that the section is actually empty, regardless of the size in the
+		// section header.
+		if section.Type == elf.SHT_NOBITS {
+			continue
+		}
+
+		if section.Name == buildIDSectionName {
+			hasBuildID = true
+		}
+
+		if slices.Contains(debugStrSectionNames, section.Name) {
+			hasDebugStr = section.Size > 0
+		}
+
+		// Some files have suspicious near-empty, partially stripped sections; consider them as not
+		// having DWARF data.
+		// The simplest binary gcc 10 can generate ("return 0") has >= 48 bytes for each section.
+		// Let's not worry about executables that may not verify this, as they would not be of
+		// interest to us.
+		if section.Size < 32 {
+			continue
+		}
+
+		if slices.Contains(debugInfoSectionNames, section.Name) {
+			return true
+		}
+	}
+
+	// Some alternate debug files only have a .debug_str section. For these we want to return true.
+	// Use the absence of program headers and presence of a Build ID as heuristic to identify
+	// alternate debug files.
+	return len(f.Progs) == 0 && hasBuildID && hasDebugStr
+}

--- a/comp/host-profiler/symboluploader/symbol/source.go
+++ b/comp/host-profiler/symboluploader/symbol/source.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symbol
+
+import "fmt"
+
+type Source int64
+
+const (
+	SourceNone Source = iota
+	SourceDynamicSymbolTable
+	SourceSymbolTable
+	SourceGoPCLnTab
+	SourceDebugInfo
+)
+
+func NewSource(s string) (Source, error) {
+	switch s {
+	case "none":
+		return SourceNone, nil
+	case "dynamic_symbol_table":
+		return SourceDynamicSymbolTable, nil
+	case "symbol_table":
+		return SourceSymbolTable, nil
+	case "debug_info":
+		return SourceDebugInfo, nil
+	case "gopclntab":
+		return SourceGoPCLnTab, nil
+	}
+	return SourceNone, fmt.Errorf("unknown symbol source: %s", s)
+}
+
+func (s Source) String() string {
+	switch s {
+	case SourceNone:
+		return "none"
+	case SourceDynamicSymbolTable:
+		return "dynamic_symbol_table"
+	case SourceSymbolTable:
+		return "symbol_table"
+	case SourceGoPCLnTab:
+		return "gopclntab"
+	case SourceDebugInfo:
+		return "debug_info"
+	}
+
+	return "unknown"
+}

--- a/comp/host-profiler/symboluploader/symbol_endpoint.go
+++ b/comp/host-profiler/symboluploader/symbol_endpoint.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+type SymbolEndpoint struct {
+	Site   string `mapstructure:"site" json:"site"`
+	APIKey string `mapstructure:"api_key" json:"api_key"`
+}

--- a/comp/host-profiler/symboluploader/symbol_querier.go
+++ b/comp/host-profiler/symboluploader/symbol_querier.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/DataDog/jsonapi"
+)
+
+const symbolQueryEndpoint = "/api/v2/profiles/symbols/query"
+
+type SymbolFile struct {
+	ID           string `json:"id" jsonapi:"primary,symbols-query-response"`
+	BuildID      string `json:"buildId" jsonapi:"attribute"`
+	SymbolSource string `json:"symbolSource" jsonapi:"attribute"`
+	BuildIDType  string `json:"buildIdType" jsonapi:"attribute"`
+}
+
+type SymbolsQueryRequest struct {
+	ID       string   `jsonapi:"primary,symbols-query-request"`
+	BuildIDs []string `json:"buildIds" jsonapi:"attribute" validate:"required"`
+	Arch     string   `json:"arch" jsonapi:"attribute" validate:"required"`
+}
+
+type SymbolQuerier interface {
+	QuerySymbols(ctx context.Context, buildIDs []string, arch string) ([]SymbolFile, error)
+}
+
+type datadogSymbolQuerier struct {
+	ddAPIKey       string
+	symbolQueryURL string
+
+	client *http.Client
+}
+
+func NewDatadogSymbolQuerier(ddSite, ddAPIKey string) (SymbolQuerier, error) {
+	symbolQueryURL := buildSymbolQueryURL(ddSite)
+
+	return &datadogSymbolQuerier{
+		ddAPIKey:       ddAPIKey,
+		symbolQueryURL: symbolQueryURL,
+		client:         &http.Client{Timeout: uploadTimeout},
+	}, nil
+}
+
+func buildSymbolQueryURL(ddSite string) string {
+	return fmt.Sprintf("https://api.%s%s", ddSite, symbolQueryEndpoint)
+}
+
+func (d *datadogSymbolQuerier) QuerySymbols(ctx context.Context, buildIDs []string,
+	arch string) ([]SymbolFile, error) {
+	symbolsQueryRequest := &SymbolsQueryRequest{
+		ID:       "symbols-query-request",
+		BuildIDs: buildIDs,
+		Arch:     arch,
+	}
+
+	body, err := jsonapi.Marshal(symbolsQueryRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling symbols query request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.symbolQueryURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Dd-Api-Key", d.ddAPIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("error while querying symbols from %s: %s, %s", d.symbolQueryURL, resp.Status, string(respBody))
+	}
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	var response []SymbolFile
+	if err = jsonapi.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("error unmarshalling symbols query response: %w", err)
+	}
+
+	return response, nil
+}

--- a/comp/host-profiler/symboluploader/symbol_query_batching.go
+++ b/comp/host-profiler/symboluploader/symbol_query_batching.go
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+)
+
+type SymbolQueryBatch []*symbol.Elf
+
+type SymbolQueryResult struct {
+	SymbolSource symbol.Source
+	Err          error
+}
+
+type ElfWithBackendSources struct {
+	*symbol.Elf
+
+	BackendSymbolSources []SymbolQueryResult
+}
+
+// GetSize returns the size of the underlying elf.
+// It will return 0 if the size can't be retrieved.
+func (e *ElfWithBackendSources) GetSize() int64 {
+	return e.Elf.GetSize()
+}
+
+func fileHash(fileID libpf.FileID) string {
+	if fileID == (libpf.FileID{}) {
+		return ""
+	}
+	return fileID.StringNoQuotes()
+}
+
+// getBuildID returns the most appropriate build ID for an executable.
+// It prioritizes GNU build ID, then Go build ID, then falls back to file hash.
+// Special handling for Bazel builds where Go build ID is "redacted".
+func getBuildID(gnuBuildID, goBuildID string, fileID libpf.FileID) string {
+	// When building Go binaries, Bazel will set the Go build ID to "redacted" to
+	// achieve deterministic builds. Since Go 1.24, the Gnu Build ID is inherited
+	// from the Go build ID - if the Go build ID is "redacted", the Gnu Build ID will
+	// be a hash of "redacted". In this case, we should use the file hash instead of build IDs.
+	if goBuildID == "redacted" {
+		return fileHash(fileID)
+	}
+	if gnuBuildID != "" {
+		return gnuBuildID
+	}
+	if goBuildID != "" {
+		return goBuildID
+	}
+
+	return fileHash(fileID)
+}
+
+func invokeQuerier(ctx context.Context, buildIDs []string, arch string, querier SymbolQuerier, ind int,
+	buildIDToResult map[string][]*ElfWithBackendSources) {
+	symbolFiles, err := querier.QuerySymbols(ctx, buildIDs, arch)
+	if err != nil {
+		for _, results := range buildIDToResult {
+			for _, result := range results {
+				result.BackendSymbolSources[ind].Err = fmt.Errorf("failed to query symbols: %w", err)
+			}
+		}
+		return
+	}
+
+	// Note that the same buildID can appear multiple times in the symbolFiles with different buildIDTypes
+	// because there is no constraint in sourcemap DB that prevents having identical goBuildID, gnuBuildID
+	// of fileHash for the same or a different executable.
+	// For a given buildID though, the backend will return first the matching gnuBuildID, then goBuildID and
+	// finally fileHash if they exist.
+	// That's why we consider the first symbol source for a given buildID and ignore the rest.
+	for _, symbolFile := range symbolFiles {
+		for _, result := range buildIDToResult[symbolFile.BuildID] {
+			queryResult := &result.BackendSymbolSources[ind]
+			if queryResult.Err != nil || queryResult.SymbolSource != symbol.SourceNone {
+				// Already set or an error occurred, skips
+				continue
+			}
+			src, err := symbol.NewSource(symbolFile.SymbolSource)
+			if err != nil {
+				result.BackendSymbolSources[ind].Err = fmt.Errorf("failed to parse symbol source: %w", err)
+			} else {
+				result.BackendSymbolSources[ind].SymbolSource = src
+			}
+		}
+	}
+}
+
+func (e *ElfWithBackendSources) fillWithError(err error) {
+	for i := range e.BackendSymbolSources {
+		e.BackendSymbolSources[i].Err = err
+	}
+}
+
+func ExecuteSymbolQueryBatch(ctx context.Context, batch SymbolQueryBatch, queriers []SymbolQuerier) []ElfWithBackendSources {
+	if len(batch) == 0 {
+		return nil
+	}
+
+	slog.Info("Querying symbols for executables", slog.Int("count", len(batch)))
+	buildIDToResult := make(map[string][]*ElfWithBackendSources)
+
+	// All the elfs in the batch are expected to have the same arch
+	arch := batch[0].Arch()
+
+	elfResults := make([]ElfWithBackendSources, 0, len(batch))
+
+	for _, e := range batch {
+		elfResults = append(elfResults,
+			ElfWithBackendSources{Elf: e, BackendSymbolSources: make([]SymbolQueryResult, len(queriers))})
+
+		result := &elfResults[len(elfResults)-1]
+		if e.Arch() != arch {
+			result.fillWithError(fmt.Errorf("arch mismatch: expected %s, got %s", arch, e.Arch()))
+			continue
+		}
+
+		buildID := getBuildID(e.GnuBuildID(), e.GoBuildID(), e.FileID())
+		if buildID == "" {
+			result.fillWithError(errors.New("empty buildID"))
+			continue
+		}
+		buildIDToResult[buildID] = append(buildIDToResult[buildID], result)
+	}
+
+	buildIDs := make([]string, 0, len(buildIDToResult))
+	for buildID := range buildIDToResult {
+		buildIDs = append(buildIDs, buildID)
+	}
+
+	if len(queriers) == 1 {
+		invokeQuerier(ctx, buildIDs, arch, queriers[0], 0, buildIDToResult)
+	} else {
+		var wg sync.WaitGroup
+		for i, querier := range queriers {
+			wg.Add(1)
+			go func(i int, querier SymbolQuerier) {
+				defer wg.Done()
+				invokeQuerier(ctx, buildIDs, arch, querier, i, buildIDToResult)
+			}(i, querier)
+		}
+		wg.Wait()
+	}
+
+	return elfResults
+}

--- a/comp/host-profiler/symboluploader/symbol_query_batching_test.go
+++ b/comp/host-profiler/symboluploader/symbol_query_batching_test.go
@@ -1,0 +1,199 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+)
+
+type key struct {
+	buildID string
+	arch    string
+}
+
+type value struct {
+	symbolSource string
+	buildIDType  string
+}
+
+type symbolMap map[key][]value
+type errorMap map[string]error
+
+type mockSymbolQuerier struct {
+	m      symbolMap
+	e      errorMap
+	ncalls int
+}
+
+func (m *mockSymbolQuerier) QuerySymbols(_ context.Context, buildIDs []string, arch string) ([]SymbolFile, error) {
+	m.ncalls++
+	if err, ok := m.e[arch]; ok {
+		return nil, err
+	}
+
+	buildIDsCopy := make([]string, len(buildIDs))
+	copy(buildIDsCopy, buildIDs)
+
+	// randomly shuffle the buildIDs
+	for i := range buildIDsCopy {
+		j := rand.Intn(i + 1) //nolint:gosec
+		buildIDsCopy[i], buildIDsCopy[j] = buildIDsCopy[j], buildIDsCopy[i]
+	}
+
+	var symbolFiles []SymbolFile
+	for _, buildID := range buildIDsCopy {
+		if values, ok := m.m[key{buildID, arch}]; ok {
+			for _, s := range values {
+				symbolFiles = append(symbolFiles, SymbolFile{
+					BuildID:      buildID,
+					SymbolSource: s.symbolSource,
+					BuildIDType:  s.buildIDType,
+				})
+			}
+		}
+	}
+
+	return symbolFiles, nil
+}
+
+func newTestQuerier1() *mockSymbolQuerier {
+	e := errorMap{"arch0": errors.New("error")}
+
+	m := symbolMap{
+		{buildID: "buildid1", arch: "arch1"}: []value{{symbolSource: "symbol_table", buildIDType: "gnu_build_id"}},
+		{buildID: "buildid2", arch: "arch1"}: []value{
+			{symbolSource: "symbol_table", buildIDType: "gnu_build_id"},
+			{symbolSource: "debug_info", buildIDType: "go_build_id"}},
+		{buildID: "buildid1", arch: "arch2"}: []value{{symbolSource: "debug_info", buildIDType: "gnu_build_id"}},
+	}
+
+	return &mockSymbolQuerier{m: m, e: e}
+}
+
+func newTestQuerier2() *mockSymbolQuerier {
+	e := errorMap{
+		"arch0": errors.New("error"),
+		"arch2": errors.New("error")}
+
+	m := symbolMap{
+		{buildID: "buildid1", arch: "arch1"}: []value{{symbolSource: "debug_info", buildIDType: "gnu_build_id"}},
+	}
+
+	return &mockSymbolQuerier{m: m, e: e}
+}
+
+func TestBatchSymbolQuerier_Multiplexing(t *testing.T) {
+	querier1 := newTestQuerier1()
+	querier2 := newTestQuerier2()
+
+	queriers := []SymbolQuerier{querier1, querier2}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	t.Run("Empty batch", func(t *testing.T) {
+		results := ExecuteSymbolQueryBatch(ctx, nil, queriers)
+		require.Empty(t, results)
+	})
+
+	t.Run("Multiple buildIDs", func(t *testing.T) {
+		fileID := libpf.FileID{}
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch1", "non_existing_buildid", "", fileID),
+			symbol.NewElfForTest("arch1", "buildid1", "buildid2", fileID), // multiple buildIDs, gnu_build_id should be used
+			symbol.NewElfForTest("arch2", "buildid1", "", fileID),         // arch mismatch
+			symbol.NewElfForTest("arch1", "", "", fileID),                 // empty buildID
+			symbol.NewElfForTest("arch1", "buildid2", "", fileID),         // multiple matching buildIDs, first one should be used
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.ElementsMatch(t, []ElfWithBackendSources{
+			{
+				Elf: elfs[0],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+				},
+			},
+			{
+				Elf: elfs[1],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						SymbolSource: symbol.SourceSymbolTable,
+					},
+					{
+						SymbolSource: symbol.SourceDebugInfo,
+					},
+				},
+			},
+			{
+				Elf: elfs[2],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						Err: errors.New("arch mismatch: expected arch1, got arch2"),
+					},
+					{
+						Err: errors.New("arch mismatch: expected arch1, got arch2"),
+					},
+				},
+			},
+			{
+				Elf: elfs[3],
+				BackendSymbolSources: []SymbolQueryResult{
+					{
+						Err: errors.New("empty buildID"),
+					},
+					{
+						Err: errors.New("empty buildID"),
+					},
+				},
+			},
+			{
+				Elf: elfs[4],
+				BackendSymbolSources: []SymbolQueryResult{
+					{ // multiple matching buildIDs, first one should be used
+						SymbolSource: symbol.SourceSymbolTable,
+					},
+					{
+						SymbolSource: symbol.SourceNone,
+					},
+				},
+			},
+		}, results)
+	})
+
+	t.Run("Errors on both endpoints", func(t *testing.T) {
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch0", "buildid1", "", libpf.FileID{}),
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.Error(t, results[0].BackendSymbolSources[0].Err)
+		require.Error(t, results[0].BackendSymbolSources[1].Err)
+	})
+
+	t.Run("Errors on one endpoint", func(t *testing.T) {
+		elfs := []*symbol.Elf{
+			symbol.NewElfForTest("arch2", "buildid1", "", libpf.FileID{}),
+		}
+		results := ExecuteSymbolQueryBatch(ctx, elfs, queriers)
+		require.Error(t, results[0].BackendSymbolSources[1].Err)
+		require.NoError(t, results[0].BackendSymbolSources[0].Err)
+		require.Equal(t, symbol.SourceDebugInfo, results[0].BackendSymbolSources[0].SymbolSource)
+	})
+}

--- a/comp/host-profiler/symboluploader/symbol_uploader.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader.go
@@ -1,0 +1,660 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+// Package symboluploader is responsible for uploading symbols to the backend.
+package symboluploader
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/zstd"
+	lru "github.com/elastic/go-freelru"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/cgroup"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pipeline"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbolcopier"
+)
+
+const (
+	uploadCacheSize = 16384
+
+	defaultSymbolRetrievalQueueSize = 1000
+	defaultRetrievalWorkerCount     = 10
+
+	defaultSymbolBatcherQueueSize  = 1000
+	defaultSymbolQueryMaxBatchSize = 100
+
+	defaultSymbolQueryQueueSize = 1000
+	defaultQueryWorkerCount     = 10
+
+	defaultUploadQueueSize   = 1000
+	defaultUploadWorkerCount = 10
+
+	sourceMapEndpoint = "/api/v2/srcmap"
+
+	symbolCopyTimeout = 10 * time.Second
+	uploadTimeout     = 15 * time.Second
+)
+
+type DatadogSymbolUploader struct {
+	symbolEndpoints       []SymbolEndpoint
+	intakeURLs            []string
+	version               string
+	name                  string
+	dryRun                bool
+	uploadDynamicSymbols  bool
+	uploadGoPCLnTab       bool
+	compressDebugSections bool
+
+	uploadCache         *lru.SyncedLRU[libpf.FileID, struct{}]
+	client              *http.Client
+	symbolQueriers      []SymbolQuerier
+	symbolQueryInterval time.Duration
+	retrievalQueue      chan *reporter.ExecutableMetadata
+	pipeline            pipeline.Pipeline[*reporter.ExecutableMetadata]
+	mut                 sync.Mutex
+	biggestBinarySize   int64
+}
+
+func NewDatadogSymbolUploader(ctx context.Context, cfg *SymbolUploaderConfig) (*DatadogSymbolUploader, error) {
+	err := exec.CommandContext(ctx, "objcopy", "--version").Run()
+	if err != nil {
+		return nil, fmt.Errorf("objcopy is not available: %w", err)
+	}
+	if len(cfg.SymbolEndpoints) == 0 {
+		return nil, errors.New("no endpoints to upload symbols to")
+	}
+
+	var intakeURLs = make([]string, len(cfg.SymbolEndpoints))
+	var symbolQueriers = make([]SymbolQuerier, len(cfg.SymbolEndpoints))
+
+	for i, endpoints := range cfg.SymbolEndpoints {
+		var symbolQuerier SymbolQuerier
+		intakeURLs[i] = buildSourcemapIntakeURL(endpoints.Site)
+
+		if symbolQuerier, err = NewDatadogSymbolQuerier(endpoints.Site, endpoints.APIKey); err != nil {
+			return nil, fmt.Errorf("failed to create Datadog symbol querier: %w", err)
+		}
+		symbolQueriers[i] = symbolQuerier
+	}
+
+	uploadCache, err := lru.NewSynced[libpf.FileID, struct{}](uploadCacheSize, libpf.FileID.Hash32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cache: %w", err)
+	}
+
+	compressDebugSections := !cfg.DisableDebugSectionCompression && CheckObjcopyZstdSupport(ctx)
+
+	httpClient := &http.Client{Timeout: uploadTimeout}
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if ok && !cfg.UseHTTP2 {
+		// This is a copy of http.DefaultTransport, but with the TLSNextProto map removed
+		// to disable HTTP/2 as documented in https://pkg.go.dev/net/http#hdr-HTTP_2.
+		// We cannot clone http.DefaultTransport because of https://github.com/golang/go/issues/39302
+		httpClient.Transport = &http.Transport{
+			Proxy:                 defaultTransport.Proxy,
+			DialContext:           defaultTransport.DialContext,
+			MaxIdleConns:          defaultTransport.MaxIdleConns,
+			IdleConnTimeout:       defaultTransport.IdleConnTimeout,
+			TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
+			ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
+			// Different from http.DefaultTransport
+			TLSNextProto:      make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
+			ForceAttemptHTTP2: false,
+		}
+	}
+
+	return &DatadogSymbolUploader{
+		symbolEndpoints:       cfg.SymbolEndpoints,
+		intakeURLs:            intakeURLs,
+		version:               cfg.Version,
+		name:                  cfg.Name,
+		dryRun:                cfg.DryRun,
+		uploadDynamicSymbols:  cfg.UploadDynamicSymbols,
+		uploadGoPCLnTab:       cfg.UploadGoPCLnTab,
+		client:                httpClient,
+		uploadCache:           uploadCache,
+		symbolQueriers:        symbolQueriers,
+		symbolQueryInterval:   cfg.SymbolQueryInterval,
+		compressDebugSections: compressDebugSections,
+	}, nil
+}
+
+func CheckObjcopyZstdSupport(ctx context.Context) bool {
+	return exec.CommandContext(ctx, "objcopy", "--compress-debug-sections=zstd", "--version").Run() == nil
+}
+
+func buildSourcemapIntakeURL(site string) string {
+	return fmt.Sprintf("https://sourcemap-intake.%s%s", site, sourceMapEndpoint)
+}
+
+func (d *DatadogSymbolUploader) Start(ctx context.Context) {
+	symbolRetrievalQueue := make(chan *reporter.ExecutableMetadata, defaultSymbolRetrievalQueueSize)
+
+	queryWorkerCount := defaultQueryWorkerCount
+	symbolQueryMaxBatchSize := defaultSymbolQueryMaxBatchSize
+	if d.symbolQueryInterval > 0 {
+		queryWorkerCount = 1
+	} else {
+		symbolQueryMaxBatchSize = 1
+	}
+
+	memoryBudget, err := cgroup.GetMemoryBudget()
+	// Couldn't read the budget from cgroups
+	if err != nil {
+		slog.Warn("Failed to fetch cgroup memory limit", slog.String("error", err.Error()))
+	}
+
+	symbolRetrievalStage := pipeline.NewStage(symbolRetrievalQueue,
+		d.symbolRetrievalWorker,
+		pipeline.WithConcurrency(defaultRetrievalWorkerCount),
+		pipeline.WithOutputChanSize(defaultSymbolBatcherQueueSize))
+	batchingStage := pipeline.NewBatchingStage(symbolRetrievalStage.GetOutputChannel(),
+		d.symbolQueryInterval, symbolQueryMaxBatchSize,
+		pipeline.WithOutputChanSize(defaultSymbolQueryQueueSize))
+	queryStage := pipeline.NewStage(batchingStage.GetOutputChannel(),
+		d.queryWorker,
+		pipeline.WithConcurrency(queryWorkerCount),
+		pipeline.WithOutputChanSize(defaultUploadQueueSize))
+
+	// Always use budgeted processing to track binary sizes via GetSize()
+	// If no memory limit, use MaxInt64 for effectively unlimited budget
+	if memoryBudget == -1 {
+		slog.Debug("No memory limit found in cgroup, unlimited budget for symbol upload")
+		memoryBudget = math.MaxInt64
+	} else {
+		slog.Debug("Memory budget for symbol upload", slog.Int64("budget", memoryBudget))
+	}
+
+	uploadWorker := pipeline.NewBudgetedProcessingFunc(memoryBudget,
+		func(elfSymbols ElfWithBackendSources) int64 {
+			size := elfSymbols.GetSize()
+			if size > memoryBudget {
+				slog.Warn("Upload size is larger than memory limit, attempting upload anyway", slog.String("elf", elfSymbols.String()))
+				size = memoryBudget
+			}
+			return size
+		},
+		d.uploadWorker)
+
+	uploadStage := pipeline.NewSinkStage(queryStage.GetOutputChannel(),
+		uploadWorker, pipeline.WithConcurrency(defaultUploadWorkerCount))
+
+	d.pipeline = pipeline.NewPipeline(symbolRetrievalQueue,
+		symbolRetrievalStage, batchingStage, queryStage, uploadStage)
+	d.pipeline.Start(ctx)
+
+	d.mut.Lock()
+	d.retrievalQueue = symbolRetrievalQueue
+	d.mut.Unlock()
+}
+
+func (d *DatadogSymbolUploader) Stop() {
+	d.mut.Lock()
+	d.retrievalQueue = nil
+	d.mut.Unlock()
+
+	d.pipeline.Stop()
+}
+
+func (d *DatadogSymbolUploader) UploadSymbols(execMeta *reporter.ExecutableMetadata) {
+	mf := execMeta.MappingFile.Value()
+	_, ok := d.uploadCache.Get(mf.FileID)
+	if ok {
+		slog.Debug("Skipping symbol upload",
+			slog.String("reason", "already_uploaded"),
+			slog.String("path", execMeta.Mapping.Path.String()))
+		return
+	}
+
+	d.mut.Lock()
+	defer d.mut.Unlock()
+
+	// if pipeline is not started, we can't upload symbols
+	if d.retrievalQueue == nil {
+		return
+	}
+
+	// For short-lived processes, executable file might disappear from under our feet by the time we
+	// try to upload symbols. It would be better to open the file here and enqueue the opened file.
+	// We still need the file to exist later when we extract the debug symbols with objcopy though.
+	// The alternative would be to dump the file to a temporary file through the opened reader and use
+	// objcopy on that temporary file. The downside would be more disk I/O and more disk space used, and
+	// do not seem to be worth it.
+	// We can revisit this choice later if we switch to a different symbol extraction method.
+	select {
+	case d.retrievalQueue <- execMeta:
+	default:
+		slog.Warn("Skipping symbol upload",
+			slog.String("reason", "upload_queue_full"),
+			slog.String("file", execMeta.Mapping.Path.String()),
+			slog.String("file_id", mf.FileID.StringNoQuotes()))
+	}
+}
+
+func (d *DatadogSymbolUploader) symbolRetrievalWorker(_ context.Context, execMeta *reporter.ExecutableMetadata, outputChan chan<- *symbol.Elf) {
+	// Record immediately to avoid duplicate uploads
+	mf := execMeta.MappingFile.Value()
+	d.uploadCache.Add(mf.FileID, struct{}{})
+	elfSymbols := d.getSymbolsFromDisk(execMeta)
+	if elfSymbols == nil {
+		// Remove from cache because we might have symbols for this exe in another context
+		d.uploadCache.Remove(mf.FileID)
+		return
+	}
+	outputChan <- elfSymbols
+}
+
+func (d *DatadogSymbolUploader) queryWorker(ctx context.Context, batch []*symbol.Elf, outputChan chan<- ElfWithBackendSources) {
+	for _, e := range ExecuteSymbolQueryBatch(ctx, batch, d.symbolQueriers) {
+		outputChan <- e
+	}
+}
+
+func (d *DatadogSymbolUploader) uploadWorker(ctx context.Context, elfSymbols ElfWithBackendSources) {
+	var endpointIndices []int
+	removeFromCache := false
+	defer func() {
+		if removeFromCache {
+			d.uploadCache.Remove(elfSymbols.FileID())
+		}
+		elfSymbols.Close()
+	}()
+
+	for i, backendSymbolSource := range elfSymbols.BackendSymbolSources {
+		if backendSymbolSource.Err != nil {
+			slog.Warn("Failed to query symbols for executable",
+				slog.String("executable", elfSymbols.String()),
+				slog.String("error", backendSymbolSource.Err.Error()))
+			removeFromCache = true
+			continue
+		}
+
+		if backendSymbolSource.SymbolSource != symbol.SourceNone {
+			slog.Debug("Existing symbols for executable",
+				slog.String("executable", elfSymbols.String()),
+				slog.Int("endpoint", i),
+				slog.String("source", backendSymbolSource.SymbolSource.String()))
+		}
+
+		upload, symbolSource := d.shouldUpload(elfSymbols.Elf, backendSymbolSource.SymbolSource, i)
+
+		if upload {
+			endpointIndices = append(endpointIndices, i)
+		}
+		if symbolSource == symbol.SourceNone {
+			// Remove from cache because we might have symbols for this exe in another context
+			removeFromCache = true
+		}
+	}
+
+	if len(endpointIndices) == 0 {
+		return
+	}
+
+	if !d.upload(ctx, elfSymbols.Elf, endpointIndices) {
+		// Remove from cache to retry later
+		removeFromCache = true
+	}
+}
+
+func (d *DatadogSymbolUploader) getSymbolSource(e *symbol.Elf) symbol.Source {
+	source := e.SymbolSource()
+
+	if source == symbol.SourceDynamicSymbolTable && !d.uploadDynamicSymbols {
+		source = symbol.SourceNone
+	}
+
+	return source
+}
+
+func (d *DatadogSymbolUploader) getSymbolSourceIfGoPCLnTab(e *symbol.Elf) symbol.Source {
+	symbolSource := d.getSymbolSource(e)
+	if !e.IsGolang() || !d.uploadGoPCLnTab {
+		return symbolSource
+	}
+	return max(symbolSource, symbol.SourceGoPCLnTab)
+}
+
+func (d *DatadogSymbolUploader) getSymbolSourceWithGoPCLnTab(e *symbol.Elf) (symbol.Source, *pclntab.GoPCLnTabInfo) {
+	symbolSource := d.getSymbolSource(e)
+	if !e.IsGolang() || !d.uploadGoPCLnTab {
+		return symbolSource, nil
+	}
+	goPCLnTabInfo, err := e.GoPCLnTab()
+	if err != nil {
+		slog.Info("Failed to extract GoPCLnTab for executable",
+			slog.String("executable", e.String()),
+			slog.String("error", err.Error()))
+		return symbolSource, nil
+	}
+	return max(symbolSource, symbol.SourceGoPCLnTab), goPCLnTabInfo
+}
+
+func (d *DatadogSymbolUploader) getSymbolsFromDisk(execMeta *reporter.ExecutableMetadata) *symbol.Elf {
+	mf := execMeta.MappingFile.Value()
+	elfSymbols, err := symbol.NewElfFromMapping(execMeta.Mapping, mf.GnuBuildID, mf.GoBuildID, mf.FileID, execMeta.Process)
+	if err != nil {
+		slog.Debug("Skipping symbol upload for executable",
+			slog.String("path", execMeta.Mapping.Path.String()),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	symbolSource := d.getSymbolSourceIfGoPCLnTab(elfSymbols)
+	if symbolSource == symbol.SourceNone {
+		slog.Debug("Skipping symbol upload",
+			slog.String("reason", "no_debug_symbols"),
+			slog.String("path", elfSymbols.Path()))
+		elfSymbols.Close()
+		return nil
+	}
+
+	return elfSymbols
+}
+
+func (d *DatadogSymbolUploader) shouldUpload(e *symbol.Elf, existingSymbolSource symbol.Source, ind int) (bool, symbol.Source) {
+	symbolSource := d.getSymbolSourceIfGoPCLnTab(e)
+	if existingSymbolSource >= symbolSource {
+		slog.Info("Skipping symbol upload",
+			slog.String("reason", "existing_symbols"),
+			slog.String("path", e.Path()),
+			slog.Int("endpoint", ind),
+			slog.String("existing_source", existingSymbolSource.String()))
+		return false, symbolSource
+	}
+
+	symbolSource, _ = d.getSymbolSourceWithGoPCLnTab(e)
+	// Recheck symbol source after GoPCLnTab extraction
+	if symbolSource == symbol.SourceNone {
+		slog.Debug("Skipping symbol upload",
+			slog.String("reason", "no_debug_symbols"),
+			slog.String("path", e.Path()),
+			slog.Int("endpoint", ind))
+		return false, symbolSource
+	}
+	if existingSymbolSource >= symbolSource {
+		slog.Info("Skipping symbol upload",
+			slog.String("reason", "existing_symbols"),
+			slog.String("path", e.Path()),
+			slog.Int("endpoint", ind),
+			slog.String("existing_source", existingSymbolSource.String()))
+		return false, symbolSource
+	}
+
+	return true, symbolSource
+}
+
+// Returns true if the upload was successful, false otherwise
+func (d *DatadogSymbolUploader) upload(ctx context.Context, e *symbol.Elf, endpointIndices []int) bool {
+	symbolFile, err := d.createSymbolFile(ctx, e)
+	if err != nil {
+		slog.Error("failed to create symbol file", slog.String("error", err.Error()))
+		return false
+	}
+	defer os.Remove(symbolFile.Name())
+	defer symbolFile.Close()
+	symbolSource, _ := d.getSymbolSourceWithGoPCLnTab(e)
+	metadata := newSymbolUploadRequestMetadata(e, symbolSource, d.name, d.version)
+
+	if d.dryRun {
+		slog.Info("Dry run: would upload symbols for executable", slog.String("executable", e.String()))
+		return true
+	}
+
+	var g errgroup.Group
+	for _, ind := range endpointIndices {
+		g.Go(func() error {
+			return d.uploadSymbols(ctx, symbolFile.Name(), metadata, ind)
+		})
+	}
+
+	err = g.Wait()
+	if err != nil {
+		slog.Error("Failed to upload symbols",
+			slog.String("error", err.Error()),
+			slog.String("executable", e.String()))
+		return false
+	}
+
+	slog.Info("Symbols uploaded successfully for executable", slog.String("executable", e.String()))
+	return true
+}
+
+type symbolUploadRequestMetadata struct {
+	Arch          string `json:"arch"`
+	GNUBuildID    string `json:"gnu_build_id"`
+	GoBuildID     string `json:"go_build_id"`
+	FileHash      string `json:"file_hash"`
+	Type          string `json:"type"`
+	SymbolSource  string `json:"symbol_source"`
+	Origin        string `json:"origin"`
+	OriginVersion string `json:"origin_version"`
+	FileName      string `json:"filename"`
+}
+
+func newSymbolUploadRequestMetadata(e *symbol.Elf, symbolSource symbol.Source, profilerName, profilerVersion string) *symbolUploadRequestMetadata {
+	return &symbolUploadRequestMetadata{
+		Arch:          runtime.GOARCH,
+		GNUBuildID:    e.GnuBuildID(),
+		GoBuildID:     e.GoBuildID(),
+		FileHash:      e.FileHash(),
+		Type:          "elf_symbol_file",
+		Origin:        profilerName,
+		OriginVersion: profilerVersion,
+		SymbolSource:  symbolSource.String(),
+		FileName:      filepath.Base(e.Path()),
+	}
+}
+
+func (d *DatadogSymbolUploader) updateBiggestBinarySize(size int64) {
+	for {
+		current := atomic.LoadInt64(&d.biggestBinarySize)
+		if current >= size {
+			break
+		}
+		if atomic.CompareAndSwapInt64(&d.biggestBinarySize, current, size) {
+			break
+		}
+	}
+}
+
+func (d *DatadogSymbolUploader) createSymbolFile(ctx context.Context, e *symbol.Elf) (*os.File, error) {
+	symbolFile, err := os.CreateTemp("", "objcopy-debug")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file to extract symbols: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			symbolFile.Close()
+			os.Remove(symbolFile.Name())
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(ctx, symbolCopyTimeout)
+	defer cancel()
+
+	symbolSource, goPCLnTabInfo := d.getSymbolSourceWithGoPCLnTab(e)
+
+	elfPath := e.SymbolPathOnDisk()
+	if elfPath == "" {
+		// No associated file -> probably vdso, dump the ELF data to a file
+		elfPath, err = e.DumpElfData()
+		if err != nil {
+			return nil, fmt.Errorf("failed to dump ELF data: %w", err)
+		}
+		// Temporary file will be cleaned by the symbol.Elf.Close()
+	}
+
+	var sectionsToKeep []symbol.SectionInfo
+	if symbolSource == symbol.SourceDynamicSymbolTable {
+		sectionsToKeep = e.GetSectionsRequiredForDynamicSymbols()
+	}
+
+	// keep track of the biggest binary size we try to upload for logging purposes
+	d.updateBiggestBinarySize(e.GetSize())
+	err = symbolcopier.CopySymbols(ctx, elfPath, symbolFile.Name(), goPCLnTabInfo, sectionsToKeep, d.compressDebugSections)
+
+	if err != nil {
+		var ExitError *exec.ExitError
+		if errors.As(err, &ExitError) && ExitError.ExitCode() == -1 { // killed by signal
+			return nil, fmt.Errorf("failed to copy symbols: got killed. Consider increasing memory limits to at least %v (biggest uncompressed elf file size found)", atomic.LoadInt64(&d.biggestBinarySize))
+		}
+
+		return nil, fmt.Errorf("failed to copy symbols: failed to extract debug symbols: %w", cleanCmdError(err))
+	}
+
+	return symbolFile, nil
+}
+
+func (d *DatadogSymbolUploader) uploadSymbols(ctx context.Context, symbolFilePath string, e *symbolUploadRequestMetadata, endpointIdx int) error {
+	symbolFile, err := os.Open(symbolFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open symbol file: %w", err)
+	}
+	defer symbolFile.Close()
+
+	pipeR, pipeW := io.Pipe()
+
+	var compressed *zstd.Writer
+	var mw *multipart.Writer
+	var contentEncoding string
+	if !d.compressDebugSections {
+		compressed = zstd.NewWriter(pipeW)
+		mw = multipart.NewWriter(compressed)
+		contentEncoding = "zstd"
+	} else {
+		mw = multipart.NewWriter(pipeW)
+	}
+
+	req, err := d.buildSymbolUploadRequest(ctx, pipeR, mw.FormDataContentType(), contentEncoding, endpointIdx)
+	if err != nil {
+		return fmt.Errorf("failed to build symbol upload request: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		defer pipeW.Close()
+		innerErr := streamRequestBody(symbolFile, e, mw)
+		if innerErr != nil {
+			pipeW.CloseWithError(fmt.Errorf("failed to stream request body: %w", innerErr))
+			return
+		}
+		// Close the multipart writer then the zstd writer
+		innerErr = mw.Close()
+		if innerErr != nil {
+			pipeW.CloseWithError(fmt.Errorf("failed to close multipart writer: %w", innerErr))
+			return
+		}
+		if compressed != nil {
+			innerErr = compressed.Close()
+			if innerErr != nil {
+				pipeW.CloseWithError(fmt.Errorf("failed to close zstd writer: %w", innerErr))
+				return
+			}
+		}
+	})
+
+	resp, err := d.client.Do(req)
+	wg.Wait()
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+
+		return fmt.Errorf("error while uploading symbols to %s: %s, %s", d.intakeURLs[endpointIdx], resp.Status, string(respBody))
+	}
+
+	return nil
+}
+
+func streamRequestBody(symbolFile *os.File, e *symbolUploadRequestMetadata, mw *multipart.Writer) error {
+	// Copy the symbol file into the multipart writer
+	filePart, err := mw.CreateFormFile("elf_symbol_file", "elf_symbol_file")
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	_, err = io.Copy(filePart, symbolFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy symbol file: %w", err)
+	}
+
+	// Write the event metadata into the multipart writer
+	eventPart, err := mw.CreatePart(textproto.MIMEHeader{
+		"Content-Disposition": []string{`form-data; name="event"; filename="event.json"`},
+		"Content-Type":        []string{"application/json"},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create event part: %w", err)
+	}
+
+	err = json.NewEncoder(eventPart).Encode(e)
+	if err != nil {
+		return fmt.Errorf("failed to write JSON metadata: %w", err)
+	}
+
+	return nil
+}
+
+func (d *DatadogSymbolUploader) buildSymbolUploadRequest(ctx context.Context, body io.Reader, contentType, contentEncoding string, ind int) (*http.Request, error) {
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, d.intakeURLs[ind], body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	r.Header.Set("Dd-Api-Key", d.symbolEndpoints[ind].APIKey)
+	r.Header.Set("Dd-Evp-Origin", d.name)
+	r.Header.Set("Dd-Evp-Origin-Version", d.version)
+	r.Header.Set("Content-Type", contentType)
+	if contentEncoding != "" {
+		r.Header.Set("Content-Encoding", contentEncoding)
+	}
+	return r, nil
+}
+
+// cleanCmdError simplifies error messages from os/exec.Cmd.Run.
+// For ExitErrors, it trims and returns stderr. By default, ExitError prints the exit
+// status but not stderr.
+//
+// cleanCmdError returns other errors unmodified.
+func cleanCmdError(err error) error {
+	var xerr *exec.ExitError
+	if errors.As(err, &xerr) {
+		if stderr := strings.TrimSpace(string(xerr.Stderr)); stderr != "" {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+	}
+	return err
+}

--- a/comp/host-profiler/symboluploader/symbol_uploader_test.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader_test.go
@@ -1,0 +1,613 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package symboluploader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/DataDog/jsonapi"
+	"github.com/DataDog/zstd"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/process"
+	"go.opentelemetry.io/ebpf-profiler/remotememory"
+	"go.opentelemetry.io/ebpf-profiler/reporter"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+	elf "github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+var objcopyZstdSupport = CheckObjcopyZstdSupport(context.Background())
+
+// dummyProcess implements pfelf.Process for testing purposes
+type dummyProcess struct {
+	pid libpf.PID
+}
+
+func (d *dummyProcess) PID() libpf.PID {
+	return d.pid
+}
+
+func (d *dummyProcess) GetMachineData() process.MachineData {
+	return process.MachineData{}
+}
+
+func (d *dummyProcess) GetMappings() ([]process.Mapping, uint32, error) {
+	return nil, 0, errors.New("not implemented")
+}
+
+func (d *dummyProcess) GetThreads() ([]process.ThreadInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *dummyProcess) GetRemoteMemory() remotememory.RemoteMemory {
+	return remotememory.RemoteMemory{}
+}
+
+func (d *dummyProcess) GetMappingFileLastModified(_ *process.Mapping) int64 {
+	return 0
+}
+
+func (d *dummyProcess) CalculateMappingFileID(m *process.Mapping) (libpf.FileID, error) {
+	return libpf.FileIDFromExecutableFile(m.Path.String())
+}
+
+func (d *dummyProcess) OpenMappingFile(m *process.Mapping) (process.ReadAtCloser, error) {
+	return os.Open(m.Path.String())
+}
+
+func (d *dummyProcess) OpenELF(name string) (*pfelf.File, error) {
+	return pfelf.Open(name)
+}
+
+func (d *dummyProcess) Close() error {
+	return nil
+}
+
+func (d *dummyProcess) GetExe() (libpf.String, error) {
+	str, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", d.pid))
+	if err != nil {
+		return libpf.NullString, err
+	}
+	return libpf.Intern(str), nil
+}
+
+func (d *dummyProcess) GetProcessMeta(_ process.MetaConfig) process.ProcessMeta {
+	return process.ProcessMeta{}
+}
+
+func newExecutableMetadata(t *testing.T, filePath, goBuildID string) *reporter.ExecutableMetadata {
+	fileID, err := libpf.FileIDFromExecutableFile(filePath)
+	require.NoError(t, err)
+	mf := libpf.NewFrameMappingFile(libpf.FrameMappingFileData{
+		FileID:     fileID,
+		FileName:   libpf.Intern(path.Base(filePath)),
+		GnuBuildID: "",
+		GoBuildID:  goBuildID,
+	})
+	pr := &dummyProcess{pid: libpf.PID(os.Getpid())}
+	m := &process.Mapping{
+		Path: libpf.Intern(filePath),
+	}
+	return &reporter.ExecutableMetadata{
+		MappingFile:       mf,
+		Process:           pr,
+		Mapping:           m,
+		DebuglinkFileName: "",
+	}
+}
+
+func findSymbol(f *elf.File, name string) *elf.Symbol {
+	syms, err := f.Symbols()
+	if err != nil {
+		return nil
+	}
+	for _, sym := range syms {
+		if sym.Name == name {
+			return &sym
+		}
+	}
+	return nil
+}
+
+func findDynamicSymbol(f *elf.File, name string) *elf.Symbol {
+	syms, err := f.DynamicSymbols()
+	if err != nil {
+		return nil
+	}
+	for _, sym := range syms {
+		if sym.Name == name {
+			return &sym
+		}
+	}
+	return nil
+}
+
+func checkGoPCLnTab(t *testing.T, f *elf.File, checkGoFunc bool) {
+	section := f.Section(".gopclntab")
+	require.NotNil(t, section)
+	require.Equal(t, elf.SHT_PROGBITS, section.Type)
+	data, err := section.Data()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(data), 16)
+
+	var quantum byte
+	switch runtime.GOARCH {
+	case "amd64":
+		quantum = 0x1
+	case "arm64":
+		quantum = 0x4
+	}
+
+	expectedHeader := []byte{0xf1, 0xff, 0xff, 0xff, 0x00, 0x00, quantum, 0x08}
+	assert.Equal(t, expectedHeader, data[:8])
+
+	if checkGoFunc {
+		require.NotNil(t, findSymbol(f, "go:func.*"))
+	}
+}
+
+func checkRequest(t *testing.T, req *http.Request, expectedSymbolSource symbol.Source, expectedGoPCLnTab bool, expectedContentEncoding string) {
+	require.Equal(t, "POST", req.Method)
+	if expectedContentEncoding != "" {
+		require.Equal(t, expectedContentEncoding, req.Header.Get("Content-Encoding"))
+	} else {
+		require.NotContains(t, req.Header, "Content-Encoding")
+	}
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	boundary, ok := params["boundary"]
+	require.True(t, ok)
+
+	var reader io.ReadCloser
+	if req.Header.Get("Content-Encoding") == "zstd" {
+		reader = zstd.NewReader(req.Body)
+		defer reader.Close()
+	} else {
+		reader = req.Body
+	}
+
+	mr := multipart.NewReader(reader, boundary)
+	form, err := mr.ReadForm(1 << 20) // 1 MiB
+	require.NoError(t, err)
+	fhs, ok := form.File["elf_symbol_file"]
+	require.True(t, ok)
+	f, err := fhs[0].Open()
+	require.NoError(t, err)
+	defer f.Close()
+
+	event, ok := form.File["event"]
+	require.True(t, ok)
+	e, err := event[0].Open()
+	require.NoError(t, err)
+	defer e.Close()
+
+	// unmarshal json into map[string]string
+	// check that the symbol source is correct
+	result := make(map[string]string)
+	err = json.NewDecoder(e).Decode(&result)
+	require.NoError(t, err)
+	require.Equal(t, expectedSymbolSource.String(), result["symbol_source"])
+
+	elfFile, err := elf.NewFile(f)
+	require.NoError(t, err)
+	defer elfFile.Close()
+
+	if expectedGoPCLnTab || expectedSymbolSource == symbol.SourceGoPCLnTab {
+		checkGoPCLnTab(t, elfFile, true)
+	}
+
+	switch expectedSymbolSource {
+	case symbol.SourceDynamicSymbolTable:
+		require.NotNil(t, findDynamicSymbol(elfFile, "_cgo_panic"))
+	case symbol.SourceSymbolTable:
+		require.NotNil(t, findSymbol(elfFile, "main.main"))
+	case symbol.SourceDebugInfo:
+		require.True(t, hasDWARFData(elfFile))
+	}
+}
+
+func hasDWARFData(elfFile *elf.File) bool {
+	hasBuildID := false
+	hasDebugStr := false
+	for _, section := range elfFile.Sections {
+		// NOBITS indicates that the section is actually empty, regardless of the size in the
+		// section header.
+		if section.Type == elf.SHT_NOBITS {
+			continue
+		}
+
+		if section.Name == ".note.gnu.build-id" {
+			hasBuildID = true
+		}
+
+		if section.Name == ".debug_str" || section.Name == ".zdebug_str" ||
+			section.Name == ".debug_str.dwo" {
+			hasDebugStr = section.Size > 0
+		}
+
+		// Some files have suspicious near-empty, partially stripped sections; consider them as not
+		// having DWARF data.
+		// The simplest binary gcc 10 can generate ("return 0") has >= 48 bytes for each section.
+		// Let's not worry about executables that may not verify this, as they would not be of
+		// interest to us.
+		if section.Size < 32 {
+			continue
+		}
+
+		if section.Name == ".debug_info" || section.Name == ".zdebug_info" {
+			return true
+		}
+	}
+
+	// Some alternate debug files only have a .debug_str section. For these we want to return true.
+	// Use the absence of program headers and presence of a Build ID as heuristic to identify
+	// alternate debug files.
+	return len(elfFile.Progs) == 0 && hasBuildID && hasDebugStr
+}
+
+var testEndpoints = []string{"a.com", "b.com", "c.com", "d.com", "e.com"}
+
+type uploaderOpts struct {
+	uploadDynamicSymbols           bool
+	uploadGoPCLnTab                bool
+	disableDebugSectionCompression bool
+}
+
+func newTestUploader(ctx context.Context, opts uploaderOpts) (*DatadogSymbolUploader, error) {
+	endpoints := make([]SymbolEndpoint, 0, len(testEndpoints))
+	for _, e := range testEndpoints {
+		endpoints = append(endpoints, SymbolEndpoint{
+			Site:   e,
+			APIKey: "api_key",
+		})
+	}
+
+	cfg := &SymbolUploaderConfig{
+		SymbolUploaderOptions: SymbolUploaderOptions{
+			Enabled:              true,
+			UploadDynamicSymbols: opts.uploadDynamicSymbols,
+			UploadGoPCLnTab:      opts.uploadGoPCLnTab,
+			SymbolQueryInterval:  0,
+			SymbolEndpoints:      endpoints,
+		},
+		DisableDebugSectionCompression: opts.disableDebugSectionCompression,
+	}
+	return NewDatadogSymbolUploader(ctx, cfg)
+}
+
+type buildOptions struct {
+	dynsym           bool
+	symtab           bool
+	debugInfos       bool
+	corruptGoPCLnTab bool
+}
+
+func buildGo(t *testing.T, tmpDir, buildID string, opts buildOptions) string {
+	f, err := os.CreateTemp(tmpDir, "helloworld")
+	require.NoError(t, err)
+	defer f.Close()
+
+	exe := f.Name()
+	args := []string{"build", "-o", exe}
+	ldflags := "-ldflags=-buildid=" + buildID + " "
+	if opts.dynsym {
+		ldflags += "-linkmode=external "
+	}
+
+	args = append(args, ldflags, "./testdata/helloworld.go")
+	cmd := exec.CommandContext(t.Context(), "go", args...) // #nosec G204
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "failed to build test binary with `%v`: %s\n%s", cmd.Args, err, out)
+
+	args = []string{"-R", ".note.gnu.build-id"}
+	if opts.debugInfos && !opts.symtab {
+		t.Errorf("Cannot have debug infos without symtab")
+	}
+
+	if !opts.debugInfos {
+		if opts.symtab {
+			args = append(args, "-g")
+		} else {
+			args = append(args, "-S")
+		}
+	}
+	if opts.corruptGoPCLnTab {
+		// Remove the pclntab section
+		args = append(args, "-R", ".gopclntab")
+	}
+	args = append(args, exe)
+	cmd = exec.CommandContext(t.Context(), "objcopy", args...)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "failed to strip test binary with `%v`: %s\n%s", cmd.Args, err, out)
+
+	return exe
+}
+
+func buildSymbolQueryResponse(t *testing.T, buildID string, symbolSource symbol.Source) string {
+	var symbolFiles []SymbolFile
+	if symbolSource != symbol.SourceNone {
+		symbolFiles = []SymbolFile{
+			{
+				ID:           "1",
+				BuildID:      buildID,
+				SymbolSource: symbolSource.String(),
+				BuildIDType:  "go_build_id",
+			},
+		}
+	}
+	r, err := jsonapi.Marshal(&symbolFiles)
+	require.NoError(t, err)
+	return string(r)
+}
+
+func registerResponders(t *testing.T, buildID string) []chan *http.Request {
+	channels := make([]chan *http.Request, 0, len(testEndpoints))
+	symbolSources := []symbol.Source{symbol.SourceNone, symbol.SourceDynamicSymbolTable, symbol.SourceSymbolTable, symbol.SourceGoPCLnTab, symbol.SourceDebugInfo}
+	for i, e := range testEndpoints {
+		c := make(chan *http.Request, 1)
+		channels = append(channels, c)
+		httpmock.RegisterResponder("POST", buildSymbolQueryURL(e),
+			httpmock.NewStringResponder(200, buildSymbolQueryResponse(t, buildID, symbolSources[i])))
+		httpmock.RegisterResponder("POST", buildSourcemapIntakeURL(e),
+			func(req *http.Request) (*http.Response, error) {
+				// Read request body before sending response otherwise client will receive the response before having sent all the data
+				b, err := io.ReadAll(req.Body)
+				if err != nil {
+					return nil, err
+				}
+				req.Body = io.NopCloser(bytes.NewReader(b))
+				c <- req
+				return httpmock.NewStringResponse(200, ""), nil
+			})
+	}
+	return channels
+}
+
+//nolint:tparallel
+func TestSymbolUpload(t *testing.T) {
+	t.Parallel()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	buildID := "some_go_build_id"
+	channels := registerResponders(t, buildID)
+
+	checkUploadsWithEncoding := func(t *testing.T, expectedSymbolSource symbol.Source, expectedGoPCLnTab bool, expectedUploads []bool, expectedEncoding string) {
+		callCountInfo := httpmock.GetCallCountInfo()
+		for i, e := range testEndpoints {
+			assert.Equal(t, 1, callCountInfo["POST "+buildSymbolQueryURL(e)])
+			if expectedUploads[i] {
+				assert.Equal(t, 1, callCountInfo["POST "+buildSourcemapIntakeURL(e)])
+				req := <-channels[i]
+				checkRequest(t, req, expectedSymbolSource, expectedGoPCLnTab, expectedEncoding)
+			} else {
+				assert.Equal(t, 0, callCountInfo["POST "+buildSourcemapIntakeURL(e)])
+			}
+		}
+	}
+
+	checkUploads := func(t *testing.T, expectedSymbolSource symbol.Source, expectedGoPCLnTab bool, expectedUploads []bool) {
+		expectedEncoding := ""
+		if !objcopyZstdSupport {
+			expectedEncoding = "zstd"
+		}
+		checkUploadsWithEncoding(t, expectedSymbolSource, expectedGoPCLnTab, expectedUploads, expectedEncoding)
+	}
+
+	goExeNoSymbols := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: false, symtab: false, debugInfos: false})
+	goExeyDynsym := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: false, debugInfos: false})
+	goExeSymtab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: false})
+	goExeDebugInfos := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: true})
+	goExeyDynsymCorruptGoPCLnTab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: false, debugInfos: false, corruptGoPCLnTab: true})
+	goExeDebugInfosCorruptGoPCLnTab := buildGo(t, t.TempDir(), buildID, buildOptions{dynsym: true, symtab: true, debugInfos: true, corruptGoPCLnTab: true})
+
+	t.Run("No symbol upload if no symbols", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeNoSymbols, buildID))
+		uploader.Stop()
+
+		assert.Equal(t, 0, httpmock.GetTotalCallCount())
+	})
+
+	t.Run("Upload if symtab", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeSymtab, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceSymbolTable, false, []bool{true, true, false, false, false})
+	})
+
+	t.Run("Upload if debug info", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeDebugInfos, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceDebugInfo, false, []bool{true, true, true, true, false})
+	})
+
+	t.Run("No upload if dynamic symbols", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeyDynsym, buildID))
+		uploader.Stop()
+
+		assert.Equal(t, 0, httpmock.GetTotalCallCount())
+	})
+
+	t.Run("Upload if dynamic symbols when enabled", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{uploadDynamicSymbols: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeyDynsym, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceDynamicSymbolTable, false, []bool{true, false, false, false, false})
+	})
+
+	t.Run("Upload pclntab when enabled", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{uploadGoPCLnTab: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeNoSymbols, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceGoPCLnTab, true, []bool{true, true, true, false, false})
+	})
+
+	t.Run("Upload debug infos if pclntab is corrupted", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{uploadGoPCLnTab: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeDebugInfosCorruptGoPCLnTab, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceDebugInfo, false, []bool{true, true, true, true, false})
+	})
+
+	t.Run("Upload dynamic symbols if pclntab is corrupted and only dyn sym when enabled", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{uploadDynamicSymbols: true, uploadGoPCLnTab: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeyDynsymCorruptGoPCLnTab, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceDynamicSymbolTable, false, []bool{true, false, false, false, false})
+	})
+
+	t.Run("No symbol upload if pclntab is corrupted and only dynsym", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{uploadGoPCLnTab: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeyDynsymCorruptGoPCLnTab, buildID))
+		uploader.Stop()
+
+		checkUploads(t, symbol.SourceNone, false, []bool{false, false, false, false, false})
+	})
+
+	t.Run("Upload compressed request when debug section compression is disabled", func(t *testing.T) {
+		httpmock.ZeroCallCounters()
+		uploader, err := newTestUploader(t.Context(), uploaderOpts{disableDebugSectionCompression: true})
+		require.NoError(t, err)
+		uploader.Start(t.Context())
+
+		uploader.UploadSymbols(newExecutableMetadata(t, goExeDebugInfos, buildID))
+		uploader.Stop()
+
+		checkUploadsWithEncoding(t, symbol.SourceDebugInfo, false, []bool{true, true, true, true, false}, "zstd")
+	})
+}
+
+// Verify that the symbol uploader transport has the same exported fields as http.DefaultTransport
+// when HTTP/2 is disabled
+func TestTransport(t *testing.T) {
+	cfg := &SymbolUploaderConfig{
+		SymbolUploaderOptions: SymbolUploaderOptions{
+			Enabled:         true,
+			UseHTTP2:        false, // This forces creation of custom transport
+			SymbolEndpoints: []SymbolEndpoint{{Site: "test.com", APIKey: "key"}},
+		},
+		Version: "test",
+	}
+
+	uploader, err := NewDatadogSymbolUploader(t.Context(), cfg)
+	require.NoError(t, err)
+
+	customTransport, ok := uploader.client.Transport.(*http.Transport)
+	require.True(t, ok, "Expected custom transport to be *http.Transport")
+
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "Expected http.DefaultTransport to be *http.Transport")
+
+	// Use reflection to compare all exported fields
+	customValue := reflect.ValueOf(customTransport).Elem()
+	defaultValue := reflect.ValueOf(defaultTransport).Elem()
+	customType := customValue.Type()
+
+	for i := range customType.NumField() {
+		field := customType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
+		customFieldValue := customValue.Field(i)
+		defaultFieldValue := defaultValue.Field(i)
+
+		// Special handling for intentionally different fields
+		switch field.Name {
+		case "TLSNextProto":
+			// TLSNextProto should be an empty map in custom transport to disable HTTP/2
+			assert.NotNil(t, customFieldValue.Interface(), "TLSNextProto should not be nil")
+			assert.Equal(t, 0, customFieldValue.Len(), "TLSNextProto should be empty map")
+		case "ForceAttemptHTTP2":
+			// ForceAttemptHTTP2 should be false in custom transport to disable HTTP/2
+			assert.False(t, customFieldValue.Bool(), "ForceAttemptHTTP2 should be false to disable HTTP/2")
+		case "TLSClientConfig":
+			// TLSClientConfig should be nil in custom transport
+			// The default transport might have a non-nil value if the default transport
+			// was used in another test (for example through the default http client)
+			assert.Nil(t, customFieldValue.Interface(), "TLSClientConfig should be nil")
+		default:
+			if customFieldValue.Kind() == reflect.Func {
+				assert.Equal(t, defaultFieldValue.Pointer(), customFieldValue.Pointer(), "Function field %s should match", field.Name)
+				continue
+			}
+			if !customFieldValue.CanInterface() || !defaultFieldValue.CanInterface() {
+				assert.Failf(t, "Cannot compare field %s", field.Name)
+				continue
+			}
+			assert.Equal(t, defaultFieldValue.Interface(), customFieldValue.Interface(),
+				"Field %s should match default transport", field.Name)
+		}
+	}
+}

--- a/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
+++ b/comp/host-profiler/symboluploader/symbolcopier/symbolcopier.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build linux
+
+// Package symbolcopier provides utilities for copying debug symbols from ELF files.
+package symbolcopier
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/oom"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/pclntab"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+	elf "github.com/DataDog/datadog-agent/pkg/util/safeelf"
+)
+
+type goPCLnTabDump struct {
+	goPCLnTabPath string
+	goFuncPath    string
+}
+
+func (g *goPCLnTabDump) Remove() {
+	os.Remove(g.goPCLnTabPath)
+	if g.goFuncPath != "" {
+		os.Remove(g.goFuncPath)
+	}
+}
+
+func dumpGoPCLnTabData(goPCLnTabInfo *pclntab.GoPCLnTabInfo) (goPCLnTabDump, error) {
+	// Dump gopclntab data to a temporary file
+	gopclntabFile, err := os.CreateTemp("", "gopclntab")
+	if err != nil {
+		return goPCLnTabDump{}, fmt.Errorf("failed to create temp file to extract GoPCLnTab: %w", err)
+	}
+	defer func() {
+		gopclntabFile.Close()
+		if err != nil {
+			os.Remove(gopclntabFile.Name())
+		}
+	}()
+
+	_, err = gopclntabFile.Write(goPCLnTabInfo.Data)
+	if err != nil {
+		return goPCLnTabDump{}, fmt.Errorf("failed to write GoPCLnTab: %w", err)
+	}
+
+	if goPCLnTabInfo.GoFuncData == nil {
+		return goPCLnTabDump{goPCLnTabPath: gopclntabFile.Name()}, nil
+	}
+
+	// Dump gofunc data to a temporary file
+	gofuncFile, err := os.CreateTemp("", "gofunc")
+	if err != nil {
+		return goPCLnTabDump{}, fmt.Errorf("failed to create temp file to extract GoFunc: %w", err)
+	}
+	defer func() {
+		gofuncFile.Close()
+		if err != nil {
+			os.Remove(gofuncFile.Name())
+		}
+	}()
+
+	_, err = gofuncFile.Write(goPCLnTabInfo.GoFuncData)
+	if err != nil {
+		return goPCLnTabDump{}, fmt.Errorf("failed to write GoFunc: %w", err)
+	}
+
+	return goPCLnTabDump{goPCLnTabPath: gopclntabFile.Name(), goFuncPath: gofuncFile.Name()}, nil
+}
+
+func CopySymbols(ctx context.Context, inputPath, outputPath string, goPCLnTabInfo *pclntab.GoPCLnTabInfo,
+	sectionsToKeep []symbol.SectionInfo, compressDebugSections bool) error {
+	args := []string{
+		"--only-keep-debug",
+		"--remove-section=.gdb_index",
+	}
+
+	if goPCLnTabInfo != nil {
+		// objcopy does not support extracting debug information (with `--only-keep-debug`) and keeping
+		// some non-debug sections (like gopclntab) at the same time.
+		// `--only-keep-debug` does not really remove non-debug sections, it keeps their memory size
+		// but makes their file size 0 by marking them NOBITS (effectively zeroing them).
+		// That's why we extract debug information and at the same time remove `.gopclntab` section (with
+		// with `--remove-section=.gopclntab`) and add it back from the temporary file.
+		gopclntabDump, err := dumpGoPCLnTabData(goPCLnTabInfo)
+		if err != nil {
+			return fmt.Errorf("failed to dump GoPCLnTab data: %w", err)
+		}
+		defer gopclntabDump.Remove()
+
+		args = append(args,
+			"--remove-section=.gopclntab",
+			"--remove-section=.data.rel.ro.gopclntab",
+			"--add-section", ".gopclntab="+gopclntabDump.goPCLnTabPath,
+			"--set-section-flags", ".gopclntab=readonly",
+			fmt.Sprintf("--change-section-address=.gopclntab=%d", goPCLnTabInfo.Address))
+
+		if gopclntabDump.goFuncPath != "" {
+			args = append(args, "--add-section", ".gofunc="+gopclntabDump.goFuncPath,
+				"--set-section-flags", ".gofunc=readonly",
+				fmt.Sprintf("--change-section-address=.gofunc=%d", goPCLnTabInfo.GoFuncAddr),
+				"--strip-symbol", "go:func.*",
+				"--add-symbol", "go:func.*=.gofunc:0")
+		} else if goPCLnTabInfo.GoFuncAddr != 0 {
+			// Gofunc is in .gopclntab, no need to add a new section for it.
+			// Just add a symbol so that we can find it easily later.
+			args = append(args, "--strip-symbol", "go:func.*",
+				"--add-symbol", fmt.Sprintf("go:func.*=.gopclntab:%d", goPCLnTabInfo.GoFuncAddr-goPCLnTabInfo.Address))
+		}
+
+		if goPCLnTabInfo.TextStart.Address != 0 && goPCLnTabInfo.TextStart.Origin == pclntab.TextStartOriginModuleData {
+			// If the text start can only be found in moduledata, we need to add a symbol so that we can find it easily later.
+			args = append(args, "--strip-symbol", "runtime.text", "--add-symbol",
+				fmt.Sprintf("runtime.text=.text:%d", goPCLnTabInfo.TextStart.Address-goPCLnTabInfo.TextStart.TextSectionAddress))
+		}
+	}
+
+	for _, section := range sectionsToKeep {
+		args = append(args, "--set-section-flags", fmt.Sprintf("%s=%s", section.Name, getStringFlags(section.Flags)))
+	}
+
+	if compressDebugSections {
+		args = append(args, "--compress-debug-sections=zstd")
+	}
+
+	args = append(args, inputPath, outputPath)
+
+	cmd := exec.CommandContext(ctx, "objcopy", args...)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start copying symbols: %w", err)
+	}
+
+	// Increase probability that objcopy gets killed in case the cgroup is OOM
+	if err := oom.SetOOMScoreAdj(cmd.Process.Pid, 1000); err != nil {
+		slog.Warn("Could not adjust OOM score", slog.String("error", err.Error()))
+	}
+
+	return cmd.Wait()
+}
+
+func getStringFlags(flags elf.SectionFlag) string {
+	flagsStr := "contents"
+	if flags&elf.SHF_WRITE == 0 {
+		flagsStr += ",readonly"
+	}
+	if flags&elf.SHF_ALLOC != 0 {
+		flagsStr += ",alloc"
+	}
+	if flags&elf.SHF_EXECINSTR != 0 {
+		flagsStr += ",exec"
+	}
+	return flagsStr
+}

--- a/comp/host-profiler/symboluploader/testdata/go.mod
+++ b/comp/host-profiler/symboluploader/testdata/go.mod
@@ -1,0 +1,3 @@
+module helloworld
+
+go 1.2

--- a/comp/host-profiler/symboluploader/testdata/helloworld.go
+++ b/comp/host-profiler/symboluploader/testdata/helloworld.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+)
+
+func hello() {
+	fmt.Println("Hello World")
+}
+
+// burnCPU is a function that burns CPU to ensure the process gets profiled.
+// This is only for testing purposes. Prevent inlining of this function.
+//
+//go:noinline
+func burnCPU() {
+	for {
+
+	}
+}
+
+func main() {
+	hello()
+	burnCPU()
+}

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -5,6 +5,7 @@
 
 //go:build linux
 
+// Package version provides version information for the host profiler.
 package version
 
 import "github.com/DataDog/datadog-agent/pkg/version"

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package version
+
+import "github.com/DataDog/datadog-agent/pkg/version"
+
+const ProfilerName = "full-host-profiler"
+
+var ProfilerVersion = version.AgentVersion

--- a/go.mod
+++ b/go.mod
@@ -168,7 +168,6 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.8.2
 	github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671
 	github.com/DataDog/datadog-traceroute v1.0.3
-	github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20260123165136-9ed3effd2c0e
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-sqllexer v0.1.12
 	github.com/DataDog/gopsutil v1.2.3
@@ -562,7 +561,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
-	github.com/elastic/go-freelru v0.16.0 // indirect
+	github.com/elastic/go-freelru v0.16.0
 	github.com/elastic/go-grok v0.3.1 // indirect
 	github.com/elastic/go-licenser v0.4.2 // indirect
 	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8 // indirect
@@ -640,7 +639,7 @@ require (
 	github.com/jaegertracing/jaeger-idl v0.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jlaffaye/ftp v0.1.0 // indirect
-	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
@@ -816,7 +815,6 @@ require (
 	github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
-	github.com/urfave/cli/v3 v3.1.1 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
 	github.com/vito/go-sse v1.0.0 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
@@ -995,6 +993,7 @@ require (
 	github.com/hashicorp/vault/api/auth/aws v0.11.0
 	github.com/hashicorp/vault/api/auth/ldap v0.11.0
 	github.com/hashicorp/vault/api/auth/userpass v0.11.0
+	github.com/jarcoal/httpmock v1.4.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/qri-io/jsonpointer v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671 h1:AO
 github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671/go.mod h1:qrisxX+IMicFX01uVrzmPWTxhSQrrmyb6fUTQdjQdN8=
 github.com/DataDog/datadog-traceroute v1.0.3 h1:84fcvLfsOmdm7T6+7Y07KmQfXJR8gjMdmD4j+vuf8Qo=
 github.com/DataDog/datadog-traceroute v1.0.3/go.mod h1:aA+OKmKRPghOH/DPIrepgLXos++CHZQ5L/uCCeaaNII=
-github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20260123165136-9ed3effd2c0e h1:OMhVn9YYbnrvMZfWFr6wEeXqiAfVz5QM+YqSaJnVWVg=
-github.com/DataDog/dd-otel-host-profiler v0.4.1-0.20260123165136-9ed3effd2c0e/go.mod h1:jb1UKSHdXrQ3H2kpQXU4jNKdM9Svioly9DdpQTQpxE0=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5/go.mod h1:oz6zVBIVeK9I/AFP9k7TljSGtA9Opslmay0FcXg0fuQ=
 github.com/DataDog/ebpf-manager v0.7.15 h1:14PbnvXFQccV3zexENfNuADAxCuwHNori7sK55CP0SU=
@@ -2539,8 +2537,6 @@ github.com/uptrace/bun/driver/pgdriver v1.2.16 h1:b1kpXKUxtTSGYow5Vlsb+dKV3z0R7a
 github.com/uptrace/bun/driver/pgdriver v1.2.16/go.mod h1:H6lUZ9CBfp1X5Vq62YGSV7q96/v94ja9AYFjKvdoTk0=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
-github.com/urfave/cli/v3 v3.1.1 h1:bNnl8pFI5dxPOjeONvFCDFoECLQsceDG4ejahs4Jtxk=
-github.com/urfave/cli/v3 v3.1.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/fastjson v1.6.7 h1:ZE4tRy0CIkh+qDc5McjatheGX2czdn8slQjomexVpBM=

--- a/modules.yml
+++ b/modules.yml
@@ -89,6 +89,7 @@ modules:
     used_by_otel: true
   comp/forwarder/orchestrator/orchestratorinterface:
     used_by_otel: true
+  comp/host-profiler/symboluploader/testdata: ignored
   comp/logs-library:
     used_by_otel: true
   comp/logs/agent/config:

--- a/pkg/util/safeelf/types.go
+++ b/pkg/util/safeelf/types.go
@@ -16,6 +16,8 @@ type Section = elf.Section
 type SectionHeader = elf.SectionHeader
 type SectionType = elf.SectionType
 type SectionIndex = elf.SectionIndex
+type SectionFlag = elf.SectionFlag
+type Machine = elf.Machine
 
 var ErrNoSymbols = elf.ErrNoSymbols
 
@@ -25,6 +27,14 @@ const SHF_EXECINSTR = elf.SHF_EXECINSTR
 const SHT_SYMTAB = elf.SHT_SYMTAB
 const SHT_DYNSYM = elf.SHT_DYNSYM
 const SHT_NOTE = elf.SHT_NOTE
+const SHT_REL = elf.SHT_REL
+const SHT_RELA = elf.SHT_RELA //nolint:misspell
+const SHT_HASH = elf.SHT_HASH
+const SHT_DYNAMIC = elf.SHT_DYNAMIC
+const SHT_GNU_HASH = elf.SHT_GNU_HASH
+const SHT_GNU_VERDEF = elf.SHT_GNU_VERDEF
+const SHT_GNU_VERNEED = elf.SHT_GNU_VERNEED
+const SHT_GNU_VERSYM = elf.SHT_GNU_VERSYM
 
 const ET_EXEC = elf.ET_EXEC
 const ET_DYN = elf.ET_DYN
@@ -43,6 +53,7 @@ const ELFCLASS64 = elf.ELFCLASS64
 
 const PF_X = elf.PF_X
 const PF_W = elf.PF_W
+const PF_R = elf.PF_R
 
 const STB_GLOBAL = elf.STB_GLOBAL
 const STB_WEAK = elf.STB_WEAK
@@ -52,6 +63,7 @@ const STT_FILE = elf.STT_FILE
 const SHN_UNDEF = elf.SHN_UNDEF
 const SHF_WRITE = elf.SHF_WRITE
 const SHT_NOBITS = elf.SHT_NOBITS
+const SHT_PROGBITS = elf.SHT_PROGBITS
 const SHN_ABS = elf.SHN_ABS
 const SHN_COMMON = elf.SHN_COMMON
 

--- a/tools/host-profiler/extract_symbols/main.go
+++ b/tools/host-profiler/extract_symbols/main.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbol"
+	"github.com/DataDog/datadog-agent/comp/host-profiler/symboluploader/symbolcopier"
+)
+
+func extractDebugInfos(elfFile, outFile string) error {
+	ef, err := symbol.NewElfFromDisk(elfFile)
+	if err != nil {
+		return fmt.Errorf("failed to open elf file: %w", err)
+	}
+	defer ef.Close()
+
+	goPCLnTabInfo, err := ef.GoPCLnTab()
+	if ef.IsGolang() {
+		if err != nil {
+			return fmt.Errorf("failed to find pclntab: %w", err)
+		}
+
+		fmt.Printf("Found GoPCLnTab at 0x%x, size %d, headerVersion: %v\n", goPCLnTabInfo.Address, len(goPCLnTabInfo.Data), goPCLnTabInfo.Version.String())
+		fmt.Printf("Found GoFunc at 0x%x, size %d\n", goPCLnTabInfo.GoFuncAddr, len(goPCLnTabInfo.GoFuncData))
+	}
+
+	var sectionsToKeep []symbol.SectionInfo
+	if ef.SymbolSource() == symbol.SourceDynamicSymbolTable {
+		sectionsToKeep = ef.GetSectionsRequiredForDynamicSymbols()
+	}
+
+	return symbolcopier.CopySymbols(context.Background(), elfFile, outFile, goPCLnTabInfo, sectionsToKeep, symboluploader.CheckObjcopyZstdSupport(context.Background()))
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Printf("Usage: %s <elf-file> <debug-file>\n", os.Args[0])
+		return
+	}
+
+	elfFile := os.Args[1]
+	outFile := os.Args[2]
+
+	err := extractDebugInfos(elfFile, outFile)
+
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tools/host-profiler/extract_symbols/main.go
+++ b/tools/host-profiler/extract_symbols/main.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+// Package main provides a tool to extract debug symbols from ELF files.
 package main
 
 import (


### PR DESCRIPTION
### What does this PR do?

This PR removes the external dependency on dd-otel-host-profiler by importing the symboluploader code directly into the datadog-agent repository under `comp/host-profiler/symboluploader`.

### Motivation

dd-otel-host-profiler is going to be deprecated and all development for host-profiler is now going to happen in datadog-agent and opentelemetry-ebpf-profiler.

### Describe how you validated your changes

Ran the profiler and verified that symbol files are uploaded successfully.