### PR TITLE
Unify JMX integration keys to include host and port in runtime status

### DIFF
--- a/comp/collector/collector/collectorimpl/agent_check_metadata.go
+++ b/comp/collector/collector/collectorimpl/agent_check_metadata.go
@@ -33,6 +33,13 @@ const (
 	firstPayloadDelay = 1 * time.Minute
 )
 
+// jmxInstanceData stores metadata about a JMX instance for building consistent check IDs
+type jmxInstanceData struct {
+	host string
+	port string
+	tags interface{}
+}
+
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
 	hostMetadataUtils.CommonPayload
@@ -122,7 +129,7 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 
 	stats := map[string]interface{}{}
 	jmxStatus.PopulateStatus(stats)
-	instanceConfByName := map[string]interface{}{}
+	instanceConfByName := map[string]*jmxInstanceData{}
 	for _, config := range jmxfetch.GetScheduledConfigs() {
 		for _, instance := range config.Instances {
 			instanceconfig := map[interface{}]interface{}{}
@@ -131,10 +138,35 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 				log.Errorf("invalid instance section: %s", err)
 				continue
 			}
+
+			// Instance name is required to map this data
+			instanceName, hasName := instanceconfig["name"].(string)
+			if !hasName {
+				continue
+			}
+
+			// Extract host with default
+			host := "unknown"
+			if h, ok := instanceconfig["host"]; ok {
+				host = fmt.Sprint(h)
+			}
+
+			// Extract port with default
+			port := "unknown"
+			if p, ok := instanceconfig["port"]; ok {
+				port = fmt.Sprint(p)
+			}
+
+			// Extract tags
+			var tags interface{} = []string{}
 			if tagsNode, ok := instanceconfig["tags"]; ok {
-				if instanceName, ok := instanceconfig["name"].(string); ok {
-					instanceConfByName[instanceName] = tagsNode
-				}
+				tags = tagsNode
+			}
+
+			instanceConfByName[instanceName] = &jmxInstanceData{
+				host: host,
+				port: port,
+				tags: tags,
 			}
 		}
 	}
@@ -157,15 +189,28 @@ func (c *collectorImpl) GetPayload(ctx context.Context) *Payload {
 					if !ok {
 						checkStatus = "OK"
 					}
-					checkID, ok := check["instance_name"].(string)
+
+					instanceName, ok := check["instance_name"].(string)
+					var checkID string
 					if !ok {
+						// No instance name - use just the check name
 						checkID = checkName
+						tags = []string{}
 					} else {
-						if tags, ok = instanceConfByName[checkID]; !ok {
+						// Instance name exists - look up full instance data
+						if instanceData, found := instanceConfByName[instanceName]; found {
+							// Build checkID in format: checkName-host-port:instanceName
+							// This matches the format used in inventory metadata (integrations_jmx.go:77-79)
+							checkID = fmt.Sprintf("%s-%s-%s:%s", checkName, instanceData.host, instanceData.port, instanceName)
+							tags = instanceData.tags
+						} else {
+							// Instance not found in config - fall back with unknown host/port
+							log.Debugf("JMX instance %s not found in scheduled configs, using unknown host/port", instanceName)
+							checkID = fmt.Sprintf("%s-unknown-unknown:%s", checkName, instanceName)
 							tags = []string{}
 						}
-						checkID = fmt.Sprintf("%s:%s", checkName, checkID)
 					}
+
 					checkError, ok := check["message"].(string)
 					if !ok {
 						checkError = ""


### PR DESCRIPTION
## Summary

Unifies the JMX integration key format between inventory metadata and runtime status payloads by including host and port information in both.

## Problem

The JMX integration currently sends two different metadata payloads with inconsistent key formats:

1. **Inventory metadata** (`/api/v1/metadata`) uses format: `jmx-host-port:instanceName`
   - Example: `jmx-localhost-9999:my_instance`

2. **Runtime status** (`/intake/`) uses format: `jmx:instanceName`
   - Example: `jmx:my_instance`

This inconsistency prevents the backend from properly correlating check configurations with their runtime status.

## Changes

Modified `agent_check_metadata.go` to:
- Add `jmxInstanceData` struct to store host, port, and tags for each instance
- Extract host and port from JMX instance configurations (with "unknown" as defaults)
- Build checkID in format `jmx-host-port:instanceName` to match inventory metadata format

### Before
```
checkID: jmx:my_instance
```

### After
```
checkID: jmx-localhost-9999:my_instance
```

## Edge Cases Handled

- Missing host: Uses "unknown" as default
- Missing port: Uses "unknown" as default
- Missing instance name: Uses just check name (no host/port)
- Instance not in scheduled configs: Falls back to `jmx-unknown-unknown:instanceName`

## Test Plan

- [x] Code compiles successfully
- [x] Pre-commit and pre-push hooks pass
- [ ] Manual verification with JMX check configuration
- [ ] Verify both metadata endpoints show matching keys
- [ ] Run JMX integration tests

## References

- Inventory metadata format: `comp/metadata/inventorychecks/inventorychecksimpl/integrations_jmx.go:77-79`