### PR TITLE
Force removal of `/tmp/gitlabci` on macOS runners

### DIFF
--- a/.gitlab/.pre/common/macos.yml
+++ b/.gitlab/.pre/common/macos.yml
@@ -27,7 +27,7 @@
   - |
     export TMPDIR=/tmp/gitlabci
     NEWTMPDIR="$RUNNER_TEMP_PROJECT_DIR/gitlabci"
-    rm -fr "$(realpath $TMPDIR)" "$NEWTMPDIR"
+    sudo rm -fr "$(realpath $TMPDIR)" "$NEWTMPDIR"
     mkdir "$NEWTMPDIR"
     sudo ln -fs "$NEWTMPDIR" $TMPDIR
     echo "Temporary folder created, TMPDIR=$TMPDIR -> $NEWTMPDIR"


### PR DESCRIPTION
### Motivation
Started seeing occurrences of:
```
$ export TMPDIR=/tmp/gitlabci
rm: /Users/ec2-user/builds/[...]/0/DataDog/datadog-agent.tmp/gitlabci: Permission denied
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1400027162))

### Additional Notes
Not sure yet why the folder changed permissions.