### PR TITLE
[autoscaling] Add error reasons in the autoscaling conditions

### DIFF
--- a/pkg/clusteragent/autoscaling/errors.go
+++ b/pkg/clusteragent/autoscaling/errors.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoscaling
+
+import (
+	"fmt"
+)
+
+// ConditionReasonType is a typed string for programmatic condition reasons.
+// Values must be CamelCase with no spaces, following the Kubernetes convention.
+type ConditionReasonType string
+
+const (
+	// ConditionReasonInvalidTargetRef indicates the targetRef API version could not be parsed.
+	ConditionReasonInvalidTargetRef ConditionReasonType = "InvalidTargetRef"
+	// ConditionReasonInvalidTarget indicates the target cannot be autoscaled (e.g. it is the cluster agent itself).
+	ConditionReasonInvalidTarget ConditionReasonType = "InvalidTarget"
+	// ConditionReasonInvalidSpec indicates the DPA spec failed validation (e.g. bad objectives or constraints).
+	ConditionReasonInvalidSpec ConditionReasonType = "InvalidSpec"
+	// ConditionReasonClusterAutoscalerLimitReached indicates the maximum number of DPA objects per cluster has been reached.
+	ConditionReasonClusterAutoscalerLimitReached ConditionReasonType = "ClusterAutoscalerLimitReached"
+	// ConditionReasonRecommendationError indicates Datadog could not compute recommendations.
+	ConditionReasonRecommendationError ConditionReasonType = "RecommendationError"
+	// ConditionReasonLocalRecommenderError indicates the local fallback recommender could not compute recommendations.
+	ConditionReasonLocalRecommenderError ConditionReasonType = "LocalRecommenderError"
+	// ConditionReasonTargetNotFound indicates the scale target could not be found.
+	ConditionReasonTargetNotFound ConditionReasonType = "TargetNotFound"
+	// ConditionReasonScaleFailed indicates the scale operation on the target failed.
+	ConditionReasonScaleFailed ConditionReasonType = "ScaleFailed"
+	// ConditionReasonScalingDisabled indicates scaling is blocked because current replicas is 0.
+	ConditionReasonScalingDisabled ConditionReasonType = "ScalingDisabled"
+	// ConditionReasonPolicyRestricted indicates the applyPolicy or strategy blocks the scaling action.
+	ConditionReasonPolicyRestricted ConditionReasonType = "PolicyRestricted"
+	// ConditionReasonFallbackRestricted indicates the fallback scaling direction is not allowed.
+	ConditionReasonFallbackRestricted ConditionReasonType = "FallbackRestricted"
+	// ConditionReasonUnsupportedTargetKind indicates vertical rollout is not supported for this workload Kind.
+	ConditionReasonUnsupportedTargetKind ConditionReasonType = "UnsupportedTargetKind"
+	// ConditionReasonRolloutFailed indicates a failure when triggering a vertical rollout on the target.
+	ConditionReasonRolloutFailed ConditionReasonType = "RolloutFailed"
+)
+
+// ConditionReason is an interface that errors can implement to provide
+// a programmatic Reason for Kubernetes conditions.
+// When an error implements this interface, Reason() populates the condition's
+// Reason field and Error() populates the Message field.
+// When an error does not implement this interface, Error() populates the
+// Message field and Reason is left empty.
+type ConditionReason interface {
+	Reason() ConditionReasonType
+}
+
+// NewConditionError wraps an existing error with a programmatic reason.
+func NewConditionError(reason ConditionReasonType, err error) error {
+	return &conditionError{reason: reason, err: err}
+}
+
+// NewConditionErrorf creates a new error with a programmatic reason and a formatted message.
+func NewConditionErrorf(reason ConditionReasonType, format string, args ...any) error {
+	return &conditionError{reason: reason, err: fmt.Errorf(format, args...)}
+}
+
+type conditionError struct {
+	reason ConditionReasonType
+	err    error
+}
+
+func (e *conditionError) Error() string               { return e.err.Error() }
+func (e *conditionError) Unwrap() error               { return e.err }
+func (e *conditionError) Reason() ConditionReasonType { return e.reason }

