### PR TITLE
discovery: Only enable by default for Linux

### DIFF
--- a/pkg/system-probe/config/config.go
+++ b/pkg/system-probe/config/config.go
@@ -199,10 +199,16 @@ func load() (*types.Config, error) {
 		}
 	}
 
-	// Enable discovery by default if system-probe has any modules enabled,
-	// unless the user has explicitly configured the discovery.enabled config
-	// key.
-	if len(c.EnabledModules) > 0 &&
+	// Enable discovery by default on Linux if system-probe has any modules
+	// enabled, unless the user has explicitly configured the discovery.enabled
+	// config key.
+	//
+	// Note that besides the support in system-probe itself (currently only
+	// implemented on Linux), the WorkloadMeta-based process collector in the
+	// core agent needs to be supported on the platform for discovery to work
+	// correctly.
+	if runtime.GOOS == "linux" &&
+		len(c.EnabledModules) > 0 &&
 		!c.ModuleIsEnabled(DiscoveryModule) &&
 		applyDefault(cfg, discoveryNS("enabled"), true) {
 		c.EnabledModules[DiscoveryModule] = struct{}{}

--- a/pkg/system-probe/config/config_test.go
+++ b/pkg/system-probe/config/config_test.go
@@ -86,6 +86,8 @@ func TestEnableDiscovery(t *testing.T) {
 		assert.False(t, cfg.GetBool(discoveryNS("enabled")))
 	})
 
+	discoveryDefaultEnabled := runtime.GOOS == "linux"
+
 	t.Run("default enabled with USM", func(t *testing.T) {
 		// Reset global config to avoid test interference
 		_ = mock.NewSystemProbe(t)
@@ -94,7 +96,7 @@ func TestEnableDiscovery(t *testing.T) {
 
 		cfg, err := New("", "")
 		require.NoError(t, err)
-		assert.True(t, cfg.ModuleIsEnabled(DiscoveryModule))
+		assert.Equal(t, discoveryDefaultEnabled, cfg.ModuleIsEnabled(DiscoveryModule))
 	})
 
 	t.Run("default enabled with NPM", func(t *testing.T) {
@@ -105,7 +107,7 @@ func TestEnableDiscovery(t *testing.T) {
 
 		cfg, err := New("", "")
 		require.NoError(t, err)
-		assert.True(t, cfg.ModuleIsEnabled(DiscoveryModule))
+		assert.Equal(t, discoveryDefaultEnabled, cfg.ModuleIsEnabled(DiscoveryModule))
 	})
 
 	t.Run("force disabled with USM via env var", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The discovery module is currently only implemented for Linux so only
enable the option by default there.

While enabling the configuration option without an implemented module
doesn't actually cause any negative effects in system-probe itself,
there is an issue with interaction with the core agent code which checks
the same configuration option:

| In the case where live process collection is disabled but discovery is
| enabled, the process check, via the process collector (which uses WLM)
| takes care of only collecting process which are identified as services
| by the discovery system-probe module. This works when the process check
| gets the process list from WLM.
|
| Howver, on non-Linux platforms, the process collector is not used, and
| the process check gets the process list directly from the system. WLM is
| not used for storing process data. So, the discovery is
| actually not supported in this case.
|
| The code fails to account for this, and currently, if discovery.enabled
| is true on a non-Linux platform, the process check reports information
| for all processes.

This can be fixed in different ways (alternative: https://github.com/DataDog/datadog-agent/pull/45748),
here we just limit the enabling by default to Linux.

### Motivation

Unexpected behaviour on Windows.

### Describe how you validated your changes

Tests updated.
