### PR TITLE
[ACTP] Add rc adapter in PAR

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	parconfig "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
+	pkgrcclient "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/enrollment"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/runners"
@@ -62,7 +63,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		return Provides{}, privateactionrunner.ErrNotEnabled
 	}
 
-	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, reqs.RcClient, reqs.Log)
+	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -77,7 +78,7 @@ func NewPrivateActionRunner(
 	ctx context.Context,
 	coreConfig model.ReaderWriter,
 	hostnameGetter hostnameinterface.Component,
-	rcClient rcclient.Component,
+	rcClient pkgrcclient.Client,
 	logger log.Component,
 ) (*PrivateActionRunner, error) {
 	persistedIdentity, err := enrollment.GetIdentityFromPreviousEnrollment(coreConfig)

--- a/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
+++ b/pkg/privateactionrunner/adapters/rcclient/rc_client_adapter.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package rcclient
+
+import (
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+type Client interface {
+	Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
+}
+
+type adapter struct {
+	comp rcclient.Component
+}
+
+func NewAdapter(comp rcclient.Component) Client {
+	return &adapter{
+		comp: comp,
+	}
+}
+
+func (a *adapter) Subscribe(product string, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
+	a.comp.Subscribe(data.Product(product), fn)
+}

--- a/pkg/privateactionrunner/task-verifier/keys_manager.go
+++ b/pkg/privateactionrunner/task-verifier/keys_manager.go
@@ -16,10 +16,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
 
@@ -30,7 +30,7 @@ type KeysManager interface {
 }
 
 type keysManager struct {
-	rcClient               RcClient
+	rcClient               rcclient.Client
 	stopChan               chan bool
 	keys                   map[string]types.DecodedKey
 	mu                     sync.RWMutex
@@ -38,11 +38,7 @@ type keysManager struct {
 	firstCallbackCompleted bool
 }
 
-type RcClient interface {
-	Subscribe(product data.Product, fn func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)))
-}
-
-func NewKeyManager(rcClient RcClient) KeysManager {
+func NewKeyManager(rcClient rcclient.Client) KeysManager {
 	return &keysManager{
 		stopChan: make(chan bool),
 		keys:     make(map[string]types.DecodedKey),


### PR DESCRIPTION
## What does this PR do?
This PR adds an adapter for rcclient for all usages in the privateactionrunner.

## Motivation
This is to allow easy integration with the cluster agent. The cluster agent doesn't use the fx component of RC which [relies on IPC.](https://github.com/DataDog/datadog-agent/blob/8bbed752aec98d52cd9b91f4f7520bd5c34f6336/comp/remote-config/rcclient/rcclientimpl/rcclient.go#L105-L111) Instead it uses a direct rcclient built from the available rcservice. https://github.com/DataDog/datadog-agent/blob/8bbed752aec98d52cd9b91f4f7520bd5c34f6336/cmd/cluster-agent/subcommands/start/command.go#L679-L685

To support both without too much hassle, we need an adapter.

## Describe how you validated your changes
I ran the PAR in local with self enrolment and actions execution still works

## Additional Notes
