### PR TITLE
Add remote_agent label to logs.bytes_sent telemetry, including support for system-probe

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -222,6 +222,9 @@ var defaultProfiles = `
         - name: dogstatsd.uds_packets_bytes
         - name: logs.bytes_missed
         - name: logs.bytes_sent
+          aggregate_tags:
+            - remote_agent
+          aggregate_total: true
         - name: logs.decoded
         - name: logs.dropped
         - name: logs.encoded_bytes_sent

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
@@ -50,6 +51,10 @@ func NewComponent(reqs Requires) (Provides, error) {
 		return Provides{}, err
 	}
 
+	// Set the agent identity for log metrics partitioning so that
+	// logs.bytes_sent is tagged with remote_agent="system-probe".
+	metrics.SetAgentIdentity("system-probe")
+
 	remoteagentImpl := &remoteagentImpl{
 		log:               reqs.Log,
 		ipc:               reqs.IPC,
@@ -79,10 +84,8 @@ type remoteagentImpl struct {
 
 func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetryRequest) (*pbcore.GetTelemetryResponse, error) {
 	prometheusText, err := r.telemetry.GatherText(false, telemetry.StaticMetricFilter(
-		// Add here the metric names that should be included in the telemetry response.
-		// This is useful to avoid sending too many metrics to the Core Agent.
-
-		// Logs metrics (the remote_agent tag is set to "system-probe" via metrics.GetAgentIdentityTag())
+		// Metrics to forward from system-probe to core agent.
+		// The remote_agent tag is set to "system-probe" via metrics.SetAgentIdentity() above.
 		"logs__bytes_sent",
 
 		// Windows Injector metrics (using double underscore format from telemetry component)

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -82,6 +82,9 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 		// Add here the metric names that should be included in the telemetry response.
 		// This is useful to avoid sending too many metrics to the Core Agent.
 
+		// Logs metrics (the remote_agent tag is set to "system-probe" via metrics.GetAgentIdentityTag())
+		"logs__bytes_sent",
+
 		// Windows Injector metrics (using double underscore format from telemetry component)
 		"injector__processes_added_to_injection_tracker",
 		"injector__processes_removed_from_injection_tracker",

--- a/comp/core/remoteagentregistry/impl/services.go
+++ b/comp/core/remoteagentregistry/impl/services.go
@@ -157,10 +157,24 @@ func collectFromPromText(ch chan<- prometheus.Metric, promText string, remoteAge
 				continue
 			}
 
+			// Check if the metric already has a remote_agent label.
+			// With explicit agent identity, metrics should already have the correct value.
+			// We only add the label if it's missing (for backward compatibility).
+			hasRemoteAgentLabel := false
+			for _, label := range metric.Label {
+				if *label.Name == remoteAgentMetricTagName {
+					hasRemoteAgentLabel = true
+					break
+				}
+			}
+
 			labelNames := make([]string, 0, len(metric.Label)+1)
 			labelValues := make([]string, 0, len(metric.Label)+1)
-			labelNames = append(labelNames, remoteAgentMetricTagName)
-			labelValues = append(labelValues, remoteAgentName)
+			// Only add remote_agent label if the metric doesn't already have one
+			if !hasRemoteAgentLabel {
+				labelNames = append(labelNames, remoteAgentMetricTagName)
+				labelValues = append(labelValues, remoteAgentName)
+			}
 			for _, label := range metric.Label {
 				labelNames = append(labelNames, *label.Name)
 				labelValues = append(labelValues, *label.Value)

--- a/comp/core/remoteagentregistry/impl/services.go
+++ b/comp/core/remoteagentregistry/impl/services.go
@@ -9,6 +9,7 @@ package remoteagentregistryimpl
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -160,13 +161,9 @@ func collectFromPromText(ch chan<- prometheus.Metric, promText string, remoteAge
 			// Check if the metric already has a remote_agent label.
 			// With explicit agent identity, metrics should already have the correct value.
 			// We only add the label if it's missing (for backward compatibility).
-			hasRemoteAgentLabel := false
-			for _, label := range metric.Label {
-				if *label.Name == remoteAgentMetricTagName {
-					hasRemoteAgentLabel = true
-					break
-				}
-			}
+			hasRemoteAgentLabel := slices.ContainsFunc(metric.Label, func(label *dto.LabelPair) bool {
+				return *label.Name == remoteAgentMetricTagName
+			})
 
 			labelNames := make([]string, 0, len(metric.Label)+1)
 			labelValues := make([]string, 0, len(metric.Label)+1)

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -331,7 +331,8 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 		sourceTag = "epforwarder"
 	}
 
-	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
+	// Use GetAgentIdentityTag() to identify which agent is sending logs
+	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), metrics.GetAgentIdentityTag(), sourceTag)
 	metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
 	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -689,7 +689,7 @@ func TestDestinationSourceTagBasedOnTelemetryName(t *testing.T) {
 
 	// Create telemetry mock
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
-	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"source"}, "")
+	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"remote_agent", "source"}, "")
 	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"source", "compression_kind"}, "")
 
 	// Create a new server
@@ -712,6 +712,7 @@ func TestDestinationSourceTagBasedOnTelemetryName(t *testing.T) {
 	metric, err := telemetryMock.(telemetry.Mock).GetCountMetric("logs", "bytes_sent")
 	assert.NoError(t, err)
 	assert.Len(t, metric, 1)
+	assert.Equal(t, "agent", metric[0].Tags()["remote_agent"]) // "agent" for core agent (via GetAgentIdentityTag)
 	assert.Equal(t, "logs", metric[0].Tags()["source"])
 
 	metric, err = telemetryMock.(telemetry.Mock).GetCountMetric("logs", "encoded_bytes_sent")
@@ -726,7 +727,7 @@ func TestDestinationSourceTagEPForwarder(t *testing.T) {
 
 	// Create telemetry mock
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
-	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"source"}, "")
+	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"remote_agent", "source"}, "")
 	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"source", "compression_kind"}, "")
 
 	// Create a new server
@@ -748,6 +749,7 @@ func TestDestinationSourceTagEPForwarder(t *testing.T) {
 	metric, err := telemetryMock.(telemetry.Mock).GetCountMetric("logs", "bytes_sent")
 	assert.NoError(t, err)
 	assert.Len(t, metric, 1)
+	assert.Equal(t, "agent", metric[0].Tags()["remote_agent"]) // "agent" for core agent (via GetAgentIdentityTag)
 	assert.Equal(t, "epforwarder", metric[0].Tags()["source"])
 
 	metric, err = telemetryMock.(telemetry.Mock).GetCountMetric("logs", "encoded_bytes_sent")

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -130,7 +130,8 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 		// Default Compression for TCP is none
 		compressionKind := "none"
 
-		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
+		// Use GetAgentIdentityTag() to identify which agent is sending logs
+		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), metrics.GetAgentIdentityTag(), sourceTag)
 		metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
 		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 		output <- payload

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -10,7 +10,6 @@ import (
 	"expvar"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 var (
@@ -157,25 +156,19 @@ func init() {
 	LogsExpvars.Set("LogsTruncated", &LogsTruncated)
 }
 
-// GetAgentIdentityTag returns the appropriate remote_agent tag value for the current agent.
-// This should be used when recording metrics that need to be partitioned by agent type.
-// Returns values like "agent", "system-probe", "trace-agent", etc.
+// agentIdentityTag holds the remote_agent tag value for this agent process.
+// It must be set once at startup via SetAgentIdentity before any log sending occurs.
+var agentIdentityTag = "agent"
+
+// SetAgentIdentity sets the remote_agent tag value for the current agent process.
+// This must be called once during agent startup, before any logs are sent.
+// Example values: "agent", "system-probe", "trace-agent", etc.
+func SetAgentIdentity(tag string) {
+	agentIdentityTag = tag
+}
+
+// GetAgentIdentityTag returns the remote_agent tag value for the current agent process.
+// The value is set at startup via SetAgentIdentity and defaults to "agent".
 func GetAgentIdentityTag() string {
-	switch flavor.GetFlavor() {
-	case flavor.DefaultAgent:
-		return "agent"
-	case flavor.SystemProbe:
-		return "system-probe"
-	case flavor.TraceAgent:
-		return "trace-agent"
-	case flavor.ProcessAgent:
-		return "process-agent"
-	case flavor.SecurityAgent:
-		return "security-agent"
-	case flavor.ClusterAgent:
-		return "cluster-agent"
-	default:
-		// For unknown flavors, return the raw flavor string
-		return flavor.GetFlavor()
-	}
+	return agentIdentityTag
 }

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -45,8 +45,11 @@ var (
 	// BytesSent is the total number of sent bytes before encoding if any
 	BytesSent = expvar.Int{}
 	// TlmBytesSent is the total number of sent bytes before encoding if any
+	// The remote_agent tag identifies which agent sent the logs. Use GetAgentIdentityTag()
+	// to get the correct value for the current agent. This tag is used by COAT to partition
+	// log bytes by agent type.
 	TlmBytesSent = telemetry.NewCounter("logs", "bytes_sent",
-		[]string{"source"}, "Total number of bytes sent before encoding if any")
+		[]string{"remote_agent", "source"}, "Total number of bytes sent before encoding if any")
 	// RetryCount is the total number of times we have retried payloads that failed to send
 	RetryCount = expvar.Int{}
 	// TlmRetryCount is the total number of times we have retried payloads that failed to send

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -158,6 +158,11 @@ func init() {
 
 // agentIdentityTag holds the remote_agent tag value for this agent process.
 // It must be set once at startup via SetAgentIdentity before any log sending occurs.
+//
+// This mirrors the pattern used by pkg/util/flavor (SetFlavor/GetFlavor) rather than
+// importing it directly, because importing flavor would pull in pkg/config/model and
+// pkg/config/setup, significantly widening the dependency graph for the 40+ files that
+// import pkg/logs/metrics.
 var agentIdentityTag = "agent"
 
 // SetAgentIdentity sets the remote_agent tag value for the current agent process.

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 	"expvar"
 
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 var (
@@ -151,4 +152,27 @@ func init() {
 	LogsExpvars.Set("SenderLatency", &SenderLatency)
 	LogsExpvars.Set("HttpDestinationStats", &DestinationExpVars)
 	LogsExpvars.Set("LogsTruncated", &LogsTruncated)
+}
+
+// GetAgentIdentityTag returns the appropriate remote_agent tag value for the current agent.
+// This should be used when recording metrics that need to be partitioned by agent type.
+// Returns values like "agent", "system-probe", "trace-agent", etc.
+func GetAgentIdentityTag() string {
+	switch flavor.GetFlavor() {
+	case flavor.DefaultAgent:
+		return "agent"
+	case flavor.SystemProbe:
+		return "system-probe"
+	case flavor.TraceAgent:
+		return "trace-agent"
+	case flavor.ProcessAgent:
+		return "process-agent"
+	case flavor.SecurityAgent:
+		return "security-agent"
+	case flavor.ClusterAgent:
+		return "cluster-agent"
+	default:
+		// For unknown flavors, return the raw flavor string
+		return flavor.GetFlavor()
+	}
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds agent-type partitioning to the logs.bytes_sent telemetry metric by introducing a remote_agent tag that explicitly identifies which agent (core agent, system-probe, etc.) is sending logs.

### Motivation

Currently, COAT reports logs.bytes_sent as a single aggregated metric without distinguishing which agent process is sending logs. With system-probe now capable of sending logs independently, we need visibility into:

  - How much log data the core agent is sending
  - How much log data system-probe is sending
  - Potential future partitioning for other agent flavors (trace-agent, process-agent, etc.)

This partitioning enables better monitoring, debugging, and capacity planning for log pipelines across different agent components.

### Describe how you validated your changes

 1. Unit tests: All existing tests pass, including updated assertions in pkg/logs/client/http/destination_test.go that verify the remote_agent tag is correctly set to "agent" for core agent metrics.
  2. Local VM testing: Built and ran both core agent and system-probe, verified metrics via Prometheus endpoints:

  System-probe (port 6666)
  logs__bytes_sent{remote_agent="system-probe",source="logs"}

  Core agent (port 5002) - consolidated view
  logs__bytes_sent{remote_agent="agent",source="epforwarder"}
  logs__bytes_sent{remote_agent="agent",source="logs"}
  logs__bytes_sent{remote_agent="system-probe",source="logs"}
  3. COAT verification: Confirmed COAT successfully collects and sends payloads (202 Accepted responses)

### Additional Notes