### PR TITLE
[SBOM] make `BoltDB.Get` return value less confusing (eval order)

### DIFF
--- a/pkg/util/trivy/db.go
+++ b/pkg/util/trivy/db.go
@@ -98,7 +98,8 @@ func (b BoltDB) Delete(keys []string, callback onDeleteCallback) error {
 // Get retrieves the value attached to the given key.
 func (b BoltDB) Get(key string) ([]byte, error) {
 	var res []byte
-	return res, b.db.View(func(tx *bolt.Tx) error {
+
+	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket([]byte(boltBucket))
 		if bucket == nil {
 			return fmt.Errorf("bucket %s not found", boltBucket)
@@ -106,6 +107,11 @@ func (b BoltDB) Get(key string) ([]byte, error) {
 		res = slices.Clone(bucket.Get([]byte(key)))
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 // Store inserts a key in the database.


### PR DESCRIPTION
### What does this PR do?

[As is it works
](https://go.dev/play/p/P5Q3XEWaEto) but it depends on a specific evaluation order maintained by the compiler. Let's simplify the code to make it extra explicit and 100% safe.

### Motivation

### Describe how you validated your changes

### Additional Notes
