### PR TITLE
deps: fix python rpath patching

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -22,10 +22,11 @@ build do
   if !windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
     command_on_repo_root "bazelisk run -- @cpython//:install --destdir='#{install_dir}/embedded'"
-    sh_lib = if linux_target? then "libpython3.so" else "libpython3.13.dylib" end
+    sh_ext = if linux_target? then "so" else "dylib" end
     command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
       " #{install_dir}/embedded/lib/pkgconfig/python*.pc" \
-      " #{install_dir}/embedded/lib/#{sh_lib}" \
+      " #{install_dir}/embedded/lib/libpython3.#{sh_ext}" \
+      " #{install_dir}/embedded/lib/libpython3.13.#{sh_ext}" \
       " #{install_dir}/embedded/lib/python3.13/lib-dynload/*.so" \
       " #{install_dir}/embedded/bin/python3*"
   elsif fips_mode?

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -25,8 +25,7 @@ build do
     sh_ext = if linux_target? then "so" else "dylib" end
     command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
       " #{install_dir}/embedded/lib/pkgconfig/python*.pc" \
-      " #{install_dir}/embedded/lib/libpython3.#{sh_ext}" \
-      " #{install_dir}/embedded/lib/libpython3.13.#{sh_ext}" \
+      " #{install_dir}/embedded/lib/libpython3.*#{sh_ext}" \
       " #{install_dir}/embedded/lib/python3.13/lib-dynload/*.so" \
       " #{install_dir}/embedded/bin/python3*"
   elsif fips_mode?


### PR DESCRIPTION
### What does this PR do?

 libpython3.so and libpython3.13.so are different libraries, which both need to be patched in order to have the correct rpath value. During the migration, we overlooked this and only patched one or the other; libpython3.so on linux, libpython3.13.dylib on macOS. 

### Motivation

This PR ensures we patch both in order to restore the correct shared libraries loading path for both

#incident-48947

### Describe how you validated your changes

`readelf` to inspect the patched binaries after a local omnibus build

Before:
```
readelf -d /tmp/libpython3.13.so

Dynamic section at offset 0x49cc60 contains 33 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libutil.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libpython3.13.so.1.0]
 0x000000000000000f (RPATH)              Library rpath: [/root/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/sandbox/processwrapper-sandbox/134/execroot/_main/bazel-out/k8-fastbuild/bin/external/+_repo_rules+cpython/python_unix.ext_build_deps/lib]
```

After:
```
readelf -d /tmp/opt/datadog-agent/embedded/lib/libpython3.13.so

Dynamic section at offset 0x49cc60 contains 33 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libutil.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
 0x000000000000000e (SONAME)             Library soname: [libpython3.13.so.1.0]
 0x000000000000001d (RUNPATH)            Library runpath: [/opt/datadog-agent/embedded/lib]
```

### Additional Notes
