### PR TITLE
Don't include filenames on openssl libraries

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = [
     "no-ssl3",
     "no-gost",
     "--libdir=lib",
+    "-fmacro-prefix-map=../../../../../../external/+_repo_rules+openssl/=",
     # This instructs openssl to dynamically *load* zlib at runtime, not
     # dynamically *link* with it at build time
     "zlib-dynamic",

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -22,8 +22,8 @@ DEFAULT_CONFIG = [
     "shared",
     "no-ssl3",
     "no-gost",
+    "no-filenames",
     "--libdir=lib",
-    "-fmacro-prefix-map=../../../../../../external/+_repo_rules+openssl/=",
     # This instructs openssl to dynamically *load* zlib at runtime, not
     # dynamically *link* with it at build time
     "zlib-dynamic",


### PR DESCRIPTION
### What does this PR do?

Remove filename information from built openssl, by adding the [`no-filenames`](https://github.com/openssl/openssl/blob/master/INSTALL.md#no-filenames) option.

### Motivation

Reduce package sizes, particularly as found during work on https://github.com/DataDog/datadog-agent/pull/43852 (and also offsetting part of the reported increase in there).

Building openssl the way we do with bazel results in some paths recorded in the built openssl libraries to include an extra `../../../../../../external/+_repo_rules+openssl/` prefix. This bakes unnecessary information into the files, which we can discard.

I initially found a possible solution to just drop the prefix, but I ended up finding a simple way to just drop these paths altogether, which seems acceptable.

### Describe how you validated your changes

CI, and SQG gains.

### Additional Notes

This will result in OpenSSL errors being reported without filename and line number, sacrificing a little bit of debugging information. However, it is rare for us to have to dig that much into the code when we see openssl errors to understand the cause.