### PR TITLE
Fix flakey Stringify method by holding references

### DIFF
--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -1099,21 +1099,6 @@ func TestUnsetForSource(t *testing.T) {
         leaf(#ptr<000006>), val:6, source:file`
 	assert.Equal(t, expect, txt)
 
-	// [AGENTCFG-314] Prevent the test from being flakey.
-	// This keeps a reference to the node for `input_chan_size`, which helps prevent
-	// an edge case that can cause this test to fail on rare occasions.
-	// Because UnsetForSource removes nodes, and we allocate more nodes later in this
-	// test, if the GC timing is right, it's possible that a future node reuses the
-	// same address as this node. Since the Stringifier caches node addresses in order
-	// to determine their unique ID, this address reuse would cause it to get confused
-	// and reuse the ID of `input_chan_size`. By holding this reference we prevent the
-	// reuse of this node's address, and prevent this edge case from occurring.
-	var keepNode Node
-	if ncfg, ok := cfg.(NodeTreeConfig); ok {
-		keepNode, _ = ncfg.GetNode("network_path.collector.input_chan_size")
-	}
-	assert.NotNil(t, keepNode)
-
 	// No change if source doesn't match
 	cfg.UnsetForSource("network_path.collector.input_chan_size", model.SourceFile)
 	assert.Equal(t, expect, txt)

--- a/pkg/config/nodetreemodel/debug_string_testonly.go
+++ b/pkg/config/nodetreemodel/debug_string_testonly.go
@@ -76,8 +76,12 @@ func (c *ntmConfig) toDebugString(source model.Source, opts ...model.StringifyOp
 }
 
 type ptrCount struct {
+	// Pointer ID, monotomically increasing number for each pointer observed by the stringifier
 	key int
+	// How many times a pointer appears, only used by option `DedupPointerAddr`
 	num int
+	// Hold a reference to the object, prevents GC from removing it and reusing addresses
+	ref interface{}
 }
 
 type treeDebugger struct {
@@ -195,6 +199,7 @@ func (d *treeDebugger) makePointer(object interface{}) string {
 			d.seenPtrs[ptr] = &ptrCount{
 				key: len(d.seenPtrs),
 				num: 0,
+				ref: object,
 			}
 			d.seenPtrOrder = append(d.seenPtrOrder, ptr)
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes the flakey tests `TestSetWhenMerged` and `TestUnsetForSource` (previously fixed by a different approach). Both tests use Stringify and remove nodes during their run. This means the GC, depending upon when it runs, may affect the behavior of Stringify by causing previously observed addresses to get reused. This PR changes Stringify to hold references to the objects that it prints, thereby removing the affect that the GC would otherwise have.

### Motivation

Fix flakey tests.

### Describe how you validated your changes

### Additional Notes
