### PR TITLE
[CWS-5866] Resolve file path before performing a hash action

### DIFF
--- a/pkg/security/probe/file_hasher.go
+++ b/pkg/security/probe/file_hasher.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/hash"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -93,16 +92,8 @@ func (p *FileHasher) HandleProcessExited(event *model.Event) {
 }
 
 // HashAndReport hash and report, returns true if the hash computation is supported for the given event
-func (p *FileHasher) HashAndReport(rule *rules.Rule, action *rules.HashDefinition, ev *model.Event) bool {
-	eventType := ev.GetEventType()
-
+func (p *FileHasher) HashAndReport(rule *rules.Rule, action *rules.HashDefinition, ev *model.Event, fileEvent *model.FileEvent) bool {
 	if !p.cfg.RuntimeSecurity.HashResolverEnabled {
-		return false
-	}
-
-	fileEvent, err := ev.GetFileField(action.Field)
-	if err != nil {
-		seclog.Errorf("failed to get file field %s: %v", action.Field, err)
 		return false
 	}
 
@@ -124,7 +115,7 @@ func (p *FileHasher) HashAndReport(rule *rules.Rule, action *rules.HashDefinitio
 		maxFileSize: action.MaxFileSize,
 		seenAt:      ev.ResolveEventTime(),
 		fileEvent:   *fileEvent,
-		eventType:   eventType,
+		eventType:   ev.GetEventType(),
 	}
 	ev.ActionReports = append(ev.ActionReports, report)
 	p.pendingReports = append(p.pendingReports, report)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3420,7 +3420,17 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				p.probe.onRuleActionPerformed(rule, action.Def)
 			}
 		case action.Def.Hash != nil:
-			if p.fileHasher.HashAndReport(rule, action.Def.Hash, ev) {
+			fileEvent, err := ev.GetFileField(action.Def.Hash.Field)
+			if err != nil {
+				seclog.Errorf("failed to get file field %s: %v", action.Def.Hash.Field, err)
+				continue
+			}
+
+			if p.fieldHandlers.ResolveFilePath(ev, fileEvent) == "" {
+				continue
+			}
+
+			if p.fileHasher.HashAndReport(rule, action.Def.Hash, ev, fileEvent) {
 				p.probe.onRuleActionPerformed(rule, action.Def)
 			}
 		case action.Def.NetworkFilter != nil:

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -667,7 +667,17 @@ func (p *EBPFLessProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 				p.probe.onRuleActionPerformed(rule, action.Def)
 			}
 		case action.Def.Hash != nil:
-			if p.fileHasher.HashAndReport(rule, action.Def.Hash, ev) {
+			fileEvent, err := ev.GetFileField(action.Def.Hash.Field)
+			if err != nil {
+				seclog.Errorf("failed to get file field %s: %v", action.Def.Hash.Field, err)
+				continue
+			}
+
+			if p.fieldHandlers.ResolveFilePath(ev, fileEvent) == "" {
+				continue
+			}
+
+			if p.fileHasher.HashAndReport(rule, action.Def.Hash, ev, fileEvent) {
 				p.probe.onRuleActionPerformed(rule, action.Def)
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Force a file path resolution when performing a hash action.

### Motivation

Otherwise the path is empty for rules like the following and the hash computation just fails:

```yaml
id: hash_open
expression: open.flags&O_CREAT == O_CREAT
actions:
  - hash:
      field: open.file
```

### Describe how you validated your changes

### Additional Notes
