### PR TITLE
Remove `copy_file` workaround from `nghttp2` build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,7 +53,7 @@ bazel_dep(name = "rules_testing", version = "0.9.0", dev_dependency = True)
 # Temporary until rules_pkg > 1.2.0 is in BCR
 git_override(
     module_name = "rules_pkg",
-    commit = "a9358d57a797f793cedd460939188496c7d30bbf",  # main as of Feb 4, 2026
+    commit = "2bd928123ad46f5b96970f537af073e0acb5b654",  # main as of Feb 10, 2026
     remote = "https://github.com/bazelbuild/rules_pkg.git",
 )
 

--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -1,6 +1,5 @@
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
@@ -142,20 +141,9 @@ pkg_files(
     },
 )
 
-# This is a hack to work around a bug in rules_pkg.
-copy_file(
-    name = "pull_fetch_ocsp_response",
-    src = "@@//third_party/nghttp2:fetch-ocsp-response",
-    out = "fetch-ocsp-response",
-)
-
 pkg_files(
     name = "fetch_ocsp_response",
-    # It would be nicer to use the target
-    # "@@//third_party/nghttp2:fetch-ocsp-response"
-    # here, but rules_pkg calculates the path as a relative ref to @nghttp2
-    # instead of the main project.
-    srcs = [":fetch-ocsp-response"],
+    srcs = ["@//third_party/nghttp2:fetch-ocsp-response"],
     attributes = pkg_attributes(mode = "0755"),
     prefix = "embedded/share/nghttp2",
 )


### PR DESCRIPTION
### What does this PR do?
Remove `copy_file` workaround for cross-repo file references from `nghttp2` build by updating `rules_pkg` to the latest main that includes our fix:
- bazelbuild/rules_pkg#1016.

### Motivation
The workaround was needed because `rules_pkg` was incorrectly calculating paths for cross-repo references.

### Describe how you validated your changes
```
bazel run @nghttp2//:install -- --destdir=/tmp/xxx
```
Output files are identical before and after changes.