### PR TITLE
Rename TCP fallback metrics to be consistent with the rest of logs agent metics 

### DIFF
--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -122,17 +122,17 @@ var (
 
 	// TlmHTTPConnectivityCheck tracks HTTP connectivity check results
 	// Tags: status (success/failure)
-	TlmHTTPConnectivityCheck = telemetry.NewCounter("logs_agent", "http_connectivity_check",
+	TlmHTTPConnectivityCheck = telemetry.NewCounter("logs", "http_connectivity_check",
 		[]string{"status"}, "Count of HTTP connectivity checks with status")
 
 	// TlmHTTPConnectivityRetryAttempt tracks HTTP connectivity retry attempts
 	// Tags: status (success/failure)
-	TlmHTTPConnectivityRetryAttempt = telemetry.NewCounter("logs_agent", "http_connectivity_retry_attempt",
+	TlmHTTPConnectivityRetryAttempt = telemetry.NewCounter("logs", "http_connectivity_retry_attempt",
 		[]string{"status"}, "Count of HTTP connectivity retry attempts with success/failure status")
 
 	// TlmRestartAttempt tracks logs agent restart attempts
 	// Tags: status (success/failure/timeout), transport (tcp/http)
-	TlmRestartAttempt = telemetry.NewCounter("logs_agent", "restart_attempt",
+	TlmRestartAttempt = telemetry.NewCounter("logs", "restart_attempt",
 		[]string{"status", "transport"}, "Count of logs agent restart attempts with status and target transport")
 )
 


### PR DESCRIPTION


### What does this PR do?

COAT metrics were expecting a `logs.` prefix, so these metrics were not being exported. Renamed the metrics to be consistent with the rest of the logs agent metrics. 

### Motivation

### Describe how you validated your changes

### Additional Notes
