### PR TITLE
Mitigate `test_kmt_local_setup_linux` 2h-timeouts

### DIFF
--- a/tasks/kernel_matrix_testing/setup/common.py
+++ b/tasks/kernel_matrix_testing/setup/common.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import re
 import shutil
+from datetime import timedelta
 from pathlib import Path
 
 from invoke.context import Context
@@ -111,7 +112,8 @@ class PulumiPlugin(Requirement):
                 return RequirementState(Status.FAIL, "pulumi plugins not installed.", fixable=True)
 
             try:
-                ctx.run("go mod download")
+                # https://github.com/golang/go/issues/63758: downloading dependencies stuck when git tag signature [...]
+                ctx.run("GIT_TERMINAL_PROMPT=0 go mod download", timeout=timedelta(minutes=5).total_seconds())
                 ctx.run("PULUMI_CONFIG_PASSPHRASE=dummy pulumi --non-interactive plugin install")
             except Exception as e:
                 return RequirementState(Status.FAIL, f"pulumi plugins installation failed: {e}")


### PR DESCRIPTION
### What does this PR do?
Mitigate the `test_kmt_local_setup_linux` CI jobs hanging for 2 hours by adding a timeout and avoiding `git` interactive prompts on `go mod download`.

### Motivation
```
Checking requirements...
LinuxBasePackages [OK]
Pulumi [OK]
TestInfraDefinitionsRepo [OK]
DDA [OK]
KMTDirectoriesRequirement [OK]
WARNING: error streaming logs for container build: context deadline exceeded
PulumiPlugin ...
ERROR: Job failed: execution took longer than 2h0m0s seconds
```
Evidence:
- full job console output: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1390183080,
- CI execution errors dashboard: https://tinyurl.com/3w766r9p.

The reason is not clearly determined, but one may realize the `PulumiPlugin` requirement downloads Go modules without timeout protection. Also, should `git` require interactive prompts (e.g., signature verification), the download might hang until the full 2-hour CI job timeout, which is a known issue:
- golang/go#63758

Job duration:
- in general: 1-2 minutes for the entire job,
- rarely: 5-6 minutes (including all checks),
- hang cases: 2 hours.

Waiting 2 hours to fail serves no purpose. By limiting each `go mod download` to 5 minutes, we:
- fail faster, triggering infrastructure retries,
- enable manual retries should all infrastructure retries be exhausted,
- iterate over should the situation not improve.

### Additional Notes
`GIT_TERMINAL_PROMPT=0` is the documented, reliable way to prevent Git from prompting in non-interactive environments like CI, while closing `stdin` alone can still result in hangs:
- https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables (`GIT_TERMINAL_PROMPT`)
- https://git-scm.com/docs/gitcredentials (Git credential helpers can open `/dev/tty` directly to _bypass_ `stdin`)

This is of course an intermediate _mitigation_ step meant to improve observability and enable faster cycles, not a _fix_ for the underlying communication issue(s), but it already eliminates a _potential_ culprit.