### PR TITLE
AllFlattenedSettingsWithSequenceID coerces val to default type

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -73,6 +73,21 @@ func TestCompareGetInt(t *testing.T) {
 	assert.Equal(t, 345, ntmConf.GetInt("port"))
 }
 
+func TestCompareGetTypesLikeDefault(t *testing.T) {
+	t.Setenv("DD_MY_FEATURE_ENABLED", "true")
+	t.Setenv("DD_PORT", "345")
+	viperConf, ntmConf := constructBothConfigs("", false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("my_feature.enabled", false)
+		cfg.BindEnvAndSetDefault("port", 0)
+	})
+
+	assert.Equal(t, true, viperConf.Get("my_feature.enabled"))
+	assert.Equal(t, 345, viperConf.Get("port"))
+
+	assert.Equal(t, true, ntmConf.Get("my_feature.enabled"))
+	assert.Equal(t, 345, ntmConf.Get("port"))
+}
+
 func TestCompareIsSet(t *testing.T) {
 	dataYaml := `port: 345`
 	viperConf, ntmConf := constructBothConfigs(dataYaml, true, nil)
@@ -140,6 +155,25 @@ func TestCompareAllSettingsWithoutDefault(t *testing.T) {
 	assert.NoError(t, err)
 	yamlText = string(yamlConf)
 	assert.Equal(t, expectedYaml, yamlText)
+}
+
+func TestCompareAllFlattenedSettingsWithSequenceID(t *testing.T) {
+	t.Setenv("DD_MY_FEATURE_ENABLED", "true")
+	t.Setenv("DD_PORT", "345")
+	viperConf, ntmConf := constructBothConfigs("", false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("my_feature.enabled", false)
+		cfg.BindEnvAndSetDefault("port", 0)
+	})
+
+	vipermap, _ := viperConf.AllFlattenedSettingsWithSequenceID()
+	ntmmap, _ := ntmConf.AllFlattenedSettingsWithSequenceID()
+
+	expectmap := map[string]interface{}{
+		"my_feature.enabled": true,
+		"port":               345,
+	}
+	assert.Equal(t, expectmap, vipermap)
+	assert.Equal(t, expectmap, ntmmap)
 }
 
 func TestCompareGetEnvVars(t *testing.T) {

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -941,7 +941,11 @@ func (c *ntmConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}
 	keys := c.collectFlattenedKeys()
 	settings := make(map[string]interface{}, len(keys))
 	for _, key := range keys {
-		settings[key] = c.getNodeValue(key)
+		v, err := c.inferTypeFromDefault(key, c.getNodeValue(key))
+		if err != nil {
+			log.Warnf("failed to get configuration value for key %q: %s", key, err)
+		}
+		settings[key] = v
 	}
 	return settings, c.sequenceID
 }


### PR DESCRIPTION
### What does this PR do?

The method `AllFlattenedSettingsWithSequenceID` will coerce type values to their default type, for example, environment variables parse string values into bools, ints, etc.

### Motivation

Fixes nodetreemodel compatibility with Viper, specifically for downstream dependencies of the `configstream` component.

### Describe how you validated your changes

Unit tests cover the behavior change.

### Additional Notes
