### PR TITLE
[ABLD-8] Create a target to (eventually) build the Agent debian package.

### DIFF
--- a/.gitlab/build/bazel/tests.yml
+++ b/.gitlab/build/bazel/tests.yml
@@ -8,6 +8,7 @@ bazel:tests:linux-amd64:
   extends: [ .bazel:tests, .bazel:runner:linux-amd64 ]
   script:
     - bazel test //bazel/tests/...
+    - bazel build //packages/agent/linux:debian
 
 bazel:tests:linux-arm64:
   extends: [ .bazel:tests, .bazel:runner:linux-arm64 ]

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -72,6 +72,7 @@ pkg_tar(
 # TODO: Look at omnibus/config/projects/agent.rb for more content here.
 pkg_deb(
     name = "debian",
+    conflicts = ["datadog-iot-agent"],
     data = ":whole_distro_tar",
     description = """Datadog Monitoring Agent
 The Datadog Monitoring Agent is a lightweight process that monitors system
@@ -82,17 +83,19 @@ forwards metrics from your applications as well as system services.
 .
 See http://www.datadoghq.com/ for more information
 """,
+    homepage = "http://www.datadoghq.com",
     # epoch 1
     # vendor = "Datadog <package@datadoghq.com>",
     license = "Apache License Version 2.0",
     maintainer = "Datadog Packages <package@datadoghq.com>",
     package = "datadog-agent",
     priority = "extra",
+    recommends = ["datadog-signing-keys (>= 1:1.4.0)"],
     section = "utils",
+    # TODO: Stamp in pipeline: 1:7.77.0~devel.git.394.fe0d0bb.pipeline.95313893-1
     version = "7",
 
-    # This does not make sense for architecture, but for testing, compilation
-    # mode is more stable than cpu.
+    # TODO: pull in target_cpu as arch.
     # architecture = "$(COMPILATION_MODE)",
     # config = "config",
     #distribution = "trusty",

--- a/packages/agent/linux/BUILD.bazel
+++ b/packages/agent/linux/BUILD.bazel
@@ -1,5 +1,6 @@
 """Agent package components specific to linux."""
 
+load("@rules_pkg//pkg:deb.bzl", "pkg_deb")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load(
     "@rules_pkg//pkg:mappings.bzl",
@@ -7,13 +8,15 @@ load(
     "pkg_filegroup",
     "pkg_mkdirs",
 )
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
 load("//compliance:package_licenses.bzl", "package_licenses")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
 # This is a placeholder for an eventual group containg (the future) top level binaries
-# such as //cmd/agent:agent
+# such as //cmd/agent:agent.  The individual items here will become dependencies of
+# those targets.
 filegroup(
     name = "all_deps",
     srcs = [
@@ -30,6 +33,69 @@ filegroup(
 package_licenses(
     name = "license_files",
     src = ":all_deps",
+)
+
+# This is good enough for today. It will go away as part of
+# https://datadoghq.atlassian.net/browse/ABLD-363
+pkg_filegroup(
+    name = "whole_distro",
+    srcs = [
+        ":license_files",
+        "//deps/msodbcsql18:all_files",
+        "//deps/nfsiostat:all_files",
+        "//deps/openscap:all_files",
+        "//packages/install_dir:embedded",
+        "//packages/install_dir:etc",
+        "@freetds//:all_files",
+        "@krb5//:all_files",
+        "@nghttp2//:all_files",
+    ],
+    prefix = "/opt/datadog-agent",
+)
+
+pkg_tar(
+    name = "whole_distro_tar",
+    srcs = [":whole_distro"] + select({
+        "//:is_standard_install": [
+            ":datadog_agent_installer_symlinks",
+        ],
+        "//conditions:default": [],
+    }),
+    extension = "tar.xz",
+    # TODO: account for pipeline injected compression level.
+    # https://datadoghq.atlassian.net/browse/ABLD-364
+    # compression_threads COMPRESSION_THREADS
+    # compression_level COMPRESSION_LEVEL
+    owner = "0.0",
+)
+
+# TODO: Look at omnibus/config/projects/agent.rb for more content here.
+pkg_deb(
+    name = "debian",
+    data = ":whole_distro_tar",
+    description = """Datadog Monitoring Agent
+The Datadog Monitoring Agent is a lightweight process that monitors system
+processes and services, and sends information back to your Datadog account.
+.
+This package installs and runs the advanced Agent daemon, which queues and
+forwards metrics from your applications as well as system services.
+.
+See http://www.datadoghq.com/ for more information
+""",
+    # epoch 1
+    # vendor = "Datadog <package@datadoghq.com>",
+    license = "Apache License Version 2.0",
+    maintainer = "Datadog Packages <package@datadoghq.com>",
+    package = "datadog-agent",
+    priority = "extra",
+    section = "utils",
+    version = "7",
+
+    # This does not make sense for architecture, but for testing, compilation
+    # mode is more stable than cpu.
+    # architecture = "$(COMPILATION_MODE)",
+    # config = "config",
+    #distribution = "trusty",
 )
 
 # Replacement for datadog-agent-installer-symlinks.rb
@@ -76,6 +142,7 @@ dd_agent_pkg_mklink(
 pkg_filegroup(
     name = "datadog_agent_installer_symlinks",
     srcs = [
+        ":dirs",
         ":experiment_link",
         ":stable_link",
         ":version_to_install_link",


### PR DESCRIPTION
This creates an initial target to build on for creating the debian packaging for the agent.

- Make use of the license and /etc targets that are already bazelized
- Depend on openscap
  - Mock up the openscap dependencies currently in the openscap.rb
- Hook it into a build job so we don't regress.

## Overall plan

This is a step towards a minimum viable product, and not the final implementation. We will build towards that over the next few weeks. The idea is to work like the Chunnel, where we build from both ends at the same time. As we finish more dependencies at the bottom we link them in. Each week we report the reduction in the delta of difference between the bazel target an the omnibus result.

- We migrate stanzas agent-finalize.rb and agent.rb directly into these rules
- Wrap some targets we want to convert later (ddot, dogstatd) that are biult with dda invocations in genrules. This will allow us to include them in the debian package without being blocked on their migration.
- Iterate until we reach file-by-file parity.
- That is the MVP, so we can cut over.

## Status so far

- Files in .deb package: 21338
- Files accounted for in this PR: 416
- Left: 20922.

Scope of future work:
- embedded python3: 20055 files
- embedded/include: 786 files
- everything else: 21338 - 416 - 20055 - 786 = 81

That feels like a very workable scope.

## Next steps (in no particular order):
- Fx all the deps which expected "embedded" to be provided by install `--destdir={install_dir}/embedded`. They should have embedded in their pkg_files `prefix` attribute
- Design and build a concept where libraries which should be in the product mark themselves as such. Then we can run an aspect down from the debian package to find and depend on them.
- Build a similar struture to add python dependencies.  20055 more files
- Wrap the binaries we will build in Q2 and beyond with genrules.
- Pull all the linux deps out of //deps:all_deps, leaving that only for windows & mac. Make sure they are accounted for in the explicit graph.
- Add the post-install control files.