### PR TITLE
bazel: force usage of DT_RPATH instead of DT_RUNPATH

### DIFF
--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -45,7 +45,7 @@ for f in "$@"; do
             ;;
         *)
             if file "$f" | grep -q ELF; then
-                ${PATCHELF} --set-rpath "$PREFIX"/lib "$f"
+                ${PATCHELF} --force-rpath --set-rpath "$PREFIX"/lib "$f"
             elif file "$f" | grep -q "Mach-O"; then
                 # Handle macOS binaries (executables and other Mach-O files)
                 install_name_tool -add_rpath "$PREFIX/lib" "$f" 2>/dev/null || true


### PR DESCRIPTION
### What does this PR do?

This ensures we get the same behavior as the omnibus builds which was using `-Wl,-rpath`

### Motivation

While DT_RPATH is deprecated and we'll need to move away frot it eventually, this also ensure that we use our rpath value *before* probing LD_LIBRARY_PATH.
From man ld.so(8)
> If a shared object dependency does not contain a slash, then it is
> searched for in the following order:
> (1) Using the directories specified in the DT_RPATH dynamic section
> attribute of the binary if present and DT_RUNPATH attribute does not
> exist.
> (2)  Using the environment variable LD_LIBRARY_PATH

[#incident-48947](https://dd.enterprise.slack.com/archives/C0ACLT30486)

### Describe how you validated your changes

before:
```
objdump -x /tmp/opt/datadog-agent/embedded/lib/libpython3.so | grep PATH
  RUNPATH              /opt/datadog-agent/embedded/lib
```

after:
```
objdump -x /tmp/opt/datadog-agent/embedded/lib/libpython3.13.so | grep PATH
  RPATH                /root/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/sandbox/processwrapper-sandbox/132/execroot/_main/bazel-out/k8-fastbuild/bin/external/+_repo_rules+cpython/python_unix.ext_build_deps/lib
```

### Additional Notes
