### PR TITLE
[CWS] don't call `model.UnmarshalBinary` with just one unmarshaller

### DIFF
--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -179,7 +179,7 @@ func (e *Process) UnmarshalProcEntryBinary(data []byte) (int, error) {
 		return 0, ErrNotEnoughData
 	}
 
-	read, err := UnmarshalBinary(data, &e.FileEvent)
+	read, err := e.FileEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -232,7 +232,7 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 	e.UserSession.K8SSessionID = binary.NativeEndian.Uint64(data[32:40])
 
 	// Unmarshal the credentials contained in pid_cache_t
-	read, err := UnmarshalBinary(data[40:], &e.Credentials)
+	read, err := e.Credentials.UnmarshalBinary(data[40:])
 	if err != nil {
 		return 0, err
 	}
@@ -411,7 +411,7 @@ func clearTopBitNsec(nsec uint64) uint64 {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *FileEvent) UnmarshalBinary(data []byte) (int, error) {
-	return UnmarshalBinary(data, &e.FileFields)
+	return e.FileFields.UnmarshalBinary(data)
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
@@ -544,7 +544,7 @@ func (s *SpanContext) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *SELinuxEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.File)
+	n, err := e.File.UnmarshalBinary(data)
 	if err != nil {
 		return n, err
 	}
@@ -652,7 +652,7 @@ func (e *SyscallContext) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *UmountEvent) UnmarshalBinary(data []byte) (int, error) {
-	n, err := UnmarshalBinary(data, &e.SyscallEvent)
+	n, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return n, err
 	}
@@ -735,7 +735,7 @@ func (e *MountReleasedEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *BPFEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -852,7 +852,7 @@ func parseHelpers(helpers []uint64) []uint32 {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *PTraceEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -889,7 +889,7 @@ func (e *MMapEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *MProtectEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -940,7 +940,7 @@ func (e *LoadModuleEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *UnloadModuleEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -958,7 +958,7 @@ func (e *UnloadModuleEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *SignalEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -990,7 +990,7 @@ func (e *SpliceEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.CGroupContext)
+	read, err := e.CGroupContext.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1013,7 +1013,7 @@ func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *CgroupWriteEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.File.PathKey)
+	read, err := e.File.PathKey.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1068,7 +1068,7 @@ func (e *NetworkDeviceContext) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *NetworkContext) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.Device)
+	read, err := e.Device.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1234,7 +1234,7 @@ func (d *NetDevice) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *NetDeviceEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1250,7 +1250,7 @@ func (e *NetDeviceEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *VethPairEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1273,7 +1273,7 @@ func (e *VethPairEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *AcceptEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1300,7 +1300,7 @@ func (e *AcceptEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1328,7 +1328,7 @@ func (e *BindEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *ConnectEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1527,7 +1527,7 @@ func (e *SysCtlEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *SetSockOptEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1558,7 +1558,7 @@ func (e *SetSockOptEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *SetrlimitEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1590,7 +1590,7 @@ func (e *CapabilitiesEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *PrCtlEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}
@@ -1617,7 +1617,7 @@ func (e *PrCtlEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *TracerMemfdSealEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.SyscallEvent)
+	read, err := e.SyscallEvent.UnmarshalBinary(data)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### What does this PR do?

We currently call `model. UnmarshalBinary` that makes the event goes through interface boxing + variadic argument array creation, while we could call the function directly. This is what this PR is doing.

### Motivation

### Describe how you validated your changes

### Additional Notes
