### PR TITLE
docs: update `tegrastats_path` requirements in the Jetson config example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -220,7 +220,7 @@
 /cmd/agent/dist/conf.d/container_image.d/      @DataDog/container-integrations
 /cmd/agent/dist/conf.d/container_lifecycle.d/  @DataDog/container-integrations
 /cmd/agent/dist/conf.d/discovery.d/          @DataDog/agent-discovery
-/cmd/agent/dist/conf.d/jetson.d/        @DataDog/agent-devx
+/cmd/agent/dist/conf.d/jetson.d/        @DataDog/agent-runtimes
 /cmd/agent/dist/conf.d/oracle.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/network_path.d/ @DataDog/cloud-network-monitoring @DataDog/network-path

--- a/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/jetson.d/conf.yaml.example
@@ -6,7 +6,8 @@ instances:
 
   -
     ## @param tegrastats_path - string - optional
-    ## Path to the tegrastats binary.
+    ## Path to the tegrastats binary. Must be an absolute path containing
+    ## only valid Linux path characters.
     ## Defaults to `/usr/bin/tegrastats`
     #
     # tegrastats_path: <PATH_TO_TEGRASTATS_UTILITY>


### PR DESCRIPTION
Follow-up of:
- https://github.com/DataDog/datadog-agent/pull/45057

### What does this PR do?

Update the configuration example of the Jetson check to match the new requirements

Change code owners of the Jetson configuration example to Agent Runtimes since the check implementation is already owned by Agent Runtimes.

### Motivation

Match configuration example with the check implementation

### Describe how you validated your changes

### Additional Notes
