### PR TITLE
[CWS] cache ssdeep result

### DIFF
--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -499,7 +499,7 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, cgroupID cont
 
 		if len(computedHashes) > 0 {
 			// Find the cheapest computed hash to use as cache key
-			cheapestHash := computedHashes[0]
+			cheapestHash = computedHashes[0]
 
 			// Check if we have a cached SSDEEP for this cheap hash
 			ssdeepKey := SSDeepCacheKey{cheapHash: cheapestHash, inode: file.Inode, size: size}

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -96,6 +96,16 @@ type LRUCacheEntry struct {
 	size   int64  // file size in bytes
 }
 
+// SSDeepCacheKey is the key used for caching ssdeep hashes based on cheaper hashes
+type SSDeepCacheKey struct {
+	cheapHash string // the cheapest hash used as cache key
+}
+
+// SSDeepCacheEntry stores the cached ssdeep hash
+type SSDeepCacheEntry struct {
+	ssdeepHash string
+}
+
 // Resolver represents a cache for mountpoints and the corresponding file systems
 type Resolver struct {
 	opts           ResolverOpts
@@ -104,7 +114,8 @@ type Resolver struct {
 	cgroupResolver *cgroup.Resolver
 	replace        map[string]string
 
-	cache *lru.Cache[LRUCacheKey, *LRUCacheEntry]
+	cache       *lru.Cache[LRUCacheKey, *LRUCacheEntry]
+	ssdeepCache *lru.Cache[SSDeepCacheKey, *SSDeepCacheEntry]
 
 	bufferPool *ddsync.TypedPool[[]byte]
 }
@@ -112,19 +123,23 @@ type Resolver struct {
 // NewResolver returns a new instance of the hash resolver
 func NewResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, cgroupResolver *cgroup.Resolver) (*Resolver, error) {
 	if !c.HashResolverEnabled {
-		return &Resolver{
-			opts: ResolverOpts{
-				Enabled: false,
-			},
-		}, nil
+		return &Resolver{}, nil
 	}
 
 	var cache *lru.Cache[LRUCacheKey, *LRUCacheEntry]
+	var ssdeepCache *lru.Cache[SSDeepCacheKey, *SSDeepCacheEntry]
 	if c.HashResolverCacheSize > 0 {
 		var err error
 		cache, err = lru.New[LRUCacheKey, *LRUCacheEntry](c.HashResolverCacheSize)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't create hash resolver cache: %w", err)
+		}
+		// Create a separate cache for ssdeep hashes only if ssdeep algorithm is enabled
+		if slices.Contains(c.HashResolverHashAlgorithms, model.SSDEEP) {
+			ssdeepCache, err = lru.New[SSDeepCacheKey, *SSDeepCacheEntry](c.HashResolverCacheSize)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't create ssdeep cache: %w", err)
+			}
 		}
 	}
 
@@ -141,13 +156,14 @@ func NewResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInte
 		opts: ResolverOpts{
 			Enabled:        true,
 			MaxFileSize:    c.HashResolverMaxFileSize,
-			HashAlgorithms: c.HashResolverHashAlgorithms,
+			HashAlgorithms: sortAlgorithmsByCost(c.HashResolverHashAlgorithms),
 			EventTypes:     c.HashResolverEventTypes,
 		},
 		cgroupResolver: cgroupResolver,
 		statsdClient:   statsdClient,
 		limiter:        rate.NewLimiter(rate.Limit(c.HashResolverMaxHashRate), burst),
 		cache:          cache,
+		ssdeepCache:    ssdeepCache,
 		bufferPool:     ddsync.NewSlicePool[byte](copyBufferSize, copyBufferSize),
 		replace:        c.HashResolverReplace,
 	}
@@ -196,6 +212,33 @@ func (resolver *Resolver) getHashFunction(algorithm model.HashAlgorithm) hash.Ha
 	default:
 		return nil
 	}
