### PR TITLE
(fix) log tailer encoding validation

### DIFF
--- a/comp/logs/agent/config/parser_test.go
+++ b/comp/logs/agent/config/parser_test.go
@@ -320,7 +320,7 @@ logs:
     port: 8080
     idle_timeout: "30s"
     path: /var/log/journal/
-    encoding: utf-8
+    encoding: utf-16-le
     exclude_paths:
       - /var/log/exclude1.log
       - /var/log/exclude2.log
@@ -371,7 +371,7 @@ logs:
 				assert.Equal(t, 8080, config.Port)
 				assert.Equal(t, "30s", config.IdleTimeout)
 				assert.Equal(t, "/var/log/journal/", config.Path)
-				assert.Equal(t, "utf-8", config.Encoding)
+				assert.Equal(t, "utf-16-le", config.Encoding)
 				require.Equal(t, len(config.ExcludePaths), 2)
 				assert.Equal(t, "beginning", config.TailingMode)
 				assert.Equal(t, "test_config_id", config.ConfigID)
@@ -556,7 +556,7 @@ logs:
 		},
 		{
 			name: "Test comprehensive JSON config",
-			data: []byte(`[{"type":"file","path":"/var/log/test.log","source":"test_source","service":"test_service","tags":["tag1","tag2"],"encoding":"utf-8","port":8080,"container_mode":true,"log_processing_rules":[{"type":"multi_line","name":"test_rule","pattern":"^\\d{4}"}]}]`),
+			data: []byte(`[{"type":"file","path":"/var/log/test.log","source":"test_source","service":"test_service","tags":["tag1","tag2"],"encoding":"shift-jis","port":8080,"container_mode":true,"log_processing_rules":[{"type":"multi_line","name":"test_rule","pattern":"^\\d{4}"}]}]`),
 			assert: func(t *testing.T, configs []*LogsConfig, err error) {
 				assert.Nil(t, err)
 				require.Equal(t, len(configs), 1)
@@ -568,7 +568,7 @@ logs:
 				require.Equal(t, len(config.Tags), 2)
 				assert.Equal(t, "tag1", config.Tags[0])
 				assert.Equal(t, "tag2", config.Tags[1])
-				assert.Equal(t, "utf-8", config.Encoding)
+				assert.Equal(t, "shift-jis", config.Encoding)
 				assert.Equal(t, 8080, config.Port)
 				assert.Equal(t, true, config.ContainerMode)
 				require.Equal(t, len(config.ProcessingRules), 1)

--- a/releasenotes/notes/fix-encoding-validation-1082457081c9897f.yaml
+++ b/releasenotes/notes/fix-encoding-validation-1082457081c9897f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Logs agent now validates the ``encoding`` field in log source configuration.
+    Invalid values like ``utf8`` or ``ascii`` are now rejected at startup with
+    a clear error message instead of being silently treated as UTF-8. Valid
+    options are: ``utf-16-be``, ``utf-16-le``, ``shift-jis``, or empty for UTF-8.


### PR DESCRIPTION
## What does this PR do?

Add validation for the `Encoding` field during config parsing to fail fast with a clear error message when invalid values are provided.

### Problem

Previously, invalid encoding values like `utf8`, `ascii`, or `utf-8` were silently accepted and treated as UTF-8 in `file_decoder.go`. This could lead to:

- Silent data corruption for users who expected their specified encoding to be used

- Confusion when logs appeared garbled without any error message

- Difficulty debugging encoding-related issues

### Solution

Added validation in `LogsConfig.Validate()` that checks the `Encoding` field for file sources and returns a clear error message for invalid values:

```

invalid encoding 'utf8', valid options are: utf-16-be, utf-16-le, shift-jis (or empty for UTF-8)

```

### Valid encodings

- `utf-16-be` - UTF-16 Big Endian

- `utf-16-le` - UTF-16 Little Endian  

- `shift-jis` - Shift JIS (Japanese)

- Empty string - UTF-8 (default)

## Motivation

Config errors should be caught at agent startup rather than causing silent failures at runtime. This follows the "fail fast" principle.

## How to test the change?

1\. Create a log configuration with an invalid encoding:

```yaml

   logs:

     - type: file

       path: /var/log/test.log

       source: test

       encoding: utf8  # Invalid!

```

2\. Start the agent

3\. Verify the agent fails to start with a clear error message

## Describe how you validated the change

- [x]  Added `TestEncodingValidation` unit test covering all valid and invalid encoding values

- [x]  All existing tests pass