### PR TITLE
[SQG] Add a pr_author tag to Datadog metrics

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -481,6 +481,8 @@ def display_pr_comment(
     dashboard_link = (
         "[📊 Static Quality Gates Dashboard](https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates)\n"
     )
+    job_url = os.environ.get("CI_JOB_URL", "")
+    job_link = f"[🔗 SQG Job]({job_url})\n" if job_url else ""
 
     # Main tables for on-disk metrics
     body_info = ""
@@ -578,7 +580,7 @@ def display_pr_comment(
         wire_section += body_wire
         wire_section += "\n</details>\n"
 
-    body = f"{SUCCESS_CHAR if final_state else FAIL_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{final_error_body}\n\n{success_section}\n{wire_section}"
+    body = f"{SUCCESS_CHAR if final_state else FAIL_CHAR} Please find below the results from static quality gates\n{ancestor_info}{dashboard_link}{job_link}{final_error_body}\n\n{success_section}\n{wire_section}"
 
     pr_commenter(ctx, title=title, body=body, pr=pr)
 


### PR DESCRIPTION
### What does this PR do?
1. It introduces a new tag `pr_author` that maps `pr_number` and `commit_sha` to an author.
2. It automatically retries pulling metrics from Datadog in case we have a race condition when an ancestor commit hasn't reported its metrics yet.
3. It adds a link to a SQG job of the pipeline to a PR comment for convenience.