--- a/pkg/clusteragent/autoscaling/max_heap.go
+++ b/pkg/clusteragent/autoscaling/max_heap.go
@@ -11,11 +11,7 @@ import (
 	"container/heap"
 	"sync"
 	"time"
-
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 )
-
-type store = Store[model.PodAutoscalerInternal]
 
 // TimestampKey is a struct that holds a timestamp and key for a `DatadogPodAutoscaler` object
 type TimestampKey struct {
@@ -79,22 +75,25 @@ func (h *MaxTimestampKeyHeap) FindIdx(key string) (int, bool) {
 }
 
 // HashHeap is a struct that holds a MaxHeap and a set of keys that exist in the heap
-type HashHeap struct {
-	MaxHeap MaxTimestampKeyHeap
-	Keys    map[string]bool
-	maxSize int
-	mu      sync.RWMutex
-	store   *store
+type HashHeap[T any] struct {
+	MaxHeap           MaxTimestampKeyHeap
+	Keys              map[string]bool
+	maxSize           int
+	mu                sync.RWMutex
+	store             *Store[T]
+	creationTimestamp func(*T) time.Time
 }
 
-// NewHashHeap returns a new MaxHeap with the given max size
-func NewHashHeap(maxSize int, store *store) *HashHeap {
-	h := &HashHeap{
-		MaxHeap: *NewMaxHeap(),
-		Keys:    make(map[string]bool),
-		maxSize: maxSize,
-		mu:      sync.RWMutex{},
-		store:   store,
+// NewHashHeap returns a new MaxHeap with the given max size.
+// creationTimestamp is used to extract the creation timestamp from stored objects.
+func NewHashHeap[T any](maxSize int, store *Store[T], creationTimestamp func(*T) time.Time) *HashHeap[T] {
+	h := &HashHeap[T]{
+		MaxHeap:           *NewMaxHeap(),
+		Keys:              make(map[string]bool),
+		maxSize:           maxSize,
+		mu:                sync.RWMutex{},
+		store:             store,
+		creationTimestamp: creationTimestamp,
 	}
 
 	store.RegisterObserver(Observer{
@@ -107,19 +106,19 @@ func NewHashHeap(maxSize int, store *store) *HashHeap {
 
 // InsertIntoHeap returns true if the key already exists in the max heap or was inserted correctly
 // Used as an ObserverFunc; accept sender as parameter to match ObserverFunc signature
-func (h *HashHeap) InsertIntoHeap(key, _sender string) {
-	// Get object from store
-	podAutoscalerInternal, podAutoscalerInternalFound := h.store.Get(key)
-	if !podAutoscalerInternalFound {
+func (h *HashHeap[T]) InsertIntoHeap(key, _sender string) {
+	obj, found := h.store.Get(key)
+	if !found {
 		return
 	}
 
-	if podAutoscalerInternal.CreationTimestamp().IsZero() {
+	ts := h.creationTimestamp(&obj)
+	if ts.IsZero() {
 		return
 	}
 
 	newTimestampKey := TimestampKey{
-		Timestamp: podAutoscalerInternal.CreationTimestamp(),
+		Timestamp: ts,
 		Key:       key,
 	}
 
@@ -147,7 +146,7 @@ func (h *HashHeap) InsertIntoHeap(key, _sender string) {
 
 // DeleteFromHeap removes the given key from the max heap
 // Used as an ObserverFunc; accept sender as parameter to match ObserverFunc signature
-func (h *HashHeap) DeleteFromHeap(key, _sender string) {
+func (h *HashHeap[T]) DeleteFromHeap(key, _sender string) {
 	// Key did not exist in heap, return early
 	if !h.Exists(key) {
 		return
@@ -167,7 +166,7 @@ func (h *HashHeap) DeleteFromHeap(key, _sender string) {
 }
 
 // Exists returns true if the given key exists in the heap
-func (h *HashHeap) Exists(key string) bool {
+func (h *HashHeap[T]) Exists(key string) bool {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	_, ok := h.Keys[key]
@@ -175,6 +174,6 @@ func (h *HashHeap) Exists(key string) bool {
 }
 
 // MaxSize returns the size limit on the hash heap
-func (h *HashHeap) MaxSize() int {
+func (h *HashHeap[T]) MaxSize() int {
 	return h.maxSize
 }

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -54,7 +54,10 @@ var (
 	}
 )
 
-type store = autoscaling.Store[model.PodAutoscalerInternal]
+type (
+	store     = autoscaling.Store[model.PodAutoscalerInternal]
+	limitHeap = autoscaling.HashHeap[model.PodAutoscalerInternal]
+)
 
 // Controller for DatadogPodAutoscaler objects
 type Controller struct {
@@ -66,7 +69,7 @@ type Controller struct {
 	eventRecorder record.EventRecorder
 	store         *store
 
-	limitHeap *autoscaling.HashHeap
+	limitHeap *limitHeap
 
 	podWatcher           PodWatcher
 	horizontalController *horizontalController
@@ -90,7 +93,7 @@ func NewController(
 	store *store,
 	podWatcher PodWatcher,
 	localSender sender.Sender,
-	limitHeap *autoscaling.HashHeap,
+	limitHeap *limitHeap,
 ) (*Controller, error) {
 	c := &Controller{
 		clusterID:         clusterID,
@@ -461,7 +464,7 @@ func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscale
 	// Check that we are within the limit of 100 DatadogPodAutoscalers
 	key := podAutoscalerInternal.ID()
 	if !c.limitHeap.Exists(key) {
-		return fmt.Errorf("Autoscaler disabled as maximum number per cluster reached (%d)", c.limitHeap.MaxSize())
+		return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonClusterAutoscalerLimitReached, "Autoscaler disabled as maximum number per cluster reached (%d)", c.limitHeap.MaxSize())
 	}
 
 	// Check that targetRef is not set to the cluster agent
@@ -485,7 +488,7 @@ func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscale
 	clusterAgentNs := namespace.GetMyNamespace()
 
 	if podAutoscalerInternal.Namespace() == clusterAgentNs && podAutoscalerInternal.Spec().TargetRef.Name == resourceName {
-		return errors.New("Autoscaling target cannot be set to the cluster agent")
+		return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidTarget, "Autoscaling target cannot be set to the cluster agent")
 	}
 	if err := validateAutoscalerObjectives(podAutoscalerInternal.Spec()); err != nil {
 		return err
@@ -497,7 +500,7 @@ func validateAutoscalerObjectives(spec *datadoghq.DatadogPodAutoscalerSpec) erro
 	if spec.Fallback != nil && len(spec.Fallback.Horizontal.Objectives) > 0 {
 		for _, objective := range spec.Fallback.Horizontal.Objectives {
 			if objective.Type == datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType {
-				return errors.New("Autoscaler fallback cannot be based on custom query objective")
+				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "Autoscaler fallback cannot be based on custom query objective")
 			}
 		}
 	}
@@ -506,15 +509,15 @@ func validateAutoscalerObjectives(spec *datadoghq.DatadogPodAutoscalerSpec) erro
 		switch objective.Type {
 		case datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType:
 			if objective.CustomQuery == nil {
-				return errors.New("Autoscaler objective type is custom query but customQueryObjective is nil")
+				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "Autoscaler objective type is custom query but customQueryObjective is nil")
 			}
 		case datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType:
 			if objective.PodResource == nil {
-				return fmt.Errorf("autoscaler objective type is %s but podResource is nil", objective.Type)
+				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "autoscaler objective type is %s but podResource is nil", objective.Type)
 			}
 		case datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType:
 			if objective.ContainerResource == nil {
-				return fmt.Errorf("autoscaler objective type is %s but containerResource is nil", objective.Type)
+				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "autoscaler objective type is %s but containerResource is nil", objective.Type)
 			}
 		}
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -47,7 +47,7 @@ type fixture struct {
 	clock           *clock.FakeClock
 	recorder        *record.FakeRecorder
 	store           *store
-	autoscalingHeap *autoscaling.HashHeap
+	autoscalingHeap *autoscaling.HashHeap[model.PodAutoscalerInternal]
 	scaler          *fakeScaler
 	podWatcher      *fakePodWatcher
 }
@@ -59,7 +59,7 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 
 	clock := clock.NewFakeClock(testTime)
 	recorder := record.NewFakeRecorder(100)
-	hashHeap := autoscaling.NewHashHeap(testMaxAutoscalerObjects, store)
+	hashHeap := autoscaling.NewHashHeap(testMaxAutoscalerObjects, store, (*model.PodAutoscalerInternal).CreationTimestamp)
 	scaler := newFakeScaler()
 	podWatcher := newFakePodWatcher()
 	return &fixture{
@@ -197,13 +197,13 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 		Spec: dpaSpec,
 		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
 		},
 	}
@@ -265,13 +265,13 @@ func TestLeaderCreateDeleteRemoteDefaultedSpec(t *testing.T) {
 		Spec: dpaSpec,
 		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
 		},
 	}
@@ -412,13 +412,13 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 				},
 				Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 					Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-						condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, "Autoscaling target cannot be set to the cluster agent", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, "InvalidTarget", "Autoscaling target cannot be set to the cluster agent", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 					},
 				},
 			}
@@ -428,7 +428,7 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 			assert.Len(t, f.store.GetAll(), 1)
 			pai, found := f.store.Get(id)
 			assert.Truef(t, found, "Expected to find DatadogPodAutoscaler in store")
-			assert.Equal(t, errors.New("Autoscaling target cannot be set to the cluster agent"), pai.Error())
+			assert.EqualError(t, pai.Error(), "Autoscaling target cannot be set to the cluster agent")
 		})
 	}
 }
@@ -538,13 +538,13 @@ func TestPodAutoscalerClearStatusOnScalingModeChange(t *testing.T) {
 		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 			CurrentReplicas: pointer.Ptr[int32](1),
 			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionFalse, "no data available", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionTrue, "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionFalse, "", "no data available", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionTrue, "", "", testTime),
 			},
 			Horizontal: &datadoghqcommon.DatadogPodAutoscalerHorizontalStatus{
 				Target: &datadoghqcommon.DatadogPodAutoscalerHorizontalRecommendation{
@@ -590,13 +590,13 @@ func TestPodAutoscalerClearStatusOnScalingModeChange(t *testing.T) {
 	expectedDPA.Generation = 1
 	expectedDPA.Status.Vertical = nil
 	expectedDPA.Status.Conditions = []datadoghqcommon.DatadogPodAutoscalerCondition{
-		condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", testTime),
-		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 	}
 
 	// Check current status is as expected
@@ -689,13 +689,13 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 		},
 		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects), testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, "ClusterAutoscalerLimitReached", fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects), testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
 		},
 	}
@@ -769,13 +769,13 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 	// Should create object in Kubernetes
 	expectedStatus := datadoghqcommon.DatadogPodAutoscalerStatus{
 		Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-			condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 		},
 	}
 	expectedUnstructured, _ := newFakePodAutoscaler("default", "dpa-0", -1, time.Time{}, dpaSpec, expectedStatus)
@@ -831,13 +831,13 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 		},
 		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
 			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
-				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects), testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", testTime),
-				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionTrue, "ClusterAutoscalerLimitReached", fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects), testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
 		},
 	}
