### PR TITLE
Do not collect vcs information in gopls

### DIFF
--- a/.vscode/settings.json.template
+++ b/.vscode/settings.json.template
@@ -2,6 +2,7 @@
     "go.buildTags": "{build_tags}",
     "go.testTags": "{build_tags}",
     "go.lintTool": "golangci-lint",
+    "go.buildFlags": ["-buildvcs=false"],
     "go.lintFlags": [
         "--build-tags",
         "{build_tags}"


### PR DESCRIPTION
### What does this PR do?
Update VSCode settings template to avoid collecting VCS information in gopls.

### Motivation
As per https://github.com/golang/go/issues/77419, gopls currently ends up collecting VCS info when collecting package information, and for the agent repository it takes minutes. It seems to be the cause for the VSCode hangs that we regularly observe.

### Describe how you validated your changes
Local testing.

### Additional Notes
Hopefully it will be fixed upstream, but in the meantime this workaround should fix it as well.