### PR TITLE
[CONTP-547] Fix bug: ensure pod containers are repopulated on every event set

### DIFF
--- a/comp/languagedetection/client/clientimpl/util.go
+++ b/comp/languagedetection/client/clientimpl/util.go
@@ -24,6 +24,12 @@ type batch map[string]*podInfo
 
 func (b batch) getOrAddPodInfo(pod *workloadmeta.KubernetesPod) *podInfo {
 	if podInfo, ok := b[pod.Name]; ok {
+		// Refresh the containers list from the current pod state.
+		// This is needed because the first process event for a pod may arrive
+		// before the kubelet has fully populated the pod's container list in
+		// workloadmeta, resulting in an empty containers map that would cause
+		// hasCompleteLanguageInfo() to always return false.
+		podInfo.containers = getContainersFromPod(pod)
 		return podInfo
 	}
 	containers := getContainersFromPod(pod)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the language detection client that may result in languages not being reported for a pod in case pod containers are not populated by the kubelet yet. 

### Motivation

Fix TestAdmissionControllerWithAutoDetectedLanguage flaky e2e.

### Describe how you validated your changes

E2E

### Additional Notes