@@ -1249,11 +1249,12 @@ func mustUnstructured(t *testing.T, structIn any) *unstructured.Unstructured {
 	return unstructOut
 }
 
-func condition(conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, status corev1.ConditionStatus, reason string, transitionTime time.Time) datadoghqcommon.DatadogPodAutoscalerCondition {
+func condition(conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, status corev1.ConditionStatus, reason, message string, transitionTime time.Time) datadoghqcommon.DatadogPodAutoscalerCondition {
 	return datadoghqcommon.DatadogPodAutoscalerCondition{
 		Type:               conditionType,
 		Status:             status,
 		Reason:             reason,
+		Message:            message,
 		LastTransitionTime: metav1.NewTime(transitionTime),
 	}
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -10,7 +10,6 @@ package workload
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -109,7 +108,7 @@ func (u *verticalController) sync(ctx context.Context, podAutoscaler *datadoghq.
 	// Check if we're allowed to rollout, we don't care about the source in this case, so passing most favorable source: manual
 	updateStrategy, reason := getVerticalPatchingStrategy(autoscalerInternal)
 	if updateStrategy == datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy {
-		autoscalerInternal.UpdateFromVerticalAction(nil, errors.New(reason))
+		autoscalerInternal.UpdateFromVerticalAction(nil, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonPolicyRestricted, "%s", reason))
 		return autoscaling.NoRequeue, nil
 	}
 
@@ -121,7 +120,7 @@ func (u *verticalController) sync(ctx context.Context, podAutoscaler *datadoghq.
 	case k8sutil.StatefulSetKind:
 		return u.syncStatefulSetKind(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID, pods, podsPerRecommendationID)
 	default:
-		autoscalerInternal.UpdateFromVerticalAction(nil, fmt.Errorf("automatic rollout not available for target Kind: %s. Applying to existing PODs require manual trigger", targetGVK.Kind))
+		autoscalerInternal.UpdateFromVerticalAction(nil, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonUnsupportedTargetKind, "automatic rollout not available for target Kind: %s. Applying to existing PODs require manual trigger", targetGVK.Kind))
 		return autoscaling.NoRequeue, nil
 	}
 }
