### PR TITLE
Bar.fins/unify http test for windows and linux

### DIFF
--- a/pkg/network/usm/monitor_common_linux_test.go
+++ b/pkg/network/usm/monitor_common_linux_test.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package usm
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	tracetestutil "github.com/DataDog/datadog-agent/pkg/trace/testutil"
+)
+
+// linuxMonitorAdapter wraps the Linux Monitor to implement TestMonitor interface.
+type linuxMonitorAdapter struct {
+	monitor *Monitor
+	t       *testing.T
+}
+
+// GetHTTPStats implements TestMonitor interface for Linux.
+func (a *linuxMonitorAdapter) GetHTTPStats() map[protocols.ProtocolType]interface{} {
+	statsObj, cleaners := a.monitor.GetProtocolStats()
+	a.t.Cleanup(cleaners)
+	return statsObj
+}
+
+// setupLinuxTestMonitor creates a Linux monitor wrapped as TestMonitor.
+func setupLinuxTestMonitor(t *testing.T, cfg *config.Config) TestMonitor {
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
+	return &linuxMonitorAdapter{
+		monitor: monitor,
+		t:       t,
+	}
+}
+
+// TestHTTPStatsCommon runs the common HTTP stats test on Linux.
+func TestHTTPStatsCommon(t *testing.T) {
+	skipTestIfKernelNotSupported(t)
+
+	serverPort := tracetestutil.FreeTCPPort(t)
+
+	runHTTPStatsTest(t, httpStatsTestParams{
+		serverPort: serverPort,
+		setupMonitor: func(t *testing.T) TestMonitor {
+			return setupLinuxTestMonitor(t, getHTTPCfg())
+		},
+	})
+}
+
+// TestHTTPMonitorIntegrationWithResponseBodyCommon runs the HTTP body size test on Linux.
+func TestHTTPMonitorIntegrationWithResponseBodyCommon(t *testing.T) {
+	skipTestIfKernelNotSupported(t)
+
+	serverPort := tracetestutil.FreeTCPPort(t)
+
+	runHTTPMonitorIntegrationWithResponseBodyTest(t, httpBodySizeTestParams{
+		serverPort: serverPort,
+		setupMonitor: func(t *testing.T) TestMonitor {
+			return setupLinuxTestMonitor(t, getHTTPCfg())
+		},
+	})
+}

