### PR TITLE
Remove support for 386 on Trace Agent setup

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -455,11 +455,7 @@ func TestFetchTraceAgent(t *testing.T) {
 	ia := getTestInventoryPayload(t, nil, nil)
 	ia.fetchTraceAgentMetadata()
 
-	if runtime.GOARCH == "386" && runtime.GOOS == "windows" {
-		assert.False(t, ia.data["feature_apm_enabled"].(bool))
-	} else {
-		assert.True(t, ia.data["feature_apm_enabled"].(bool))
-	}
+	assert.True(t, ia.data["feature_apm_enabled"].(bool))
 	assert.Equal(t, "", ia.data["config_apm_dd_url"].(string))
 
 	fetchTraceConfig = func(_ pkgconfigmodel.Reader, _ ipc.HTTPClient) (string, error) {

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -9,7 +9,6 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"errors"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -64,14 +63,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 
 	bindVectorOptions(config, Traces)
 
-	if runtime.GOARCH == "386" && runtime.GOOS == "windows" {
-		// on Windows-32 bit, the trace agent isn't installed.  Set the default to disabled
-		// so that there aren't messages in the log about failing to start.
-		config.BindEnvAndSetDefault("apm_config.enabled", false, "DD_APM_ENABLED")
-	} else {
-		config.BindEnvAndSetDefault("apm_config.enabled", true, "DD_APM_ENABLED")
-	}
-
+	config.BindEnvAndSetDefault("apm_config.enabled", true, "DD_APM_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.receiver_enabled", true, "DD_APM_RECEIVER_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.receiver_port", 8126, "DD_APM_RECEIVER_PORT", "DD_RECEIVER_PORT")
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck


### PR DESCRIPTION
### What does this PR do?
We no longer release the Agent on arch 386, we can remove this custom initialization of APM.

### Motivation
See above

### Describe how you validated your changes

### Additional Notes
