### PR TITLE
Add WithVolumeThroughput option for E2E EC2 VMs

### DIFF
--- a/test/e2e-framework/scenarios/aws/ec2/vm.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vm.go
@@ -58,6 +58,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 			HTTPTokensRequired: vmArgs.httpTokensRequired,
 			Tenancy:            vmArgs.tenancy,
 			HostID:             pulumi.String(vmArgs.hostID),
+			VolumeThroughput:   vmArgs.volumeThroughput,
 		}
 
 		if vmArgs.osInfo.Family() == os.MacOSFamily && vmArgs.hostID == "" {
@@ -168,6 +169,12 @@ func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 		if vmArgs.osInfo.Family() == os.WindowsFamily {
 			vmArgs.instanceType = e.DefaultWindowsInstanceType()
 		}
+	}
+
+	if vmArgs.volumeThroughput == 0 && vmArgs.osInfo.Family() == os.WindowsFamily {
+		// Increase throughput for Windows instances to 400 MiB/s to reduce test flakiness
+		// May be able to lower this if we can disable some on-boot services in custom AMIs
+		vmArgs.volumeThroughput = 400
 	}
 
 	// macOS dedicated host defaults

--- a/test/e2e-framework/scenarios/aws/ec2/vmargs.go
+++ b/test/e2e-framework/scenarios/aws/ec2/vmargs.go
@@ -25,6 +25,7 @@ import (
 //   - [WithName]
 //   - [WithHostID]
 //   - [WithTenancy]
+//   - [WithVolumeThroughput]
 //   - [WithPulumiResourceOptions]
 //
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
@@ -40,6 +41,7 @@ type vmArgs struct {
 	hostID          string
 
 	httpTokensRequired    bool
+	volumeThroughput      int // GP3 volume throughput in MiB/s (125-1000, default 125)
 	pulumiResourceOptions []pulumi.ResourceOption
 }
 
@@ -132,6 +134,16 @@ func WithTenancy(tenancy string) VMOption {
 func WithPulumiResourceOptions(options ...pulumi.ResourceOption) VMOption {
 	return func(p *vmArgs) error {
 		p.pulumiResourceOptions = options
+		return nil
+	}
+}
+
+// WithVolumeThroughput sets the throughput for the root GP3 volume in MiB/s.
+// Valid range: 125-1000. Default is 125 MiB/s if not specified.
+// This option only applies to GP3 volumes.
+func WithVolumeThroughput(throughput int) VMOption {
+	return func(p *vmArgs) error {
+		p.volumeThroughput = throughput
 		return nil
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Adds `WithVolumeThroughput` option to configure GP3 volume throughput (MiB/s) for E2E EC2 instances.
Set default to 400 for Windows VMs (value used for gitlab runners)

### Motivation

Allow tuning disk I/O performance for Windows E2E tests.
Seeing failures/flakes that seem related to disk I/O. Many tests hitting `aws.ebs.volume_throughput_exceeded_check`.
no tests hitting `aws.ebs.volume_iopsexceeded_check` right now.