### PR TITLE
[CWS] make sure we wait for tc classifier loop and sysctl loop before closing

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -790,11 +790,19 @@ func (p *EBPFProbe) Start() error {
 	p.replayEvents(true)
 
 	// start new tc classifier loop
-	go p.startSetupNewTCClassifierLoop()
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		p.startSetupNewTCClassifierLoop()
+	}()
 
 	if p.config.RuntimeSecurity.IsSysctlSnapshotEnabled() {
 		// start sysctl snapshot loop
-		go p.startSysCtlSnapshotLoop()
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			p.startSysCtlSnapshotLoop()
+		}()
 	}
 
 	return p.eventStream.Start(&p.wg)


### PR DESCRIPTION
### What does this PR do?

When closing the probe, we first cancel the context, then wait on the wait group. It's important to include the sysctl loop and the tc classifier in this wait group to ensure those loops are done before continuing the close operation, especially before we start closing the api server and the logs context queue. Otherwise we might hit panics like:

```
panic: send on closed channel
goroutine 839 [running]:
github.com/DataDog/datadog-agent/pkg/security/reporter.(*RuntimeReporter).ReportRaw(0x40005bf6e0, {0x400621e000, 0x7102, 0x8000}, {0x400367ecc8, 0xd}, {0x4002625aa8?, 0x18ea91c?, 0x0?}, {0x4002f1b208, ...})
	github.com/DataDog/datadog-agent/pkg/security/reporter/reporter.go:40 +0x1d0
github.com/DataDog/datadog-agent/pkg/security/module.(*DirectEventMsgSender).Send(0x4002eb6390, 0x40017b3e00, 0x3a?)
	github.com/DataDog/datadog-agent/pkg/security/module/msg_sender.go:103 +0x138
github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).SendEvent(0x4000d4cb00, 0x4001d3f480, {0x298f4e0, 0x40083a04e0}, 0x0, {0x0, 0x0})
	github.com/DataDog/datadog-agent/pkg/security/module/server.go:546 +0xa54
github.com/DataDog/datadog-agent/pkg/security/module.(*CWSConsumer).SendEvent(0x4002099520, 0x4001d3f480, {0x298f4e0, 0x40083a04e0}, 0x0, {0x0, 0x0})
	github.com/DataDog/datadog-agent/pkg/security/module/cws.go:348 +0x7c
github.com/DataDog/datadog-agent/pkg/security/module.(*CWSConsumer).HandleCustomEvent(0x4000a39808?, 0x47?, 0x2327d60?)
	github.com/DataDog/datadog-agent/pkg/security/module/cws.go:341 +0x34
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchCustomEvent(0x4000a39808, 0x4001d3f480, 0x40083a04e0)
	github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:366 +0x64
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).startSysCtlSnapshotLoop(0x40004da808)
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2238 +0x278
created by github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Start in goroutine 1
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:799 +0xc0

```

### Motivation

### Describe how you validated your changes

### Additional Notes
