### PR TITLE
[CWS] Stop swapping overlay inodes in dentry resolver to prevent path corruption

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -335,11 +335,6 @@ static struct inode * __attribute__((always_inline)) get_ovl_lower_inode_direct(
     return lower;
 }
 
-static int __attribute__((always_inline)) get_ovl_lower_ino_direct(struct dentry *dentry) {
-    struct inode *lower = get_ovl_lower_inode_direct(dentry);
-    return get_inode_ino(lower);
-}
-
 static struct dentry * __attribute__((always_inline)) get_ovl_lower_dentry_from_ovl_path(struct dentry *dentry) {
     struct inode *d_inode = get_dentry_inode(dentry);
 
@@ -348,11 +343,6 @@ static struct dentry * __attribute__((always_inline)) get_ovl_lower_dentry_from_
     bpf_probe_read(&lower, sizeof(lower), (char *)d_inode + get_sizeof_inode() + 16);
 
     return lower;
-}
-
-static int __attribute__((always_inline)) get_ovl_lower_ino_from_ovl_path(struct dentry *dentry) {
-    struct dentry *lower = get_ovl_lower_dentry_from_ovl_path(dentry);
-    return get_dentry_ino(lower);
 }
 
 static struct dentry * __attribute__((always_inline)) get_ovl_lower_dentry_from_ovl_entry(struct dentry *dentry) {
@@ -370,11 +360,6 @@ static struct dentry * __attribute__((always_inline)) get_ovl_lower_dentry_from_
     bpf_probe_read(&lower, sizeof(lower), (char *)oe + 4 + 4 + 8);
 
     return lower;
-}
-
-static int __attribute__((always_inline)) get_ovl_lower_ino_from_ovl_entry(struct dentry *dentry) {
-    struct dentry *lower = get_ovl_lower_dentry_from_ovl_entry(dentry);
-    return get_dentry_ino(lower);
 }
 
 static struct dentry * __attribute__((always_inline)) get_ovl_upper_dentry(struct dentry *dentry) {

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -394,16 +394,6 @@ static int __attribute__((always_inline)) get_ovl_upper_ino(struct dentry *dentr
     return get_dentry_ino(upper);
 }
 
-static int __attribute__((always_inline)) get_ovl_lower_ino(struct dentry *dentry) {
-    switch (get_ovl_path_in_inode()) {
-    case 2:
-        return get_ovl_lower_ino_from_ovl_entry(dentry);
-    case 1:
-        return get_ovl_lower_ino_from_ovl_path(dentry);
-    }
-    return get_ovl_lower_ino_direct(dentry);
-}
-
 static int __attribute__((always_inline)) get_ovl_upper_nlink(struct dentry *dentry) {
     struct dentry *upper = get_ovl_upper_dentry(dentry);
     return get_dentry_nlink(upper);

--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -439,22 +439,7 @@ static int __attribute__((always_inline)) get_overlayfs_layer(struct dentry *den
 }
 
 static void __attribute__((always_inline)) set_overlayfs_inode(struct dentry *dentry, struct file_t *file) {
-    u64 orig_inode = file->path_key.ino;
-    u64 lower_inode = get_ovl_lower_ino(dentry);
     u64 upper_inode = get_ovl_upper_ino(dentry);
-
-    // NOTE(safchain) both lower & upper inode seems to be incorrect sometimes on kernel >= 6.8.
-    // Need to investigate the root cause.
-    if (get_ovl_path_in_inode() == 2 && lower_inode != orig_inode && upper_inode != orig_inode) {
-        return;
-    }
-
-    if (lower_inode) {
-        file->path_key.ino = lower_inode;
-    } else if (upper_inode) {
-        file->path_key.ino = upper_inode;
-    }
-
     file->flags |= upper_inode != 0 ? UPPER_LAYER : LOWER_LAYER;
 }
 


### PR DESCRIPTION
### What does this PR do?

Modifies set_overlayfs_inode in the eBPF dentry resolver to stop replacing the overlay inode with the lower/upper filesystem inode in path_key.ino. The function now only sets the UPPER_LAYER/LOWER_LAYER flags for layer detection, keeping the overlay inode as the pathnames map key.
This also removes the kernel >= 6.8 safety guard that was added to work around symptoms of the same underlying issue.

### Motivation

We observe events where file paths are incorrectly resolved with duplicated components, for example /usr/bin/bash becomes /usr/usr/bin/bash.

### Describe how you validated your changes

### Additional Notes
