### PR TITLE
[ AGNTLOG-497 ] Remove memory leak from transient log endpoint creation

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -337,7 +337,9 @@ func Diagnose() []diagnose.Diagnosis {
 			continue
 		}
 		configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, cfg)
-		endpoints, err := config.BuildHTTPEndpointsWithConfig(cfg, configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
+		// Use ForDiagnostic variant to avoid registering config update callbacks
+		// since these endpoints are transient and will be discarded after the diagnostic check
+		endpoints, err := config.BuildEndpointsForDiagnostic(cfg, configKeys, desc.hostnameEndpointPrefix, config.DiagnosticHTTP, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 		if err != nil {
 			diagnoses = append(diagnoses, diagnose.Diagnosis{
 				Status:      diagnose.DiagnosisFail,

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -73,9 +73,19 @@ func buildEndpoints(coreConfig model.Reader) (*config.Endpoints, error) {
 	return config.BuildEndpointsWithVectorOverride(coreConfig, httpConnectivity, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
 }
 
-// buildHTTPEndpointsForConnectivityCheck builds HTTP endpoints for connectivity testing only
+// buildHTTPEndpointsForConnectivityCheck builds HTTP endpoints for connectivity testing only.
+// Uses BuildEndpointsForDiagnostic to avoid registering config update callbacks since these
+// endpoints are transient and will be discarded after the connectivity check.
 func buildHTTPEndpointsForConnectivityCheck(coreConfig model.Reader) (*config.Endpoints, error) {
-	return config.BuildHTTPEndpointsWithVectorOverride(coreConfig, intakeTrackType, config.AgentJSONIntakeProtocol, config.DefaultIntakeOrigin)
+	return config.BuildEndpointsForDiagnostic(
+		coreConfig,
+		config.DefaultLogsConfigKeysWithVectorOverride(coreConfig),
+		config.DefaultDiagnosticPrefix,
+		config.DiagnosticHTTP,
+		intakeTrackType,
+		config.AgentJSONIntakeProtocol,
+		config.DefaultIntakeOrigin,
+	)
 }
 
 // checkHTTPConnectivityStatus performs an HTTP connectivity check and returns the status

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -32,6 +32,10 @@ const (
 	serverlessHTTPEndpointPrefix = "http-intake.logs."
 )
 
+// DefaultDiagnosticPrefix is the default prefix for diagnostic endpoints, and will resolve to the endpoints customarily expected by the logs agent.
+// Is expected to always be safe for both TCP and HTTP diagnostic variants
+const DefaultDiagnosticPrefix = httpEndpointPrefix
+
 // legacyPathPrefixes are the path prefixes that match existing log intake endpoints present
 // at the time that logs_dd_url was extended to support the ability to specify a path prefix.
 // Users with these set are assumed to be relying on legacy logs_dd_url behavior and will
@@ -136,7 +140,7 @@ func BuildEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *Logs
 		"To benefit from increased reliability and better network performances, "+
 		"we strongly encourage switching over to compressed HTTPS which is now the default protocol.",
 		logsConfig.getConfigKey("force_use_tcp"), logsConfig.getConfigKey("socks5_proxy_address"))
-	return buildTCPEndpoints(coreConfig, logsConfig)
+	return buildTCPEndpoints(coreConfig, logsConfig, true)
 }
 
 // BuildServerlessEndpoints returns the endpoints to send logs for the Serverless agent.
@@ -227,9 +231,9 @@ func ValidateFingerprintConfig(config *types.FingerprintConfig) error {
 	return nil
 }
 
-func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys) (*Endpoints, error) {
+func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, registerCallback bool) (*Endpoints, error) {
 	useProto := logsConfig.devModeUseProto()
-	main := newTCPEndpoint(logsConfig)
+	main := newTCPEndpoint(logsConfig, registerCallback)
 
 	if logsDDURL, defined := logsConfig.logsDDURL(); defined {
 		// Proxy settings, expect 'logs_config.logs_dd_url' to respect the format '<HOST>:<PORT>'
@@ -258,7 +262,7 @@ func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigK
 		main.useSSL = !logsConfig.devModeNoSSL()
 	}
 
-	additionals := loadTCPAdditionalEndpoints(main, logsConfig)
+	additionals := loadTCPAdditionalEndpoints(main, logsConfig, registerCallback)
 
 	// Add in the MRF endpoint if MRF is enabled.
 	if coreConfig.GetBool("multi_region_failover.enabled") {
@@ -306,20 +310,45 @@ func BuildHTTPEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, inta
 
 // BuildHTTPEndpointsWithCompressionOverride returns the HTTP endpoints to send logs to with compression options.
 func BuildHTTPEndpointsWithCompressionOverride(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin, compressionOptions EndpointCompressionOptions) (*Endpoints, error) {
-	return buildHTTPEndpoints(coreConfig, logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin, compressionOptions)
+	return buildHTTPEndpoints(coreConfig, logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin, compressionOptions, true)
 }
 
 // BuildHTTPEndpointsWithConfig returns the HTTP endpoints to send logs to.
 func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
-	return buildHTTPEndpoints(coreConfig, logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin, EndpointCompressionOptions{})
+	return buildHTTPEndpoints(coreConfig, logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin, EndpointCompressionOptions{}, true)
+}
+
+// BuildEndpointsForDiagnostic builds endpoints for diagnostic/transient use without
+// registering config update callbacks. The protocol parameter explicitly specifies
+// whether to build HTTP or TCP endpoints, bypassing all dynamic protocol selection logic.
+//
+// Use this for connectivity checks, diagnostic commands, and other short-lived operations
+// where endpoints will be discarded after use.
+func BuildEndpointsForDiagnostic(
+	coreConfig pkgconfigmodel.Reader,
+	logsConfig *LogsConfigKeys,
+	endpointPrefix string,
+	protocol DiagnosticProtocol,
+	intakeTrackType IntakeTrackType,
+	intakeProtocol IntakeProtocol,
+	intakeOrigin IntakeOrigin,
+) (*Endpoints, error) {
+	if protocol == DiagnosticHTTP {
+		return buildHTTPEndpoints(coreConfig, logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin, EndpointCompressionOptions{}, false)
+	}
+
+	// Note: Any change to TCP endpoint construction that allows for a custom endpoint prefix requires alteration of the DefaultDiagnosticPrefix to maintain safety.
+	return buildTCPEndpoints(coreConfig, logsConfig, false)
 }
 
 // buildHTTPEndpoints uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() w ldHTTPEndpointsWithConfigdefault variables logsConfigDefaultKeys and httpEndpointPrefix
-func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin, compressionOptions EndpointCompressionOptions) (*Endpoints, error) {
+// If registerCallback is true, the endpoints will register for config updates to receive API key rotations.
+// Use registerCallback=false for transient/diagnostic endpoints that will be discarded after use.
+func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin, compressionOptions EndpointCompressionOptions, registerCallback bool) (*Endpoints, error) {
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
-	main := newHTTPEndpoint(logsConfig)
+	main := newHTTPEndpoint(logsConfig, registerCallback)
 
 	if logsConfig.useV2API() && intakeTrackType != "" {
 		main.Version = EPIntakeVersion2
@@ -364,7 +393,7 @@ func buildHTTPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfig
 		main.useSSL = useSSL
 	}
 
-	additionals := loadHTTPAdditionalEndpoints(main, logsConfig, intakeTrackType, intakeProtocol, intakeOrigin)
+	additionals := loadHTTPAdditionalEndpoints(main, logsConfig, intakeTrackType, intakeProtocol, intakeOrigin, registerCallback)
 
 	// Add in the MRF endpoint if MRF is enabled.
 	if coreConfig.GetBool("multi_region_failover.enabled") {
@@ -487,4 +516,9 @@ func AggregationTimeout(coreConfig pkgconfigmodel.Reader) time.Duration {
 // MaxMessageSizeBytes is used to cap the maximum log message size in bytes
 func MaxMessageSizeBytes(coreConfig pkgconfigmodel.Reader) int {
 	return defaultLogsConfigKeys(coreConfig).maxMessageSizeBytes()
+}
+
+// DefaultLogsConfigKeysWithVectorOverride returns the default logs config keys with vector override (exported for diagnostic use)
+func DefaultLogsConfigKeysWithVectorOverride(coreConfig pkgconfigmodel.Reader) *LogsConfigKeys {
+	return defaultLogsConfigKeysWithVectorOverride(coreConfig)
 }

--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -347,7 +347,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
 	}
 
 	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false)
-	endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+	endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config), true)
 
 	suite.Nil(err)
 	suite.compareEndpoints(expectedEndpoints, endpoints)
@@ -570,7 +570,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsInConf() {
 	}
 
 	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false)
-	endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+	endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config), true)
 
 	suite.Nil(err)
 	suite.compareEndpoints(expectedEndpoints, endpoints)