+}
+
+// getHashCost returns the relative computational cost of a hash algorithm
+// Lower values indicate cheaper algorithms
+func getHashCost(algorithm model.HashAlgorithm) int {
+	switch algorithm {
+	case model.MD5:
+		return 1
+	case model.SHA1:
+		return 2
+	case model.SHA256:
+		return 3
+	case model.SSDEEP:
+		return 100 // SSDEEP is significantly more expensive
+	default:
+		return 999
+	}
+}
+
+// sortAlgorithmsByCost sorts hash algorithms from least costly to most costly
+func sortAlgorithmsByCost(algorithms []model.HashAlgorithm) []model.HashAlgorithm {
+	sorted := make([]model.HashAlgorithm, len(algorithms))
+	copy(sorted, algorithms)
+	slices.SortFunc(sorted, func(a, b model.HashAlgorithm) int {
+		return getHashCost(a) - getHashCost(b)
+	})
+	return sorted
 }
 
 type fileUniqKey struct {
@@ -382,62 +425,138 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, cgroupID cont
 		}
 	}
 
+	// Map to store computed hashes by algorithm (to preserve original order)
+	var computedHashes []string
+
+	// Step 1: Compute all non-SSDEEP hashes in a single pass (ordered by cost)
 	var hashers []io.Writer
+	var hasherAlgorithms []model.HashAlgorithm
 	for _, algorithm := range resolver.opts.HashAlgorithms {
+		// SSDEEP is handled separately
+		if algorithm == model.SSDEEP {
+			continue
+		}
+
 		h := resolver.getHashFunction(algorithm)
 		if h == nil {
 			// shouldn't happen, ignore
 			continue
 		}
 		hashers = append(hashers, h)
+		hasherAlgorithms = append(hasherAlgorithms, algorithm)
 	}
-	multiWriter := newSizeLimitedWriter(io.MultiWriter(hashers...), int(resolver.opts.MaxFileSize))
 
-	buffer := resolver.bufferPool.Get()
-	_, err := io.CopyBuffer(multiWriter, f, *buffer)
-	resolver.bufferPool.Put(buffer)
-	if err != nil {
-		if errors.Is(err, ErrSizeLimitReached) {
-			hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileTooBig.String())
-			file.HashState = model.FileTooBig
+	if len(hashers) > 0 {
+		multiWriter := newSizeLimitedWriter(io.MultiWriter(hashers...), int(resolver.opts.MaxFileSize))
+
+		buffer := resolver.bufferPool.Get()
+		_, err := io.CopyBuffer(multiWriter, f, *buffer)
+		resolver.bufferPool.Put(buffer)
+		if err != nil {
+			if errors.Is(err, ErrSizeLimitReached) {
+				hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileTooBig.String())
+				file.HashState = model.FileTooBig
+				return
+			}
+			// We can't read this file, most likely because it isn't a regular file (despite the check above). Example seen
+			// in production:
+			//  - read(/host/proc/2076/root/proc/1/fdinfo/64) => no such file or directory
+			//  - read(/host/proc/2328/root/run/netns/a574a27c) => invalid argument
+			hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileOpenError.String())
+			file.HashState = model.FileOpenError
 			return
 		}
-		// We can't read this file, most likely because it isn't a regular file (despite the check above). Example seen
-		// in production:
-		//  - read(/host/proc/2076/root/proc/1/fdinfo/64) => no such file or directory
-		//  - read(/host/proc/2328/root/run/netns/a574a27c) => invalid argument
-		hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileOpenError.String())
-		file.HashState = model.FileOpenError
-		return
-	}
 
-	for i, algorithm := range resolver.opts.HashAlgorithms {
-		var hashStr strings.Builder
-		hashStr.WriteString(algorithm.String())
-		if hashStr.Len() > 0 {
-			hashStr.WriteByte(':')
-		}
-		digest := hashers[i].(hash.Hash).Sum(nil)
-		if algorithm == model.SSDEEP {
-			if len(digest) == 0 {
-				// we failed to compute the digest
-				hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.HashFailed.String())
-				continue
+		// Store computed hashes in map
+		for i, algorithm := range hasherAlgorithms {
+			var hashStr strings.Builder
+			hashStr.WriteString(algorithm.String())
+			if hashStr.Len() > 0 {
+				hashStr.WriteByte(':')
 			}
-			hashStr.Write(digest)
-		} else {
+			digest := hashers[i].(hash.Hash).Sum(nil)
 			hencoder := hex.NewEncoder(&hashStr)
 			if _, err := hencoder.Write(digest); err != nil {
 				// we failed to compute the digest
 				hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.HashFailed.String())
 				continue
 			}
-		}
 
-		file.Hashes = append(file.Hashes, hashStr.String())
-		hashResolverTelemetry.hashCount.Inc(eventType.String(), algorithm.String())
+			computedHashes = append(computedHashes, hashStr.String())
+			hashResolverTelemetry.hashCount.Inc(eventType.String(), algorithm.String())
+		}
 	}
 
