### PR TITLE
[ACTP] Add identity store component for PAR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -382,6 +382,7 @@
 /comp/networkdeviceconfig @DataDog/ndm-integrations
 /comp/notableevents @DataDog/windows-products
 /comp/privateactionrunner @DataDog/action-platform
+/comp/privateactionrunner/identitystore @DataDog/action-platform
 /comp/publishermetadatacache @DataDog/windows-products
 /comp/rdnsquerier @DataDog/ndm-integrations
 /comp/serializer/logscompression @DataDog/agent-log-pipelines

--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	privateactionrunnerfx "github.com/DataDog/datadog-agent/comp/privateactionrunner/fx"
+	identitystorefx "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/fx"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient/rcclientimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
@@ -69,6 +70,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		rcserviceimpl.Module(),
 		rcclientimpl.Module(),
 		fx.Supply(rcclient.Params{AgentName: "private-action-runner", AgentVersion: version.AgentVersion}),
+		identitystorefx.Module(),
 		privateactionrunnerfx.Module(),
 	}
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -807,6 +807,12 @@ Package notableevents provides a component that monitors notable system events a
 
 Package privateactionrunner provides a component that enables private actions executions
 
+### [comp/privateactionrunner/identitystore](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore)
+
+*Datadog Team*: action-platform
+
+Package identitystore provides an interface for storing and retrieving PAR identity
+
 ### [comp/publishermetadatacache](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/publishermetadatacache)
 
 *Datadog Team*: windows-products

--- a/comp/privateactionrunner/identitystore/def/component.go
+++ b/comp/privateactionrunner/identitystore/def/component.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package identitystore provides an interface for storing and retrieving PAR identity
+package identitystore
+
+import (
+	"context"
+)
+
+// team: action-platform
+
+// Component is the component type for identity storage
+type Component interface {
+	// GetIdentity retrieves the persisted PAR identity
+	// Returns nil if no identity exists
+	GetIdentity(ctx context.Context) (*Identity, error)
+
+	// PersistIdentity saves the PAR identity
+	PersistIdentity(ctx context.Context, identity *Identity) error
+
+	// DeleteIdentity removes the persisted identity (for testing/cleanup)
+	DeleteIdentity(ctx context.Context) error
+}
+
+// Identity represents a persisted PAR identity
+type Identity struct {
+	// PrivateKey is the base64-encoded JWK private key
+	PrivateKey string `json:"private_key"`
+	// URN is the unique runner name (urn:dd:apps:on-prem-runner:{region}:{orgId}:{runnerId})
+	URN string `json:"urn"`
+}

