### PR TITLE
[SQG] Fix bump task to update all increasing gates

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -159,7 +159,7 @@ configure_make(
         ],
         "@platforms//os:windows": [],
     }),
-    copts = select({
+    copts = ["-O2"] + select({
         "@platforms//os:windows": ["-DSIO_UDP_NETRESET=_WSAIOW\\(IOC_VENDOR,15\\)"],
         "//conditions:default": [],
     }),

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -159,7 +159,7 @@ configure_make(
         ],
         "@platforms//os:windows": [],
     }),
-    copts = ["-O2"] + select({
+    copts = select({
         "@platforms//os:windows": ["-DSIO_UDP_NETRESET=_WSAIOW\\(IOC_VENDOR,15\\)"],
         "//conditions:default": [],
     }),

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -52,6 +52,8 @@ class GateMetricsData:
     current_on_wire_size: int | None = None
     max_on_disk_size: int | None = None
     max_on_wire_size: int | None = None
+    relative_on_disk_size: int | None = None
+    relative_on_wire_size: int | None = None
 
 
 def _extract_gate_name_from_scope(scope: str) -> str | None:
@@ -92,6 +94,8 @@ def fetch_pr_metrics(pr_number: int) -> dict[str, GateMetricsData]:
         "on_wire_size": "current_on_wire_size",
         "max_allowed_on_disk_size": "max_on_disk_size",
         "max_allowed_on_wire_size": "max_on_wire_size",
+        "relative_on_disk_size": "relative_on_disk_size",
+        "relative_on_wire_size": "relative_on_wire_size",
     }
 
     # Single query with all metrics (comma-separated)
@@ -205,6 +209,32 @@ def identify_failing_gates(pr_metrics: dict[str, GateMetricsData]) -> dict[str, 
             failing[gate_name] = metrics
 
     return failing
+
+
+# Threshold for considering a size change as meaningful (not noise)
+# Changes below this threshold are considered neutral and won't trigger a bump
+SIZE_INCREASE_THRESHOLD_BYTES = 2 * 1024  # 2 KiB
+
+
+def identify_gates_with_size_increase(pr_metrics: dict[str, GateMetricsData]) -> dict[str, GateMetricsData]:
+    """
+    Identify all gates that have a meaningful on-disk size increase.
+
+    This is used for exception bumps where we want to bump ALL gates
+    with size increases, not just the ones that are currently failing.
+
+    A gate is included if relative_on_disk_size > SIZE_INCREASE_THRESHOLD_BYTES.
+
+    Returns gates where on_disk_size has increased beyond the noise threshold.
+    """
+    gates_to_bump: dict[str, GateMetricsData] = {}
+
+    for gate_name, metrics in pr_metrics.items():
+        # Check if there's a meaningful size increase
+        if metrics.relative_on_disk_size is not None and metrics.relative_on_disk_size > SIZE_INCREASE_THRESHOLD_BYTES:
+            gates_to_bump[gate_name] = metrics
+
+    return gates_to_bump
 
 
 def get_pr_for_branch(branch: str):
@@ -875,26 +905,26 @@ def exception_threshold_bump(ctx, pr_number):
 
     print(color_message(f"Found metrics for {len(pr_metrics)} gates", "cyan"))
 
-    # Step 2: Identify failing gates
-    failing_gates = identify_failing_gates(pr_metrics)
-    if not failing_gates:
-        print(color_message("[INFO] No failing gates found - nothing to bump!", "green"))
+    # Step 2: Identify gates with size increase (not just failing gates)
+    gates_to_bump = identify_gates_with_size_increase(pr_metrics)
+    if not gates_to_bump:
+        print(color_message("[INFO] No gates with size increase found - nothing to bump!", "green"))
         return
 
-    print(color_message(f"Found {len(failing_gates)} failing gates:", "orange"))
-    for gate_name, metrics in failing_gates.items():
+    print(color_message(f"Found {len(gates_to_bump)} gates with size increase:", "orange"))
+    for gate_name, metrics in gates_to_bump.items():
         short_name = gate_name.replace("static_quality_gate_", "")
-        disk_excess = (metrics.current_on_disk_size or 0) - (metrics.max_on_disk_size or 0)
-        wire_excess = (metrics.current_on_wire_size or 0) - (metrics.max_on_wire_size or 0)
+        disk_delta = metrics.relative_on_disk_size or 0
+        wire_delta = metrics.relative_on_wire_size or 0
         print(
             color_message(
-                f"  - {short_name}: disk +{byte_to_string(disk_excess)}, wire +{byte_to_string(wire_excess)}", "orange"
+                f"  - {short_name}: disk +{byte_to_string(disk_delta)}, wire +{byte_to_string(wire_delta)}", "orange"
             )
         )
 
-    # Step 3: Fetch main branch headroom (only for failing gates to minimize API footprint)
+    # Step 3: Fetch main branch headroom (for gates with size increase)
     print(color_message("Fetching main branch metrics for headroom calculation...", "cyan"))
-    main_headroom = fetch_main_headroom(list(failing_gates.keys()))
+    main_headroom = fetch_main_headroom(list(gates_to_bump.keys()))
 
     if not main_headroom:
         print(color_message("[ERROR] Unable to fetch main branch metrics from Datadog.", "red"))
@@ -905,9 +935,9 @@ def exception_threshold_bump(ctx, pr_number):
     with open(GATE_CONFIG_PATH) as f:
         config = yaml.safe_load(f)
 
-    # Step 5: Calculate and apply new thresholds for failing gates ONLY
+    # Step 5: Calculate and apply new thresholds for gates with size increase
     updated_gates = []
-    for gate_name, pr_gate_metrics in failing_gates.items():
+    for gate_name, pr_gate_metrics in gates_to_bump.items():
         if gate_name not in config:
             print(color_message(f"[WARN] Gate {gate_name} not found in config, skipping", "orange"))
             continue


### PR DESCRIPTION
### What does this PR do?
The task is supposed to bump not only the gates that are failing but all the gates that report size increase. This PR solves this. 

ABLD-354


### Describe how you validated your changes
Removed `-O2` flag from openssl build to deliberately increase its size and then ran
`dd-auth -- dda inv quality-gates.exception-threshold-bump 45960`

Reported size increase in the PR comment corresponded to the bumped values.

### Additional Notes
