### PR TITLE
[ACTP] Integrate the private action runner in the cluster agent

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -430,7 +430,7 @@ func start(log log.Component,
 			products = append(products, state.ProductGradualRollout)
 		}
 		// Add private action runner product if enabled
-		if config.GetBool("privateactionrunner.enabled") {
+		if config.GetBool("private_action_runner.enabled") {
 			products = append(products, state.ProductActionPlatformRunnerKeys)
 		}
 
@@ -550,7 +550,7 @@ func start(log log.Component,
 		appsec.Cleanup(mainCtx, log, config, le.Subscribe)
 	}
 
-	if config.GetBool("privateactionrunner.enabled") {
+	if config.GetBool("private_action_runner.enabled") {
 		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, log)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -551,7 +551,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, log)
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, log, taggerComp)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -687,11 +687,12 @@ func startPrivateActionRunner(
 	hostnameGetter hostnameinterface.Component,
 	rcClient *rcclient.Client,
 	log log.Component,
+	tagger tagger.Component,
 ) (func(), error) {
 	if rcClient == nil {
 		return nil, errors.New("Remote config is disabled or failed to initialize, remote config is a required dependency for private action runner")
 	}
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log)
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -557,8 +557,6 @@ func start(log log.Component,
 		} else {
 			defer drain()
 		}
-	} else {
-		log.Info("Private action runner is disabled")
 	}
 
 	if config.GetBool("admission_controller.enabled") {

--- a/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
+++ b/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
@@ -11,6 +11,26 @@ package privatebundles
 import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
+	com_datadoghq_gitlab_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/branches"
+	com_datadoghq_gitlab_commits "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/commits"
+	com_datadoghq_gitlab_customattributes "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/customattributes"
+	com_datadoghq_gitlab_deployments "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/deployments"
+	com_datadoghq_gitlab_environments "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/environments"
+	com_datadoghq_gitlab_graphql "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/graphql"
+	com_datadoghq_gitlab_groups "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/groups"
+	com_datadoghq_gitlab_issues "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/issues"
+	com_datadoghq_gitlab_jobs "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/jobs"
+	com_datadoghq_gitlab_labels "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/labels"
+	com_datadoghq_gitlab_members "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/members"
+	com_datadoghq_gitlab_merge_requests "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/mergerequests"
+	com_datadoghq_gitlab_notes "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/notes"
+	com_datadoghq_gitlab_pipelines "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/pipelines"
+	com_datadoghq_gitlab_projects "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/projects"
+	com_datadoghq_gitlab_protected_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/protectedbranches"
+	com_datadoghq_gitlab_repositories "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/repositories"
+	com_datadoghq_gitlab_repository_files "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/repositoryfiles"
+	com_datadoghq_gitlab_tags "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/tags"
+	com_datadoghq_gitlab_users "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/users"
 	com_datadoghq_http "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/http"
 	com_datadoghq_jenkins "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/jenkins"
 	com_datadoghq_kubernetes_apiextensions "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/apiextensions"
@@ -18,7 +38,10 @@ import (
 	com_datadoghq_kubernetes_batch "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/batch"
 	com_datadoghq_kubernetes_core "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/core"
 	com_datadoghq_kubernetes_customresources "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/customresources"
+	com_datadoghq_mongodb "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/mongodb"
+	com_datadoghq_postgresql "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/postgresql"
 	com_datadoghq_script "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/script"
+	com_datadoghq_temporal "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/temporal"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
 
@@ -30,6 +53,26 @@ func NewRegistry(configuration *config.Config) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),
+			"com.datadoghq.gitlab.branches":            com_datadoghq_gitlab_branches.NewGitlabBranches(),
+			"com.datadoghq.gitlab.commits":             com_datadoghq_gitlab_commits.NewGitlabCommits(),
+			"com.datadoghq.gitlab.customattributes":    com_datadoghq_gitlab_customattributes.NewGitlabCustomAttributes(),
+			"com.datadoghq.gitlab.deployments":         com_datadoghq_gitlab_deployments.NewGitlabDeployments(),
+			"com.datadoghq.gitlab.environments":        com_datadoghq_gitlab_environments.NewGitlabEnvironments(),
+			"com.datadoghq.gitlab.graphql":             com_datadoghq_gitlab_graphql.NewGitlabGraphql(),
+			"com.datadoghq.gitlab.groups":              com_datadoghq_gitlab_groups.NewGitlabGroups(),
+			"com.datadoghq.gitlab.issues":              com_datadoghq_gitlab_issues.NewGitlabIssues(),
+			"com.datadoghq.gitlab.jobs":                com_datadoghq_gitlab_jobs.NewGitlabJobs(),
+			"com.datadoghq.gitlab.labels":              com_datadoghq_gitlab_labels.NewGitlabLabels(),
+			"com.datadoghq.gitlab.members":             com_datadoghq_gitlab_members.NewGitlabMembers(),
+			"com.datadoghq.gitlab.mergerequests":       com_datadoghq_gitlab_merge_requests.NewGitlabMergeRequests(),
+			"com.datadoghq.gitlab.notes":               com_datadoghq_gitlab_notes.NewGitlabNotes(),
+			"com.datadoghq.gitlab.pipelines":           com_datadoghq_gitlab_pipelines.NewGitlabPipelines(),
+			"com.datadoghq.gitlab.projects":            com_datadoghq_gitlab_projects.NewGitlabProjects(),
+			"com.datadoghq.gitlab.protectedbranches":   com_datadoghq_gitlab_protected_branches.NewGitlabProtectedBranches(),
+			"com.datadoghq.gitlab.repositories":        com_datadoghq_gitlab_repositories.NewGitlabRepositories(),
+			"com.datadoghq.gitlab.repositoryfiles":     com_datadoghq_gitlab_repository_files.NewGitlabRepositoryFiles(),
+			"com.datadoghq.gitlab.tags":                com_datadoghq_gitlab_tags.NewGitlabTags(),
+			"com.datadoghq.gitlab.users":               com_datadoghq_gitlab_users.NewGitlabUsers(),
 			"com.datadoghq.http":                       com_datadoghq_http.NewHttpBundle(configuration),
 			"com.datadoghq.jenkins":                    com_datadoghq_jenkins.NewJenkins(configuration),
 			"com.datadoghq.kubernetes.apiextensions":   com_datadoghq_kubernetes_apiextensions.NewKubernetesApiExtensions(),
@@ -37,7 +80,10 @@ func NewRegistry(configuration *config.Config) *Registry {
 			"com.datadoghq.kubernetes.batch":           com_datadoghq_kubernetes_batch.NewKubernetesBatch(),
 			"com.datadoghq.kubernetes.core":            com_datadoghq_kubernetes_core.NewKubernetesCore(),
 			"com.datadoghq.kubernetes.customresources": com_datadoghq_kubernetes_customresources.NewKubernetesCustomResources(),
+			"com.datadoghq.mongodb":                    com_datadoghq_mongodb.NewMongoDB(),
+			"com.datadoghq.postgresql":                 com_datadoghq_postgresql.NewPostgreSQL(),
 			"com.datadoghq.script":                     com_datadoghq_script.NewScript(),
+			"com.datadoghq.temporal":                   com_datadoghq_temporal.NewTemporal(),
 		},
 	}
 }

