### PR TITLE
Clone values read from bbolt transactions to fix race

### DIFF
--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -7,11 +7,13 @@ package uptane
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // dbBucket contains the data of the bucket
@@ -287,7 +289,7 @@ func (t *transaction) get(bucketName string, path string) ([]byte, error) {
 		if bucket == nil {
 			return nil
 		}
-		data = bucket.Get([]byte(path))
+		data = slices.Clone(bucket.Get([]byte(path)))
 		return nil
 	})
 

--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	bolt "go.etcd.io/bbolt"
 )
@@ -102,7 +103,7 @@ func (b BoltDB) Get(key string) ([]byte, error) {
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", boltBucket)
 		}
-		res = bucket.Get([]byte(key))
+		res = slices.Clone(bucket.Get([]byte(key)))
 		return nil
 	})
 }


### PR DESCRIPTION
### What does this PR do?
Clone slices obtained from bbolt and used outside the transaction.

### Motivation
The documentation of `bucket.Get` says
> The returned value is only valid for the life of the transaction.

We are returning and using those values outside the transaction, which leads to races while reading the value, and I suspect is the root cause of this panic while unmarshalling a payload.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1340109256#L237

### Describe how you validated your changes
CI.

### Additional Notes
