### PR TITLE
Revert "Remove http_batch_flush from uprobe to avoid race condition (#38749)"

### DIFF
--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -263,6 +263,7 @@ int uprobe__http_process(struct pt_regs *ctx) {
     bpf_memcpy(&event.tuple, &args->tup, sizeof(conn_tuple_t));
     read_into_user_buffer_http(event.http.request_fragment, args->buffer_ptr);
     http_process(&event, NULL, args->tags);
+    http_batch_flush(ctx);
 
     return 0;
 }
@@ -281,6 +282,7 @@ int uprobe__http_termination(struct pt_regs *ctx) {
     skb_info_t skb_info = {0};
     skb_info.tcp_flags |= TCPHDR_FIN;
     http_process(&event, &skb_info, NO_TAGS);
+    http_batch_flush(ctx);
 
     return 0;
 }


### PR DESCRIPTION
### What does this PR do?
Reverts #38749 on top of 7.70.x to reintroduce `http_batch_flush` in both HTTP uprobes.

### Motivation
Restore the prior batching behavior on 7.70.x that was removed by #38749.

### Describe how you validated your changes
- Not run (revert-only change)

### Possible Drawbacks / Trade-offs
Reintroduces the race-condition risk that #38749 attempted to mitigate.

### Additional Notes
None.
