### PR TITLE
Fix SNMP telemetry metrics collection by managing session lifecycle in Run()

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -235,12 +235,39 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	startTime := time.Now()
 	staticTags := append(d.config.GetStaticTags(), d.config.GetNetworkTags()...)
 
-	// Fetch and report metrics
-	var checkErr error
-	var deviceStatus metadata.DeviceStatus
-	var pingStatus metadata.DeviceStatus
+	// Connect to device
+	sess, deviceReachable, err := d.connMgr.Connect()
 
-	deviceReachable, profile, dynamicTags, values, checkErr := d.getValuesAndTags()
+	// Ensure session cleanup regardless of errors
+	defer func() {
+		if sess != nil {
+			err := d.connMgr.Close()
+			if err != nil {
+				d.sessionCloseErrorCount.Inc()
+				log.Warnf("failed to close session (count: %d): %v", d.sessionCloseErrorCount.Load(), err)
+			}
+		}
+	}()
+
+	var checkErr error
+	if err != nil {
+		d.diagnoses.Add("error", "SNMP_FAILED_TO_OPEN_CONNECTION", "Agent failed to open connection.")
+		checkErr = fmt.Errorf("snmp connection error: %s", err)
+		sess = nil // Prevent using invalid session
+	} else if !deviceReachable {
+		d.diagnoses.Add("error", "SNMP_FAILED_TO_POLL_DEVICE", "Agent failed to poll this network device. Check the authentication method and ensure the agent can ping it.")
+	}
+
+	profile := d.profileCache.GetProfile()
+	var dynamicTags []string
+	var values *valuestore.ResultValueStore
+
+	if sess != nil {
+		profile, dynamicTags, values, err = d.getValuesAndTags(sess, deviceReachable)
+		if err != nil {
+			checkErr = fmt.Errorf("failed to fetch values: %w", err)
+		}
+	}
 
 	tags := utils.CopyStrings(staticTags)
 	if checkErr != nil {
@@ -265,6 +292,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		d.sender.ReportMetrics(profile.Metrics, values, metricTags, d.config.DeviceID)
 	}
 
+	var pingStatus metadata.DeviceStatus
 	// Get a system appropriate ping check
 	if d.devicePinger != nil {
 		log.Tracef("%s: pinging host", d.config.IPAddress)
@@ -290,6 +318,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		log.Tracef("%s: SNMP ping disabled for host", d.config.IPAddress)
 	}
 
+	var deviceStatus metadata.DeviceStatus
 	if d.config.CollectDeviceMetadata {
 		if deviceReachable {
 			deviceStatus = metadata.DeviceStatusReachable
@@ -315,7 +344,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 			deviceStatus, pingStatus, deviceDiagnosis)
 	}
 
-	d.submitTelemetryMetrics(startTime, metricTags)
+	d.submitTelemetryMetrics(sess, startTime, metricTags)
 	d.setDeviceHostExternalTags()
 	d.interfaceBandwidthState.RemoveExpiredBandwidthUsageRates(startTime.UnixNano())
 
