### PR TITLE
[CWS] Don't skip remaining rule actions on kill error

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3399,7 +3399,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 		case action.Def.Kill != nil:
 			// do not handle kill action on event with error
 			if ev.Error != nil {
-				return
+				continue
 			}
 
 			tryToKill, report := p.processKiller.KillAndReport(action.Def.Kill, rule, ev)
@@ -3425,7 +3425,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 			}
 		case action.Def.NetworkFilter != nil:
 			if !p.config.RuntimeSecurity.EnforcementEnabled {
-				return
+				continue
 			}
 
 			var policy rawpacket.Policy

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -660,7 +660,7 @@ func (p *EBPFLessProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 		case action.Def.Kill != nil:
 			// do not handle kill action on event with error
 			if ev.Error != nil {
-				return
+				continue
 			}
 			tryToKill, _ := p.processKiller.KillAndReport(action.Def.Kill, rule, ev)
 			if tryToKill {


### PR DESCRIPTION
### What does this PR do?

Don't skip remaining rule actions on errors in kill or network_filter actions 

### Motivation

### Describe how you validated your changes

### Additional Notes
