### PR TITLE
Restore installer layer in Windows Agent OCI package

### DIFF
--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -106,8 +106,29 @@
           echo "Unknown WIN_SOURCE_TYPE: ${WIN_SOURCE_TYPE}"; exit 1
           ;;
       esac
+    - |
+      # Add installer binary for datadog-agent OCI package
+      if [ "${OCI_PRODUCT}" = "datadog-agent" ]; then
+        INSTALLER_BIN=$(ls -1 "${PIPE_DIR}"/datadog-installer-*-x86_64.exe 2>/dev/null | head -1)
+        if [ -n "$INSTALLER_BIN" ]; then
+          EXTRA_FLAGS="${EXTRA_FLAGS} --installer ${INSTALLER_BIN}"
+        else
+          echo "ERROR: No installer binary found for datadog-agent OCI package"
+          exit 1
+        fi
+      fi
     - export PATH="$PATH:$(go env GOPATH)/bin"
     - datadog-package create --version "${PACKAGE_VERSION}" --package "${OCI_PRODUCT}" --os windows --arch amd64 --archive --archive-path "${PIPE_DIR}/${OCI_PRODUCT}-${PACKAGE_VERSION}-windows-amd64.oci.tar" ${EXTRA_FLAGS} "${SRC_DIR}/"
+    - |
+      # Verify datadog-agent OCI package contains the installer layer
+      if [ "${OCI_PRODUCT}" = "datadog-agent" ]; then
+        OCI_TAR="${PIPE_DIR}/${OCI_PRODUCT}-${PACKAGE_VERSION}-windows-amd64.oci.tar"
+        if ! crane manifest "oci:${OCI_TAR}" | grep -q "vnd.datadog.package.installer.layer.v1"; then
+          echo "ERROR: OCI package is missing installer layer (vnd.datadog.package.installer.layer.v1)"
+          exit 1
+        fi
+        echo "OCI package verified: installer layer present"
+      fi
     - ls -l "${PIPE_DIR}"
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -76,6 +76,7 @@
 .package_oci_win:
   extends: .package_oci
   script:
+    - !reference [.retrieve_linux_go_tools_deps]
     - |
       set -u pipefail
       PIPE_DIR="$OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID"
@@ -140,6 +141,7 @@ agent_win_oci:
   needs:
     - job: "windows_msi_and_bosh_zip_x64-a7"
       artifacts: true
+    - go_tools_deps
   variables:
     OCI_PRODUCT: "datadog-agent"
     WIN_SOURCE_TYPE: "msi"
@@ -175,6 +177,7 @@ ddot_win_oci:
   needs:
     - job: "windows_zip_ddot_x64"
       artifacts: true
+    - go_tools_deps
   variables:
     OCI_PRODUCT: "datadog-agent-ddot"
     WIN_SOURCE_TYPE: "zip"

--- a/.gitlab/build/packaging/oci.yml
+++ b/.gitlab/build/packaging/oci.yml
@@ -76,7 +76,6 @@
 .package_oci_win:
   extends: .package_oci
   script:
-    - !reference [.retrieve_linux_go_tools_deps]
     - |
       set -u pipefail
       PIPE_DIR="$OMNIBUS_PACKAGE_DIR/pipeline-$CI_PIPELINE_ID"
@@ -120,16 +119,6 @@
       fi
     - export PATH="$PATH:$(go env GOPATH)/bin"
     - datadog-package create --version "${PACKAGE_VERSION}" --package "${OCI_PRODUCT}" --os windows --arch amd64 --archive --archive-path "${PIPE_DIR}/${OCI_PRODUCT}-${PACKAGE_VERSION}-windows-amd64.oci.tar" ${EXTRA_FLAGS} "${SRC_DIR}/"
