### PR TITLE
fix(service.datadog.yaml): Remove the pagerduty integration

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -146,9 +146,6 @@ tags:
   - team:container-integrations
   - service:datadog-cluster-agent
   - app:datadog-cluster-agent
-integrations:
-  pagerduty:
-    service-url: https://datadog.pagerduty.com/service-directory/P55U2GM
 ---
 schema-version: v2.1
 dd-service: datadog-agent-cluster-worker
@@ -195,9 +192,6 @@ tags:
   - team:container-integrations
   - service:datadog-agent-cluster-worker
   - app:datadog-agent-cluster-worker
-integrations:
-  pagerduty:
-    service-url: https://datadog.pagerduty.com/service-directory/P55U2GM
 ---
 apiVersion: v3
 kind: service


### PR DESCRIPTION
### What does this PR do?
Remove references to pagerduty as we don't use it anymore

### Motivation
We received a notification on the [service check](https://app.datadoghq.com/dashboard/ebi-u94-22h/service-metadata-validation-failures?fromUser=false&refresh_mode=sliding&tpl_var_team_handle=agent-devx&from_ts=1770026249382&to_ts=1770631049382&live=true)

### Describe how you validated your changes
Simple deletion, no test neede

### Additional Notes
