### PR TITLE
fix(e2e): Add missing fakeintake redirects for data_streams and event_management forwarders

### DIFF
--- a/test/e2e-framework/components/datadog/agentparams/params.go
+++ b/test/e2e-framework/components/datadog/agentparams/params.go
@@ -302,6 +302,10 @@ service_discovery.forwarder.logs_dd_url: %[1]s:%[2]d
 service_discovery.forwarder.logs_no_ssl: true
 software_inventory.forwarder.logs_dd_url: %[1]s:%[2]d
 software_inventory.forwarder.logs_no_ssl: true
+data_streams.forwarder.logs_dd_url: %[1]s:%[2]d
+data_streams.forwarder.logs_no_ssl: true
+event_management.forwarder.logs_dd_url: %[1]s:%[2]d
+event_management.forwarder.logs_no_ssl: true
 `, hostname, port, scheme)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil


### PR DESCRIPTION
### What does this PR do?

Adds missing `data_streams.forwarder` and `event_management.forwarder` endpoint redirects to fakeintake in the e2e test agent configuration.

### Motivation

The `TestDiagnoseExclude` test on `TestLinuxDiagnoseSuite` is flaky because the `connectivity-datadog-event-platform` diagnose suite attempts to connect to the **real** `trace.agent.datadoghq.com.` endpoint instead of fakeintake for the Data Streams pipeline.

The `withIntakeHostname` function in `agentparams/params.go` configures most event platform pipelines to point to fakeintake, but `data_streams.forwarder` and `event_management.forwarder` were missing. Without these overrides, the agent falls back to `GetMainEndpoint()` which builds a URL from the default `site` config (`datadoghq.com`), resulting in real connectivity checks that intermittently time out.

### Describe how you validated your changes

- Cross-referenced all `endpointsConfigPrefix` values in `epforwarder.go` against the fakeintake config in `withIntakeHostname` to confirm `data_streams.forwarder` and `event_management.forwarder` were the only missing entries.
- Verified that `event_management` is currently skipped in diagnose (due to ECT-4273), but added it for completeness since the forwarder itself still sends to the configured endpoint.

### Additional Notes

The flaky failure manifests as:
```
"name": "Connectivity to https://trace.agent.datadoghq.com./api/v2/data_streams_messages"
"rawerror": "Post \"https://trace.agent.datadoghq.com./api/v2/data_streams_messages\": context deadline exceeded"
```

The trailing dot (FQDN) comes from `convert_dd_site_fqdn.enabled` being true by default. The test VMs sometimes have internet access (test passes) and sometimes the connection times out (test fails), causing flakiness.