### PR TITLE
Fix bad usage of `EventuallyWithT` in `TestAdmissionController` e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1247,14 +1247,14 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 	// libraries for the detected language are injected
 	if languageShouldBeAutoDetected {
 
-		suite.Require().EventuallyWithTf(func(_ *assert.CollectT) {
+		suite.Require().EventuallyWithTf(func(c *assert.CollectT) {
 			appPod, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("workload-mutated-lib-injection").List(ctx, metav1.ListOptions{
 				LabelSelector: fields.OneTermEqualSelector("app", name).String(),
 				Limit:         1,
 			})
 
-			suite.Require().NoError(err)
-			suite.Require().Len(appPod.Items, 1)
+			require.NoError(c, err)
+			require.Len(c, appPod.Items, 1)
 
 			nodeName := appPod.Items[0].Spec.NodeName
 
@@ -1264,27 +1264,21 @@ func (suite *k8sSuite) testAdmissionControllerPod(namespace string, name string,
 				Limit:         1,
 			})
 
-			suite.Require().NoError(err)
-			suite.Require().Len(agentPod.Items, 1)
+			require.NoError(c, err)
+			require.Len(c, agentPod.Items, 1)
 
 			stdout, _, err := suite.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agentPod.Items[0].Name, "agent", []string{"agent", "workload-list", "-v"})
-			suite.Require().NoError(err)
-			suite.Contains(stdout, "Language: python")
-			if suite.T().Failed() {
+			require.NoError(c, err)
+			if !assert.Contains(c, stdout, "Language: python") {
 				suite.T().Log(stdout)
 			}
 		}, 5*time.Minute, 10*time.Second, "Language python was never detected by node agent.")
 
 		suite.Require().EventuallyWithTf(func(c *assert.CollectT) {
 			deployment, err := suite.Env().KubernetesCluster.Client().AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
-			if !assert.NoError(c, err) {
-				c.Errorf("deployment with name %s in namespace %s not found", name, namespace)
-				return
-			}
+			require.NoErrorf(c, err, "deployment with name %s in namespace %s not found", name, namespace)
 
-			if deployment.Status.AvailableReplicas == 0 {
-				c.Errorf("deployment with name %s in namespace %s has 0 available replicas", name, namespace)
-			}
+			assert.NotZerof(c, deployment.Status.AvailableReplicas, "deployment with name %s in namespace %s has 0 available replicas", name, namespace)
 
 			detectedLangsLabelIsSet := false
 			detectedLangsAnnotationRegex := regexp.MustCompile(`^internal\.dd\.datadoghq\.com/.*\.detected_langs$`)


### PR DESCRIPTION
### What does this PR do?

Fix a bad usage of `require.EventuallyWithT(…)` in the `testAdmissionControllerPod` e2e test.
`require.EventuallyWithT(…)` is normally used to retry a task until it succeeds or times out.
But the use of `suite.Require()` inside the function made the test fail immediately in case of assertion failure.
In order to benefit from the retry mechanism of `EventuallyWithT`, errors must be collected in the `CollectT` param instead.

### Motivation

[Test `TestAdmissionControllerWithAutoDetectedLanguage` is currently very flaky.](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3ATestKindSuite%2FTestAdmissionControllerWithAutoDetectedLanguage&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%3A471%2C%40duration%3A144%2C%40test.service%3A135%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&index=citest&mode=sliding&saved-view-id=2236559&start=1769598672135&end=1770203472135&paused=false)

### Describe how you validated your changes

Wait for the CI to execute e2e tests.

### Additional Notes
