### PR TITLE
[ACTP] [privateactionrunner] namespace identity storage config

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -14,11 +14,12 @@ const (
 	PARLogFile = "private_action_runner.log_file"
 
 	// Identity / enrollment configuration
-	PARSelfEnroll         = "private_action_runner.self_enroll"
-	PARIdentityFilePath   = "private_action_runner.identity_file_path"
-	PARIdentitySecretName = "private_action_runner.identity_secret_name"
-	PARPrivateKey         = "private_action_runner.private_key"
-	PARUrn                = "private_action_runner.urn"
+	PARSelfEnroll           = "private_action_runner.self_enroll"
+	PARIdentityUseK8sSecret = "private_action_runner.identity_store.use_k8s_secret"
+	PARIdentityFilePath     = "private_action_runner.identity_store.file_path"
+	PARIdentitySecretName   = "private_action_runner.identity_store.secret_name"
+	PARPrivateKey           = "private_action_runner.private_key"
+	PARUrn                  = "private_action_runner.urn"
 
 	// General config
 	PARTaskTimeoutSeconds = "private_action_runner.task_timeout_seconds"


### PR DESCRIPTION
## What does this PR do?
Namespace the private action runner identity persistency config under `private_action_runner.identity_store`

## Motivation
It feels more natural than `private_action_runner.identity_secret_name` and `private_action_runner.identity_use_k8s_secret`

## Describe how you validated your changes
```
# tests
dda inv test --targets=./pkg/privateactionrunner/...

# build and run
dda inv privateactionrunner.build
go run ./cmd/privateactionrunner run -c dev/dist/datadog.yaml
```
## Additional Notes
