### PR TITLE
[WINA-2116][ACTP-1147] add PAR to windows services start list

### DIFF
--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -84,7 +84,7 @@ func subservices(coreConf model.Reader, sysprobeConf model.Reader) []Servicedef 
 		{
 			name: "private-action-runner",
 			configKeys: map[string]model.Reader{
-				"privateactionrunner.enabled": coreConf,
+				"private_action_runner.enabled": coreConf,
 			},
 			serviceName:    "datadog-private-action-runner",
 			serviceInit:    nil,

--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -87,7 +87,7 @@ func subservices(coreConf model.Reader, sysprobeConf model.Reader) []Servicedef 
 				"private_action_runner.enabled": coreConf,
 			},
 			serviceName:    "datadog-private-action-runner",
-			serviceInit:    nil,
+			serviceInit:    parInit,
 			shouldShutdown: true,
 		},
 		{
@@ -123,6 +123,10 @@ func installerInit() error {
 }
 
 func otelInit() error {
+	return nil
+}
+
+func parInit() error {
 	return nil
 }
 

--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -82,6 +82,15 @@ func subservices(coreConf model.Reader, sysprobeConf model.Reader) []Servicedef 
 			shouldShutdown: true,
 		},
 		{
+			name: "private-action-runner",
+			configKeys: map[string]model.Reader{
+				"privateactionrunner.enabled": coreConf,
+			},
+			serviceName:    "datadog-private-action-runner",
+			serviceInit:    nil,
+			shouldShutdown: true,
+		},
+		{
 			name: "otel",
 			configKeys: map[string]model.Reader{
 				"otelcollector.enabled": coreConf,

--- a/releasenotes/notes/windows-par-config-key-alignment-9c3b9b0d6d0f8f2a.yaml
+++ b/releasenotes/notes/windows-par-config-key-alignment-9c3b9b0d6d0f8f2a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Start the Windows Private Action Runner service alongside the Agent
+    when ``private_action_runner.enabled`` is set in ``datadog.yaml``.
+


### PR DESCRIPTION
### What does this PR do?
This PR adds PAR to windows services start list, controlled by `private_action_runner` config under `datadog.yaml`.

### Motivation
This change is part of the Private Action Runner integration with Agent on Windows.

### Describe how you validated your changes
started agent windows service with both
```datadog.yaml
  private_action_runner:
    enabled: true
```
and 
```datadog.yaml
  private_action_runner:
    enabled: false
```

### Additional Notes
