### PR TITLE
dyninst: fix EventPairingExpectation enum mismatch with eBPF

### DIFF
--- a/pkg/dyninst/output/event.go
+++ b/pkg/dyninst/output/event.go
@@ -28,8 +28,8 @@ const (
 	EventPairingExpectationNone                  EventPairingExpectation = 0
 	EventPairingExpectationEntryPairingExpected  EventPairingExpectation = 1
 	EventPairingExpectationReturnPairingExpected EventPairingExpectation = 2
-	EventPairingExpectationCallMapFull           EventPairingExpectation = 3
-	EventPairingExpectationCallCountExceeded     EventPairingExpectation = 4
+	EventPairingExpectationCallCountExceeded     EventPairingExpectation = 3
+	EventPairingExpectationCallMapFull           EventPairingExpectation = 4
 	EventPairingExpectationBufferFull            EventPairingExpectation = 5
 	EventPairingExpectationNoneInlined           EventPairingExpectation = 6
 	EventPairingExpectationNoneNoBody            EventPairingExpectation = 7


### PR DESCRIPTION
### What does this PR do?

The Go constants for CallMapFull and CallCountExceeded were swapped relative to the eBPF enum in framing.h, causing events to be misinterpreted and incorrect error messages to be logged.

### Motivation

This would cause the two reasons to be swapped.

### Describe how you validated your changes

Just looking at the code, see https://github.com/DataDog/datadog-agent/blob/7d83cf04c5ba306ec51af22e77a5fd5604ceb066/pkg/dyninst/ebpf/framing.h#L17-L18

### Additional Notes