--- a/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
+++ b/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
@@ -11,26 +11,6 @@ package privatebundles
 import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
-	com_datadoghq_gitlab_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/branches"
-	com_datadoghq_gitlab_commits "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/commits"
-	com_datadoghq_gitlab_customattributes "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/customattributes"
-	com_datadoghq_gitlab_deployments "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/deployments"
-	com_datadoghq_gitlab_environments "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/environments"
-	com_datadoghq_gitlab_graphql "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/graphql"
-	com_datadoghq_gitlab_groups "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/groups"
-	com_datadoghq_gitlab_issues "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/issues"
-	com_datadoghq_gitlab_jobs "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/jobs"
-	com_datadoghq_gitlab_labels "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/labels"
-	com_datadoghq_gitlab_members "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/members"
-	com_datadoghq_gitlab_merge_requests "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/mergerequests"
-	com_datadoghq_gitlab_notes "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/notes"
-	com_datadoghq_gitlab_pipelines "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/pipelines"
-	com_datadoghq_gitlab_projects "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/projects"
-	com_datadoghq_gitlab_protected_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/protectedbranches"
-	com_datadoghq_gitlab_repositories "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/repositories"
-	com_datadoghq_gitlab_repository_files "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/repositoryfiles"
-	com_datadoghq_gitlab_tags "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/tags"
-	com_datadoghq_gitlab_users "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/users"
 	com_datadoghq_http "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/http"
 	com_datadoghq_jenkins "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/jenkins"
 	com_datadoghq_kubernetes_apiextensions "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/apiextensions"
