### PR TITLE
fix a few typos in `cmd/system-probe`

### DIFF
--- a/cmd/system-probe/modules/language_detection.go
+++ b/cmd/system-probe/modules/language_detection.go
@@ -99,7 +99,7 @@ func (l *languageDetectionModule) detectLanguage(writer http.ResponseWriter, req
 	resp := toDetectLanguageResponse(l.languageDetector.DetectWithPrivileges(procs))
 	b, err = proto.Marshal(resp)
 	if err != nil {
-		handleError(writer, http.StatusInternalServerError, fmt.Errorf("seralize response: %v", err))
+		handleError(writer, http.StatusInternalServerError, fmt.Errorf("serialize response: %v", err))
 		return
 	}
 

--- a/cmd/system-probe/subcommands/runtime/activity_dump.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump.go
@@ -310,7 +310,7 @@ func diffCommands(globalParams *command.GlobalParams) []*cobra.Command {
 		&cliParams.format,
 		"format",
 		"json",
-		"output formeat",
+		"output format",
 	)
 
 	return []*cobra.Command{activityDumpDiffCmd}

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -201,7 +201,7 @@ func downloadPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command
 
 	downloadPolicyCmd.Flags().BoolVar(&downloadPolicyArgs.check, "check", false, "Check policies after downloading")
 	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.outputPath, "output-path", "", "Output path for downloaded policies")
-	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.source, "source", "all", `Specify wether should download the custom, default or all policies. allowed: "all", "default", "custom"`)
+	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.source, "source", "all", `Specify whether should download the custom, default or all policies. allowed: "all", "default", "custom"`)
 
 	return []*cobra.Command{downloadPolicyCmd}
 }
@@ -353,7 +353,7 @@ func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Compone
 func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliParams) error {
 	if args.evaluateAllPolicySources {
 		if args.windowsModel {
-			return errors.New("unable to evaluator loaded policies using the windows model")
+			return errors.New("unable to evaluate loaded policies using the windows model")
 		}
 
 		client, err := secagent.NewRuntimeSecurityCmdClient()


### PR DESCRIPTION
### What does this PR do?

Fixes a few typos in cmd/system-probe, especially important for error message and CLI usage messages.

### Motivation

### Describe how you validated your changes

### Additional Notes
