### PR TITLE
Move crate definition to crates.MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -205,11 +205,7 @@ use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")
 
-crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")
-
 include("//deps:crates.MODULE.bazel")
-
-use_repo(crate, "sdagent_crates")
 
 #########################
 ## Native dependencies ##

--- a/deps/crates.MODULE.bazel
+++ b/deps/crates.MODULE.bazel
@@ -5,3 +5,4 @@ crate.from_cargo(
     lockfile = "//pkg/discovery/module/rust:Cargo.Bazel.lock",
     manifests = ["//pkg/discovery/module/rust:Cargo.toml"],
 )
+use_repo(crate, "sdagent_crates")


### PR DESCRIPTION
### What does this PR do?
`MODULE.bazel` should only have basic definitions of tools, toolchains and rulesets that are required to build everything. The rest, such as components' dependencies, subcomponents, etc, should reside in their own `MODULE` files. Current structure isn't wrong, but looks a little bit scattered. Also, we use `crate` extension twice, although can just use it once inside `deps/crates.MODULE.bazel`.

### Motivation
This is done as a clean up whilst working on `RUST.md` doc that is supposed to navigate users in case they want to introduce more `rust` components in the agent.
