### PR TITLE
[EBPF-1041] gpu: rename encoder/decoder utilization metrics

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -121,8 +121,8 @@ func processUtilizationSample(device ddnvml.Device, lastTimestamp uint64) ([]Met
 			allMetrics = append(allMetrics,
 				Metric{Name: "process.sm_active", Value: float64(sample.SmUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads, Priority: Medium}, // There's an ebpf based fallback for this metric which should have lower priority
 				Metric{Name: "process.dram_active", Value: float64(sample.MemUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
-				Metric{Name: "process.encoder_utilization", Value: float64(sample.EncUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
-				Metric{Name: "process.decoder_utilization", Value: float64(sample.DecUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
+				Metric{Name: "process.encoder_active", Value: float64(sample.EncUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
+				Metric{Name: "process.decoder_active", Value: float64(sample.DecUtil), Type: ddmetrics.GaugeType, AssociatedWorkloads: workloads},
 			)
 
 			if sample.SmUtil > maxSmUtil {
@@ -172,13 +172,13 @@ func createSampleAPIs() []apiCallInfo {
 		{
 			Name: "encoder_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "encoder_utilization", nvml.ENC_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "encoder_active", nvml.ENC_UTILIZATION_SAMPLES, lastTimestamp)
 			},
 		},
 		{
 			Name: "decoder_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "decoder_utilization", nvml.DEC_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "decoder_active", nvml.DEC_UTILIZATION_SAMPLES, lastTimestamp)
 			},
 		}}
 }

--- a/releasenotes/notes/gpum-encoder-5572ae55ef85b5e8.yaml
+++ b/releasenotes/notes/gpum-encoder-5572ae55ef85b5e8.yaml
@@ -8,4 +8,4 @@
 ---
 deprecations:
   - |
-    "GPUm: renamed metrics gpu.process.{encoder,decoder}_utilization to gpu.process.{encoder,decoder}_active for consistency with the 'active' suffix in the rest of the GPUm metrics"
+    GPUm: renamed metrics gpu.process.{encoder,decoder}_utilization to gpu.process.{encoder,decoder}_active for consistency with the 'active' suffix in the rest of the GPUm metrics

--- a/releasenotes/notes/gpum-encoder-5572ae55ef85b5e8.yaml
+++ b/releasenotes/notes/gpum-encoder-5572ae55ef85b5e8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    "GPUm: renamed metrics gpu.process.{encoder,decoder}_utilization to gpu.process.{encoder,decoder}_active for consistency with the 'active' suffix in the rest of the GPUm metrics"


### PR DESCRIPTION
### What does this PR do?

Renames the encoder/decoder utilization metrics to use the `_active` suffix.

### Motivation

Consistency with other "utilization/active" metric suffixes.

### Describe how you validated your changes

CI passing

### Additional Notes

These metrics are not exposed in the product yet, so impact of renaming them is low. GPUm is in preview mode still too.
