### PR TITLE
[SQG] Bump on wire gates using sd-agent exception

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,9 +1,9 @@
 static_quality_gate_agent_deb_amd64:
   max_on_disk_size: 756.33 MiB
-  max_on_wire_size: 184.81 MiB
+  max_on_wire_size: 185.36 MiB
 static_quality_gate_agent_deb_amd64_fips:
   max_on_disk_size: 716.82 MiB
-  max_on_wire_size: 177.56 MiB
+  max_on_wire_size: 178.78 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 329.53 MiB
   max_on_wire_size: 88.45 MiB
@@ -12,40 +12,40 @@ static_quality_gate_agent_msi:
   max_on_wire_size: 143.3 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 756.30 MiB
-  max_on_wire_size: 188.16 MiB
+  max_on_wire_size: 188.86 MiB
 static_quality_gate_agent_rpm_amd64_fips:
   max_on_disk_size: 716.81 MiB
-  max_on_wire_size: 178.9 MiB
+  max_on_wire_size: 179.71 MiB
 static_quality_gate_agent_rpm_arm64:
   max_on_disk_size: 738.64 MiB
   max_on_wire_size: 169.93 MiB
 static_quality_gate_agent_rpm_arm64_fips:
   max_on_disk_size: 700.23 MiB
-  max_on_wire_size: 163.12 MiB
+  max_on_wire_size: 163.61 MiB
 static_quality_gate_agent_suse_amd64:
   max_on_disk_size: 756.30 MiB
-  max_on_wire_size: 188.16 MiB
+  max_on_wire_size: 188.86 MiB
 static_quality_gate_agent_suse_amd64_fips:
   max_on_disk_size: 716.81 MiB
-  max_on_wire_size: 178.9 MiB
+  max_on_wire_size: 179.71 MiB
 static_quality_gate_agent_suse_arm64:
   max_on_disk_size: 738.64 MiB
   max_on_wire_size: 169.93 MiB
 static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 700.23 MiB
-  max_on_wire_size: 163.12 MiB
+  max_on_wire_size: 163.61 MiB
 static_quality_gate_docker_agent_amd64:
   max_on_disk_size: 818.64 MiB
-  max_on_wire_size: 277.4 MiB
+  max_on_wire_size: 278.13 MiB
 static_quality_gate_docker_agent_arm64:
   max_on_disk_size: 825.32 MiB
-  max_on_wire_size: 266.04 MiB
+  max_on_wire_size: 266.76 MiB
 static_quality_gate_docker_agent_jmx_amd64:
   max_on_disk_size: 1009.52 MiB
-  max_on_wire_size: 346.02 MiB
+  max_on_wire_size: 346.74 MiB
 static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 1004.92 MiB
-  max_on_wire_size: 330.66 MiB
+  max_on_wire_size: 331.37 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 181.2 MiB
   max_on_wire_size: 64.51 MiB


### PR DESCRIPTION
### What does this PR do?
A continuation of #46197. Since the metrics weren't reported to Datadog, we cannot use the bump task and had to adjust the thresholds manually. Previous PR didn't take `on wire` gates into account.

The bump values were taken from the PR report:
https://github.com/DataDog/datadog-agent/pull/45998#issuecomment-3859921120

