### PR TITLE
[ACTP-1275] Add default script config to the agent installation

### DIFF
--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+pkg_files(
+    name = "all_files",
+    srcs = ["script-config.yaml"],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0644",
+        owner = "root",
+    ),
+    prefix = "etc/datadog-agent/private-action-runner",
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
+    ],
+)

--- a/pkg/privateactionrunner/autoconnections/conf/script-config.yaml
+++ b/pkg/privateactionrunner/autoconnections/conf/script-config.yaml
@@ -1,0 +1,10 @@
+schemaId: script-credentials-v1
+runPredefinedScript:
+  echo:
+    command:
+      - echo
+      - "Hello World!"
+  echo-parametrized:
+    command:
+      - echo
+      - "{{ parameters.echoValue }}"


### PR DESCRIPTION
### Summary
This PR adds a default configuration of the Private Action Runner Script connection.

### Motivation
The Script connection used by the Script Action requires a configuration with predefined scripts.

### Changes
- Added a default Script connection config file (`script-config.yaml`)