@@ -1299,7 +1299,7 @@ func (suite *ConfigTestSuite) TestTCPEndpointsPortLookup() {
 			suite.config.SetWithoutSource("site", tt.site)
 			suite.config.SetWithoutSource("convert_dd_site_fqdn.enabled", true) // FQDN is enabled by default
 
-			endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+			endpoints, err := buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config), true)
 
 			suite.Nil(err)
 			suite.Equal(tt.expectedHost, endpoints.Main.Host, "Host should match expected FQDN with trailing dot")
@@ -1309,7 +1309,7 @@ func (suite *ConfigTestSuite) TestTCPEndpointsPortLookup() {
 			suite.config.SetWithoutSource("site", tt.site)
 			suite.config.SetWithoutSource("convert_dd_site_fqdn.enabled", false)
 
-			endpoints, err = buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config))
+			endpoints, err = buildTCPEndpoints(suite.config, defaultLogsConfigKeys(suite.config), true)
 
 			suite.Nil(err)
 			suite.Equal(tt.expectedPort, endpoints.Main.Port, "Port should match the value from logsEndpoints map")

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -41,6 +41,16 @@ const (
 // EmptyPathPrefix is the default path prefix for the endpoint.
 const EmptyPathPrefix = ""
 
+// DiagnosticProtocol specifies which protocol to use for diagnostic endpoints.
+type DiagnosticProtocol int
+
+const (
+	// DiagnosticHTTP builds HTTP endpoints for diagnostic use
+	DiagnosticHTTP DiagnosticProtocol = iota
+	// DiagnosticTCP builds TCP endpoints for diagnostic use
+	DiagnosticTCP
+)
+
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
 type Endpoint struct {
 	isReliable bool
@@ -111,7 +121,9 @@ func NewEndpoint(apiKey string, apiKeyConfigPath string, host string, port int, 
 
 // newTCPEndpoint returns a new TCP Endpoint based on LogsConfigKeys. The endpoint is by default reliable and will use
 // socks proxy and SSL settings from the configuration.
-func newTCPEndpoint(logsConfig *LogsConfigKeys) Endpoint {
+// If registerCallback is true, the endpoint will register for config updates to receive API key rotations.
+// Use registerCallback=false for transient/diagnostic endpoints that will be discarded after use.
+func newTCPEndpoint(logsConfig *LogsConfigKeys, registerCallback bool) Endpoint {
 	apiKey, configPath := logsConfig.getMainAPIKey()
 	e := Endpoint{
 		apiKey:                  atomic.NewString(apiKey),
@@ -121,13 +133,17 @@ func newTCPEndpoint(logsConfig *LogsConfigKeys) Endpoint {
 		useSSL:                  logsConfig.logsNoSSL(),
 		isReliable:              true, // by default endpoints are reliable
 	}
-	e.onConfigUpdate(logsConfig)
+	if registerCallback {
+		e.onConfigUpdate(logsConfig)
+	}
 	return e
 }
 
 // newHTTPEndpoint returns a new HTTP Endpoint based on LogsConfigKeys The endpoint is by default reliable and will use
 // the settings related to HTTP from the configuration (compression, Backoff, recovery, ...).
-func newHTTPEndpoint(logsConfig *LogsConfigKeys) Endpoint {
+// If registerCallback is true, the endpoint will register for config updates to receive API key rotations.
+// Use registerCallback=false for transient/diagnostic endpoints that will be discarded after use.
+func newHTTPEndpoint(logsConfig *LogsConfigKeys, registerCallback bool) Endpoint {
 
 	apiKey, configPath := logsConfig.getMainAPIKey()
 	e := Endpoint{
@@ -145,14 +161,18 @@ func newHTTPEndpoint(logsConfig *LogsConfigKeys) Endpoint {
 		useSSL:                  logsConfig.logsNoSSL(),
 		isReliable:              true, // by default endpoints are reliable
 	}
-	e.onConfigUpdate(logsConfig)
+	if registerCallback {
+		e.onConfigUpdate(logsConfig)
+	}
 	return e
 }
 
 // The setting from 'logs_config.additional_endpoints' is directly unmarshalled from the configuration into a
 // []unmarshalEndpoint and do not use the constructors. In this case, the Endpoint is initialized to returned the API
 // key from the loaded data instead of 'api_key'/'logs_config.api_key'.
-func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys) []Endpoint {
+// If registerCallback is true, the endpoints will register for config updates to receive API key rotations.
+// Use registerCallback=false for transient/diagnostic endpoints that will be discarded after use.
+func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, registerCallback bool) []Endpoint {
 	additionals, configKeyUsed := l.getAdditionalEndpoints()
 
 	newEndpoints := make([]Endpoint, 0, len(additionals))
@@ -183,12 +203,17 @@ func loadTCPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys) []Endpoint {
 			newE.useSSL = main.useSSL
 		}
 		newEndpoints = append(newEndpoints, newE)
-		newE.onConfigUpdate(l)
+		if registerCallback {
+			newE.onConfigUpdate(l)
+		}
 	}
 	return newEndpoints
 }
 
-func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) []Endpoint {
+// loadHTTPAdditionalEndpoints loads additional HTTP endpoints from configuration.
+// If registerCallback is true, the endpoints will register for config updates to receive API key rotations.
+// Use registerCallback=false for transient/diagnostic endpoints that will be discarded after use.
+func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin, registerCallback bool) []Endpoint {
 	additionals, configKeyUsed := l.getAdditionalEndpoints()
 
 	newEndpoints := make([]Endpoint, 0, len(additionals))
@@ -229,7 +254,9 @@ func loadHTTPAdditionalEndpoints(main Endpoint, l *LogsConfigKeys, intakeTrackTy
 		}
 
 		newEndpoints = append(newEndpoints, newE)
-		newE.onConfigUpdate(l)
+		if registerCallback {
+			newE.onConfigUpdate(l)
+		}
 	}
 	return newEndpoints
 }

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -638,8 +638,8 @@ func (suite *EndpointsTestSuite) TestMainApiKeyRotation() {
 	suite.config.SetWithoutSource("api_key", "1234")
 	logsConfig := defaultLogsConfigKeys(suite.config)
 
-	tcp := newTCPEndpoint(logsConfig)
-	http := newHTTPEndpoint(logsConfig)
+	tcp := newTCPEndpoint(logsConfig, true)
+	http := newHTTPEndpoint(logsConfig, true)
 
 	suite.Equal("1234", tcp.GetAPIKey())
 	suite.Equal("1234", http.GetAPIKey())
@@ -671,8 +671,8 @@ func (suite *EndpointsTestSuite) TestLogsConfigApiKeyRotation() {
 	suite.config.SetWithoutSource("logs_config.api_key", "1234")
 	logsConfig := defaultLogsConfigKeys(suite.config)
 
-	tcp := newTCPEndpoint(logsConfig)
-	http := newHTTPEndpoint(logsConfig)
+	tcp := newTCPEndpoint(logsConfig, true)
+	http := newHTTPEndpoint(logsConfig, true)
 
 	suite.Equal("1234", tcp.GetAPIKey())
 	suite.Equal("1234", http.GetAPIKey())
@@ -691,9 +691,9 @@ func (suite *EndpointsTestSuite) TestLogsConfigApiKeyRotation() {
 func (suite *EndpointsTestSuite) TestEndpointOnUpdate() {
 	loadAdditionalEndpoints := map[string]func(Endpoint, *LogsConfigKeys) []Endpoint{
 		"http": func(main Endpoint, l *LogsConfigKeys) []Endpoint {
-			return loadHTTPAdditionalEndpoints(main, l, "", "", "")
+			return loadHTTPAdditionalEndpoints(main, l, "", "", "", true)
 		},
-		"tcp": func(main Endpoint, l *LogsConfigKeys) []Endpoint { return loadTCPAdditionalEndpoints(main, l) },
+		"tcp": func(main Endpoint, l *LogsConfigKeys) []Endpoint { return loadTCPAdditionalEndpoints(main, l, true) },
 	}
 
 	for endpointType, additionalEndpointsLoader := range loadAdditionalEndpoints {
@@ -719,7 +719,7 @@ func (suite *EndpointsTestSuite) TestEndpointOnUpdate() {
 			"is_reliable": false
 			}]`)
 
-			mainEndpoint := newHTTPEndpoint(logsConfig)
+			mainEndpoint := newHTTPEndpoint(logsConfig, true)
 			additionalEndpoints := additionalEndpointsLoader(mainEndpoint, logsConfig)
 			suite.Suite.Require().Len(additionalEndpoints, 2)
 
@@ -808,7 +808,7 @@ func (suite *EndpointsTestSuite) TestloadTCPAdditionalEndpoints() {
 
 	main := Endpoint{useSSL: true}
 	logsConfig := defaultLogsConfigKeys(suite.config)
-	endpoints := loadTCPAdditionalEndpoints(main, logsConfig)
+	endpoints := loadTCPAdditionalEndpoints(main, logsConfig, true)
 
 	suite.Suite.Require().Len(endpoints, 2)
 	compareEndpoint(suite.T(), expected1, endpoints[0])
@@ -877,6 +877,7 @@ func (suite *EndpointsTestSuite) TestloadHTTPAdditionalEndpoints() {
 		"some track type",
 		"some intake protocol",
 		"some intake origin",
+		true,
 	)
 
 	suite.Suite.Require().Len(endpoints, 2)
@@ -956,7 +957,7 @@ func (suite *EndpointsTestSuite) TestMRFApiKeyUpdate() {
 		{
 			name: "TCP",
 			endpointGetter: func(cfg model.Reader) (*Endpoints, error) {
-				return buildTCPEndpoints(cfg, defaultLogsConfigKeys(cfg))
+				return buildTCPEndpoints(cfg, defaultLogsConfigKeys(cfg), true)
 			},
 		},
 	}

--- a/pkg/compliance/cli/check.go
+++ b/pkg/compliance/cli/check.go
@@ -188,7 +188,7 @@ func dumpComplianceEvents(reportFile string, events []*compliance.CheckEvent) er
 func reportComplianceEvents(hostname string, events []*compliance.CheckEvent, compression logscompression.Component) error {
 	endpoints, context, err := common.NewLogContextCompliance()
 	if err != nil {
-		return fmt.Errorf("reporter: could not reate log context for compliance: %w", err)
+		return fmt.Errorf("reporter: could not create log context for compliance: %w", err)
 	}
 	reporter := compliance.NewLogReporter(hostname, "compliance-agent", "compliance", endpoints, context, compression)
 	defer reporter.Stop()

--- a/pkg/diagnose/connectivity/core_endpoint.go
+++ b/pkg/diagnose/connectivity/core_endpoint.go
@@ -35,29 +35,20 @@ func getLogsEndpoints(useTCP bool) (*logsConfig.Endpoints, error) {
 	datadogConfig := pkgconfigsetup.Datadog()
 	logsConfigKey := logsConfig.NewLogsConfigKeys("logs_config.", datadogConfig)
 
-	var endpoints *logsConfig.Endpoints
-	var err error
-
+	protocol := logsConfig.DiagnosticHTTP
 	if useTCP {
-		endpoints, err = logsConfig.BuildEndpointsWithConfig(
-			datadogConfig,
-			logsConfigKey,
-			"agent-http-intake.logs.",
-			false,
-			"logs",
-			logsConfig.AgentJSONIntakeProtocol,
-			logsConfig.DefaultIntakeOrigin)
-	} else {
-		endpoints, err = logsConfig.BuildHTTPEndpointsWithConfig(
-			datadogConfig,
-			logsConfigKey,
-			"agent-http-intake.logs.",
-			"logs",
-			logsConfig.AgentJSONIntakeProtocol,
-			logsConfig.DefaultIntakeOrigin)
+		protocol = logsConfig.DiagnosticTCP
 	}
 
-	return endpoints, err
+	return logsConfig.BuildEndpointsForDiagnostic(
+		datadogConfig,
+		logsConfigKey,
+		logsConfig.DefaultDiagnosticPrefix,
+		protocol,
+		"logs",
+		logsConfig.AgentJSONIntakeProtocol,
+		logsConfig.DefaultIntakeOrigin,
+	)
 }
 
 // getLogsUseTCP returns true if the agent should use TCP to transport logs

--- a/releasenotes/notes/endpoint-memory-leak-ad9a2b8ff074d85e.yaml
+++ b/releasenotes/notes/endpoint-memory-leak-ad9a2b8ff074d85e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a minor but persistent memory leak in the logs endpoint diagnostic behavior.


### PR DESCRIPTION
### What does this PR do?
Behavior was introduced to allow the live modification of log endpoint configurations, specifically allowing api keys to be dynamically updated via remote configuration. This feature is based upon the addition of an OnUpdate callback that each endpoint will register with the configuration management service. 
However, there are several specific usages of the logs endpoint structures that are inherently transient, creating and recreating new endpoints as necessary to facilitate diagnostic behaviors. This opens up a memory leak: the registered callbacks do not currently expose a method by which they can be deregistered, and a long running agent will continuously accrue an unlimited quantity of orphaned callbacks in its queue. 
As an immediate fix to this issue, an alternative endpoint constructor has been exposed that is explicitly for transient/diagnostic useage, which will not trigger an OnUpdate callback registration.

### Motivation

### Describe how you validated your changes

### Additional Notes
