### PR TITLE
Apply suggested Rust format

### DIFF
--- a/pkg/discovery/module/rust/tests/fallback_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/fallback_integration_test.rs
@@ -339,7 +339,7 @@ fn test_killswitch_enabled_runs_sd_agent() {
     // Terminate the process
     #[cfg(unix)]
     {
-        use nix::sys::signal::{kill, Signal};
+        use nix::sys::signal::{Signal, kill};
         use nix::unistd::Pid;
         kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM).unwrap();
     }


### PR DESCRIPTION
### Motivation
When giving a try with `bazel build --config=ci //...`, I stumbled upon the following error:
```
ERROR: /go/src/github.com/DataDog/datadog-agent/pkg/discovery/module/rust/BUILD.bazel:189:10: Rustfmt //pkg/discovery/module/rust:fallback_integration_test failed: (Exit 1): process_wrapper failed: error executing Rustfmt command (from target //pkg/discovery/module/rust:fallback_integration_test)
```

### What does this PR do?
It applies the suggested change to `pkg/discovery/module/rust/tests/fallback_integration_test.rs`:
```diff
     // Terminate the process
     #[cfg(unix)]
     {
-        use nix::sys::signal::{kill, Signal};
+        use nix::sys::signal::{Signal, kill};
         use nix::unistd::Pid;
         kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM).unwrap();
     }
```