--- a/pkg/network/usm/monitor_common_test.go
+++ b/pkg/network/usm/monitor_common_test.go
@@ -1,0 +1,395 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build (linux_bpf || (windows && npm)) && test
+
+package usm
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"math/rand"
+	nethttp "net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+)
+
+// TestMonitor is an interface for testing monitors across platforms.
+// Both Linux and Windows monitors implement this interface for unified testing.
+type TestMonitor interface {
+	// GetHTTPStats returns HTTP protocol statistics.
+	GetHTTPStats() map[protocols.ProtocolType]interface{}
+}
+
+// statusCodeCount holds the expected status code and count for validation.
+type statusCodeCount struct {
+	statusCode uint16
+	count      int
+}
+
+// getHTTPLikeProtocolStatsGeneric extracts HTTP protocol stats from any monitor implementing TestMonitor.
+func getHTTPLikeProtocolStatsGeneric(t *testing.T, monitor TestMonitor, protocolType protocols.ProtocolType) map[http.Key]*http.RequestStats {
+	t.Helper()
+
+	allStats := monitor.GetHTTPStats()
+	if allStats == nil {
+		return nil
+	}
+
+	statsObj, ok := allStats[protocolType]
+	if !ok {
+		return nil
+	}
+
+	stats, ok := statsObj.(map[http.Key]*http.RequestStats)
+	if !ok {
+		return nil
+	}
+
+	return stats
+}
+
+// verifyHTTPStats validates that the expected HTTP endpoints are present in the stats.
+// expectedEndpoints maps http.Key (without connection details) to expected status code and count.
+// serverPort is used to filter stats to only those matching the server port.
+// additionalValidator is optional - if provided, performs custom validation on each RequestStat.
+// Returns true if all expected endpoints are found with matching status codes and counts.
+func verifyHTTPStats(t *testing.T, monitor TestMonitor, expectedEndpoints map[http.Key]statusCodeCount, serverPort int, additionalValidator func(*testing.T, *http.RequestStat) bool) bool {
+	t.Helper()
+
+	stats := getHTTPLikeProtocolStatsGeneric(t, monitor, protocols.HTTP)
+	if len(stats) == 0 {
+		return false
+	}
+
+	// Build result map from actual stats
+	result := make(map[http.Key]statusCodeCount)
+
+	for key, reqStats := range stats {
+		// Only check stats matching the server port
+		if key.SrcPort != uint16(serverPort) && key.DstPort != uint16(serverPort) {
+			continue
+		}
+
+		// Iterate through all status codes in the stats
+		for statusCode, stat := range reqStats.Data {
+			if stat == nil || stat.Count == 0 {
+				continue
+			}
+
+			// Run additional validation if provided
+			if additionalValidator != nil && !additionalValidator(t, stat) {
+				continue
+			}
+
+			// Create a simplified key for comparison (normalize path and method only)
+			simpleKey := http.Key{
+				Method: key.Method,
+				Path: http.Path{
+					Content: key.Path.Content,
+				},
+			}
+
+			// Store in result map
+			result[simpleKey] = statusCodeCount{
+				statusCode: statusCode,
+				count:      stat.Count,
+			}
+		}
+	}
+
+	// Compare result with expected endpoints
+	if len(result) != len(expectedEndpoints) {
+		return false
+	}
+
+	for key, expected := range expectedEndpoints {
+		actual, ok := result[key]
+		if !ok {
+			return false
+		}
+		if actual.statusCode != expected.statusCode || actual.count != expected.count {
+			return false
+		}
+	}
+
+	return true
+}
+
+// makeExpectedEndpoint creates an http.Key for expected endpoint verification.
+func makeExpectedEndpoint(method http.Method, path string) http.Key {
+	return http.Key{
+		Path:   http.Path{Content: http.Interner.GetString(path)},
+		Method: method,
+	}
+}
+
+// httpStatsTestParams holds parameters for the common HTTP stats test.
+type httpStatsTestParams struct {
+	// serverPort is the port the test server will listen on
+	serverPort int
+	// setupMonitor is a platform-specific function to set up the monitor
+	setupMonitor func(t *testing.T) TestMonitor
+}
+
+// runHTTPStatsTest runs the common HTTP stats test logic.
+func runHTTPStatsTest(t *testing.T, params httpStatsTestParams) {
+	serverAddr := fmt.Sprintf("127.0.0.1:%d", params.serverPort)
+	t.Logf("Using server address: %s (port: %d)", serverAddr, params.serverPort)
+
+	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
+		EnableKeepAlive: true,
+	})
+	t.Cleanup(srvDoneFn)
+
+	monitor := params.setupMonitor(t)
+
+	// Define test endpoints with status codes in path
+	testEndpointPath := "/" + strconv.Itoa(nethttp.StatusNoContent) + "/test"
+	healthEndpointPath := "/" + strconv.Itoa(nethttp.StatusOK) + "/api/health"
+
+	// Make first request: GET /204/test with 204 status
+	resp1, err := nethttp.Get("http://" + serverAddr + testEndpointPath)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+
+	// Make second request: GET /200/api/health with 200 status
+	resp2, err := nethttp.Get("http://" + serverAddr + healthEndpointPath)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	srvDoneFn()
+
+	// Define expected endpoints
+	expectedEndpoints := map[http.Key]statusCodeCount{
+		makeExpectedEndpoint(http.MethodGet, testEndpointPath): {
+			statusCode: 204,
+			count:      1,
+		},
+		makeExpectedEndpoint(http.MethodGet, healthEndpointPath): {
+			statusCode: 200,
+			count:      1,
+		},
+	}
+
+	// Verify both endpoints were captured by the monitor
+	require.Eventuallyf(t, func() bool {
+		return verifyHTTPStats(t, monitor, expectedEndpoints, params.serverPort, nil)
+	}, 3*time.Second, 100*time.Millisecond, "HTTP connections not found for %s", serverAddr)
+}
+
+// Size constants for body tests
+const (
+	kb = 1024
+	mb = 1024 * kb
+)
+
+var (
+	httpMethods         = []string{nethttp.MethodGet, nethttp.MethodHead, nethttp.MethodPost, nethttp.MethodPut, nethttp.MethodPatch, nethttp.MethodDelete, nethttp.MethodOptions, nethttp.MethodTrace}
+	httpMethodsWithBody = []string{nethttp.MethodPost, nethttp.MethodPut, nethttp.MethodPatch, nethttp.MethodDelete}
+	statusCodes         = []int{nethttp.StatusOK, nethttp.StatusMultipleChoices, nethttp.StatusBadRequest, nethttp.StatusInternalServerError}
+)
+
+// requestGenerator creates a function that generates HTTP requests with random methods and status codes.
+// If reqBody is non-empty, it will use methods that support request bodies.
+func requestGenerator(t *testing.T, targetAddr string, reqBody []byte) func() *nethttp.Request {
+	var (
+		random  = rand.New(rand.NewSource(time.Now().Unix()))
+		idx     = 0
+		client  = new(nethttp.Client)
+		reqBuf  = make([]byte, 0, len(reqBody))
+		respBuf = make([]byte, 512)
+	)
+
+	// Disabling http2
+	tr := nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+	tr.ForceAttemptHTTP2 = false
+	tr.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) nethttp.RoundTripper)
+
+	client.Transport = tr
+
+	return func() *nethttp.Request {
+		idx++
+		var method string
+		var body io.Reader
+		var finalBody []byte
+		if len(reqBody) > 0 {
+			finalBody = reqBuf[:0]
+			finalBody = append(finalBody, []byte(strings.Repeat(" ", idx))...)
+			finalBody = append(finalBody, reqBody...)
+			body = bytes.NewReader(finalBody)
+
+			// save resized-buffer
+			reqBuf = finalBody
+
+			method = httpMethodsWithBody[random.Intn(len(httpMethodsWithBody))]
+		} else {
+			method = httpMethods[random.Intn(len(httpMethods))]
+		}
+		status := statusCodes[random.Intn(len(statusCodes))]
+		url := fmt.Sprintf("http://%s/%d/request-%d", targetAddr, status, idx)
+		req, err := nethttp.NewRequest(method, url, body)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		if strings.Contains(targetAddr, "ignore") {
+			return req
+		}
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		if len(reqBody) > 0 {
+			for {
+				n, err := resp.Body.Read(respBuf)
+				require.True(t, n <= len(finalBody))
+				require.Equal(t, respBuf[:n], finalBody[:n])
+				if err != nil {
+					assert.Equal(t, io.EOF, err)
+					break
+				}
+				finalBody = finalBody[n:]
+			}
+		}
+		return req
+	}
+}
+
+// countRequestOccurrences counts how many times a request appears in the stats.
+func countRequestOccurrences(allStats map[http.Key]*http.RequestStats, req *nethttp.Request) int {
+	expectedStatus := testutil.StatusFromPath(req.URL.Path)
+	occurrences := 0
+	for key, stats := range allStats {
+		if key.Method.String() != req.Method {
+			continue
+		}
+		if key.Path.Content.Get() != req.URL.Path {
+			continue
+		}
+		if requests, exists := stats.Data[expectedStatus]; exists && requests.Count > 0 {
+			occurrences++
+		}
+	}
+
+	return occurrences
+}
+
+// isRequestIncludedOnce checks if a request appears exactly once in the stats.
+func isRequestIncludedOnce(allStats map[http.Key]*http.RequestStats, req *nethttp.Request) (bool, error) {
+	occurrences := countRequestOccurrences(allStats, req)
+
+	if occurrences == 1 {
+		return true, nil
+	} else if occurrences == 0 {
+		return false, nil
+	}
+	return false, fmt.Errorf("expected to find 1 occurrence of %v, but found %d instead", req, occurrences)
+}
+
+// assertAllRequestsExist verifies that all given requests were captured by the monitor.
+func assertAllRequestsExist(t *testing.T, monitor TestMonitor, requests []*nethttp.Request) {
+	requestsExist := make([]bool, len(requests))
+
+	assert.Eventually(t, func() bool {
+		stats := getHTTPLikeProtocolStatsGeneric(t, monitor, protocols.HTTP)
+
+		if len(stats) == 0 {
+			return false
+		}
+
+		for reqIndex, req := range requests {
+			if !requestsExist[reqIndex] {
+				exists, err := isRequestIncludedOnce(stats, req)
+				require.NoError(t, err)
+				requestsExist[reqIndex] = exists
+			}
+		}
+
+		// Slight optimization here, if one is missing, then go into another cycle of checking the new connections.
+		// otherwise, if all present, abort.
+		for _, exists := range requestsExist {
+			if !exists {
+				return false
+			}
+		}
+
+		return true
+	}, 3*time.Second, time.Millisecond*100, "connection not found")
+
+	if t.Failed() {
+		for reqIndex, exists := range requestsExist {
+			if !exists {
+				// reqIndex is 0 based, while the number is requests[reqIndex] is 1 based.
+				t.Logf("request %d was not found (req %v)", reqIndex+1, requests[reqIndex])
+			}
+		}
+	}
+}
+
+// httpBodySizeTestParams holds parameters for the HTTP body size test.
+type httpBodySizeTestParams struct {
+	// serverPort is the port the test server will listen on
+	serverPort int
+	// setupMonitor is a platform-specific function to set up the monitor
+	setupMonitor func(t *testing.T) TestMonitor
+}
+
+// runHTTPMonitorIntegrationWithResponseBodyTest runs the test for various HTTP body sizes.
+func runHTTPMonitorIntegrationWithResponseBodyTest(t *testing.T, params httpBodySizeTestParams) {
+	serverAddr := fmt.Sprintf("localhost:%d", params.serverPort)
+
+	tests := []struct {
+		name            string
+		requestBodySize int
+	}{
+		{
+			name:            "no body",
+			requestBodySize: 0,
+		},
+		{
+			name:            "1kb body",
+			requestBodySize: 1 * kb,
+		},
+		{
+			name:            "10kb body",
+			requestBodySize: 10 * kb,
+		},
+		{
+			name:            "500kb body",
+			requestBodySize: 500 * kb,
+		},
+		{
+			name:            "10mb body",
+			requestBodySize: 10 * mb,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			monitor := params.setupMonitor(t)
+			srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
+				EnableKeepAlive: true,
+			})
+			t.Cleanup(srvDoneFn)
+
+			requestFn := requestGenerator(t, serverAddr, bytes.Repeat([]byte("a"), tt.requestBodySize))
+			var requests []*nethttp.Request
+			for i := 0; i < 100; i++ {
+				requests = append(requests, requestFn())
+			}
+			srvDoneFn()
+
+			assertAllRequestsExist(t, monitor, requests)
+		})
+	}
+}