@@ -152,14 +151,15 @@ func (u *verticalController) triggerRollout(
 		},
 	})
 	if err != nil {
-		autoscalerInternal.UpdateFromVerticalAction(nil, fmt.Errorf("Unable to produce JSONPatch : %v", err))
+		err = autoscaling.NewConditionError(autoscaling.ConditionReasonRolloutFailed, fmt.Errorf("Unable to produce JSONPatch : %v", err))
+		autoscalerInternal.UpdateFromVerticalAction(nil, err)
 		return autoscaling.Requeue, err
 	}
 
 	// Apply patch to trigger rollout
 	_, err = u.dynamicClient.Resource(gvr).Namespace(target.Namespace).Patch(ctx, target.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		err = fmt.Errorf("failed to trigger rollout for gvk: %s, name: %s, err: %v", targetGVK.String(), autoscalerInternal.Spec().TargetRef.Name, err)
+		err = autoscaling.NewConditionError(autoscaling.ConditionReasonRolloutFailed, fmt.Errorf("failed to trigger rollout for gvk: %s, name: %s, err: %v", targetGVK.String(), autoscalerInternal.Spec().TargetRef.Name, err))
 		telemetryVerticalRolloutTriggered.Inc(target.Namespace, target.Name, autoscalerInternal.Name(), "error", le.JoinLeaderValue)
 		autoscalerInternal.UpdateFromVerticalAction(nil, err)
 		u.eventRecorder.Event(podAutoscaler, corev1.EventTypeWarning, model.FailedTriggerRolloutEventReason, err.Error())

--- a/pkg/clusteragent/autoscaling/workload/local/recommender.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender.go
@@ -105,7 +105,7 @@ func (r *Recommender) updateAutoscaler(key string, horizontalRecommendation *mod
 	recommendation := model.ScalingValues{}
 
 	if err != nil {
-		recommendation.HorizontalError = err
+		recommendation.HorizontalError = autoscaling.NewConditionError(autoscaling.ConditionReasonLocalRecommenderError, err)
 	}
 
 	if horizontalRecommendation != nil {

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -17,6 +17,7 @@ import (
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
 	corev1 "k8s.io/api/core/v1"
@@ -360,24 +361,28 @@ func (p *PodAutoscalerInternal) UpdateFromStatus(status *datadoghqcommon.Datadog
 		p.currentReplicas = status.CurrentReplicas
 	}
 
-	// Reading potential errors from conditions. Resetting internal errors first.
-	// We're only keeping error string, loosing type, but it's not important for what we do.
+	// Reading potential errors from conditions.
+	// We restore the error with its programmatic reason when available.
 	for _, cond := range status.Conditions {
 		switch {
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerErrorCondition && cond.Status == corev1.ConditionTrue:
 			// Error condition could refer to a controller error or from a general Datadog error
 			// We're restoring this to error as it's the most generic
-			p.error = errors.New(cond.Reason)
+			p.error = errorFromCondition(cond)
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
-			p.scalingValues.HorizontalError = errors.New(cond.Reason)
+			p.scalingValues.HorizontalError = errorFromCondition(cond)
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition && cond.Status == corev1.ConditionFalse:
-			p.horizontalLastActionError = errors.New(cond.Reason)
+			p.horizontalLastActionError = errorFromCondition(cond)
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition && cond.Status == corev1.ConditionTrue:
-			p.horizontalLastLimitReason = cond.Reason
+			p.horizontalLastLimitReason = cond.Message
+			// Backward compatibility: if Message is empty, fall back to Reason
+			if p.horizontalLastLimitReason == "" {
+				p.horizontalLastLimitReason = cond.Reason
+			}
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
-			p.scalingValues.VerticalError = errors.New(cond.Reason)
+			p.scalingValues.VerticalError = errorFromCondition(cond)
 		case cond.Type == datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply && cond.Status == corev1.ConditionFalse:
-			p.verticalLastActionError = errors.New(cond.Reason)
+			p.verticalLastActionError = errorFromCondition(cond)
 		}
 	}
 }
@@ -522,7 +527,7 @@ func (p *PodAutoscalerInternal) TargetGVK() (schema.GroupVersionKind, error) {
 
 	gv, err := schema.ParseGroupVersion(p.spec.TargetRef.APIVersion)
 	if err != nil || gv.Group == "" || gv.Version == "" {
-		return schema.GroupVersionKind{}, fmt.Errorf("failed to parse API version '%s', err: %w", p.spec.TargetRef.APIVersion, err)
+		return schema.GroupVersionKind{}, autoscaling.NewConditionError(autoscaling.ConditionReasonInvalidTargetRef, fmt.Errorf("failed to parse API version '%s', err: %w", p.spec.TargetRef.APIVersion, err))
 	}
 
 	p.targetGVK = schema.GroupVersionKind{
@@ -624,9 +629,9 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 
 	// Building active condition, should handle multiple reasons, currently only disabled if target replicas = 0
 	if p.currentReplicas != nil && *p.currentReplicas == 0 {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "Target has been scaled to 0 replicas", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "", "Target has been scaled to 0 replicas", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
 	} else {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, "", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, "", "", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
 	}
 
 	// Building errors related to compute recommendations
@@ -634,7 +639,7 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	if horizontalEnabled && (p.scalingValues.HorizontalError != nil || p.scalingValues.Horizontal != nil) {
 		horizontalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.HorizontalError, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
 	} else {
-		horizontalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
+		horizontalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
 	}
 	status.Conditions = append(status.Conditions, horizontalAbleToRecommend)
 
@@ -642,37 +647,37 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	if verticalEnabled && (p.scalingValues.VerticalError != nil || p.scalingValues.Vertical != nil) {
 		verticalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.VerticalError, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
 	} else {
-		verticalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
+		verticalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", "", currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
 	}
 	status.Conditions = append(status.Conditions, verticalAbleToRecommend)
 
 	// Horizontal: handle scaling limited condition
 	if horizontalEnabled && p.horizontalLastLimitReason != "" {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, p.horizontalLastLimitReason, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, "", p.horizontalLastLimitReason, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
 	} else {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "", "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
 	}
 
 	// Building rollout errors
-	var horizontalReason string
+	var horizontalReason, horizontalMessage string
 	horizontalStatus := corev1.ConditionUnknown
 	if p.horizontalLastActionError != nil {
 		horizontalStatus = corev1.ConditionFalse
-		horizontalReason = p.horizontalLastActionError.Error()
+		horizontalReason, horizontalMessage = reasonAndMessageFromError(p.horizontalLastActionError)
 	} else if len(p.horizontalLastActions) > 0 {
 		horizontalStatus = corev1.ConditionTrue
 	}
-	status.Conditions = append(status.Conditions, newCondition(horizontalStatus, horizontalReason, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, existingConditions))
+	status.Conditions = append(status.Conditions, newCondition(horizontalStatus, horizontalReason, horizontalMessage, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, existingConditions))
 
-	var verticalReason string
+	var verticalReason, verticalMessage string
 	rolloutStatus := corev1.ConditionUnknown
 	if p.verticalLastActionError != nil {
 		rolloutStatus = corev1.ConditionFalse
-		verticalReason = p.verticalLastActionError.Error()
+		verticalReason, verticalMessage = reasonAndMessageFromError(p.verticalLastActionError)
 	} else if p.verticalLastAction != nil {
 		rolloutStatus = corev1.ConditionTrue
 	}
-	status.Conditions = append(status.Conditions, newCondition(rolloutStatus, verticalReason, currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, existingConditions))
+	status.Conditions = append(status.Conditions, newCondition(rolloutStatus, verticalReason, verticalMessage, currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, existingConditions))
 
 	return status
 }
@@ -736,33 +741,71 @@ func addRecommendationToHistory(currentTime time.Time, retention time.Duration, 
 	return history
 }
 
-func newConditionFromError(trueOnError bool, currentTime metav1.Time, err error, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
-	var condition corev1.ConditionStatus
+// errorFromCondition restores an error from a Kubernetes condition.
+// If the condition has a programmatic Reason, the error is wrapped with it.
+// For backward compatibility, if Message is empty, Reason is used as the error message
+// (matching the old behavior where err.Error() was stored in the Reason field).
+func errorFromCondition(cond datadoghqcommon.DatadogPodAutoscalerCondition) error {
+	message := cond.Message
+	// Backward compatibility: if Message is empty, fall back to Reason as error message
+	if message == "" {
+		message = cond.Reason
+		if message == "" {
+			return errors.New("unknown error")
+		}
+		return errors.New(message)
+	}
 
-	var reason string
+	if cond.Reason != "" {
+		return autoscaling.NewConditionError(autoscaling.ConditionReasonType(cond.Reason), errors.New(message))
+	}
+	return errors.New(message)
+}
+
+// reasonAndMessageFromError extracts a programmatic reason and human-readable message from an error.
+// If the error implements autoscaling.ConditionReason, the reason is extracted from it.
+// The message is always the error's Error() string.
+func reasonAndMessageFromError(err error) (reason, message string) {
+	if err == nil {
+		return "", ""
+	}
+
+	message = err.Error()
+	var cr autoscaling.ConditionReason
+	if errors.As(err, &cr) {
+		reason = string(cr.Reason())
+	}
+	return reason, message
+}
+
+func newConditionFromError(trueOnError bool, currentTime metav1.Time, err error, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
+	var status corev1.ConditionStatus
+
+	var reason, message string
 	if err != nil {
-		reason = err.Error()
+		reason, message = reasonAndMessageFromError(err)
 		if trueOnError {
-			condition = corev1.ConditionTrue
+			status = corev1.ConditionTrue
 		} else {
-			condition = corev1.ConditionFalse
+			status = corev1.ConditionFalse
 		}
 	} else {
 		if trueOnError {
-			condition = corev1.ConditionFalse
+			status = corev1.ConditionFalse
 		} else {
-			condition = corev1.ConditionTrue
+			status = corev1.ConditionTrue
 		}
 	}
 
-	return newCondition(condition, reason, currentTime, conditionType, existingConditions)
+	return newCondition(status, reason, message, currentTime, conditionType, existingConditions)
 }
 
-func newCondition(status corev1.ConditionStatus, reason string, currentTime metav1.Time, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
+func newCondition(status corev1.ConditionStatus, reason, message string, currentTime metav1.Time, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
 	condition := datadoghqcommon.DatadogPodAutoscalerCondition{
-		Type:   conditionType,
-		Status: status,
-		Reason: reason,
+		Type:    conditionType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
 	}
 
 	prevCondition := existingConditions[conditionType]

--- a/pkg/clusteragent/autoscaling/workload/model/rc_schema.go
+++ b/pkg/clusteragent/autoscaling/workload/model/rc_schema.go
@@ -12,6 +12,8 @@ import (
 
 	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	datadoghqv1alpha2 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 )
 
 // ReccomendationError is an error encountered while computing a recommendation on Datadog side
@@ -20,6 +22,11 @@ type ReccomendationError kubeAutoscaling.Error
 // Error returns the error message
 func (e *ReccomendationError) Error() string {
 	return e.Message
+}
+
+// Reason implements ConditionReason, providing a programmatic reason for conditions.
+func (e *ReccomendationError) Reason() autoscaling.ConditionReasonType {
+	return autoscaling.ConditionReasonRecommendationError
 }
 
 // AutoscalingSettingsList holds a list of AutoscalingSettings

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -69,7 +69,7 @@ func StartWorkloadAutoscaling(
 	}
 
 	maxDatadogPodAutoscalerObjects := pkgconfigsetup.Datadog().GetInt("autoscaling.workload.limit")
-	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store)
+	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store, (*model.PodAutoscalerInternal).CreationTimestamp)
 
 	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Add codified `Reason` in the DPA Status to allow better error matching and understanding

### Motivation

### Describe how you validated your changes

There are a significant number of error cases, testing everything is not required.
To test an easy one, you can create an Autoscaler that references an unsupported `apiGroup`

### Additional Notes