@@ -50,26 +30,6 @@ func NewRegistry(configuration *config.Config) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),
-			"com.datadoghq.gitlab.branches":            com_datadoghq_gitlab_branches.NewGitlabBranches(),
-			"com.datadoghq.gitlab.commits":             com_datadoghq_gitlab_commits.NewGitlabCommits(),
-			"com.datadoghq.gitlab.customattributes":    com_datadoghq_gitlab_customattributes.NewGitlabCustomAttributes(),
-			"com.datadoghq.gitlab.deployments":         com_datadoghq_gitlab_deployments.NewGitlabDeployments(),
-			"com.datadoghq.gitlab.environments":        com_datadoghq_gitlab_environments.NewGitlabEnvironments(),
-			"com.datadoghq.gitlab.graphql":             com_datadoghq_gitlab_graphql.NewGitlabGraphql(),
-			"com.datadoghq.gitlab.groups":              com_datadoghq_gitlab_groups.NewGitlabGroups(),
-			"com.datadoghq.gitlab.issues":              com_datadoghq_gitlab_issues.NewGitlabIssues(),
-			"com.datadoghq.gitlab.jobs":                com_datadoghq_gitlab_jobs.NewGitlabJobs(),
-			"com.datadoghq.gitlab.labels":              com_datadoghq_gitlab_labels.NewGitlabLabels(),
-			"com.datadoghq.gitlab.members":             com_datadoghq_gitlab_members.NewGitlabMembers(),
-			"com.datadoghq.gitlab.mergerequests":       com_datadoghq_gitlab_merge_requests.NewGitlabMergeRequests(),
-			"com.datadoghq.gitlab.notes":               com_datadoghq_gitlab_notes.NewGitlabNotes(),
-			"com.datadoghq.gitlab.pipelines":           com_datadoghq_gitlab_pipelines.NewGitlabPipelines(),
-			"com.datadoghq.gitlab.projects":            com_datadoghq_gitlab_projects.NewGitlabProjects(),
-			"com.datadoghq.gitlab.protectedbranches":   com_datadoghq_gitlab_protected_branches.NewGitlabProtectedBranches(),
-			"com.datadoghq.gitlab.repositories":        com_datadoghq_gitlab_repositories.NewGitlabRepositories(),
-			"com.datadoghq.gitlab.repositoryfiles":     com_datadoghq_gitlab_repository_files.NewGitlabRepositoryFiles(),
-			"com.datadoghq.gitlab.tags":                com_datadoghq_gitlab_tags.NewGitlabTags(),
-			"com.datadoghq.gitlab.users":               com_datadoghq_gitlab_users.NewGitlabUsers(),
 			"com.datadoghq.http":                       com_datadoghq_http.NewHttpBundle(configuration),
 			"com.datadoghq.jenkins":                    com_datadoghq_jenkins.NewJenkins(configuration),
 			"com.datadoghq.kubernetes.apiextensions":   com_datadoghq_kubernetes_apiextensions.NewKubernetesApiExtensions(),

--- a/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
+++ b/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Integrate the Private Action Runner into the Datadog Cluster Agent.
+    The Cluster Agent binary size has been reduced by excluding database and temporal bundles
+    from the Private Action Runner registry.

--- a/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
+++ b/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
@@ -9,3 +9,5 @@
 features:
   - |
     Integrate the Private Action Runner into the Datadog Cluster Agent.
+    The Cluster Agent binary size has been reduced by excluding database and temporal bundles
+    from the Private Action Runner registry.

--- a/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
+++ b/releasenotes/notes/par-in-dca-03647a027cda2907.yaml
@@ -9,5 +9,3 @@
 features:
   - |
     Integrate the Private Action Runner into the Datadog Cluster Agent.
-    The Cluster Agent binary size has been reduced by excluding database and temporal bundles
-    from the Private Action Runner registry.

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,11 +47,11 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 1004.92 MiB
   max_on_wire_size: 331.37 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 181.2 MiB
-  max_on_wire_size: 64.51 MiB
+  max_on_disk_size: 191.32 MiB
+  max_on_wire_size: 67.22 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 198.49 MiB
-  max_on_wire_size: 61.17 MiB
+  max_on_disk_size: 208.19 MiB
+  max_on_wire_size: 63.64 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB
   max_on_wire_size: 3.33 MiB


### PR DESCRIPTION
## What does this PR do?
Integrates the Private Action Runner (PAR) component into the Datadog Cluster Agent, enabling the cluster agent to execute private actions from Datadog workflows and other products.

## Motivation
The Private Action Runner allows customers to execute actions within their own infrastructure in response to Datadog workflows, monitors, and other automation triggers. 

By integrating PAR into the cluster agent:

- Customers can deploy PAR alongside their existing cluster agent installation
- No additional deployment/management overhead for PAR
- Leverages cluster agent's existing remote config infrastructure
- Provides a unified deployment model for Kubernetes environments

## Describe how you validated your changes

- ✅ Verified PAR starts successfully when enabled via `private_action_runner.enabled:
true`
- ✅ Confirmed PAR self-enrollment works and creates proper identity
- ✅ Tested that PAR remains disabled when configuration flag is false
- ✅ Validated remote config integration and action execution
- ✅ Checked that cluster agent continues to function normally when PAR is disabled

All of these have been tested in local + staging experimental cluster

## Additional Notes

- PAR is disabled by default and must be explicitly enabled via configuration
- Requires remote config to be enabled (PAR will fail to start if RC is disabled)
- This PR adds the foundation; multi-replica coordination will be added in a follow-up PR