### PR TITLE
[ABLD-8] Split the pkgconfig files from "all_files" but leave in pkg_install.

### DIFF
--- a/deps/acl/overlay/overlay.BUILD.bazel
+++ b/deps/acl/overlay/overlay.BUILD.bazel
@@ -217,13 +217,14 @@ pkg_filegroup(
     srcs = [
         ":hdr_files",
         ":lib_files",
-        ":pc_file",
     ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [
         ":all_files",
+        ":pc_file",
     ],
 )

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -7,7 +7,7 @@ load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
 
@@ -135,11 +135,19 @@ pkg_files(
     prefix = "embedded/lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_file",
     ],
 )

--- a/deps/bzip2/overlay.BUILD.bazel
+++ b/deps/bzip2/overlay.BUILD.bazel
@@ -172,11 +172,14 @@ pkg_filegroup(
     srcs = [
         ":hdr_files",
         ":lib_files",
-        ":pkg_pc_file",
     ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
-    srcs = [":all_files"],
+    srcs = [
+        ":all_files",
+        ":pkg_pc_file",
+    ],
 )

--- a/deps/dbus/dbus.BUILD.bazel
+++ b/deps/dbus/dbus.BUILD.bazel
@@ -1,9 +1,9 @@
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
 
@@ -26,7 +26,7 @@ copy_file(
 cc_library(
     name = "config_h",
     hdrs = [
-        ":copy_config_h"
+        ":copy_config_h",
     ],
 )
 
@@ -64,7 +64,7 @@ expand_template(
         "@DBUS_MAJOR_VERSION@": "1",
         "@DBUS_MINOR_VERSION@": "16",
         "@DBUS_MICRO_VERSION@": "2",
-    }
+    },
 )
 
 cc_library(
@@ -118,12 +118,12 @@ cc_library(
         "dbus/dbus-transport-unix.c",
         "dbus/dbus-userdb.c",
         ":dbus_arch_deps_h",
-    ] + glob(["dbus/*.h"], exclude=PUBLIC_HEADERS),
+    ] + glob(["dbus/*.h"], exclude = PUBLIC_HEADERS),
     hdrs = PUBLIC_HEADERS,
     local_defines = [
         "_GNU_SOURCE",
         "__USE_MINGW_ANSI_STDIO=0",
-        "dbus_1_EXPORTS"
+        "dbus_1_EXPORTS",
     ],
     copts = [
         "-O2",
@@ -155,7 +155,7 @@ expand_template(
         "@VERSION@": "1.16.2",
         "@LIBDBUS_LIBS@": "-pthread",
         "@DBUS_STATIC_BUILD_CPPFLAGS@": "",
-    }
+    },
 )
 
 pkg_files(
@@ -183,12 +183,20 @@ pkg_files(
     prefix = "lib/dbus-1.0/include/dbus",
 )
 
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":headers",
+        ":lib_files",
+        ":dbus_arch_deps_install",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
 pkg_install(
     name = "install",
     srcs = [
-        ":headers",
+        ":all_files",
         ":pkgconfig",
-        ":lib_files",
-        ":dbus_arch_deps_install"
     ],
 )

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -6,7 +6,7 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
     default_package_metadata = [":license"],
@@ -779,11 +779,19 @@ pkg_files(
     prefix = "include",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_file",
     ],
 )

--- a/deps/krb5/krb5.BUILD.bazel
+++ b/deps/krb5/krb5.BUILD.bazel
@@ -161,12 +161,20 @@ pkg_filegroup(
     prefix = "embedded/",
 )
 
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":hdr_files",
+        ":bin_files",
+        ":all_libs",
+    ],
+    visibility = ["@@//packages:__subpackages__"],
+)
+
 pkg_install(
     name = "install",
     srcs = [
-        ":hdr_files",
+        ":all_files",
         ":pc_files",
-        ":bin_files",
-        ":all_libs",
     ],
 )

--- a/deps/libselinux.BUILD.bazel
+++ b/deps/libselinux.BUILD.bazel
@@ -4,7 +4,7 @@ load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
     default_package_metadata = [":package_metadata"],
@@ -112,11 +112,19 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_file",
     ],
 )

--- a/deps/libsepol.BUILD.bazel
+++ b/deps/libsepol.BUILD.bazel
@@ -5,7 +5,7 @@ load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":package_metadata", ":ship_source_offer"])
 
@@ -120,12 +120,20 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":policy_hdr_files",
         ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_file",
     ],
 )

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -4,7 +4,7 @@ load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 XSLT_VERSION = "1.1.43"
 EXSLT_VERSION = "0.8.25"
@@ -245,13 +245,21 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":xslt_headers",
         ":exslt_headers",
-        ":pkgconfig",
         ":xslt_lib_files",
         ":exslt_lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
+        ":pkgconfig",
     ],
 )

--- a/deps/libyaml.BUILD.bazel
+++ b/deps/libyaml.BUILD.bazel
@@ -4,7 +4,7 @@ load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 VERSION = "0.2.5"
 
@@ -82,11 +82,19 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":headers",
+        ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
 pkg_install(
     name = "install",
     srcs = [
-        ":lib_files",
-        ":headers",
+        ":all_files",
         ":pkgconfig",
     ],
 )

--- a/deps/msodbcsql18/BUILD.bazel
+++ b/deps/msodbcsql18/BUILD.bazel
@@ -103,11 +103,14 @@ pkg_filegroup(
         "@krb5//:all_libs",
         "@krb5//:bin_files",
         "@krb5//:hdr_files",
-        "@krb5//:pc_files",
     ],
