### PR TITLE
[ACTP] fix team label assignment for action-platform

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -57,6 +57,13 @@ jira_statuses = ["To Do", "In Progress", "Done"]
 github_team = "agent-build"
 github_labels = ["team/agent-build"]
 
+[teams."Action Platform"]
+jira_project = "ACTP"
+jira_issue_type = "Task"
+jira_statuses = ["To Do", "In Progress", "Done"]
+github_team = "action-platform"
+github_labels = ["team/action-platform"]
+
 [teams."Agent Discovery"]
 jira_project = "DSCVR"
 jira_issue_type = "Task"


### PR DESCRIPTION
### What does this PR do?
As the title says, the auto-assignment is required by CI for all changes under the `privateactionrunner` path.

### Motivation

### Describe how you validated your changes

### Additional Notes