+	// Step 2: Handle SSDEEP separately with caching based on cheapest hash
+	if resolver.ssdeepCache != nil {
+		// Find the cheapest computed hash to use as cache key
+		cheapestHash := computedHashes[0]
+
+		var ssdeepHashStr string
+		foundInCache := false
+
+		// Check if we have a cached SSDEEP for this cheap hash
+		if cheapestHash != "" {
+			ssdeepKey := SSDeepCacheKey{cheapHash: cheapestHash}
+			if cached, ok := resolver.ssdeepCache.Get(ssdeepKey); ok {
+				ssdeepHashStr = cached.ssdeepHash
+				foundInCache = true
+				hashResolverTelemetry.hashCacheHit.Inc(eventType.String())
+			}
+		}
+
+		// Compute SSDEEP if not found in cache
+		if !foundInCache {
+			// Seek back to the beginning of the file
+			if _, err := f.Seek(0, 0); err != nil {
+				hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileOpenError.String())
+			} else {
+				ssdeepHasher := ssdeep.New()
+				limitedWriter := newSizeLimitedWriter(ssdeepHasher, int(resolver.opts.MaxFileSize))
+
+				buffer := resolver.bufferPool.Get()
+				_, err := io.CopyBuffer(limitedWriter, f, *buffer)
+				resolver.bufferPool.Put(buffer)
+
+				if err != nil {
+					if !errors.Is(err, ErrSizeLimitReached) {
+						hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.FileOpenError.String())
+					}
+				} else {
+					digest := ssdeepHasher.Sum(nil)
+					if len(digest) > 0 {
+						var hashStr strings.Builder
+						hashStr.WriteString("ssdeep:")
+						hashStr.Write(digest)
+						ssdeepHashStr = hashStr.String()
+
+						// Cache the SSDEEP hash with the cheapest hash as key
+						if resolver.ssdeepCache != nil && cheapestHash != "" {
+							ssdeepKey := SSDeepCacheKey{cheapHash: cheapestHash}
+							resolver.ssdeepCache.Add(ssdeepKey, &SSDeepCacheEntry{ssdeepHash: ssdeepHashStr})
+						}
+
+						hashResolverTelemetry.hashCount.Inc(eventType.String(), model.SSDEEP.String())
+					} else {
+						hashResolverTelemetry.hashMiss.Inc(eventType.String(), model.HashFailed.String())
+					}
+				}
+			}
+		} else {
+			// Still count the cached ssdeep (but as a cache hit, already counted above)
+			if ssdeepHashStr != "" {
+				// Note: Already counted as cache hit, but also increment the hash count
+				hashResolverTelemetry.hashCount.Inc(eventType.String(), model.SSDEEP.String())
+			}
+		}
+
+		// Store SSDEEP in the map
+		if ssdeepHashStr != "" {
+			computedHashes = append(computedHashes, ssdeepHashStr)
+		}
+	}
+
+	file.Hashes = computedHashes
 	file.HashState = model.Done
 
 	// cache entry with file metadata

--- a/pkg/security/resolvers/hash/resolver_test.go
+++ b/pkg/security/resolvers/hash/resolver_test.go
@@ -11,7 +11,6 @@ package hash
 import (
 	"math"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -26,6 +25,14 @@ func generateFileData(size int) []byte {
 	var out []byte
 	for i := 0; i < size; i++ {
 		out = append(out, byte('a'))
+	}
+	return out
+}
+
+func generateFileDataWithPattern(size int, pattern byte) []byte {
+	var out []byte
+	for i := 0; i < size; i++ {
+		out = append(out, byte(pattern+byte(i%256)))
 	}
 	return out
 }
@@ -232,9 +239,7 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				t.Fatalf("couldn't instantiate a new hash resolver: %v", err)
 			}
 			got := resolver.ComputeHashesFromEvent(tt.args.event, tt.args.file, 0)
-			if !reflect.DeepEqual(strings.Join(got, "-"), strings.Join(tt.want, "-")) {
-				t.Errorf("ComputeHashes() = %v, want %v", got, tt.want)
-			}
+			assert.ElementsMatch(t, tt.want, got, "invalid output hashes")
 			assert.Equal(t, tt.wantHashState, tt.args.file.HashState, "invalid output hash state")
 		})
 	}
