### PR TITLE
[ACTP] retrieve hostname through agent remote hostname component

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -9,6 +9,7 @@ package run
 import (
 	"errors"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -61,6 +62,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					}
 				}),
 				settingsimpl.Module(),
+				remotehostnameimpl.Module(),
 				ipcfx.ModuleReadWrite(),
 				rcserviceimpl.Module(),
 				rcclientimpl.Module(),

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
@@ -26,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/runners"
 	taskverifier "github.com/DataDog/datadog-agent/pkg/privateactionrunner/task-verifier"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 )
 
 // isEnabled checks if the private action runner is enabled in the configuration
@@ -40,6 +40,7 @@ type Requires struct {
 	Log       log.Component
 	Lifecycle compdef.Lifecycle
 	RcClient  rcclient.Component
+	Hostname  hostname.Component
 }
 
 // Provides defines the output of the privateactionrunner component
@@ -76,7 +77,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	canSelfEnroll := reqs.Config.GetBool("privateactionrunner.self_enroll")
 	if cfg.IdentityIsIncomplete() && canSelfEnroll {
 		reqs.Log.Info("Identity not found and self-enrollment enabled. Self-enrolling private action runner")
-		updatedCfg, err := performSelfEnrollment(reqs.Log, reqs.Config, cfg)
+		updatedCfg, err := performSelfEnrollment(reqs.Log, reqs.Config, reqs.Hostname, cfg)
 		if err != nil {
 			return Provides{}, fmt.Errorf("self-enrollment failed: %w", err)
 		}
@@ -133,13 +134,12 @@ func (p *privateactionrunnerImpl) Stop(ctx context.Context) error {
 }
 
 // performSelfEnrollment handles the self-registration of a private action runner
-func performSelfEnrollment(log log.Component, ddConfig config.Component, cfg *parconfig.Config) (*parconfig.Config, error) {
+func performSelfEnrollment(log log.Component, ddConfig config.Component, hostnameComp hostnameinterface.Component, cfg *parconfig.Config) (*parconfig.Config, error) {
 	ddSite := ddConfig.GetString("site")
 	apiKey := ddConfig.GetString("api_key")
 	appKey := ddConfig.GetString("app_key")
 
-	env.DetectFeatures(ddConfig)
-	runnerHostname, err := hostname.Get(context.Background())
+	runnerHostname, err := hostnameComp.Get(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -37,7 +37,7 @@ type PersistedIdentity struct {
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
-func SelfEnroll(ddSite, runnerName, apiKey, appKey string) (*Result, error) {
+func SelfEnroll(ctx context.Context, ddSite, runnerName, apiKey, appKey string) (*Result, error) {
 	privateJwk, publicJwk, err := util.GenerateKeys()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key pair: %w", err)
@@ -46,7 +46,6 @@ func SelfEnroll(ddSite, runnerName, apiKey, appKey string) (*Result, error) {
 	ddBaseURL := "https://api." + ddSite
 	publicClient := opms.NewPublicClient(ddBaseURL)
 
-	ctx := context.Background()
 	runnerModes := []modes.Mode{modes.ModePull}
 
 	createRunnerResponse, err := publicClient.EnrollWithApiKey(


### PR DESCRIPTION
### What does this PR do?

Retrieve the hostname by using the agent remote hostname component

### Motivation

This is required by the node agent component (see https://github.com/DataDog/datadog-operator/pull/2516#discussion_r2758138997)

### Describe how you validated your changes

Ran self enrollment from a PAR with a running agent. I'll also test it in the context of the datadog operator
Edit : tested by building a local version of the operator and deploying it locally

### Additional Notes