### PR TITLE
Use ParamsFromEnvironment for windows VM

### DIFF
--- a/test/e2e-framework/scenarios/aws/ec2/windows/run_args.go
+++ b/test/e2e-framework/scenarios/aws/ec2/windows/run_args.go
@@ -58,6 +58,16 @@ func newRunParams() *RunParams {
 // GetRunParams returns RunParams after applying options
 func GetRunParams(opts ...RunOption) *RunParams {
 	p := newRunParams()
+
+	// Enable TestSigning when testsigned drivers are requested via environment
+	// this is used for kicking off testsigned windows drivers on CI
+	if v := os.Getenv("WINDOWS_DDNPM_DRIVER"); v == "testsigned" {
+		p.testsigningOptions = append(p.testsigningOptions, testsigning.WithTestSigningEnabled())
+	}
+	if v := os.Getenv("WINDOWS_DDPROCMON_DRIVER"); v == "testsigned" {
+		p.testsigningOptions = append(p.testsigningOptions, testsigning.WithTestSigningEnabled())
+	}
+
 	if err := optional.ApplyOptions(p, opts); err != nil {
 		panic(fmt.Errorf("unable to apply RunOption, err: %w", err))
 	}

--- a/test/e2e-framework/testing/provisioners/aws/host/windows/host.go
+++ b/test/e2e-framework/testing/provisioners/aws/host/windows/host.go
@@ -69,15 +69,19 @@ func Provisioner(opts ...ProvisionerOption) provisioners.TypedProvisioner[enviro
 	runParams := scenwin.GetRunParams(params.runOptions...)
 
 	provisioner := provisioners.NewTypedPulumiProvisioner(provisionerBaseID+runParams.Name, func(ctx *pulumi.Context, env *environments.WindowsHost) error {
-		// We ALWAYS need to make a deep copy of `params`, as the provisioner can be called multiple times.
-		// and it's easy to forget about it, leading to hard to debug issues.
-		params := GetProvisionerParams(opts...)
-		runParams := scenwin.GetRunParams(params.runOptions...)
-
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {
 			return err
 		}
+
+		// Start from environment-based params (reads WINDOWS_DDNPM_DRIVER, etc.)
+		// then layer programmatic RunOptions on top so callers can override.
+		runParams := scenwin.ParamsFromEnvironment(awsEnv)
+		params := GetProvisionerParams(opts...)
+		if err := optional.ApplyOptions(runParams, params.runOptions); err != nil {
+			return err
+		}
+
 		return scenwin.RunWithEnv(ctx, awsEnv, env, runParams)
 
 	}, nil)


### PR DESCRIPTION
### What does this PR do?
Check env for test signing and provisions VMs as test signing. This reenables ability to run test signed drivers and verify they work with the agent correctly.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2369

### Describe how you validated your changes
Pipeline still succeeds, manually ran pipeline with test signing a verified that test signing is enabled again.  

### Additional Notes
