### PR TITLE
Push to `bazel*` caches from the `main` branch only

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -375,6 +375,7 @@ workflow:
     - <<: *if_triggered_pipeline
     - <<: *if_main_branch
       variables:
+        BAZEL_CACHE_POLICY_SUFFIX: "-push"
         GO_TEST_SKIP_FLAKE: "false"
     - <<: *if_release_branch
     - <<: *if_deploy

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -13,14 +13,14 @@
       paths:
         - .cache/bazelisk
         - .cache/bazel/*/install
-      policy: pull-push
+      policy: pull$BAZEL_CACHE_POLICY_SUFFIX
       when: on_success
     - &bazel_cache
       key: bazel-$CI_RUNNER_DESCRIPTION
       paths:
         - .cache/bazel/*/cache
         - .cache/pip
-      policy: pull-push
+      policy: pull$BAZEL_CACHE_POLICY_SUFFIX
       when: on_success
   variables:
     XDG_CACHE_HOME: "$CI_PROJECT_DIR/.cache"


### PR DESCRIPTION
### What does this PR do?
Configure GitLab `bazel*` caches on ephemeral runners to use a `pull`-only policy by default, and `pull-push` only when running on the `main` branch.

This restriction applies only to **GitLab** caches - at this stage, the `bazel` **remote** cache remains indeed shared across all branches.

### Motivation
1. avoid cache pollution from feature and release branches while allowing `main` to populate the cache in a _progressive_ manner,
2. because the GitLab cache is uploaded to a shared S3 bucket, restricting uploads to `main` reduces S3 write contention and costs incurred by parallel cache overwrites.

Since the GitLab cache is shared across pipelines, allowing feature or release branches to push artifacts pollutes the cache with _experimental_ entries from feature branches and _meanwhile-evicted_ entries from oldest release branches.

### Additional Notes
Release branches and feature branches _behind_ `main` may fetch _older_ dependencies, whereas feature branches _ahead_ of `main` may fetch _newer_ dependencies, but:
- they'll still benefit from the `bazel` remote cache,
- they'll no longer incur the overhead of uploading GitLab caches.