### PR TITLE
fix(sqg): Revert threshold update to fully manual

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -510,6 +510,14 @@ workflow:
       <<: *artifacts_build_impacting_paths
       compare_to: $COMPARE_TO_BRANCH
 
+.on_dev_branches_with_artifact_changes_manual:
+  - !reference [.on_dev_branches]
+  - changes:
+      <<: *artifacts_build_impacting_paths
+      compare_to: $COMPARE_TO_BRANCH
+    when: manual
+    allow_failure: true
+
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy
     when: always

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -76,7 +76,7 @@ manual_gate_threshold_update:
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
     - !reference [.on_main_manual]
-    - !reference [.on_dev_branches_with_artifact_changes]
+    - !reference [.on_dev_branches_with_artifact_changes_manual]
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64


### PR DESCRIPTION
### What does this PR do?
Put back the `manual_gate_threshold_update` as fully manual

### Motivation
The `on_dev_branches_with_artifact_change` has no `when` clause. On #45947 I wanted to align the rules for both jobs and missed there was no such clause. As a consequence the manual_trigger is no more manual but automatic and triggers creation of useless PR.

Setting back the rule as a strict exclusion will solve the issue:
- the `on_dev_branches` has `when: never` clauses for all its rules
- the default is thus the final `when: manual`

### Describe how you validated your changes

### Additional Notes
