### PR TITLE
Run SSI e2e tests on Google Kubernetes Engine (GKE)

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -1009,6 +1009,22 @@ new-e2e-ssi-eks:
     E2E_STACK_NAME_SUFFIX: eks
     E2E_PRE_INITIALIZED: "true"
 
+new-e2e-ssi-gke-init:
+  extends: .new-e2e_ssi_extra_distribution_init
+  variables:
+    E2E_PROVISIONER: gke
+    E2E_STACK_NAME_SUFFIX: gke
+
+new-e2e-ssi-gke:
+  extends: .new-e2e_ssi_extra_distribution
+  needs:
+    - !reference [.new-e2e_ssi_extra_distribution, needs]
+    - new-e2e-ssi-gke-init
+  variables:
+    E2E_PROVISIONER: gke
+    E2E_STACK_NAME_SUFFIX: gke
+    E2E_PRE_INITIALIZED: "true"
+
 .new-e2e_package_signing:
   variables:
     TARGETS: ./tests/agent-platform/package-signing

--- a/test/e2e-framework/testing/provisioners/gcp/kubernetes/gke.go
+++ b/test/e2e-framework/testing/provisioners/gcp/kubernetes/gke.go
@@ -7,6 +7,7 @@
 package gcpkubernetes
 
 import (
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/gcp"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/gcp/gke"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -60,6 +61,11 @@ func GKERunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 		return err
 	}
 
+	// If InitOnly is set, return after creating the cluster without deploying the agent.
+	if gcpEnv.InitOnly() {
+		return nil
+	}
+
 	agentOptions := params.agentOptions
 
 	// Deploy a fakeintake