+    visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
-    srcs = [":all_files"],
+    srcs = [
+        ":all_files",
+        "@krb5//:pc_files",
+    ],
 )

--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -168,7 +168,7 @@ pkg_filegroup(
         ":lib_files",
         ":fetch_ocsp_response",
     ],
-    visibility = ["//packages:__subpackages__"],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 
 #  This is generally installed with destdir={install_dir}

--- a/deps/openscap/BUILD.bazel
+++ b/deps/openscap/BUILD.bazel
@@ -1,5 +1,11 @@
 # openscap
 
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_filegroup",
+)
+
+# Things we depend on. This is used to gather liceneses
 alias(
     name = "all_deps",
     actual = "@openscap//:all_deps",
@@ -10,4 +16,46 @@ alias(
         "//compliance:__pkg__",
         "//packages:__subpackages__",
     ],
+)
+
+# Files to install in the distro. This is distinct from all_deps.
+# In the future, we should merge the two by being able to designate
+# that individual build targets, like a .so file, should be packaged
+# for distribution IFF the top level binary actually depends on them.
+# That needs design w.r.t. stripping debug symbols and rpath fixes.
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":all_embedded",
+        "@acl//:all_files",
+        "@attr//:all_files",
+        "@bzip2//:all_files",
+    ],
+    # Do not pick up with ... expansion.
+    tags = ["manual"],
+    visibility = ["//packages:__subpackages__"],
+)
+
+# TODO: Fix all of these packages so that embedded is part of the prefix they
+# know about. Right now, we rely on the pkg_install dest_dir to put it into
+# embedded.
+pkg_filegroup(
+    name = "all_embedded",
+    srcs = [
+        "@dbus//:all_files",
+        "@gcrypt//:all_files",
+        "@libselinux//:all_files",
+        "@libsepol//:all_files",
+        "@libxslt//:all_files",
+        "@libyaml//:all_files",
+        "@pcre2//:all_files",
+        "@popt//:all_files",
+        "@rpm//:all_files",
+        "@util-linux//:all_files",
+        "@xmlsec//:all_files",
+    ],
+    prefix = "embedded",
+    # Do not pick up with ... expansion.
+    tags = ["manual"],
+    visibility = ["//packages:__subpackages__"],
 )

--- a/deps/pcre2.BUILD.bazel
+++ b/deps/pcre2.BUILD.bazel
@@ -7,7 +7,7 @@ load("@package_metadata//licenses/rules:license.bzl", "license")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
     default_package_metadata = [":package_metadata"],
@@ -186,7 +186,7 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [":pcre2test_dotc_headers", ":libpcre2", ":libpcre2-posix"],
-    dynamic_deps = [":pcre2-8", ":pcre2-posix"]
+    dynamic_deps = [":pcre2-8", ":pcre2-posix"],
 )
 
 filegroup(
@@ -287,12 +287,20 @@ pkg_files(
     prefix = "include",
 )
 
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":headers",
+        ":pcre2_libfiles",
+        ":pcre2posix_libfiles",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
 pkg_install(
     name = "install",
     srcs = [
-        ":headers",
+        ":all_files",
         ":pkgconfig",
-        ":pcre2_libfiles",
-        ":pcre2posix_libfiles",
     ],
 )

--- a/deps/popt.BUILD.bazel
+++ b/deps/popt.BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
 
@@ -110,11 +110,19 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":lib_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_file",
     ],
 )

--- a/deps/rpm/rpm.BUILD.bazel
+++ b/deps/rpm/rpm.BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
 
@@ -339,13 +339,21 @@ pkg_files(
     prefix = "lib/rpm",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":librpmio_files",
         ":librpm_files",
-        ":pc_file",
         ":misc_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":pc_file",
+        ":all_files",
     ],
 )

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -4,7 +4,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(
     default_applicable_licenses = [":license"],
@@ -83,11 +83,18 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":hdr_files",
         ":lib_files",
+    ],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pkgconfig",
     ],
 )

--- a/deps/util-linux.BUILD.bazel
+++ b/deps/util-linux.BUILD.bazel
@@ -2,7 +2,7 @@ load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -134,11 +134,19 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "blkid_install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":blkid_hdr_files",
         ":libblkid_libfiles",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "blkid_install",
+    srcs = [
+        ":all_files",
         ":blkid_pc_file",
     ],
 )

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 
 package(default_package_metadata = [":license"])
 
@@ -237,13 +237,21 @@ pkg_files(
     prefix = "lib/pkgconfig",
 )
 
-pkg_install(
-    name = "install",
+pkg_filegroup(
+    name = "all_files",
     srcs = [
         ":headers_files",
         ":openssl_headers_files",
         ":libxmlsec_files",
         ":libxmlsec_openssl_files",
+    ],
+    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [
+        ":all_files",
         ":pc_files",
     ],
 )


### PR DESCRIPTION
Split the pkgconfig files out from "all_files" and leave only in the pkg_install rule, through the deps tree.

In https://github.com/DataDog/datadog-agent/pull/46025, we will start to include "all_files" directly.

- That is more managable than having to know all the component parts of each dependency.
- This limits installing .pc files to the omnibus scripts.
- Since they do not go into the package image, we don't have to delete them later.
- Eventually we'll just delete the pc targets since they won't be needed any more.

This probably has missed some packages. That is fine. We can discover and fix them later, after https://github.com/DataDog/datadog-agent/pull/46025 is landed and they merge into that scheme.

## Testing
Compared the .deb files for  a recent PR #45988 to this. They are identical except for the expected diff of the link opt/datadog-packages/datadog-agent/stable