### PR TITLE
[ABLD-317] Add `toolchain` directive to root `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/DataDog/datadog-agent
 
 go 1.25.6
+toolchain go1.25.6
 
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)

--- a/tasks/unit_tests/update_go_tests.py
+++ b/tasks/unit_tests/update_go_tests.py
@@ -1,10 +1,18 @@
+import os
+import shutil
+import tempfile
 import unittest
 
+from pathlib import Path
+from invoke.exceptions import Exit
+from unittest.mock import patch
+from tasks.libs.common.gomodules import GoModule
 from tasks.update_go import (
     PATTERN_MAJOR_MINOR,
     PATTERN_MAJOR_MINOR_BUGFIX,
     _get_major_minor_version,
     _get_pattern,
+    _update_go_mods,
 )
 
 
@@ -15,3 +23,89 @@ class TestUpdateGo(unittest.TestCase):
     def test_get_pattern(self):
         self.assertEqual(_get_pattern("p+e", "p.st", is_bugfix=True), rf'(p\+e){PATTERN_MAJOR_MINOR_BUGFIX}(p\.st)')
         self.assertEqual(_get_pattern("p(re)", "p*st", is_bugfix=False), rf'(p\(re\)){PATTERN_MAJOR_MINOR}(p\*st)')
+
+
+class TestUpdateGoMods(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp()
+        self._oldpwd = os.getcwd()
+        os.chdir(self._tmpdir)
+
+    def tearDown(self):
+        os.chdir(self._oldpwd)
+        shutil.rmtree(self._tmpdir)
+
+    @patch(
+        "tasks.update_go.get_default_modules",
+        return_value={
+            ".": GoModule(path="."),
+            "comp/core/test": GoModule(path="comp/core/test"),
+        },
+    )
+    def test_update_toolchain_with_real_files(self, mock_get_modules):
+        root_gomod = Path("go.mod")
+        root_gomod.write_text("""
+module github.com/DataDog/datadog-agent
+
+go 1.25.6
+toolchain go1.25.6
+""")
+        child_gomod = Path("comp/core/test/go.mod")
+        child_gomod.parent.mkdir(parents=True)
+        child_gomod.write_text("""
+module github.com/DataDog/datadog-agent/comp/core/test
+
+go 1.25.6
+""")
+
+        _update_go_mods(warn=False, version="1.25.7", include_otel_modules=False)
+
+        self.assertEqual(
+            root_gomod.read_text(),
+            """
+module github.com/DataDog/datadog-agent
+
+go 1.25.0
+toolchain go1.25.7
+""",
+        )
+        self.assertEqual(
+            child_gomod.read_text(),
+            """
+module github.com/DataDog/datadog-agent/comp/core/test
+
+go 1.25.0
+""",
+        )
+
+    @patch(
+        "tasks.update_go.get_default_modules",
+        return_value={
+            ".": GoModule(path="."),
+        },
+    )
+    def test_update_toolchain_fails_when_invalid(self, mock_get_modules):
+        for case, (expected_error, content) in {
+            "missing toolchain": (
+                "expected 1 matches but got 0",
+                """
+module github.com/DataDog/datadog-agent
+
+go 1.25.6
+""",
+            ),
+            "duplicate toolchain": (
+                "expected 1 matches but got 2",
+                """
+module github.com/DataDog/datadog-agent
+
+go 1.25.6
+toolchain go1.25.6
+toolchain go1.25.5
+""",
+            ),
+        }.items():
+            with self.subTest(case):
+                Path("go.mod").write_text(content)
+                with self.assertRaisesRegex(Exit, expected_error):
+                    _update_go_mods(warn=False, version="1.25.7", include_otel_modules=False)

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -194,6 +194,14 @@ def _update_go_mods(warn: bool, version: str, include_otel_modules: bool, dry_ru
         major_minor_zero = f"{major_minor}.0"
         # $ only matches \n, not \r\n, so we need to use \r?$ to make it work on Windows
         update_file(warn, mod_file, f"^go {PATTERN_MAJOR_MINOR_BUGFIX}\r?$", f"go {major_minor_zero}", dry_run=dry_run)
+        if path == ".":  # only update `toolchain` directive in root go.mod
+            update_file(
+                warn,
+                mod_file,
+                f"^toolchain go{PATTERN_MAJOR_MINOR_BUGFIX}\r?$",
+                f"toolchain go{version}",
+                dry_run=dry_run,
+            )
 
 
 def _create_releasenote(ctx: Context, version: str):


### PR DESCRIPTION
### What does this PR do?
Add a `toolchain` directive (prescribing a Go SDK) to the root `go.mod` file and enhance the `update-go` tool to manage it during Go version updates.

### Motivation
tl;dr: this is a follow-up of:
- #45714.

The `toolchain` directive was introduced in [Go 1.21](https://go.dev/doc/go1.21#tools) to separate concerns between minimum **compatibility** (`go` directive) and the Go SDK used to **build** the project.

This separation enables:
1. flexibility: the `go` directive can remain at the minimum version required by dependencies (e.g., `go 1.25.0`), maximizing compatibility, while `toolchain` prescribes the Go SDK actually used in development and CI (e.g., `toolchain go1.25.6`), aiming at improving:
2. reproducibility ([Go Toolchains](https://go.dev/doc/toolchain)):
   > For [repeatability](https://research.swtch.com/vgo-principles#repeatability), any command that updates the go line also updates the toolchain line to record its own toolchain name. The next time the go command runs in that workspace or module, it will use that updated toolchain line during [toolchain selection](https://go.dev/doc/toolchain#select),
3. `bazel` integration: when `toolchain` is absent, `rules_go` falls back to the `go` directive on a best effort basis, but this selects the minimum required version rather than the prescribed SDK. The [clarification](https://github.com/DataDog/datadog-agent/pull/46067#discussion_r2783592488) brought to the PR `Update Go version to 1.25.7` revealed the prior ambuiguity,
4. alignment with current practice: the `datadog-agent` repository uses `go.work` to specify the Go SDK for _workspace_ operations, but the root `go.mod` toolchain is still critical for module builds outside the workspace context (`bazel` and probably other tools as well as workspace-agnostic IDEs).

### Describe how you validated your changes
1. added unit tests covering  toolchain update in root `go.mod`,
2. ran `dda inv update-go --version=1.25.7` locally.