--- a/pkg/network/usm/monitor_common_windows_test.go
+++ b/pkg/network/usm/monitor_common_windows_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && npm
+
+package usm
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	tracetestutil "github.com/DataDog/datadog-agent/pkg/trace/testutil"
+)
+
+// windowsMonitorAdapter wraps the Windows Monitor to implement TestMonitor interface.
+// Note: Windows Monitor interface already has GetHTTPStats(), so this is a simple wrapper.
+type windowsMonitorAdapter struct {
+	monitor Monitor
+}
+
+// GetHTTPStats implements TestMonitor interface for Windows.
+func (a *windowsMonitorAdapter) GetHTTPStats() map[protocols.ProtocolType]interface{} {
+	return a.monitor.GetHTTPStats()
+}
+
+// setupWindowsTestMonitor creates a Windows monitor wrapped as TestMonitor.
+func setupWindowsTestMonitor(t *testing.T, cfg *config.Config) TestMonitor {
+	monitor := setupWindowsMonitor(t, cfg)
+	return &windowsMonitorAdapter{
+		monitor: monitor,
+	}
+}
+
+// TestHTTPStatsCommon runs the common HTTP stats test on Windows.
+func TestHTTPStatsCommon(t *testing.T) {
+	serverPort := tracetestutil.FreeTCPPort(t)
+
+	runHTTPStatsTest(t, httpStatsTestParams{
+		serverPort: serverPort,
+		setupMonitor: func(t *testing.T) TestMonitor {
+			return setupWindowsTestMonitor(t, getHTTPCfg())
+		},
+	})
+}
+
+// TestHTTPMonitorIntegrationWithResponseBodyCommon runs the HTTP body size test on Windows.
+func TestHTTPMonitorIntegrationWithResponseBodyCommon(t *testing.T) {
+	serverPort := tracetestutil.FreeTCPPort(t)
+
+	runHTTPMonitorIntegrationWithResponseBodyTest(t, httpBodySizeTestParams{
+		serverPort: serverPort,
+		setupMonitor: func(t *testing.T) TestMonitor {
+			return setupWindowsTestMonitor(t, getHTTPCfg())
+		},
+	})
+}