@@ -338,38 +367,16 @@ func (d *DeviceCheck) buildExternalTags() []string {
 
 // getValuesAndTags build (or fetches from cache) a profile describing all the
 // metrics, tags, etc. to be fetched for this device, fetches the resulting
-// values, and returns (reachable, profile, tags, values, error). In the event
+// values, and returns (profile, tags, values, error). In the event
 // of an error, the returned profile will be the last cached profile.
-func (d *DeviceCheck) getValuesAndTags() (bool, profiledefinition.ProfileDefinition, []string, *valuestore.ResultValueStore, error) {
-	var deviceReachable bool
+func (d *DeviceCheck) getValuesAndTags(sess session.Session, deviceReachable bool) (profiledefinition.ProfileDefinition, []string, *valuestore.ResultValueStore, error) {
 	var checkErrors []string
 	var tags []string
 
-	// Create connection with automatic UDP fallback for unexpected network behavior
-	sess, deviceReachable, connErr := d.connMgr.Connect()
-
-	// If connection failed, cannot proceed
-	if connErr != nil {
-		d.diagnoses.Add("error", "SNMP_FAILED_TO_OPEN_CONNECTION", "Agent failed to open connection.")
-		// cannot connect -> use cached profile
-		return false, d.profileCache.GetProfile(), tags, nil, fmt.Errorf("snmp connection error: %s", connErr)
-	}
-
-	defer func() {
-		err := d.connMgr.Close()
-		if err != nil {
-			d.sessionCloseErrorCount.Inc()
-			log.Warnf("failed to close session (count: %d): %v", d.sessionCloseErrorCount.Load(), err)
-		}
-	}()
-
-	// Check if the device is reachable
+	// Log device reachability status
 	if !deviceReachable {
-		// Connection succeeded but reachability check failed
-		d.diagnoses.Add("error", "SNMP_FAILED_TO_POLL_DEVICE", "Agent failed to poll this network device. Check the authentication method and ensure the agent can ping it.")
 		checkErrors = append(checkErrors, "check device reachable: failed: no value for GetNext")
 	} else {
-		// Both connection and reachability check succeeded
 		if log.ShouldLog(log.DebugLvl) {
 			log.Debugf("check device reachable: success (verified during connection)")
 		}
@@ -399,7 +406,7 @@ func (d *DeviceCheck) getValuesAndTags() (bool, profiledefinition.ProfileDefinit
 	if len(checkErrors) > 0 {
 		joinedError = errors.New(strings.Join(checkErrors, "; "))
 	}
-	return deviceReachable, profile, tags, valuesStore, joinedError
+	return profile, tags, valuesStore, joinedError
 }
 
 func (d *DeviceCheck) getSysObjectID(sess session.Session) (string, error) {
@@ -426,7 +433,7 @@ func (d *DeviceCheck) detectMetricsToMonitor(sess session.Session) (profiledefin
 	return profile, nil
 }
 
-func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string) {
+func (d *DeviceCheck) submitTelemetryMetrics(sess session.Session, startTime time.Time, tags []string) {
 	newTags := append(utils.CopyStrings(tags), snmpLoaderTag, utils.GetAgentVersionTag())
 
 	d.sender.Gauge("snmp.devices_monitored", float64(1), newTags)
@@ -436,12 +443,11 @@ func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string)
 	d.sender.Gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), newTags)
 	d.sender.Gauge("datadog.snmp.submitted_metrics", float64(d.sender.GetSubmittedMetrics()), newTags)
 
-	// Get session for SNMP request counts
-	sess, err := d.connMgr.GetSession()
-	if err != nil {
-		log.Debugf("failed to get session for telemetry metrics: %s", err)
+	// Only collect SNMP request metrics if session is available
+	if sess == nil {
 		return
 	}
+
 	d.sender.Gauge(snmpRequestMetric, float64(sess.GetSnmpGetCount()), append(utils.CopyStrings(newTags), snmpGetRequestTag))
 	d.sender.Gauge(snmpRequestMetric, float64(sess.GetSnmpGetBulkCount()), append(utils.CopyStrings(newTags), snmpGetBulkRequestTag))
 	d.sender.Gauge(snmpRequestMetric, float64(sess.GetSnmpGetNextCount()), append(utils.CopyStrings(newTags), snmpGetNextReqestTag))

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -265,7 +265,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	if sess != nil {
 		profile, dynamicTags, values, err = d.getValuesAndTags(sess, deviceReachable)
 		if err != nil {
-			checkErr = fmt.Errorf("failed to fetch values: %w", err)
+			checkErr = err
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -127,6 +127,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
 
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
+
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
 	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
@@ -158,6 +163,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
+
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
 	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
@@ -623,6 +633,16 @@ profiles:
 	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", servicecheck.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), "snmp connection error: some error")
 	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 1., "", snmpTags)
 	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 0., "", snmpTags)
+
+	// Verify that basic telemetry metrics are still sent even when session is nil
+	telemetryTagsForError := append(utils.CopyStrings(snmpTags), "agent_version:"+version.AgentVersion)
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", telemetryTagsForError)
+	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTagsForError)
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTagsForError)
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTagsForError)
+
+	// Verify that session-dependent SNMP request counter metrics are NOT sent when session is nil
+	sender.AssertNotCalled(t, "Gauge", "datadog.snmp.requests", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestRun_sessionCloseError(t *testing.T) {
@@ -779,6 +799,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
 
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
+
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
 	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
@@ -810,6 +835,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
+
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
 	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)
@@ -927,6 +957,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
 
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
+
 	// Should see f5-specific 'sysStatMemoryTotal' but not fake metrics
 	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(60), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.anotherMetric", mock.Anything, mock.Anything, mock.Anything)
@@ -958,6 +993,11 @@ profiles:
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", telemetryTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.submitted_metrics", telemetryTags)
+
+	// Assert SNMP request counter metrics
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:get"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getbulk"))
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.requests", append(utils.CopyStrings(telemetryTags), "request_type:getnext"))
 	// Should see fake metrics but not f5-specific 'sysStatMemoryTotal'
 	sender.AssertMetric(t, "Gauge", "snmp.anotherMetric", float64(100), "", snmpTags)
 	sender.AssertNotCalled(t, "Gauge", "snmp.sysStatMemoryTotal", mock.Anything, mock.Anything, mock.Anything)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where SNMP telemetry metrics (specifically `datadog.snmp.requests` with request type tags) were not being collected correctly because the session was closed before the telemetry collection could access it.

