### PR TITLE
[ACTP] align all par configs with the new private_action_runner prefix

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -52,7 +52,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		}),
 		fx.Supply(core.BundleParams{
 			ConfigParams: config.NewAgentParams(confPath, config.WithExtraConfFiles(extraConfFiles)),
-			LogParams:    log.ForDaemon(command.LoggerName, "privateactionrunner.log_file", pkgconfigsetup.DefaultPrivateActionRunnerLogFile)}),
+			LogParams:    log.ForDaemon(command.LoggerName, pkgconfigsetup.PARLogFile, pkgconfigsetup.DefaultPrivateActionRunnerLogFile)}),
 		core.Bundle(),
 		secretsnoopfx.Module(),
 		fx.Provide(func(c config.Component) settings.Params {

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -69,7 +69,7 @@ type PrivateActionRunner struct {
 func NewComponent(reqs Requires) (Provides, error) {
 	ctx := context.Background()
 	if !isEnabled(reqs.Config) {
-		reqs.Log.Info("private-action-runner is not enabled. Set privateactionrunner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATEACTIONRUNNER_ENABLED=true.")
+		reqs.Log.Info("private-action-runner is not enabled. Set private_action_runner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATE_ACTION_RUNNER_ENABLED=true.")
 		return Provides{}, privateactionrunner.ErrNotEnabled
 	}
 

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -44,14 +44,14 @@ const (
 
 func FromDDConfig(config config.Component) (*Config, error) {
 	ddSite := config.GetString("site")
-	encodedPrivateKey := config.GetString("privateactionrunner.private_key")
-	urn := config.GetString("privateactionrunner.urn")
+	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
+	urn := config.GetString(setup.PARUrn)
 
 	var privateKey *ecdsa.PrivateKey
 	if encodedPrivateKey != "" {
 		jwk, err := util.Base64ToJWK(encodedPrivateKey)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode privateactionrunner.private_key: %w", err)
+			return nil, fmt.Errorf("failed to decode %s: %w", setup.PARPrivateKey, err)
 		}
 		privateKey = jwk.Key.(*ecdsa.PrivateKey)
 	}

--- a/releasenotes/notes/add-par-binary-and-run-linux-0d05dcecf3ea2226.yaml
+++ b/releasenotes/notes/add-par-binary-and-run-linux-0d05dcecf3ea2226.yaml
@@ -10,4 +10,4 @@ features:
   - |
     Add ``privateactionrunner`` binary in Agent artifacts to allow running actions using the Agent,
     and enable running it on Linux. The binary is disabled by default. To enable it, set
-    ``privateactionrunner.enabled: true`` in your configuration file.
+    ``private_action_runner.enabled: true`` in your configuration file.

--- a/releasenotes/notes/private-action-runner-config-keys-7f0f6b9a1e6b0f7d.yaml
+++ b/releasenotes/notes/private-action-runner-config-keys-7f0f6b9a1e6b0f7d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Align Private Action Runner configuration keys and log guidance to the
+    ``private_action_runner.*`` snake-case names.
+


### PR DESCRIPTION
### What does this PR do?
As the title says, aligning PAR configs to follow `private_action_runner` prefix instead of legacy `privateactionrunner`.

### Motivation

### Describe how you validated your changes
```
# tests
dda inv test --targets=./pkg/privateactionrunner/...

# build and run
dda inv privateactionrunner.build
go run ./cmd/privateactionrunner run -c dev/dist/datadog.yaml
```

### Additional Notes
