### PR TITLE
[Backport 7.75.x] [EBPF] gpu: change name for GPM metric (#46066)

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -39,13 +39,13 @@ type gpmMetric struct {
 
 var allGpmMetrics = map[nvml.GpmMetricId]gpmMetric{
 	nvml.GPM_METRIC_GRAPHICS_UTIL: {
-		// Despite the name, this GPM metric returns the percentage of SMs that were in use, not whether any of them were
-		// active in the interval like gr_engine_active does.
-		name:       "sm_utilization",
+		name:       "gr_engine_active",
 		metricType: metrics.GaugeType,
 	},
 	nvml.GPM_METRIC_SM_UTIL: {
-		name:       "sm_active",
+		// Despite the name, this GPM metric returns the percentage of SMs that were in use, not whether any of them were
+		// active in the interval like gr_engine_active does.
+		name:       "sm_utilization",
 		metricType: metrics.GaugeType,
 	},
 	nvml.GPM_METRIC_SM_OCCUPANCY: {

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -39,7 +39,9 @@ type gpmMetric struct {
 
 var allGpmMetrics = map[nvml.GpmMetricId]gpmMetric{
 	nvml.GPM_METRIC_GRAPHICS_UTIL: {
-		name:       "gr_engine_active",
+		// Despite the name, this GPM metric returns the percentage of SMs that were in use, not whether any of them were
+		// active in the interval like gr_engine_active does.
+		name:       "sm_utilization",
 		metricType: metrics.GaugeType,
 	},
 	nvml.GPM_METRIC_SM_UTIL: {


### PR DESCRIPTION
## What does this PR do?
This PR changes the name for the metric we use to emit the GPM metric GPM_METRIC_SM_UTIL, as we have found that it doesn't report the same concept.

## Motivation
Accurate metric values.

## Describe how you validated your changes
Tests passing.

## Additional Notes