### PR TITLE
Correct permissions of artifacts in a final step

### DIFF
--- a/deps/compile_policy/BUILD.bazel
+++ b/deps/compile_policy/BUILD.bazel
@@ -28,7 +28,7 @@ pkg_files(
         "//:windows_x86_64": None,  # Windows doesn't use Unix permissions
         "//conditions:default": pkg_attributes(
             group = "root",
-            mode = "0555",
+            mode = "0755",
             owner = "root",
         ),
     }),

--- a/deps/secret_connector/BUILD.bazel
+++ b/deps/secret_connector/BUILD.bazel
@@ -19,7 +19,7 @@ alias(
 
 posix_attributes = pkg_attributes(
     group = "root",
-    mode = "0500",
+    mode = "0755",
     owner = "root",
 )
 

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -396,3 +396,9 @@ if linux_target? or windows_target?
   strip_build windows_target? || do_build
   debug_path ".debug"  # the strip symbols will be in here
 end
+
+if linux_target?
+  # Strip runs before packaging, so restore final perms after strip.
+  chmod_before_packaging "#{install_dir}/embedded/bin/dd-compile-policy", 0555
+  chmod_before_packaging "#{install_dir}/embedded/bin/secret-generic-connector", 0500
+end


### PR DESCRIPTION
### What does this PR do?

This relaxes the initial permission bits of some binaries and then applies the original configuration at the end.

### Motivation

I'm changing the build and developer environment images to run as a non-root user. When one is not root, you get errors like the following during the stripping phase:

```
❯ whoami
dd
❯ dda inv -- -e omnibus.build --skip-deps
...
               [Stripper] I | 2026-02-04T19:31:35+00:00 | Running strip on agent
#<Thread:0x00007fd108a7ba30 /opt/dd/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-ruby-b29eb2add13a/lib/omnibus/thread_pool.rb:56 run> terminated with exception (report_on_exception is true):
/opt/dd/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-ruby-b29eb2add13a/lib/omnibus/util.rb:101:in `rescue in shellout!': The following shell command exited with status 1: (Omnibus::CommandFailed)

    $ strip --strip-debug --strip-unneeded /opt/datadog-agent/embedded/bin/dd-compile-policy

Output:

    (nothing)

Error:

    strip: unable to copy file '/opt/datadog-agent/embedded/bin/dd-compile-policy'; reason: Permission denied
        from /opt/dd/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-ruby-b29eb2add13a/lib/omnibus/util.rb:96:in `shellout!'
        from /opt/dd/rvm/gems/ruby-2.7.2/bundler/gems/omnibus-ruby-b29eb2add13a/lib/omnibus/stripper.rb:95:in `block (3 levels) in strip_linux'
```

### Describe how you validated your changes

```
❯ whoami
dd
❯ dda inv -- -e omnibus.build --skip-deps
...
Build component timing:
Bundle: 0.357266902923584
Omnibus: 1253.137847661972
Missing required environment variables, this is probably not a CI job.
                  skipping sending build metrics
```

### Additional Notes

The build image changes will require another PR to fix up some paths to directories but this gets the build passing immediately.