### PR TITLE
Stop running install-script and similar e2e tests by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -547,9 +547,6 @@ workflow:
     when: never
   - <<: *if_installer_tests
   - <<: *on_build_changes
-  - <<: *if_auto_e2e_tests
-    variables:
-      E2E_DESCRIPTORS: $E2E_BRANCH_DESCRIPTORS
 
 .security_agent_change_paths: &security_agent_change_paths
   - pkg/ebpf/**/*


### PR DESCRIPTION
### What does this PR do?

By default all the install-script and associated tests are running on all PRs. The goal of these tests is to check that the agent can be installed/upgraded without pain. Only changes to the way the agent is built/packaged should impact such operations

### Motivation

Reduce tests we execute on PRs.

### Describe how you validated your changes

### Additional Notes
