### PR TITLE
feat(ask_review): Do not ask review on revert PRs

### DIFF
--- a/.github/workflows/ask_review.yml
+++ b/.github/workflows/ask_review.yml
@@ -42,4 +42,4 @@ jobs:
               exit 0
             fi
           fi
-          dda inv -- -e issue.ask-reviews -p "${{ github.event.pull_request.number }}" "${options[@]}"
+          dda inv -- -e issue.ask-reviews -p "${{ github.event.pull_request.number }}" -a "${{ github.event.action }}" "${options[@]}"

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -14,11 +14,14 @@ from tasks.libs.pipeline.notifications import (
 
 
 @task(iterable=["team_slugs"])
-def ask_reviews(_, pr_id, team_slugs):
+def ask_reviews(_, pr_id, action, team_slugs):
     gh = GithubAPI()
     pr = gh.repo.get_pull(int(pr_id))
     if pr.base.ref != 'main':
         print("We don't ask for reviews on non main target PRs.")
+        return
+    if action != "labeled" and _is_revert(pr):
+        print("We don't ask for reviews on revert PRs creation, only on label requests.")
         return
     if any(label.name == 'no-review' for label in pr.get_labels()):
         print("This PR has the no-review label, we don't need to ask for reviews.")
@@ -76,6 +79,17 @@ def ask_reviews(_, pr_id, team_slugs):
         except Exception as e:
             message = f"An error occurred while sending a review message from {actor} for PR <{pr.html_url}/s|{pr.title}> to channel {channel}. Error: {e}"
             client.chat_postMessage(channel=DEFAULT_SLACK_CHANNEL, text=message)
+
+
+def _is_revert(pr) -> bool:
+    """
+    Check if a PR is a revert PR.
+    """
+    commits = pr.get_commits()
+    # Only check the first commit message
+    if re.match(r"^Revert \"(.*)\"\n\nThis reverts commit (\w+).", commits[0].commit.message):
+        return True
+    return False
 
 
 @task

--- a/tasks/unit_tests/issue_tests.py
+++ b/tasks/unit_tests/issue_tests.py
@@ -147,9 +147,12 @@ class TestAskReviews(unittest.TestCase):
     @patch('slack_sdk.WebClient')
     def test_label_with_ask_review(self, slack_mock, gh_mock, print_mock):
         pr_mock = MagicMock()
-        pr_mock.title = "This is a feature"
+        pr_mock.title = "This is a revert"
         pr_mock.base.ref = "main"
         pr_mock.get_labels.return_value = [types.SimpleNamespace(name='ask-review')]
+        pr_mock.get_commits.return_value = [
+            MagicMock(commit=MagicMock(message="Revert \"This is a feature\"\n\nThis reverts commit 1234567890")),
+        ]
         pr_mock.html_url = "https://github.com/foo/bar/pull/1"
         pr_mock.title = "Nominal PR"
 
@@ -170,7 +173,7 @@ class TestAskReviews(unittest.TestCase):
         GITHUB_SLACK_REVIEW_MAP['@datadog/team1'] = 'channel1'
         GITHUB_SLACK_REVIEW_MAP['@datadog/team2'] = 'channel2'
 
-        ask_reviews(MockContext(), 5, team_slugs=["team1", "team2"])
+        ask_reviews(MockContext(), 5, "labeled", team_slugs=["team1", "team2"])
         channels = [call.kwargs['channel'] for call in slack_client.chat_postMessage.mock_calls]
         self.assertIn('channel1', channels)
         self.assertIn('channel2', channels)
@@ -192,6 +195,7 @@ class TestAskReviews(unittest.TestCase):
             types.SimpleNamespace(name='ask-review'),
             types.SimpleNamespace(name='no-review'),
         ]
+        pr_mock.get_commits.return_value = [MagicMock(commit=MagicMock(message="This is a feature"))]
         pr_mock.user.login = "actorlogin"
         pr_mock.user.name = None
         # ask_reviews returns early on no-review before reading events, but keep events non-empty
@@ -201,7 +205,7 @@ class TestAskReviews(unittest.TestCase):
         gh_instance.repo.get_pull.return_value = pr_mock
         gh_mock.return_value = gh_instance
 
-        ask_reviews(MockContext(), 11, team_slugs=["team1"])
+        ask_reviews(MockContext(), 11, "labeled", team_slugs=["team1"])
 
         print_mock.assert_any_call("This PR has the no-review label, we don't need to ask for reviews.")
         slack_mock.assert_not_called()
@@ -221,6 +225,7 @@ class TestAskReviews(unittest.TestCase):
         pr_mock.get_labels.return_value = [
             types.SimpleNamespace(name='no-review'),
         ]
+        pr_mock.get_commits.return_value = [MagicMock(commit=MagicMock(message="This is a feature"))]
         pr_mock.user.login = "actorlogin"
         pr_mock.user.name = None
         # ask_reviews returns early on no-review before reading events, but keep events non-empty
@@ -230,9 +235,39 @@ class TestAskReviews(unittest.TestCase):
         gh_instance.repo.get_pull.return_value = pr_mock
         gh_mock.return_value = gh_instance
 
-        ask_reviews(MockContext(), 11, team_slugs=["team1"])
+        ask_reviews(MockContext(), 11, "review_requested", team_slugs=["team1"])
 
         print_mock.assert_any_call("This PR has the no-review label, we don't need to ask for reviews.")
