### PR TITLE
[EBPF-1041] gpu: change name for GPM metric

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -11,6 +11,7 @@ package gpu
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -413,6 +414,10 @@ func (c *Check) emitSingleMetric(metric *nvidia.Metric, snd sender.Sender, curre
 
 	metricName := gpuMetricsNs + metric.Name
 	allTags := append(append(deviceTags, metricTags...), metric.Tags...)
+
+	if strings.Contains(metricName, "sm_active") {
+		log.Warnf("sm_active metric: %s, value: %f, tags: %v", metricName, metric.Value, allTags)
+	}
 
 	// Use the current execution time as the timestamp for the metrics, that way we can ensure that the metrics are aligned with the check interval.
 	// We need this to ensure weighted metrics are calibrated correctly.

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -11,7 +11,6 @@ package gpu
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -414,10 +413,6 @@ func (c *Check) emitSingleMetric(metric *nvidia.Metric, snd sender.Sender, curre
 
 	metricName := gpuMetricsNs + metric.Name
 	allTags := append(append(deviceTags, metricTags...), metric.Tags...)
-
-	if strings.Contains(metricName, "sm_active") {
-		log.Warnf("sm_active metric: %s, value: %f, tags: %v", metricName, metric.Value, allTags)
-	}
 
 	// Use the current execution time as the timestamp for the metrics, that way we can ensure that the metrics are aligned with the check interval.
 	// We need this to ensure weighted metrics are calibrated correctly.

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -502,7 +502,7 @@ func TestConfiguredMetricPriority(t *testing.T) {
 
 	// Set up the expected metric order. The first collector in the list should have the highest priority over the rest.
 	desiredMetricPriority := map[string][]CollectorName{
-		"sm_active":         {gpm, sampling, ebpf},
+		"sm_active":         {sampling, ebpf},
 		"process.sm_active": {sampling, ebpf},
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -43,7 +43,9 @@ var allGpmMetrics = map[nvml.GpmMetricId]gpmMetric{
 		metricType: metrics.GaugeType,
 	},
 	nvml.GPM_METRIC_SM_UTIL: {
-		name:       "sm_active",
+		// Despite the name, this GPM metric returns the percentage of SMs that were in use, not whether any of them were
+		// active in the interval like gr_engine_active does.
+		name:       "sm_utilization",
 		metricType: metrics.GaugeType,
 	},
 	nvml.GPM_METRIC_SM_OCCUPANCY: {


### PR DESCRIPTION
### What does this PR do?

This PR changes the name for the metric we use to emit the GPM metric `GPM_METRIC_SM_UTIL`, as we have found that it doesn't report the same concept.

### Motivation

Accurate metric values.

https://datadoghq.atlassian.net/browse/EBPF-1041

### Describe how you validated your changes

Tests passing.

### Additional Notes