--- a/comp/privateactionrunner/identitystore/fx/fx_default.go
+++ b/comp/privateactionrunner/identitystore/fx/fx_default.go
@@ -40,8 +40,9 @@ type Provides struct {
 
 // newIdentityStore creates a file-based identity store (K8s not available in this build)
 func newIdentityStore(reqs Requires) (Provides, error) {
-	if reqs.Config.GetBool("private_action_runner.use_k8s_secret") {
-		reqs.Log.Warn("Kubernetes secret store requested but not available in this build (kubeapiserver build tag required). Using file-based identity store.")
+	storeKind := reqs.Config.GetString("private_action_runner.identity_store.kind")
+	if storeKind == "k8s-secret" {
+		reqs.Log.Warn("Kubernetes secret store requested but not available in this build. Using file-based identity store.")
 	} else {
 		reqs.Log.Info("Using file-based identity store for PAR")
 	}

--- a/comp/privateactionrunner/identitystore/fx/fx_default.go
+++ b/comp/privateactionrunner/identitystore/fx/fx_default.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package fx
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+	filestoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module provides the identity store component (file-based only for non-kubeapiserver builds)
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(newIdentityStore),
+	)
+}
+
+// Requires defines dependencies for the selector
+type Requires struct {
+	compdef.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+// Provides defines the selected implementation
+type Provides struct {
+	compdef.Out
+
+	Comp identitystore.Component
+}
+
+// newIdentityStore creates a file-based identity store (K8s not available in this build)
+func newIdentityStore(reqs Requires) (Provides, error) {
+	if reqs.Config.GetBool("private_action_runner.use_k8s_secret") {
+		reqs.Log.Warn("Kubernetes secret store requested but not available in this build (kubeapiserver build tag required). Using file-based identity store.")
+	} else {
+		reqs.Log.Info("Using file-based identity store for PAR")
+	}
+
+	fileReqs := filestoreimpl.Requires{
+		Config: reqs.Config,
+		Log:    reqs.Log,
+	}
+	return Provides{Comp: filestoreimpl.NewComponent(fileReqs).Comp}, nil
+}

--- a/comp/privateactionrunner/identitystore/fx/fx_default.go
+++ b/comp/privateactionrunner/identitystore/fx/fx_default.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
-	filestoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
+	fileimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -47,9 +47,9 @@ func newIdentityStore(reqs Requires) (Provides, error) {
 		reqs.Log.Info("Using file-based identity store for PAR")
 	}
 
-	fileReqs := filestoreimpl.Requires{
+	fileReqs := fileimpl.Requires{
 		Config: reqs.Config,
 		Log:    reqs.Log,
 	}
-	return Provides{Comp: filestoreimpl.NewComponent(fileReqs).Comp}, nil
+	return Provides{Comp: fileimpl.NewComponent(fileReqs).Comp}, nil
 }

--- a/comp/privateactionrunner/identitystore/fx/fx_kubeapiserver.go
+++ b/comp/privateactionrunner/identitystore/fx/fx_kubeapiserver.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package fx
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+	filestoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
+	k8sstoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-k8s"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module provides the identity store component with smart selection
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(newIdentityStore),
+	)
+}
+
+// Requires defines dependencies for the selector
+type Requires struct {
+	compdef.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+// Provides defines the selected implementation
+type Provides struct {
+	compdef.Out
+
+	Comp identitystore.Component
+}
+
+// newIdentityStore selects the appropriate implementation based on configuration
+func newIdentityStore(reqs Requires) (Provides, error) {
+	// Determine which implementation to use based on config
+	useK8sSecret := reqs.Config.GetBool("privateactionrunner.use_k8s_secret")
+
+	if useK8sSecret {
+		reqs.Log.Info("Using Kubernetes secret-based identity store for PAR")
+
+		// Create K8s implementation
+		k8sReqs := k8sstoreimpl.Requires{
+			Config: reqs.Config,
+			Log:    reqs.Log,
+		}
+		k8sProvides, err := k8sstoreimpl.NewComponent(k8sReqs)
+		if err != nil {
+			// Fall back to file-based if K8s client fails
+			reqs.Log.Warnf("Failed to create K8s identity store, falling back to file-based: %v", err)
+			return Provides{Comp: createFileStore(reqs)}, nil
+		}
+		return Provides{Comp: k8sProvides.Comp}, nil
+	}
+
+	reqs.Log.Info("Using file-based identity store for PAR")
+	return Provides{Comp: createFileStore(reqs)}, nil
+}
+
+func createFileStore(reqs Requires) identitystore.Component {
+	fileReqs := filestoreimpl.Requires{
+		Config: reqs.Config,
+		Log:    reqs.Log,
+	}
+	return filestoreimpl.NewComponent(fileReqs).Comp
+}

--- a/comp/privateactionrunner/identitystore/fx/fx_kubeapiserver.go
+++ b/comp/privateactionrunner/identitystore/fx/fx_kubeapiserver.go
@@ -12,8 +12,8 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
-	filestoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
-	k8sstoreimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-k8s"
+	fileimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-file"
+	k8simpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/impl-k8s"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -51,11 +51,11 @@ func newIdentityStore(reqs Requires) (Provides, error) {
 }
 
 func createKubeAPIServerStore(reqs Requires) (Provides, error) {
-	k8sReqs := k8sstoreimpl.Requires{
+	k8sReqs := k8simpl.Requires{
 		Config: reqs.Config,
 		Log:    reqs.Log,
 	}
-	k8sProvides, err := k8sstoreimpl.NewComponent(k8sReqs)
+	k8sProvides, err := k8simpl.NewComponent(k8sReqs)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -63,10 +63,10 @@ func createKubeAPIServerStore(reqs Requires) (Provides, error) {
 }
 
 func createFileStore(reqs Requires) (Provides, error) {
-	fileReqs := filestoreimpl.Requires{
+	fileReqs := fileimpl.Requires{
 		Config: reqs.Config,
 		Log:    reqs.Log,
 	}
-	fileProvides := filestoreimpl.NewComponent(fileReqs)
+	fileProvides := fileimpl.NewComponent(fileReqs)
 	return Provides{Comp: fileProvides.Comp}, nil
 }

--- a/comp/privateactionrunner/identitystore/impl-file/filestore.go
+++ b/comp/privateactionrunner/identitystore/impl-file/filestore.go
@@ -23,8 +23,7 @@ import (
 // These mirror the constants in pkg/config/setup but are defined here
 // because comp/ packages cannot import pkg/config/setup (depguard rule).
 const (
-	parIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
-	parIdentityFilePath     = "private_action_runner.identity_file_path"
+	parIdentityFilePath     = "private_action_runner.identity_store.file_path"
 	defaultIdentityFileName = "privateactionrunner_private_identity.json"
 )
 

--- a/comp/privateactionrunner/identitystore/impl-file/filestore.go
+++ b/comp/privateactionrunner/identitystore/impl-file/filestore.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package filestoreimpl
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+)
+
+// Configuration keys for the private action runner.
+// These mirror the constants in pkg/config/setup but are defined here
+// because comp/ packages cannot import pkg/config/setup (depguard rule).
+const (
+	parIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
+	parIdentityFilePath     = "private_action_runner.identity_file_path"
+	defaultIdentityFileName = "privateactionrunner_private_identity.json"
+)
+
+// Requires defines the dependencies for the file-based identity store
+type Requires struct {
+	compdef.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+// Provides defines the output of the file-based identity store
+type Provides struct {
+	compdef.Out
+
+	Comp identitystore.Component
+}
+
+type fileStore struct {
+	config config.Component
+	log    log.Component
+}
+
+// NewComponent creates a new file-based identity store
+func NewComponent(reqs Requires) Provides {
+	return Provides{
+		Comp: &fileStore{
+			config: reqs.Config,
+			log:    reqs.Log,
+		},
+	}
+}
+
+func (f *fileStore) GetIdentity(ctx context.Context) (*identitystore.Identity, error) {
+	filePath := f.getIdentityFilePath()
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		f.log.Debugf("Identity file does not exist at path: %s", filePath)
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read identity file: %w", err)
+	}
+
+	var identity identitystore.Identity
+	if err := json.Unmarshal(data, &identity); err != nil {
+		return nil, fmt.Errorf("failed to parse identity file JSON: %w", err)
+	}
+
+	if identity.URN == "" {
+		return nil, errors.New("URN is empty in identity file")
+	}
+	if identity.PrivateKey == "" {
+		return nil, errors.New("private key is empty in identity file")
+	}
+
+	f.log.Infof("Loaded PAR identity from file: %s", filePath)
+	return &identity, nil
+}
+
+func (f *fileStore) PersistIdentity(ctx context.Context, identity *identitystore.Identity) error {
+	filePath := f.getIdentityFilePath()
+
+	jsonData, err := json.Marshal(identity)
+	if err != nil {
+		return fmt.Errorf("failed to marshal identity to JSON: %w", err)
+	}
+
+	if err := os.WriteFile(filePath, jsonData, 0600); err != nil {
+		return fmt.Errorf("failed to write identity file: %w", err)
+	}
+
+	f.log.Infof("Private Runner identity successfully persisted to %s", filePath)
+	return nil
+}
+
+func (f *fileStore) DeleteIdentity(ctx context.Context) error {
+	filePath := f.getIdentityFilePath()
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil // Already deleted
+	}
+
+	if err := os.Remove(filePath); err != nil {
+		return fmt.Errorf("failed to delete identity file: %w", err)
+	}
+
+	f.log.Infof("Deleted identity file: %s", filePath)
+	return nil
+}
+
+// getIdentityFilePath returns the path to the identity file
+func (f *fileStore) getIdentityFilePath() string {
+	// Priority 1: Explicit config
+	if configPath := f.config.GetString(parIdentityFilePath); configPath != "" {
+		return configPath
+	}
+
+	// Priority 2: Next to auth_token_file_path
+	// similarly to pkg/api/security/cert/cert_getter.go we also check if auth_token_file_path as a fallback since customers would probably want these files to be next to each other
+	if authTokenPath := f.config.GetString("auth_token_file_path"); authTokenPath != "" {
+		dest := filepath.Join(filepath.Dir(authTokenPath), defaultIdentityFileName)
+		return dest
+	}
+
+	// Priority 3: Next to datadog.yaml
+	return filepath.Join(filepath.Dir(f.config.ConfigFileUsed()), defaultIdentityFileName)
+}

--- a/comp/privateactionrunner/identitystore/impl-file/filestore.go
+++ b/comp/privateactionrunner/identitystore/impl-file/filestore.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package filestoreimpl
+package fileimpl
 
 import (
 	"context"

--- a/comp/privateactionrunner/identitystore/impl-file/filestore_test.go
+++ b/comp/privateactionrunner/identitystore/impl-file/filestore_test.go
@@ -1,0 +1,277 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package filestoreimpl
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func setupTest(t *testing.T) (identitystore.Component, config.Component, func()) {
+	// Create temp directory
+	tempDir := t.TempDir()
+
+	// Create mock config
+	cfg := mock.New(t)
+	cfg.SetWithoutSource(parIdentityFilePath, filepath.Join(tempDir, "test_identity.json"))
+
+	// Create mock logger
+	logger := logmock.New(t)
+
+	// Create file store
+	reqs := Requires{
+		Config: cfg,
+		Log:    logger,
+	}
+	provides := NewComponent(reqs)
+
+	cleanup := func() {
+		// Cleanup is handled by t.TempDir()
+	}
+
+	return provides.Comp, cfg, cleanup
+}
+
+func TestFileStore_PersistAndGetIdentity(t *testing.T) {
+	store, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create test identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-private-key-base64",
+		URN:        "urn:dd:apps:on-prem-runner:us:123456789:runner-id-xyz",
+	}
+
+	// Persist identity
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Retrieve identity
+	retrievedIdentity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedIdentity)
+
+	// Verify identity matches
+	assert.Equal(t, testIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+	assert.Equal(t, testIdentity.URN, retrievedIdentity.URN)
+}
+
+func TestFileStore_GetIdentity_NotExists(t *testing.T) {
+	store, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Try to get identity that doesn't exist
+	identity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestFileStore_GetIdentity_InvalidJSON(t *testing.T) {
+	store, cfg, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Write invalid JSON to file
+	filePath := cfg.GetString(parIdentityFilePath)
+	err := os.WriteFile(filePath, []byte("invalid json"), 0600)
+	require.NoError(t, err)
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "failed to parse identity file JSON")
+}
+
+func TestFileStore_GetIdentity_EmptyURN(t *testing.T) {
+	store, cfg, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Manually write empty URN to test validation
+	filePath := cfg.GetString(parIdentityFilePath)
+	err := os.WriteFile(filePath, []byte(`{"private_key":"test-key","urn":""}`), 0600)
+	require.NoError(t, err)
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "URN is empty")
+}
+
+func TestFileStore_GetIdentity_EmptyPrivateKey(t *testing.T) {
+	store, cfg, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Manually write empty private key to test validation
+	filePath := cfg.GetString(parIdentityFilePath)
+	err := os.WriteFile(filePath, []byte(`{"private_key":"","urn":"urn:dd:apps:on-prem-runner:us:123:456"}`), 0600)
+	require.NoError(t, err)
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "private key is empty")
+}
+
+func TestFileStore_DeleteIdentity(t *testing.T) {
+	store, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create and persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-private-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Verify identity exists
+	identity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, identity)
+
+	// Delete identity
+	err = store.DeleteIdentity(ctx)
+	require.NoError(t, err)
+
+	// Verify identity is deleted
+	identity, err = store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestFileStore_DeleteIdentity_NotExists(t *testing.T) {
+	store, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Delete identity that doesn't exist (should not error)
+	err := store.DeleteIdentity(ctx)
+	assert.NoError(t, err)
+}
+
+func TestFileStore_UpdateIdentity(t *testing.T) {
+	store, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create and persist initial identity
+	initialIdentity := &identitystore.Identity{
+		PrivateKey: "initial-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, initialIdentity)
+	require.NoError(t, err)
+
+	// Update with new identity
+	updatedIdentity := &identitystore.Identity{
+		PrivateKey: "updated-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:789:012",
+	}
+	err = store.PersistIdentity(ctx, updatedIdentity)
+	require.NoError(t, err)
+
+	// Retrieve and verify updated identity
+	retrievedIdentity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedIdentity)
+
+	assert.Equal(t, updatedIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+	assert.Equal(t, updatedIdentity.URN, retrievedIdentity.URN)
+	assert.NotEqual(t, initialIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+}
+
+func TestFileStore_FilePathPriority(t *testing.T) {
+	tests := []struct {
+		name             string
+		configPath       string
+		authTokenPath    string
+		expectedFileName string
+	}{
+		{
+			name:             "explicit config path takes priority",
+			configPath:       "/custom/path/identity.json",
+			authTokenPath:    "/some/auth/path/auth_token",
+			expectedFileName: "/custom/path/identity.json",
+		},
+		{
+			name:             "auth token path fallback",
+			configPath:       "",
+			authTokenPath:    "/auth/path/auth_token",
+			expectedFileName: "/auth/path/privateactionrunner_private_identity.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := mock.New(t)
+			logger := logmock.New(t)
+
+			if tt.configPath != "" {
+				cfg.SetWithoutSource(parIdentityFilePath, tt.configPath)
+			}
+			if tt.authTokenPath != "" {
+				cfg.SetWithoutSource("auth_token_file_path", tt.authTokenPath)
+			}
+
+			fs := &fileStore{
+				config: cfg,
+				log:    logger,
+			}
+
+			actualPath := fs.getIdentityFilePath()
+			assert.Equal(t, tt.expectedFileName, actualPath)
+		})
+	}
+}
+
+func TestFileStore_FilePermissions(t *testing.T) {
+	store, cfg, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create and persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Check file permissions
+	filePath := cfg.GetString(parIdentityFilePath)
+	fileInfo, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	// Verify permissions are 0600
+	assert.Equal(t, os.FileMode(0600), fileInfo.Mode().Perm())
+}

--- a/comp/privateactionrunner/identitystore/impl-file/filestore_test.go
+++ b/comp/privateactionrunner/identitystore/impl-file/filestore_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package filestoreimpl
+package fileimpl
 
 import (
 	"context"

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
@@ -30,11 +30,10 @@ import (
 // These mirror the constants in pkg/config/setup but are defined here
 // because comp/ packages cannot import pkg/config/setup (depguard rule).
 const (
-	parIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
-	parIdentitySecretName   = "private_action_runner.identity_secret_name"
-	defaultSecretName       = "private-action-runner-identity"
-	privateKeyField         = "private_key"
-	urnField                = "urn"
+	parIdentitySecretName = "private_action_runner.identity_store.secret_name"
+	defaultSecretName     = "private-action-runner-identity"
+	privateKeyField       = "private_key"
+	urnField              = "urn"
 )
 
 // Requires defines the dependencies for the K8s-based identity store

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
@@ -5,7 +5,7 @@
 
 //go:build kubeapiserver
 
-package k8sstoreimpl
+package k8simpl
 
 import (
 	"context"

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore.go
@@ -1,0 +1,171 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package k8sstoreimpl
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Configuration keys for the private action runner.
+// These mirror the constants in pkg/config/setup but are defined here
+// because comp/ packages cannot import pkg/config/setup (depguard rule).
+const (
+	parIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
+	parIdentitySecretName   = "private_action_runner.identity_secret_name"
+	defaultSecretName       = "private-action-runner-identity"
+	privateKeyField         = "private_key"
+	urnField                = "urn"
+)
+
+// Requires defines the dependencies for the K8s-based identity store
+type Requires struct {
+	compdef.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+// Provides defines the output of the K8s-based identity store
+type Provides struct {
+	compdef.Out
+
+	Comp identitystore.Component
+}
+
+type k8sStore struct {
+	config    config.Component
+	log       log.Component
+	client    kubernetes.Interface
+	namespace string
+}
+
+// NewComponent creates a new Kubernetes secret-based identity store
+func NewComponent(reqs Requires) (Provides, error) {
+	// Get Kubernetes client
+	kubeClient, err := apiserver.GetKubeClient(10*time.Second, 0, 0)
+	if err != nil {
+		return Provides{}, fmt.Errorf("failed to get Kubernetes client: %w", err)
+	}
+
+	ns := namespace.GetResourcesNamespace()
+
+	return Provides{
+		Comp: &k8sStore{
+			config:    reqs.Config,
+			log:       reqs.Log,
+			client:    kubeClient,
+			namespace: ns,
+		},
+	}, nil
+}
+
+func (k *k8sStore) GetIdentity(ctx context.Context) (*identitystore.Identity, error) {
+	secretName := k.getSecretName()
+
+	secret, err := k.client.CoreV1().Secrets(k.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			k.log.Debugf("Identity secret %s/%s does not exist", k.namespace, secretName)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get identity secret: %w", err)
+	}
+
+	privateKey, ok := secret.Data[privateKeyField]
+	if !ok || len(privateKey) == 0 {
+		return nil, errors.New("private_key field is missing or empty in secret")
+	}
+
+	urn, ok := secret.Data[urnField]
+	if !ok || len(urn) == 0 {
+		return nil, errors.New("urn field is missing or empty in secret")
+	}
+
+	k.log.Infof("Loaded PAR identity from K8s secret: %s/%s", k.namespace, secretName)
+
+	return &identitystore.Identity{
+		PrivateKey: string(privateKey),
+		URN:        string(urn),
+	}, nil
+}
+
+func (k *k8sStore) PersistIdentity(ctx context.Context, identity *identitystore.Identity) error {
+	secretName := k.getSecretName()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: k.namespace,
+			Name:      secretName,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "datadog-cluster-agent",
+				"app.kubernetes.io/component":  "private-action-runner",
+				"app.kubernetes.io/managed-by": "datadog-cluster-agent",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			privateKeyField: []byte(identity.PrivateKey),
+			urnField:        []byte(identity.URN),
+		},
+	}
+
+	// Try to create the secret
+	_, err := k.client.CoreV1().Secrets(k.namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to create secret: %w", err)
+		}
+		// Secret already exists, update it
+		_, err = k.client.CoreV1().Secrets(k.namespace).Update(ctx, secret, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update existing secret: %w", err)
+		}
+		k.log.Infof("Updated PAR identity in K8s secret: %s/%s", k.namespace, secretName)
+		return nil
+	}
+
+	k.log.Infof("Created PAR identity in K8s secret: %s/%s", k.namespace, secretName)
+	return nil
+}
+
+func (k *k8sStore) DeleteIdentity(ctx context.Context) error {
+	secretName := k.getSecretName()
+
+	err := k.client.CoreV1().Secrets(k.namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil // Already deleted
+		}
+		return fmt.Errorf("failed to delete identity secret: %w", err)
+	}
+
+	k.log.Infof("Deleted identity secret: %s/%s", k.namespace, secretName)
+	return nil
+}
+
+func (k *k8sStore) getSecretName() string {
+	if secretName := k.config.GetString(parIdentitySecretName); secretName != "" {
+		return secretName
+	}
+	return defaultSecretName
+}

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_noop.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_noop.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+package k8sstoreimpl
+
+import (
+	"context"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+)
+
+// Requires defines the dependencies for the K8s-based identity store
+type Requires struct {
+	compdef.In
+
+	Config config.Component
+	Log    log.Component
+}
+
+// Provides defines the output of the K8s-based identity store
+type Provides struct {
+	compdef.Out
+
+	Comp identitystore.Component
+}
+
+type noopStore struct{}
+
+// NewComponent creates a noop K8s identity store when kubeapiserver build tag is not set
+func NewComponent(reqs Requires) (Provides, error) {
+	return Provides{}, errors.New("Kubernetes identity store is not available in this build (kubeapiserver build tag required)")
+}
+
+func (n *noopStore) GetIdentity(ctx context.Context) (*identitystore.Identity, error) {
+	return nil, errors.New("Kubernetes identity store is not available in this build")
+}
+
+func (n *noopStore) PersistIdentity(ctx context.Context, identity *identitystore.Identity) error {
+	return errors.New("Kubernetes identity store is not available in this build")
+}
+
+func (n *noopStore) DeleteIdentity(ctx context.Context) error {
+	return errors.New("Kubernetes identity store is not available in this build")
+}

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_noop.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_noop.go
@@ -5,7 +5,7 @@
 
 //go:build !kubeapiserver
 
-package k8sstoreimpl
+package k8simpl
 
 import (
 	"context"

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_test.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_test.go
@@ -5,7 +5,7 @@
 
 //go:build kubeapiserver
 
-package k8sstoreimpl
+package k8simpl
 
 import (
 	"context"

--- a/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_test.go
+++ b/comp/privateactionrunner/identitystore/impl-k8s/k8sstore_test.go
@@ -1,0 +1,367 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package k8sstoreimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	identitystore "github.com/DataDog/datadog-agent/comp/privateactionrunner/identitystore/def"
+	"github.com/DataDog/datadog-agent/pkg/config/mock"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func setupK8sTest(t *testing.T) (identitystore.Component, *fake.Clientset, config.Component) {
+	// Create fake Kubernetes client
+	fakeClient := fake.NewSimpleClientset()
+
+	// Create mock config
+	cfg := mock.New(t)
+	cfg.SetWithoutSource(parIdentitySecretName, "test-identity")
+
+	// Create mock logger
+	logger := logmock.New(t)
+
+	// Create k8s store with fake client
+	store := &k8sStore{
+		config:    cfg,
+		log:       logger,
+		client:    fakeClient,
+		namespace: "test-namespace",
+	}
+
+	return store, fakeClient, cfg
+}
+
+func TestK8sStore_PersistAndGetIdentity(t *testing.T) {
+	store, _, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create test identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-private-key-base64",
+		URN:        "urn:dd:apps:on-prem-runner:us:123456789:runner-id-xyz",
+	}
+
+	// Persist identity
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Retrieve identity
+	retrievedIdentity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedIdentity)
+
+	// Verify identity matches
+	assert.Equal(t, testIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+	assert.Equal(t, testIdentity.URN, retrievedIdentity.URN)
+}
+
+func TestK8sStore_GetIdentity_NotExists(t *testing.T) {
+	store, _, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Try to get identity that doesn't exist
+	identity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestK8sStore_PersistIdentity_Update(t *testing.T) {
+	store, _, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create and persist initial identity
+	initialIdentity := &identitystore.Identity{
+		PrivateKey: "initial-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, initialIdentity)
+	require.NoError(t, err)
+
+	// Update with new identity
+	updatedIdentity := &identitystore.Identity{
+		PrivateKey: "updated-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:789:012",
+	}
+	err = store.PersistIdentity(ctx, updatedIdentity)
+	require.NoError(t, err)
+
+	// Retrieve and verify updated identity
+	retrievedIdentity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, retrievedIdentity)
+
+	assert.Equal(t, updatedIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+	assert.Equal(t, updatedIdentity.URN, retrievedIdentity.URN)
+	assert.NotEqual(t, initialIdentity.PrivateKey, retrievedIdentity.PrivateKey)
+}
+
+func TestK8sStore_GetIdentity_MissingPrivateKey(t *testing.T) {
+	store, fakeClient, cfg := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create secret with missing private_key field
+	secretName := cfg.GetString(parIdentitySecretName)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			urnField: []byte("urn:dd:apps:on-prem-runner:us:123:456"),
+		},
+	}
+	_, err := fakeClient.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "private_key field is missing or empty")
+}
+
+func TestK8sStore_GetIdentity_MissingURN(t *testing.T) {
+	store, fakeClient, cfg := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create secret with missing urn field
+	secretName := cfg.GetString(parIdentitySecretName)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			privateKeyField: []byte("test-key"),
+		},
+	}
+	_, err := fakeClient.CoreV1().Secrets("test-namespace").Create(ctx, secret, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "urn field is missing or empty")
+}
+
+func TestK8sStore_DeleteIdentity(t *testing.T) {
+	store, _, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create and persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-private-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Verify identity exists
+	identity, err := store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, identity)
+
+	// Delete identity
+	err = store.DeleteIdentity(ctx)
+	require.NoError(t, err)
+
+	// Verify identity is deleted
+	identity, err = store.GetIdentity(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, identity)
+}
+
+func TestK8sStore_DeleteIdentity_NotExists(t *testing.T) {
+	store, _, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Delete identity that doesn't exist (should not error)
+	err := store.DeleteIdentity(ctx)
+	assert.NoError(t, err)
+}
+
+func TestK8sStore_SecretLabels(t *testing.T) {
+	store, fakeClient, cfg := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create and persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Get the created secret
+	secretName := cfg.GetString(parIdentitySecretName)
+	secret, err := fakeClient.CoreV1().Secrets("test-namespace").Get(ctx, secretName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify labels
+	expectedLabels := map[string]string{
+		"app.kubernetes.io/name":       "datadog-cluster-agent",
+		"app.kubernetes.io/component":  "private-action-runner",
+		"app.kubernetes.io/managed-by": "datadog-cluster-agent",
+	}
+	assert.Equal(t, expectedLabels, secret.Labels)
+}
+
+func TestK8sStore_CustomSecretName(t *testing.T) {
+	store, fakeClient, cfg := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Set custom secret name
+	customSecretName := "custom-par-identity"
+	cfg.SetWithoutSource(parIdentitySecretName, customSecretName)
+
+	// Create and persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Verify secret was created with custom name
+	secret, err := fakeClient.CoreV1().Secrets("test-namespace").Get(ctx, customSecretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, customSecretName, secret.Name)
+}
+
+func TestK8sStore_GetIdentity_K8sAPIError(t *testing.T) {
+	store, fakeClient, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Inject error into fake client
+	fakeClient.PrependReactor("get", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, k8serrors.NewInternalError(assert.AnError)
+	})
+
+	// Try to get identity
+	identity, err := store.GetIdentity(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, identity)
+	assert.Contains(t, err.Error(), "failed to get identity secret")
+}
+
+func TestK8sStore_PersistIdentity_CreateError(t *testing.T) {
+	store, fakeClient, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Inject error into fake client for create operation
+	fakeClient.PrependReactor("create", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, k8serrors.NewInternalError(assert.AnError)
+	})
+
+	// Try to persist identity
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create secret")
+}
+
+func TestK8sStore_PersistIdentity_UpdateError(t *testing.T) {
+	store, fakeClient, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create initial secret
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Inject error into fake client for update operation
+	fakeClient.PrependReactor("update", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, k8serrors.NewInternalError(assert.AnError)
+	})
+
+	// Try to update identity
+	updatedIdentity := &identitystore.Identity{
+		PrivateKey: "updated-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:789:012",
+	}
+	err = store.PersistIdentity(ctx, updatedIdentity)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update existing secret")
+}
+
+func TestK8sStore_DeleteIdentity_Error(t *testing.T) {
+	store, fakeClient, _ := setupK8sTest(t)
+	ctx := context.Background()
+
+	// Create initial secret
+	testIdentity := &identitystore.Identity{
+		PrivateKey: "test-key",
+		URN:        "urn:dd:apps:on-prem-runner:us:123:456",
+	}
+	err := store.PersistIdentity(ctx, testIdentity)
+	require.NoError(t, err)
+
+	// Inject error into fake client for delete operation
+	fakeClient.PrependReactor("delete", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		// Return a non-NotFound error
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{}, "test", assert.AnError)
+	})
+
+	// Try to delete identity
+	err = store.DeleteIdentity(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to delete identity secret")
+}
+
+func TestK8sStore_GetSecretName_Default(t *testing.T) {
+	cfg := mock.New(t)
+	logger := logmock.New(t)
+
+	// Don't set custom secret name
+	store := &k8sStore{
+		config:    cfg,
+		log:       logger,
+		namespace: "test-namespace",
+	}
+
+	secretName := store.getSecretName()
+	assert.Equal(t, defaultSecretName, secretName)
+}
+
+func TestK8sStore_GetSecretName_Custom(t *testing.T) {
+	cfg := mock.New(t)
+	logger := logmock.New(t)
+
+	customName := "my-custom-secret"
+	cfg.SetWithoutSource(parIdentitySecretName, customName)
+
+	store := &k8sStore{
+		config:    cfg,
+		log:       logger,
+		namespace: "test-namespace",
+	}
+
+	secretName := store.getSecretName()
+	assert.Equal(t, customName, secretName)
+}

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -14,12 +14,12 @@ const (
 	PARLogFile = "private_action_runner.log_file"
 
 	// Identity / enrollment configuration
-	PARSelfEnroll           = "private_action_runner.self_enroll"
-	PARIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
-	PARIdentityFilePath     = "private_action_runner.identity_file_path"
-	PARIdentitySecretName   = "private_action_runner.identity_secret_name"
-	PARPrivateKey           = "private_action_runner.private_key"
-	PARUrn                  = "private_action_runner.urn"
+	PARSelfEnroll         = "private_action_runner.self_enroll"
+	PARIdentityStoreKind  = "private_action_runner.identity_store.kind"
+	PARIdentityFilePath   = "private_action_runner.identity_store.file_path"
+	PARIdentitySecretName = "private_action_runner.identity_store.secret_name"
+	PARPrivateKey         = "private_action_runner.private_key"
+	PARUrn                = "private_action_runner.urn"
 
 	// General config
 	PARTaskTimeoutSeconds = "private_action_runner.task_timeout_seconds"
@@ -41,7 +41,7 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 
 	// Identity / enrollment configuration
 	config.BindEnvAndSetDefault(PARSelfEnroll, true)
-	config.BindEnvAndSetDefault(PARIdentityUseK8sSecret, false)
+	config.BindEnvAndSetDefault(PARIdentityStoreKind, "file")
 	config.BindEnvAndSetDefault(PARIdentitySecretName, "private-action-runner-identity")
 	config.BindEnvAndSetDefault(PARIdentityFilePath, "")
 	config.BindEnvAndSetDefault(PARPrivateKey, "")

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -14,10 +14,12 @@ const (
 	PARLogFile = "private_action_runner.log_file"
 
 	// Identity / enrollment configuration
-	PARSelfEnroll       = "private_action_runner.self_enroll"
-	PARIdentityFilePath = "private_action_runner.identity_file_path"
-	PARPrivateKey       = "private_action_runner.private_key"
-	PARUrn              = "private_action_runner.urn"
+	PARSelfEnroll           = "private_action_runner.self_enroll"
+	PARIdentityUseK8sSecret = "private_action_runner.use_k8s_secret"
+	PARIdentityFilePath     = "private_action_runner.identity_file_path"
+	PARIdentitySecretName   = "private_action_runner.identity_secret_name"
+	PARPrivateKey           = "private_action_runner.private_key"
+	PARUrn                  = "private_action_runner.urn"
 
 	// General config
 	PARTaskTimeoutSeconds = "private_action_runner.task_timeout_seconds"
@@ -39,6 +41,8 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 
 	// Identity / enrollment configuration
 	config.BindEnvAndSetDefault(PARSelfEnroll, true)
+	config.BindEnvAndSetDefault(PARIdentityUseK8sSecret, false)
+	config.BindEnvAndSetDefault(PARIdentitySecretName, "private-action-runner-identity")
 	config.BindEnvAndSetDefault(PARIdentityFilePath, "")
 	config.BindEnvAndSetDefault(PARPrivateKey, "")
 	config.BindEnvAndSetDefault(PARUrn, "")

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -17,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
 )
 
-const defaultIdentityFileName = "privateactionrunner_private_identity.json"
-
 // Result contains the result of a successful enrollment
 type Result struct {
 	PrivateKey *ecdsa.PrivateKey

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -139,3 +139,19 @@ func PersistIdentity(cfg configModel.Reader, result *Result) error {
 	log.Infof("Private Runner identity successfully persisted to %s", filePath)
 	return nil
 }
+
+// ConvertResultToIdentityData converts an enrollment result to the data needed for identity storage
+func ConvertResultToIdentityData(result *Result) (privateKey string, urn string, err error) {
+	privateKeyJWK, err := util.EcdsaToJWK(result.PrivateKey)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to convert private key to JWK: %w", err)
+	}
+
+	marshalledPrivateKey, err := privateKeyJWK.MarshalJSON()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal private key to JSON: %w", err)
+	}
+
+	encodedPrivateKey := base64.RawURLEncoding.EncodeToString(marshalledPrivateKey)
+	return encodedPrivateKey, result.URN, nil
+}

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -9,15 +9,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/base64"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 
-	configModel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
-	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
@@ -68,76 +61,6 @@ func SelfEnroll(ctx context.Context, ddSite, runnerName, apiKey, appKey string) 
 		PrivateKey: privateJwk.Key.(*ecdsa.PrivateKey),
 		URN:        urn,
 	}, nil