+        slack_mock.assert_not_called()
+
+    @patch('builtins.print')
+    @patch(
+        'os.environ',
+        {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'fake-token'},
+    )
+    @patch('tasks.issue.GithubAPI')
+    @patch('slack_sdk.WebClient')
+    def test_revert_pr(self, slack_mock, gh_mock, print_mock):
+        """Test that any PR with no-review label is skipped (independent of event type)"""
+        pr_mock = MagicMock()
+        pr_mock.title = "Revert: This is a feature"
+        pr_mock.base.ref = "main"
+        pr_mock.get_labels.return_value = [
+            types.SimpleNamespace(name='no-review'),
+        ]
+        pr_mock.get_commits.return_value = [
+            MagicMock(commit=MagicMock(message="Revert \"This is a feature\"\n\nThis reverts commit 1234567890"))
+        ]
+        pr_mock.user.login = "actorlogin"
+        pr_mock.user.name = None
+
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+
+        ask_reviews(MockContext(), 42, "review_requested", team_slugs=["team1"])
+
+        print_mock.assert_any_call("We don't ask for reviews on revert PRs creation, only on label requests.")
         slack_mock.assert_not_called()
 
     @patch('builtins.print')
@@ -256,7 +291,7 @@ class TestAskReviews(unittest.TestCase):
         gh_mock.return_value = gh_instance
 
         # team_slugs is required; value doesn't matter because backport returns early
-        ask_reviews(MockContext(), 6, team_slugs=["team1"])
+        ask_reviews(MockContext(), 6, "labeled", team_slugs=["team1"])
         print_mock.assert_any_call("We don't ask for reviews on non main target PRs.")
         slack_mock.assert_not_called()
 
@@ -274,6 +309,7 @@ class TestAskReviews(unittest.TestCase):
         pr_mock.title = "Title"
         pr_mock.base.ref = "main"
         pr_mock.get_labels.return_value = [types.SimpleNamespace(name='ask-review')]
+        pr_mock.get_commits.return_value = [MagicMock(commit=MagicMock(message="This is a feature"))]
         pr_mock.user.login = "actorlogin"
         pr_mock.user.name = None
         pr_mock.html_url = "http://foo"
@@ -289,7 +325,7 @@ class TestAskReviews(unittest.TestCase):
 
         # Clear the mapping so all reviewers fall back to DEFAULT_SLACK_CHANNEL
         GITHUB_SLACK_REVIEW_MAP.clear()
-        ask_reviews(MockContext(), 7, team_slugs=["newteam1", "newteam2"])
+        ask_reviews(MockContext(), 7, "review_requested", team_slugs=["newteam1", "newteam2"])
 
         # Only one message because all reviewers fall back to DEFAULT_SLACK_CHANNEL
         slack_client.chat_postMessage.assert_called_once()
@@ -309,6 +345,7 @@ class TestAskReviews(unittest.TestCase):
         pr_mock.title = "Some PR"
         pr_mock.base.ref = "main"
         pr_mock.get_labels.return_value = [types.SimpleNamespace(name='ask-review')]
+        pr_mock.get_commits.return_value = [MagicMock(commit=MagicMock(message="This is a feature"))]
         pr_mock.user.name = "actorlogin"
         pr_mock.html_url = "http://foo"
         pr_mock.title = "Test"
@@ -326,7 +363,7 @@ class TestAskReviews(unittest.TestCase):
         GITHUB_SLACK_REVIEW_MAP['@datadog/teamx'] = 'chan-shared'
         GITHUB_SLACK_REVIEW_MAP['@datadog/teamy'] = 'chan-shared'
 
-        ask_reviews(MockContext(), 8, team_slugs=["teamx", "teamy"])
+        ask_reviews(MockContext(), 8, "review_requested", team_slugs=["teamx", "teamy"])
 
         # Only one message because both reviewers map to the same channel
         slack_client.chat_postMessage.assert_called_once()
@@ -344,9 +381,13 @@ class TestAskReviews(unittest.TestCase):
     def test_review_request_one_team(self, slack_mock, gh_mock, print_mock):
         """Test that when a specific team is requested (review_request event), only that team is notified"""
         pr_mock = MagicMock()
-        pr_mock.title = "Feature PR"
+        pr_mock.title = "This is a feature"
         pr_mock.base.ref = "main"
         pr_mock.get_labels.return_value = [types.SimpleNamespace(name='ask-review')]
+        pr_mock.get_commits.return_value = [
+            MagicMock(commit=MagicMock(message="This is a feature")),
+            MagicMock(commit=MagicMock(message="Revert \"This is a feature\"\n\nThis reverts commit 1234567890")),
+        ]
         pr_mock.user.login = "actorlogin"
         pr_mock.user.name = "actorname"
         pr_mock.html_url = "https://github.com/foo/bar/pull/9"
@@ -364,7 +405,7 @@ class TestAskReviews(unittest.TestCase):
         GITHUB_SLACK_REVIEW_MAP.clear()
         GITHUB_SLACK_REVIEW_MAP['@datadog/team1'] = 'channel1'
 
-        ask_reviews(MockContext(), 9, team_slugs=["team1"])
+        ask_reviews(MockContext(), 9, "review_requested", team_slugs=["team1"])
 
         # Only one message should be sent (the requested team only)
         slack_client.chat_postMessage.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

This PR modifies the `ask_reviews` workflow to skip requesting reviews on revert PRs when they are created or when a review is directly requested. Reviews will still be requested if someone explicitly adds the `ask-review` label.

### Motivation

Revert PRs are typically urgent fixes that need to be merged quickly. Automatically requesting reviews on creation adds unnecessary noise and delays the revert process. However, if someone explicitly requests a review via the `ask-review` label, we should still honor that request.

### Describe how you validated your changes

- Added unit test `test_revert_pr` to verify revert PRs skip the review request
- Updated existing tests to pass the new `action` parameter
- Added test coverage for PR with revert commit not as first commit (should not be detected as revert)

### Additional Notes

The revert detection checks if the first commit message matches the standard GitHub revert format:
```
Revert "<original PR title>"

This reverts commit <sha>.
```