### PR TITLE
Move aux `bazel` jobs back to ephemeral runners

### DIFF
--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -49,13 +49,20 @@
   variables:
     XDG_CACHE_HOME: c:/bzl
 
+# ⚠️ swap `extends` and `tags` only for *experimental* purposes with persistent runners
 .bazel:runner:linux-amd64:
-  extends: .bazel:defs:cache:persistent
-  tags: [ "k8s-persistent:amd64", "specific:true" ]
+  #extends: .bazel:defs:cache:persistent
+  #tags: [ "k8s-persistent:amd64", "specific:true" ]
+  extends: .bazel:defs:cache:ephemeral
+  tags: [ "arch:amd64", "specific:true" ]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 .bazel:runner:linux-arm64:
-  extends: .bazel:defs:cache:persistent
-  tags: [ "k8s-persistent:arm64", "specific:true" ]
+  #extends: .bazel:defs:cache:persistent
+  #tags: [ "k8s-persistent:arm64", "specific:true" ]
+  extends: .bazel:defs:cache:ephemeral
+  tags: [ "arch:arm64", "specific:true" ]
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
 
 .bazel:runner:macos-amd64:
   extends: .bazel:defs:cache:macos


### PR DESCRIPTION
### Motivation
It turns out jobs running on persistent runners have to be allow-listed **outside** of the present repo: [here](https://github.com/DataDog/dd-source/blob/e9ab3086d80dcc670af2ebb7d36395d384b5ca60/domains/devex/ci/gitlab/config/k8s/gitlab-runner-k8s-persistent/values/datadog-agent-amd64.yaml#L40-L48).

Problems:
- adding a _new_ job would fail on:
  ```
  ERROR: Job failed (system failure): Job is not allowed to run on this runner. For support, please reach out in #ci-infra-support.
  ```
  ([tentative](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1400699592)),
- the same would happen when simply _renaming_ an existing job,
- to move forward, a distinct PR would have to be filed to https://github.com/DataDog/dd-source and waited for: reviewed, approved, merged and eventually in effect (deployed/active)... in addition to the present repo's own Lead Time for Changes...
- CI pipelines are very likely to change across release branches, which means we would have to keep track of earlier job layouts,
- the persistent runners seem to be reserved for _occasional_ needs that CI by definition does not meet:
  > These were meant to be an experiment
- as per security guidelines, "production" jobs are not allowed to run on persistent runners:
  > By production [they] mean "user facing". They are running on default branch and actual developer feature branches.

### What does this PR do?
Move auxiliary `bazel:*` jobs back to ephemeral runners.

With this change, we however retain the ability to _experiment_ by swapping the `extends` and `tags` fields of the target runner definition(s).