### PR TITLE
Remove `ask-review` label from auto-update PR

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -67,4 +67,4 @@ jobs:
             ### Describe how you validated your changes
             CI is considered enough to validate changes.
           team-reviewers: agent-runtimes
-          labels: team/agent-runtimes,qa/done,changelog/no-changelog,ask-review
+          labels: team/agent-runtimes,qa/done,changelog/no-changelog


### PR DESCRIPTION
### What does this PR do?
Since #45186 review is automatically asked in slack at PR creation. The `ask-review` label creates duplicate queries when added.

### Motivation
Clean-up

### Describe how you validated your changes
n/a

### Additional Notes
