### PR TITLE
fix(reno): Do not use sparse-checkout with reno

### DIFF
--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -19,15 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout base repo for trusted code (tasks, dda install)
+      # NOTE: Do NOT use sparse-checkout here — reno uses dulwich which doesn't
+      # support the extensions.worktreeConfig that sparse-checkout enables.
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
           fetch-depth: 0
-          sparse-checkout: |
-            .gitlab-ci.yml
-            .github/actions/install-dda
-            tasks
           persist-credentials: false
       # Fetch and checkout only releasenotes folders from PR (data only, no code execution)
       # Using refs/pull/NUMBER/head works for both fork and non-fork PRs


### PR DESCRIPTION
### What does this PR do?

Removes `sparse-checkout` from the `release-note-check` job in the `label-analysis` workflow.

`sparse-checkout` causes Git to set `extensions.worktreeConfig = true` in `.git/config`. `reno` uses `dulwich` (a Python Git library) which doesn't support that extension, resulting in:
```
dulwich.repo.UnsupportedExtension: b'worktreeConfig'
```

See https://github.com/DataDog/datadog-agent/actions/runs/21820574446/job/62952555264?pr=46059 for a failed run example.

### Motivation

The `release-note-check` job has been failing on all PRs since #45330 was merged.

### Describe how you validated your changes

- Reproduced the error locally by enabling `sparse-checkout` and running `reno lint`
- Confirmed the error disappears once `sparse-checkout` (and its `extensions.worktreeConfig` side effect) is removed

### Additional Notes

`sparse-checkout` is not needed for this job because:
- It checks out `ref: main` (trusted code), not PR code
- It already uses `fetch-depth: 0` for full git history (needed by reno)
- PR-specific releasenotes are safely fetched separately via `git checkout FETCH_HEAD -- releasenotes ...`