-    - |
-      # Verify datadog-agent OCI package contains the installer layer
-      if [ "${OCI_PRODUCT}" = "datadog-agent" ]; then
-        OCI_TAR="${PIPE_DIR}/${OCI_PRODUCT}-${PACKAGE_VERSION}-windows-amd64.oci.tar"
-        if ! crane manifest "oci:${OCI_TAR}" | grep -q "vnd.datadog.package.installer.layer.v1"; then
-          echo "ERROR: OCI package is missing installer layer (vnd.datadog.package.installer.layer.v1)"
-          exit 1
-        fi
-        echo "OCI package verified: installer layer present"
-      fi
     - ls -l "${PIPE_DIR}"
   artifacts:
     expire_in: 2 weeks
@@ -141,7 +130,6 @@ agent_win_oci:
   needs:
     - job: "windows_msi_and_bosh_zip_x64-a7"
       artifacts: true
-    - go_tools_deps
   variables:
     OCI_PRODUCT: "datadog-agent"
     WIN_SOURCE_TYPE: "msi"
@@ -177,7 +165,6 @@ ddot_win_oci:
   needs:
     - job: "windows_zip_ddot_x64"
       artifacts: true
-    - go_tools_deps
   variables:
     OCI_PRODUCT: "datadog-agent-ddot"
     WIN_SOURCE_TYPE: "zip"

--- a/.gitlab/test/e2e_install_packages/windows.yml
+++ b/.gitlab/test/e2e_install_packages/windows.yml
@@ -211,6 +211,8 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeWithAgentUser$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeWithLocalSystemUser$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestDowngradeWithMissingInstallSource$"
+      - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackageOCIBootstrap$"
+      - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackageMSIBootstrap$"
       - EXTRA_PARAMS: --run "TestAgentUpgradesOnDC$/TestUpgradeMSI$"
       - EXTRA_PARAMS: --run "TestAgentUpgradesOnDC$/TestUpgradeAgentPackage$"
       - EXTRA_PARAMS: --run "TestAgentUpgradesAfterDCPromotion$/TestUpgradeAfterDCPromotion$"


### PR DESCRIPTION
### What does this PR do?

Restores the `--installer` flag when creating Windows Agent OCI packages, ensuring the installer binary is included as a dedicated layer. Also adds E2E tests to explicitly validate both OCI and MSI bootstrap paths.

### Motivation

This change restores the improvements made to upgrade time and network usage originally added in 7.71 by #39513.

The installer layer was accidentally removed in 7.72 by #40119 when the OCI packaging was migrated from PowerShell (`Generate-OCIPackage.ps1`) to the Linux-based `.gitlab/build/packaging/oci.yml`.

Our E2E tests succeeded because all the upgrades silently used the MSI admin install fallback path, masking the regression.

We accidentally discovered the issue because the tests failed during #45199 (WiX version upgrade) - the WiX version bump changed the admin install path from `ProgramFiles64Folder` to `PFiles64`, which broke the MSI fallback path. This was only visible because the OCI layer was missing.

With the OCI layer restored, `TestAgentUpgradesFromGA` will still catch admin install path regressions because the GA version (7.65.x) doesn't support the OCI layer, so upgrading from < 7.71 always uses the MSI path. We also added new tests that explicitly instrument the OCI and MSI bootstrap paths individually.

### Describe how you validated your changes

new and existing e2e tests

| Test | Purpose | Bootstrap Path | How Enforced |
|------|---------|----------------|--------------|
| `TestUpgradeAgentPackageOCIBootstrap` | Validates OCI path works | OCI (forced) | `InstallerBootstrapMode=OCI` |
| `TestUpgradeAgentPackageMSIBootstrap` | Validates MSI fallback works | MSI (forced) | `InstallerBootstrapMode=MSI` |
| `TestUpgradeAgentPackage` | General upgrade workflow | Default (OCI→MSI) | Not set |
| `TestAgentUpgradesFromGA` | Upgrade from GA (7.65.x) | MSI fallback | 7.65 installer lacks OCI layer support |

manually query image created by pipeline
```bash
crane manifest installtesting.datad0g.com/agent-package:pipeline-95083365 --platform windows/amd64 | jq
```