### PR TITLE
[SBOM] do not use windows nodes in e2e test

### DIFF
--- a/test/new-e2e/tests/sbom/eks_test.go
+++ b/test/new-e2e/tests/sbom/eks_test.go
@@ -26,7 +26,6 @@ func TestSBOMEKSSuite(t *testing.T) {
 			proveks.WithRunOptions(
 				sceneks.WithEKSOptions(
 					sceneks.WithLinuxNodeGroup(),
-					sceneks.WithWindowsNodeGroup(),
 					sceneks.WithBottlerocketNodeGroup(),
 					sceneks.WithLinuxARMNodeGroup(),
 				),
@@ -35,7 +34,6 @@ func TestSBOMEKSSuite(t *testing.T) {
 				sceneks.WithAgentOptions(
 					kubernetesagentparams.WithDualShipping(),
 					kubernetesagentparams.WithHelmValues(helmValues),
-					kubernetesagentparams.WithWindowsImage(),
 				),
 				sceneks.WithDeployArgoRollout(),
 			),

--- a/test/new-e2e/tests/sbom/k8s_test.go
+++ b/test/new-e2e/tests/sbom/k8s_test.go
@@ -77,7 +77,7 @@ func (suite *k8sSuite) TearDownSuite() {
 // is run first.
 func (suite *k8sSuite) Test00UpAndRunning() {
 	timeout := 10 * time.Minute
-	// Windows FIPS images are bigger and take longer to pull and start
+	// FIPS images are bigger and take longer to pull and start
 	if suite.Env().Agent.FIPSEnabled {
 		timeout = 20 * time.Minute
 	}


### PR DESCRIPTION
### What does this PR do?

The SBOM e2e tests don't need windows image/nodes, let's remove the creation of those when creating the eks cluster.

### Motivation

### Describe how you validated your changes

### Additional Notes