-}
-
-// GetIdentityFromPreviousEnrollment returns the identity of the private action runner from the identity file. Returns nil if the identity file does not exist
-func GetIdentityFromPreviousEnrollment(cfg configModel.Reader) (*PersistedIdentity, error) {
-	filePath := getIdentityFilePath(cfg)
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return nil, nil
-	}
-
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read identity file: %w", err)
-	}
-
-	var identityContent PersistedIdentity
-	if err := json.Unmarshal(data, &identityContent); err != nil {
-		return nil, fmt.Errorf("failed to parse identity file JSON: %w", err)
-	}
-
-	if identityContent.URN == "" {
-		return nil, errors.New("URN is empty in identity file")
-	}
-	if identityContent.PrivateKey == "" {
-		return nil, errors.New("private key is empty in identity file")
-	}
-
-	return &identityContent, nil
-}
-
-// getIdentityFilePath returns the path to the file which contains the identity of the private action runner when doing self-enrollment
-func getIdentityFilePath(cfg configModel.Reader) string {
-	if configPath := cfg.GetString(setup.PARIdentityFilePath); configPath != "" {
-		return configPath
-	}
-	// similarly to pkg/api/security/cert/cert_getter.go we also check if auth_token_file_path as a fallback since customers would probably want these files to be next to each other
-	if cfg.GetString("auth_token_file_path") != "" {
-		dest := filepath.Join(filepath.Dir(cfg.GetString("auth_token_file_path")), defaultIdentityFileName)
-		log.Warnf("IPC cert/key created or retrieved next to auth_token_file_path location: %v", dest)
-		return dest
-	}
-	return filepath.Join(filepath.Dir(cfg.ConfigFileUsed()), defaultIdentityFileName)
-}
-
-// PersistIdentity saves the enrollment result to the identity file
-func PersistIdentity(cfg configModel.Reader, result *Result) error {
-	filePath := getIdentityFilePath(cfg)
-
-	privateKeyJWK, err := util.EcdsaToJWK(result.PrivateKey)
-	if err != nil {
-		return fmt.Errorf("failed to convert private key to JWK: %w", err)
-	}
-	marshalledPrivateKey, err := privateKeyJWK.MarshalJSON()
-	if err != nil {
-		return fmt.Errorf("failed to marshal private key to JSON: %w", err)
-	}
-
-	jsonData, err := json.Marshal(PersistedIdentity{
-		PrivateKey: base64.RawURLEncoding.EncodeToString(marshalledPrivateKey),
-		URN:        result.URN,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to marshal identity content to JSON: %w", err)
-	}
-
-	if err := os.WriteFile(filePath, jsonData, 0600); err != nil {
-		return fmt.Errorf("failed to write temporary identity file: %w", err)
-	}
-
-	log.Infof("Private Runner identity successfully persisted to %s", filePath)
-	return nil
 }
 
 // ConvertResultToIdentityData converts an enrollment result to the data needed for identity storage

--- a/releasenotes/notes/par-identity-store-component-e0a2b9caf7b38b40.yaml
+++ b/releasenotes/notes/par-identity-store-component-e0a2b9caf7b38b40.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Private Action Runner now supports storing identity credentials in Kubernetes secrets.
+    Configure with ``private_action_runner.identity_store.kind``
+    set to ``k8s-secret`` to enable Kubernetes secret storage. The implementation is
+    backward compatible, defaulting to file-based storage when not explicitly configured.


### PR DESCRIPTION
## What does this PR do?
Implements a clean identity store abstraction for Private Action Runner with support for both file-based and Kubernetes secret storage.

- Interface definition in `comp/privateactionrunner/identitystore/def/`
- File-based implementation for node agents
- Kubernetes secret implementation for cluster agents
- Smart fx selector based on configuration and build tags

The config now looks like
```yaml
private_action_runner:
  enabled: true
  identity_store:
    kind: "file" # file | k8s-secret
```

## Motivation

This provides the foundation for multi-replica cluster agent deployments with shared identity stored in Kubernetes secrets. Future PRs will add leader election integration.

## Describe how you validated your changes
```bash
# tests
dda inv test --targets=./pkg/privateactionrunner/...

# build and run
dda inv privateactionrunner.build
go run ./cmd/privateactionrunner run -c dev/dist/datadog.yaml
```

## Additional Notes


Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

