### PR TITLE
system-probe: Run bazel build for checks

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1638,6 +1638,9 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
             continue
 
         install_dest = output_dir / source_path if output_dir else Path(source_path)
+        # Run the build separately first to ensure that the aspects (e.g.
+        # clippy) are run (on CI)
+        ctx.run(f"bazelisk build {platform_flag} -- @//{source_path}/...")
         ctx.run(f"bazelisk run {platform_flag} -- @//{source_path}:install --destdir={install_dest}")
 
 


### PR DESCRIPTION
### What does this PR do?

In .bazelrc, we run clippy and rustfmt checks in the build step using
Bazel's aspects feature when in CI (using --config=ci, added by
tools/bazel, which is automatically invoked by bazelisk, if the CI
environment variable is present).

However, it appears that these are only run when explicitly running the
build step, not when, for example, a install step is run via "bazel run"
which in turn depends on a build step. Since the system-probe build task
only invokes the latter, the checks are not actually run. So add an
explicit call to build before the install step.

### Motivation

Actually catch rustfmt and clippy errors in CI.

### Describe how you validated your changes

Introduced a formatting error and run CI
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1416891445
