### PR TITLE
Switch `test_kmt_local_setup_macos` to ARM64 runner

### DIFF
--- a/.gitlab/build/source_test/kmt_tasks.yml
+++ b/.gitlab/build/source_test/kmt_tasks.yml
@@ -43,7 +43,7 @@ test_kmt_local_setup_macos:
     - !reference [.install_python_dependencies]
     # See there is no virtualization, we need to clean the environment regularly
     - !reference [.macos_runner_maintenance]
-  tags: ["macos:sonoma-amd64", "specific:true"]
+  tags: ["macos:sonoma-arm64", "specific:true"]
   variables:
      # Some requirements cannot be tested in the CI yet:
     # - Docker,Compiler,UserInDockerGroup: no docker-in-docker support in these jobs yet


### PR DESCRIPTION
### What does this PR do?
Run the `test_kmt_local_setup_macos` CI job on ARM64 macOS runners.

### Motivation
I started observing longer queue times than usual for CI this job and realized it was still running on x86_64 macOS runners.

Not sure yet whether queue times will improve, but since the vast [majority](https://metabase-analytics.us1.prod.dog/question/135006-macos-agent-host-count-per-real-cpu-type) of macOS agents now run on Apple Silicon, it doesn't "harm" to switch the job to ARM64 runners (more representative testing environment).