### PR TITLE
Remove obsolete cloning of `test-infra-definitions`

### DIFF
--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -12,11 +12,8 @@
           - .gitlab/build/source_test/kmt_tasks.yml
         compare_to: $COMPARE_TO_BRANCH
   script:
-    - token="$(dda inv -- auth.gitlab --repo test-infra-definitions)"
-    - git config --global url."https://gitlab-ci-token:${token}@gitlab.ddbuild.io/DataDog/".insteadOf "git@github.com:"
     # Avoid rate limits when running kmt.init (pulumi queries the Github API to get the releases of plugins)
     - export GITHUB_TOKEN=$(dda inv github.get-token-from-app)
-    - export KMT_TEST_INFRA_DEFINITIONS_PATH="$(go env GOPATH)"/src/github.com/DataDog/datadog-agent/test/e2e-framework
     - dda inv -- kmt.init --remote-setup-only --skip-ssh-setup --exclude-requirements $KMT_EXCLUDE_REQUIREMENTS --images ""
     - export PATH=$PATH:$HOME/.pulumi/bin  # Simulate a shell restart, required for the check
     - dda inv -- kmt.selfcheck --remote-setup-only --exclude-requirements $KMT_EXCLUDE_REQUIREMENTS --show-flare-for-failures

--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -80,48 +80,19 @@ class Pulumi(Requirement):
 
 class TestInfraDefinitionsRepo(Requirement):
     @staticmethod
-    def get_candidate_paths() -> list[Path]:
-        # Allow callers to force a specific path
-        env_path = os.environ.get("KMT_TEST_INFRA_DEFINITIONS_PATH")
-        if env_path is not None:
-            return [Path(env_path)]
-
-        # Default to common paths if a specific setting has not been forced
-        return [
-            get_repo_root() / "test/e2e-framework",
-            Path("~/go/src/github.com/DataDog/datadog-agent/test/e2e-framework").expanduser(),
-        ]
-
-    @staticmethod
-    def get_repo_path() -> Path | None:
-        for path in TestInfraDefinitionsRepo.get_candidate_paths():
-            if path.is_dir():
-                return path
-
-        return None
+    def get_repo_path() -> Path:
+        return get_repo_root() / "test/e2e-framework"
 
     def check(self, ctx: Context, fix: bool) -> RequirementState:
         repo_path = self.get_repo_path()
-        if repo_path is not None:
-            return RequirementState(Status.OK, "test-infra-definitions repository found.")
+        if repo_path.is_dir():
+            return RequirementState(Status.OK, "e2e-framework directory found.")
 
-        candidate_paths = TestInfraDefinitionsRepo.get_candidate_paths()
-        if not fix:
-            return RequirementState(
-                Status.FAIL,
-                f"test-infra-definitions repository not found in any of the expected locations {', '.join(map(os.fspath, candidate_paths))}.",
-                fixable=True,
-            )
-
-        clone_opts = "--depth 1 --single-branch --branch=main" if os.environ.get("CI") else ""
-        repo_access = "https://github.com/" if os.environ.get("CI") else "git@github.com:"
-
-        try:
-            ctx.run(f"git clone {repo_access}DataDog/test-infra-definitions.git {candidate_paths[0]} {clone_opts}")
-        except Exception as e:
-            return RequirementState(Status.FAIL, f"test-infra-definitions could not be cloned: {e}", fixable=True)
-
-        return RequirementState(Status.OK, "test-infra-definitions repository cloned.")
+        return RequirementState(
+            Status.FAIL,
+            f"e2e-framework directory not found at {repo_path}.",
+            fixable=False,
+        )
 
 
 class PulumiPlugin(Requirement):


### PR DESCRIPTION
### What does this PR do?
Remove the obsolete logic in KMT setup that clones the `test-infra-definitions` GitHub repository.

### Motivation
After #43238 and its follow-up PRs, `test-infra-definitions` is now an in-tree module located at `test/e2e-framework/`. The clone logic is therefore longer needed and should be removed.