### PR TITLE
[CWS] don't start the tc classifier loop if network is disabled

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -789,12 +789,14 @@ func (p *EBPFProbe) Start() error {
 	// Apply rules to the already stored data before starting the event stream to avoid concurrency issues
 	p.replayEvents(true)
 
-	// start new tc classifier loop
-	p.wg.Add(1)
-	go func() {
-		defer p.wg.Done()
-		p.startSetupNewTCClassifierLoop()
-	}()
+	if p.probe.IsNetworkEnabled() {
+		// start new tc classifier loop
+		p.wg.Add(1)
+		go func() {
+			defer p.wg.Done()
+			p.startSetupNewTCClassifierLoop()
+		}()
+	}
 
 	if p.config.RuntimeSecurity.IsSysctlSnapshotEnabled() {
 		// start sysctl snapshot loop


### PR DESCRIPTION
### What does this PR do?

No need to start the tc classifier loop if network is disabled in the probe.

### Motivation

### Describe how you validated your changes

### Additional Notes