## Motivation

The SNMP session lifecycle was managed inside `getValuesAndTags()`, which closed the session via a deferred `Close()` call. However, `submitTelemetryMetrics()` needs the session to remain open to collect telemetry counters like:
- `datadog.snmp.requests` (with `request_type:get` tag)
- `datadog.snmp.requests` (with `request_type:getbulk` tag)
- `datadog.snmp.requests` (with `request_type:getnext` tag)
- `snmp.devices.using_unconnected_socket`

This resulted in telemetry collection failing silently or returning stale data.

## Changes

### Core Changes
1. **Moved session lifecycle management to `Run()` method**
   - Session creation (`Connect()`) and cleanup (`Close()`) now happen at the top level in `Run()`
   - Session remains open for all operations that need it

2. **Updated method signatures**
   - `getValuesAndTags()`: Now accepts `session.Session` and `deviceReachable` as parameters instead of creating the session internally
   - `submitTelemetryMetrics()`: Now accepts `session.Session` as parameter instead of calling `GetSession()`

3. **Added graceful degradation**
   - `submitTelemetryMetrics()` checks if session is nil and returns early if unavailable
   - Basic telemetry metrics (devices_monitored, check_interval, check_duration) are still sent even when session is nil
   - Session-dependent metrics (SNMP request counters) are only sent when session is available

### Test Improvements
4. **Added test assertions for SNMP request counter metrics**
   - Previously, tests only checked for basic telemetry metrics but not session-dependent ones
   - Added assertions to verify `datadog.snmp.requests` metrics are collected correctly
   - This will catch regressions if the session lifecycle management breaks again

5. **Added connection error scenario test**
   - Verifies that basic telemetry metrics are still sent when session is nil
   - Verifies that session-dependent metrics are correctly skipped when session is nil

## Test plan

- ✅ All existing unit tests pass (30 tests)
- ✅ All linters pass (0 issues)
- ✅ New test assertions verify SNMP request counter metrics are collected
- ✅ Connection error test verifies graceful degradation

## Additional Notes

The fix ensures proper session lifecycle management:
```
Run()
  → Connect() creates session
  → getValuesAndTags(sess) uses session
  → submitTelemetryMetrics(sess) uses session ✅
  → defer Close() cleans up session
```

Previously, the session was closed too early:
```
Run()
  → getValuesAndTags()
      → Connect() creates session
      → defer Close() schedules cleanup
      → returns (session closes here) ❌
  → submitTelemetryMetrics()
      → GetSession() returns nil/closed session ❌
```