### PR TITLE
Avoid repeated `gcc-toolchain` refetchings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,6 +119,7 @@ git_override(
         "//bazel/patches:gcc-toolchain/0001-Remove-fortran-related-actions-adapt-to-our-ctng-too.patch",
         "//bazel/patches:gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
+        "//bazel/patches:gcc-toolchain/0004-fix-re-fetching.patch",  # https://github.com/f0rmiga/gcc-toolchain/pull/207
     ],
     remote = "https://github.com/f0rmiga/gcc-toolchain.git",
 )

--- a/bazel/patches/gcc-toolchain/0004-fix-re-fetching.patch
+++ b/bazel/patches/gcc-toolchain/0004-fix-re-fetching.patch
@@ -1,0 +1,62 @@
+From 84454594d1cdc67ab2a9780ea2d5aa904efdcdf4 Mon Sep 17 00:00:00 2001
+From: Borja Lorente <blorente.me@gmail.com>
+Date: Mon, 29 Sep 2025 17:08:07 +0100
+Subject: [PATCH] fix: Stop using is_bzlmod_enabled as it invalidates the
+ repository rule
+
+Rebased to apply after removal of extra_fflags.
+---
+ toolchain/defs.bzl              | 8 ++++++--
+ toolchain/module_extensions.bzl | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 0e55fd7..ecc680e 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -18,12 +18,12 @@
+ """This module provides the definitions for registering a GCC toolchain for C and C++.
+ """
+ 
+-load("@aspect_bazel_lib//lib:utils.bzl", "is_bzlmod_enabled")
+ load("@bazel_skylib//lib:dicts.bzl", "dicts")
+ load("@bazel_skylib//lib:paths.bzl", "paths")
+ 
+ def _gcc_toolchain_impl(rctx):
+     versions = json.decode(rctx.attr.gcc_versions)
++    is_bzlmod_module = rctx.attr.private_is_bzlmod_module
+     rctx.download_and_extract(
+         url = versions[rctx.attr.gcc_version][rctx.attr.target_arch]["url"],
+         sha256 = versions[rctx.attr.gcc_version][rctx.attr.target_arch]["sha256"],
+@@ -42,7 +42,7 @@ def _gcc_toolchain_impl(rctx):
+     def _format_builtins(builtins):
+         # In bzlmod, external dependencies have their own canonical subdirectories, so we can't rely on %workspace%.
+         # Instead, we want to resolve paths relative to the root of the module where the toolchain is installed.
+-        if is_bzlmod_enabled():
++        if is_bzlmod_module:
+             return [d.replace("%workspace%", toolchain_root) for d in builtins]
+         return builtins
+ 
+@@ -369,6 +369,10 @@ _PRIVATE_ATTRS = {
+     "_wrapper_sh_template": attr.label(
+         default = Label("//toolchain:wrapper.sh.tpl"),
+     ),
++    "private_is_bzlmod_module": attr.bool(
++        default = False,
++        doc = "Whether this repository rule is instantiate in a Bzlmod module. This is a workaround for https://github.com/bazel-contrib/bazel-lib/issues/1183, please don't use it directly.",
++    ),
+ }
+ 
+ gcc_toolchain = repository_rule(
+diff --git a/toolchain/module_extensions.bzl b/toolchain/module_extensions.bzl
+index 1eb37ab..883a33b 100644
+--- a/toolchain/module_extensions.bzl
++++ b/toolchain/module_extensions.bzl
+@@ -19,6 +19,7 @@ def _gcc_register_toolchain_module_extension(mctx):
+                 extra_cflags = declare.extra_cflags,
+                 extra_cxxflags = declare.extra_cxxflags,
+                 extra_ldflags = declare.extra_ldflags,
++                private_is_bzlmod_module = True,
+             )
+ 
+     # Since we know that for each gcc toolchain repository we'll generate the same files, we mark the rule as reproducible.


### PR DESCRIPTION
### What does this PR do?
Apply a temporary patch to `gcc-toolchain` to fix repository cache invalidation that causes generated toolchain repositories to be re-fetched and re-extracted on every Bazel server restart (as well as `bazel fetch`).

### Motivation
The `gcc-toolchain` dependency suffers from [Bazel keeps Fetching and extracting gcc-toolchain](https://github.com/f0rmiga/gcc-toolchain/issues/207), where calling `is_bzlmod_enabled()` from within a repository rule causes Bazel to invalidate the repository cache:
```
Fetching repository @@gcc_toolchain++gcc_toolchains+gcc_toolchain_aarch64; starting
Fetching repository @@gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64; starting
Fetching /path/to/external/gcc_toolchain++gcc_toolchains+gcc_toolchain_aarch64; Extracting datadog_agent_cc_toolchain_ubuntu_22_gcc_12.3.0_aarch64.tar.gz
Fetching /path/to/external/gcc_toolchain++gcc_toolchains+gcc_toolchain_x86_64; Extracting datadog_agent_cc_toolchain_ubuntu_22_gcc_11.4.0_x86_64.tar.gz
```
This results in:
- disk pressure: repeated extraction of the toolchain tarballs (extracted, `gcc_toolchain_x86_64` takes about 347M and `gcc_toolchain_aarch64` about 329M),
- slower build times: locally (facing this more often while working on adding Go repositories), but also in CI where `bazel` dies when the job's container stops.

### Describe how you validated your changes
`bazel shutdown && bazel build //... && bazel shutdown && bazel build //...` fetches/extracts `gcc_toolchain`-generated repositories at most once.

### Additional Notes
Two upstream PRs would address this:
1. f0rmiga/gcc-toolchain#208
2. f0rmiga/gcc-toolchain#216

Maintainers has been notified in the Bazel Slack workspace. Until they pick one, the present change applies a patch generated from the 1st PR (https://github.com/f0rmiga/gcc-toolchain/pull/208.patch) because it comes with a smaller patch surface and only addresses the immediate issue.