--- a/pkg/network/usm/monitor_windows_test.go
+++ b/pkg/network/usm/monitor_windows_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	nethttp "net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,9 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http"
-	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	iistestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
 	tracetestutil "github.com/DataDog/datadog-agent/pkg/trace/testutil"
 )
@@ -67,99 +64,12 @@ func setupWindowsMonitor(t *testing.T, cfg *config.Config) Monitor {
 	return monitor
 }
 
-// statusCodeCount holds the expected status code and count for validation.
-type statusCodeCount struct {
-	statusCode uint16
-	count      int
-}
-
-// getHTTPLikeProtocolStats extracts HTTP protocol stats from the monitor.
-func getHTTPLikeProtocolStats(t *testing.T, monitor Monitor, protocolType protocols.ProtocolType) map[http.Key]*http.RequestStats {
+// verifyHTTPStatsWindows validates HTTP stats using the Windows Monitor interface.
+// This is a convenience wrapper around the common verifyHTTPStats for Windows-specific tests.
+func verifyHTTPStatsWindows(t *testing.T, monitor Monitor, expectedEndpoints map[http.Key]statusCodeCount, serverPort int, additionalValidator func(*testing.T, *http.RequestStat) bool) bool {
 	t.Helper()
-
-	allStats := monitor.GetHTTPStats()
-	if allStats == nil {
-		return nil
-	}
-
-	statsObj, ok := allStats[protocolType]
-	if !ok {
-		return nil
-	}
-
-	stats, ok := statsObj.(map[http.Key]*http.RequestStats)
-	if !ok {
-		return nil
-	}
-
-	return stats
-}
-
-// verifyHTTPStats validates that the expected HTTP endpoints are present in the stats.
-// expectedEndpoints maps http.Key (without connection details) to expected status code and count.
-// serverPort is used to filter stats to only those matching the server port.
-// additionalValidator is optional - if provided, performs custom validation on each RequestStat.
-// Returns true if all expected endpoints are found with matching status codes and counts.
-func verifyHTTPStats(t *testing.T, monitor Monitor, expectedEndpoints map[http.Key]statusCodeCount, serverPort int, additionalValidator func(*testing.T, *http.RequestStat) bool) bool {
-	t.Helper()
-
-	stats := getHTTPLikeProtocolStats(t, monitor, protocols.HTTP)
-	if len(stats) == 0 {
-		return false
-	}
-
-	// Build result map from actual stats
-	result := make(map[http.Key]statusCodeCount)
-
-	for key, reqStats := range stats {
-		// Only check stats matching the server port
-		if key.SrcPort != uint16(serverPort) && key.DstPort != uint16(serverPort) {
-			continue
-		}
-
-		// Iterate through all status codes in the stats
-		for statusCode, stat := range reqStats.Data {
-			if stat == nil || stat.Count == 0 {
-				continue
-			}
-
-			// Run additional validation if provided
-			if additionalValidator != nil && !additionalValidator(t, stat) {
-				continue
-			}
-
-			// Create a simplified key for comparison (normalize path and method only)
-			simpleKey := http.Key{
-				Method: key.Method,
-				Path: http.Path{
-					Content: key.Path.Content,
-				},
-			}
-
-			// Store in result map
-			result[simpleKey] = statusCodeCount{
-				statusCode: statusCode,
-				count:      stat.Count,
-			}
-		}
-	}
-
-	// Compare result with expected endpoints
-	if len(result) != len(expectedEndpoints) {
-		return false
-	}
-
-	for key, expected := range expectedEndpoints {
-		actual, ok := result[key]
-		if !ok {
-			return false
-		}
-		if actual.statusCode != expected.statusCode || actual.count != expected.count {
-			return false
-		}
-	}
-
-	return true
+	// Windows Monitor interface satisfies TestMonitor, so we can cast directly
+	return verifyHTTPStats(t, monitor, expectedEndpoints, serverPort, additionalValidator)
 }
 
 // makeIISTagValidator creates a validator function that checks for expected IIS dynamic tags.
@@ -186,59 +96,6 @@ func makeIISTagValidator(expectedTags map[string]struct{}) func(*testing.T, *htt
 		t.Logf("Successfully captured IIS HTTP traffic: %d requests with IIS tags verified", stat.Count)
 		return true
 	}
-}
-
-// TestHTTPStats tests basic HTTP monitoring functionality on Windows.
-func TestHTTPStats(t *testing.T) {
-	serverPort := tracetestutil.FreeTCPPort(t)
-	serverAddr := fmt.Sprintf("127.0.0.1:%d", serverPort)
-	t.Logf("Using server address: %s (port: %d)", serverAddr, serverPort)
-
-	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
-		EnableKeepAlive: true,
-	})
-	t.Cleanup(srvDoneFn)
-
-	monitor := setupWindowsMonitor(t, getHTTPCfg())
-
-	// Define test endpoints with status codes in path
-	testEndpointPath := "/" + strconv.Itoa(nethttp.StatusNoContent) + "/test"
-	healthEndpointPath := "/" + strconv.Itoa(nethttp.StatusOK) + "/api/health"
-
-	// Make first request: GET /204/test with 204 status
-	resp1, err := nethttp.Get("http://" + serverAddr + testEndpointPath)
-	require.NoError(t, err)
-	defer resp1.Body.Close()
-
-	// Make second request: GET /200/api/health with 200 status
-	resp2, err := nethttp.Get("http://" + serverAddr + healthEndpointPath)
-	require.NoError(t, err)
-	defer resp2.Body.Close()
-
-	srvDoneFn()
-
-	// Define expected endpoints
-	expectedEndpoints := map[http.Key]statusCodeCount{
-		{
-			Path:   http.Path{Content: http.Interner.GetString(testEndpointPath)},
-			Method: http.MethodGet,
-		}: {
-			statusCode: 204,
-			count:      1,
-		},
-		{
-			Path:   http.Path{Content: http.Interner.GetString(healthEndpointPath)},
-			Method: http.MethodGet,
-		}: {
-			statusCode: 200,
-			count:      1,
-		},
-	}
-
-	// Verify both endpoints were captured by the monitor
-	require.Eventuallyf(t, func() bool {
-		return verifyHTTPStats(t, monitor, expectedEndpoints, serverPort, nil)
-	}, 3*time.Second, 100*time.Millisecond, "HTTP connections not found for %s", serverAddr)
 }
 
 // TestHTTPStatsWithIIS tests HTTP monitoring with a real IIS server.
@@ -305,6 +162,6 @@ func TestHTTPStatsWithIIS(t *testing.T) {
 
 	// Verify the monitor captured the HTTP traffic with IIS tags
 	require.Eventuallyf(t, func() bool {
-		return verifyHTTPStats(t, monitor, expectedEndpoints, serverPort, makeIISTagValidator(expectedTags))
+		return verifyHTTPStatsWindows(t, monitor, expectedEndpoints, serverPort, makeIISTagValidator(expectedTags))
 	}, 5*time.Second, 100*time.Millisecond, "HTTP connection to IIS not found for %s", serverAddr)
 }


### PR DESCRIPTION
### What does this PR do?
  Extracts common HTTP monitor test utilities into shared files (monitor_common_test.go) with platform-specific adapters for Windows and Linux.                         

### Motivation
  Reduce code duplication and ensure consistent test behavior across platforms.

### Describe how you validated your changes
Run shared tests on both Windows and Linux.

### Additional Notes
https://datadoghq.atlassian.net/browse/USMON-1516
