### PR TITLE
Fix data race in GUI intent token handling

### DIFF
--- a/comp/core/gui/guiimpl/gui.go
+++ b/comp/core/gui/guiimpl/gui.go
@@ -154,7 +154,7 @@ func newGui(deps dependencies) provides {
 		OnStart: g.start,
 		OnStop:  g.stop})
 
-	p.Comp = option.New[guicomp.Component](g)
+	p.Comp = option.New[guicomp.Component](&g)
 	p.Endpoint = api.NewAgentEndpointProvider(g.getIntentToken, "/gui/intent", "GET")
 
 	return p

--- a/comp/core/gui/guiimpl/gui.go
+++ b/comp/core/gui/guiimpl/gui.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"time"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
@@ -56,6 +57,7 @@ type gui struct {
 
 	auth         authenticator
 	intentTokens map[string]bool
+	intentMu     sync.Mutex
 
 	// To compute uptime
 	startTimestamp int64
@@ -187,10 +189,13 @@ func (g *gui) getIntentToken(w http.ResponseWriter, _ *http.Request) {
 	key := make([]byte, 32)
 	_, e := rand.Read(key)
 	if e != nil {
-		http.Error(w, e.Error(), 500)
+		http.Error(w, e.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	token := base64.RawURLEncoding.EncodeToString(key)
+	g.intentMu.Lock()
+	defer g.intentMu.Unlock()
 	g.intentTokens[token] = true
 	w.Write([]byte(token))
 }
@@ -258,18 +263,19 @@ func (g *gui) getAccessToken(w http.ResponseWriter, r *http.Request) {
 	// intentToken is present in the query when the GUI is opened from the CLI
 	intentToken := r.URL.Query().Get("intent")
 	if intentToken == "" {
-		w.WriteHeader(http.StatusUnauthorized)
-		http.Error(w, "missing intentToken", 401)
+		http.Error(w, "missing intentToken", http.StatusUnauthorized)
 		return
 	}
-	if _, ok := g.intentTokens[intentToken]; !ok {
-		w.WriteHeader(http.StatusUnauthorized)
-		http.Error(w, "invalid intentToken", 401)
+	g.intentMu.Lock()
+	_, ok := g.intentTokens[intentToken]
+	if !ok {
+		g.intentMu.Unlock()
+		http.Error(w, "invalid intentToken", http.StatusUnauthorized)
 		return
 	}
-
-	// Remove single use token from map
+	// Remove single use token from map (atomic with validation)
 	delete(g.intentTokens, intentToken)
+	g.intentMu.Unlock()
 
 	// generate accessToken
 	accessToken := g.auth.GenerateAccessToken()


### PR DESCRIPTION
### What does this PR do?
The GUI uses in-memory, single-use `intentTokens` to authenticate browser access when launching the GUI from the CLI. These tokens are generated via the Agent CMD API (`/agent/gui/intent`) and later validated by the GUI HTTP server (`/auth`).

Both endpoints can be hit concurrently, but access to intentTokens was previously unsynchronized. As such, we added a `sync.Mutex` to protect the `intentTokens` map, and ensured that token validation and deletion happen atomically.

### Motivation

We received an issue where a user ran a fresh installation of the agent on my mac laptop, and got an invalid intentToken error when trying to open the web ui:
<img width="1482" height="280" alt="image" src="https://github.com/user-attachments/assets/c5aa8fe7-91a3-4daf-9d8e-0d4db8a33986" />

They were able to fix this issue by killing the gui process running on port 5002, but we would like for this issue to not happen in the first place.

### Describe how you validated your changes

I ran the unit tests for the gui test suite with the `-race` flag, ensuring that no race conditions appeared. Additionally, I was able to run the gui with a local version of the agent with these changes incorporated.

### Additional Notes
