### PR TITLE
[CWS] fix load module event unmarshal check

### DIFF
--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -912,7 +912,7 @@ func (e *LoadModuleEvent) UnmarshalBinary(data []byte) (int, error) {
 		return 0, err
 	}
 
-	if len(data)-read < 188 {
+	if len(data)-read < 192 {
 		return 0, ErrNotEnoughData
 	}
 


### PR DESCRIPTION
### What does this PR do?

The function needs to read 192 bytes after unmarshalling SyscallEvent and File:

  - Name: 56 bytes (line 919)
  - Args: 128 bytes (line 926)
  - ArgsTruncated: 4 bytes (line 929)
  - LoadedFromMemory: 4 bytes (line 935)

  Total: 56 + 128 + 4 + 4 = 192 bytes

  But the bounds check says:
 ` if len(data)-read < 188 {`

This PR fixes this.

Found by: https://github.com/DataDog/datadog-agent/pull/46116

### Motivation

### Describe how you validated your changes

### Additional Notes
