### PR TITLE
Remove obsolete `boto3` runtime installation

### DIFF
--- a/.gitlab/test/dynamic_test/consolidate.yml
+++ b/.gitlab/test/dynamic_test/consolidate.yml
@@ -6,5 +6,4 @@ index-consolidation:
   rules:
     - !reference [.on_coverage_pipeline]
   script:
-    - pip install boto3==1.38.8 # TODO: Remove this before merging, after dda is bumped in test-infra-definitions
     - dda inv -- -e dyntest.consolidate-index-in-s3 --commit-sha $CI_COMMIT_SHA --bucket-uri $S3_PERMANENT_ARTIFACTS_URI

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -101,7 +101,6 @@
     - |
       if [ -d "$E2E_COVERAGE_OUT_DIR" ]; then
         dda inv -- -e coverage.process-e2e-coverage-folders $E2E_COVERAGE_OUT_DIR
-        pip install boto3==1.38.8 # TODO: Remove this before merging, after dda is bumped in test-infra-definitions
         dda inv -- -e dyntest.compute-and-upload-job-index --bucket-uri $S3_PERMANENT_ARTIFACTS_URI --coverage-folder $E2E_COVERAGE_OUT_DIR --commit-sha $CI_COMMIT_SHA --job-id $CI_JOB_ID
       fi
   artifacts:


### PR DESCRIPTION
### What does this PR do?
Remove temporary `pip install boto3==1.38.8` from CI jobs.

### Motivation
After #43238 moved `test-infra-definitions` in-tree and #45966 removed the dynamic test evaluation job, these runtime installations are no longer needed.