@@ -282,6 +287,145 @@ func TestResolver_ComputeHashes(t *testing.T) {
 // BenchmarkHashFunctions/md5/50Mb-16         	      18	  61665791 ns/op	   43324 B/op	      24 allocs/op
 // BenchmarkHashFunctions/md5/100Mb-16        	       9	 119887060 ns/op	   43452 B/op	      24 allocs/op
 // BenchmarkHashFunctions/md5/500Mb-16        	       2	 620456840 ns/op	   44348 B/op	      26 allocs/op
+
+func TestSSDeepCaching(t *testing.T) {
+	client := statsdclient.NewStatsdClient()
+	pid := uint32(os.Getpid())
+
+	// Create a test file
+	tmpFile, err := os.CreateTemp("", "ssdeep_cache_test")
+	if err != nil {
+		t.Fatalf("couldn't create test file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Write some data (SSDEEP requires at least 4KB typically)
+	testData := generateFileDataWithPattern(8192, 'a')
+	if _, err := tmpFile.Write(testData); err != nil {
+		t.Fatalf("couldn't write file content: %v", err)
+	}
+	tmpFile.Close()
+
+	// Create resolver with MD5 and SSDEEP
+	config := &config.RuntimeSecurityConfig{
+		HashResolverEnabled:        true,
+		HashResolverEventTypes:     []model.EventType{model.ExecEventType},
+		HashResolverHashAlgorithms: []model.HashAlgorithm{model.MD5, model.SSDEEP},
+		HashResolverMaxHashRate:    math.MaxInt,
+		HashResolverMaxFileSize:    math.MaxInt64,
+		HashResolverCacheSize:      100,
+	}
+
+	resolver, err := NewResolver(config, client, nil)
+	if err != nil {
+		t.Fatalf("couldn't instantiate a new hash resolver: %v", err)
+	}
+
+	// First computation - should compute both MD5 and SSDEEP
+	event := &model.Event{
+		BaseEvent: model.BaseEvent{
+			FieldHandlers: &model.FakeFieldHandlers{},
+			Type:          uint32(model.ExecEventType),
+			ProcessContext: &model.ProcessContext{
+				Process: model.Process{
+					PIDContext: model.PIDContext{
+						Pid: pid,
+					},
+				},
+			},
+		},
+	}
+
+	file := &model.FileEvent{
+		PathnameStr:           tmpFile.Name(),
+		IsPathnameStrResolved: true,
+	}
+
+	hashes1 := resolver.ComputeHashesFromEvent(event, file, 0)
+	assert.Equal(t, model.Done, file.HashState, "first computation should succeed")
+	assert.Equal(t, 2, len(hashes1), "should have 2 hashes")
+
+	// Extract MD5 and SSDEEP from first computation
+	var md5Hash1, ssdeepHash1 string
+	for _, hash := range hashes1 {
+		if strings.HasPrefix(hash, "md5:") {
+			md5Hash1 = hash
+		} else if strings.HasPrefix(hash, "ssdeep:") {
+			ssdeepHash1 = hash
+		}
+	}
+	assert.NotEmpty(t, md5Hash1, "should have MD5 hash")
+	assert.NotEmpty(t, ssdeepHash1, "should have SSDEEP hash")
+
+	// Verify SSDEEP is cached with MD5 as key
+	if resolver.ssdeepCache != nil {
+		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash1}
+		cached, ok := resolver.ssdeepCache.Get(ssdeepKey)
+		assert.True(t, ok, "SSDEEP should be cached with MD5 as key")
+		assert.Equal(t, ssdeepHash1, cached.ssdeepHash, "cached SSDEEP should match")
+	}
+
+	// Second computation on same file - SSDEEP should be retrieved from cache
+	file2 := &model.FileEvent{
+		PathnameStr:           tmpFile.Name(),
+		IsPathnameStrResolved: true,
+	}
+
+	hashes2 := resolver.ComputeHashesFromEvent(event, file2, 0)
+	assert.Equal(t, 2, len(hashes2), "should have 2 hashes")
+
+	var md5Hash2, ssdeepHash2 string
+	for _, hash := range hashes2 {
+		if strings.HasPrefix(hash, "md5:") {
+			md5Hash2 = hash
+		} else if strings.HasPrefix(hash, "ssdeep:") {
+			ssdeepHash2 = hash
+		}
+	}
+
+	assert.Equal(t, md5Hash1, md5Hash2, "MD5 should be the same")
+	assert.Equal(t, ssdeepHash1, ssdeepHash2, "SSDEEP should be the same (from cache)")
+
+	// Modify the file with a significantly different pattern
+	f, err := os.OpenFile(tmpFile.Name(), os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("couldn't open file for modification: %v", err)
+	}
+	newData := generateFileDataWithPattern(16384, 'z')
+	if _, err := f.Write(newData); err != nil {
+		t.Fatalf("couldn't write new content: %v", err)
+	}
+	f.Close()
+
+	// Third computation - file changed, both hashes should be recomputed
+	file3 := &model.FileEvent{
+		PathnameStr:           tmpFile.Name(),
+		IsPathnameStrResolved: true,
+	}
+
+	hashes3 := resolver.ComputeHashesFromEvent(event, file3, 0)
+	assert.Equal(t, 2, len(hashes3), "should have 2 hashes")
+
+	var md5Hash3, ssdeepHash3 string
+	for _, hash := range hashes3 {
+		if strings.HasPrefix(hash, "md5:") {
+			md5Hash3 = hash
+		} else if strings.HasPrefix(hash, "ssdeep:") {
+			ssdeepHash3 = hash
+		}
+	}
+
+	assert.NotEqual(t, md5Hash1, md5Hash3, "MD5 should be different after file change")
+	assert.NotEqual(t, ssdeepHash1, ssdeepHash3, "SSDEEP should be different after file change")
+
+	// Verify new SSDEEP is cached with new MD5
+	if resolver.ssdeepCache != nil {
+		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash3}
+		cached, ok := resolver.ssdeepCache.Get(ssdeepKey)
+		assert.True(t, ok, "new SSDEEP should be cached with new MD5 as key")
+		assert.Equal(t, ssdeepHash3, cached.ssdeepHash, "cached SSDEEP should match new hash")
+	}
+}
 
 func BenchmarkHashFunctions(b *testing.B) {
 	client := statsdclient.NewStatsdClient()

--- a/pkg/security/resolvers/hash/resolver_test.go
+++ b/pkg/security/resolvers/hash/resolver_test.go
@@ -299,8 +299,10 @@ func TestSSDeepCaching(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
+	size := 8192
+
 	// Write some data (SSDEEP requires at least 4KB typically)
-	testData := generateFileDataWithPattern(8192, 'a')
+	testData := generateFileDataWithPattern(size, 'a')
 	if _, err := tmpFile.Write(testData); err != nil {
 		t.Fatalf("couldn't write file content: %v", err)
 	}
@@ -359,7 +361,7 @@ func TestSSDeepCaching(t *testing.T) {
 
 	// Verify SSDEEP is cached with MD5 as key
 	if resolver.ssdeepCache != nil {
-		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash1}
+		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash1, inode: file.Inode, size: int64(size)}
 		cached, ok := resolver.ssdeepCache.Get(ssdeepKey)
 		assert.True(t, ok, "SSDEEP should be cached with MD5 as key")
 		assert.Equal(t, ssdeepHash1, cached.ssdeepHash, "cached SSDEEP should match")
@@ -391,7 +393,10 @@ func TestSSDeepCaching(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't open file for modification: %v", err)
 	}
-	newData := generateFileDataWithPattern(16384, 'z')
+
+	size = 16384
+
+	newData := generateFileDataWithPattern(size, 'z')
 	if _, err := f.Write(newData); err != nil {
 		t.Fatalf("couldn't write new content: %v", err)
 	}
@@ -420,7 +425,7 @@ func TestSSDeepCaching(t *testing.T) {
 
 	// Verify new SSDEEP is cached with new MD5
 	if resolver.ssdeepCache != nil {
-		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash3}
+		ssdeepKey := SSDeepCacheKey{cheapHash: md5Hash3, inode: file.Inode, size: int64(size)}
 		cached, ok := resolver.ssdeepCache.Get(ssdeepKey)
 		assert.True(t, ok, "new SSDEEP should be cached with new MD5 as key")
 		assert.Equal(t, ssdeepHash3, cached.ssdeepHash, "cached SSDEEP should match new hash")


### PR DESCRIPTION
### What does this PR do?

SSDEEP cache calculation is expensive. Use on of the lcheapest one as a ssdeep cache key. The idea is to limit the SSDEEP calculation only when it is needed meaning when the file content changed.

### Motivation

### Describe how you validated your changes

### Additional Notes