@@ -86,6 +92,13 @@ func GKERunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Provi
 		err = agent.Export(ctx, &env.Agent.KubernetesAgentOutput)
 		if err != nil {
 			return err
+		}
+		dependsOnDDAgent := utils.PulumiDependsOn(agent)
+		for _, appFunc := range params.agentDependentWorkloadAppFuncs {
+			_, err := appFunc(&gcpEnv, cluster.KubeProvider, dependsOnDDAgent)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		env.Agent = nil

--- a/test/e2e-framework/testing/provisioners/gcp/kubernetes/params.go
+++ b/test/e2e-framework/testing/provisioners/gcp/kubernetes/params.go
@@ -24,20 +24,22 @@ import (
 
 // ProvisionerParams contains all the parameters needed to create the environment
 type ProvisionerParams struct {
-	name              string
-	fakeintakeOptions []fakeintake.Option
-	agentOptions      []kubernetesagentparams.Option
-	gkeOptions        []gke.Option
-	workloadAppFuncs  []WorkloadAppFunc
-	extraConfigParams runner.ConfigMap
+	name                           string
+	fakeintakeOptions              []fakeintake.Option
+	agentOptions                   []kubernetesagentparams.Option
+	gkeOptions                     []gke.Option
+	workloadAppFuncs               []WorkloadAppFunc
+	agentDependentWorkloadAppFuncs []kubeComp.AgentDependentWorkloadAppFunc
+	extraConfigParams              runner.ConfigMap
 }
 
 func newProvisionerParams(opts ...ProvisionerOption) *ProvisionerParams {
 	params := &ProvisionerParams{
-		name:              "gke",
-		fakeintakeOptions: []fakeintake.Option{},
-		agentOptions:      []kubernetesagentparams.Option{},
-		workloadAppFuncs:  []WorkloadAppFunc{},
+		name:                           "gke",
+		fakeintakeOptions:              []fakeintake.Option{},
+		agentOptions:                   []kubernetesagentparams.Option{},
+		workloadAppFuncs:               []WorkloadAppFunc{},
+		agentDependentWorkloadAppFuncs: []kubeComp.AgentDependentWorkloadAppFunc{},
 	}
 	err := optional.ApplyOptions(params, opts)
 	if err != nil {
@@ -96,6 +98,14 @@ type WorkloadAppFunc func(e config.Env, kubeProvider *kubernetes.Provider) (*kub
 func WithWorkloadApp(appFunc WorkloadAppFunc) ProvisionerOption {
 	return func(params *ProvisionerParams) error {
 		params.workloadAppFuncs = append(params.workloadAppFuncs, appFunc)
+		return nil
+	}
+}
+
+// WithAgentDependentWorkloadApp adds a workload app that depends on the agent being deployed first.
+func WithAgentDependentWorkloadApp(appFunc kubeComp.AgentDependentWorkloadAppFunc) ProvisionerOption {
+	return func(params *ProvisionerParams) error {
+		params.agentDependentWorkloadAppFuncs = append(params.agentDependentWorkloadAppFuncs, appFunc)
 		return nil
 	}
 }

--- a/test/new-e2e/tests/ssi/provisioner.go
+++ b/test/new-e2e/tests/ssi/provisioner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
 	proveks "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/eks"
 	provkindvm "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/kubernetes/kindvm"
+	provgke "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/gcp/kubernetes"
 	localkind "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/local/kubernetes"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
@@ -31,6 +32,8 @@ const (
 	ProvisionerKindLocal ProvisionerType = "kind-local"
 	// ProvisionerEKS uses Amazon EKS.
 	ProvisionerEKS ProvisionerType = "eks"
+	// ProvisionerGKE uses Google Kubernetes Engine.
+	ProvisionerGKE ProvisionerType = "gke"
 )
 
 // ProvisionerOptions contains the common options for Kubernetes provisioners.
@@ -41,7 +44,7 @@ type ProvisionerOptions struct {
 }
 
 // Provisioner returns a Kubernetes provisioner based on E2E_PROVISIONER and E2E_DEV_LOCAL parameters.
-// Supported provisioners: "kind" (default), "kind-local", "eks".
+// Supported provisioners: "kind" (default), "kind-local", "eks", "gke".
 // E2E_DEV_LOCAL=true is a shortcut for E2E_PROVISIONER=kind-local.
 func Provisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
 	provisionerType := getProvisionerType()
@@ -50,6 +53,8 @@ func Provisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environm
 		return localKindProvisioner(opts)
 	case ProvisionerEKS:
 		return eksProvisioner(opts)
+	case ProvisionerGKE:
+		return gkeProvisioner(opts)
 	default:
 		return awsKindProvisioner(opts)
 	}
@@ -125,4 +130,20 @@ func eksProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[envir
 		runOpts = append(runOpts, scenarioeks.WithAgentDependentWorkloadApp(opts.AgentDependentWorkloadAppFunc))
 	}
 	return proveks.Provisioner(proveks.WithRunOptions(runOpts...))
+}
+
+// gkeProvisioner returns a Google Kubernetes Engine provisioner.
+func gkeProvisioner(opts ProvisionerOptions) provisioners.TypedProvisioner[environments.Kubernetes] {
+	var gkeOpts []provgke.ProvisionerOption
+
+	if len(opts.AgentOptions) > 0 {
+		gkeOpts = append(gkeOpts, provgke.WithAgentOptions(opts.AgentOptions...))
+	}
+	if opts.WorkloadAppFunc != nil {
+		gkeOpts = append(gkeOpts, provgke.WithWorkloadApp(provgke.WorkloadAppFunc(opts.WorkloadAppFunc)))
+	}
+	if opts.AgentDependentWorkloadAppFunc != nil {
+		gkeOpts = append(gkeOpts, provgke.WithAgentDependentWorkloadApp(opts.AgentDependentWorkloadAppFunc))
+	}
+	return provgke.GKEProvisioner(gkeOpts...)
 }


### PR DESCRIPTION
### What does this PR do?

Adds support for running SSI e2e tests on Google Kubernetes Engine (GKE), as done for Amazon EKS in https://github.com/DataDog/datadog-agent/pull/45974

Tests on GKE don't run on every PR. Only:
- on main/rc/release branches
- when triggered manually
- when the test folder is modified

Changes:
- Adds `WithAgentDependentWorkloadApp` to the GKE provisioner
- Adds `E2E_PROVISIONER=gke` option
- Adds `new-e2e-ssi-gke` CI job

### Motivation

https://datadoghq.atlassian.net/browse/INPLAT-919

Complete cloud provider coverage for SSI tests 

### Describe how you validated your changes

### Additional Notes
