### PR TITLE
[CNM-5149] Fix ebpfless edge case with preexisting DNS connection

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -345,6 +345,12 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 		}
 	}
 
+	// if direction is still unknown after processing, don't persist this
+	// connection (it's preexisting and we can't determine direction)
+	if conn.Direction == network.UNKNOWN {
+		return ProcessResultNone, nil
+	}
+
 	// if the connection is still established, we should update the connection map
 	if st.tcpState == connStatEstablished {
 		return ProcessResultStoreConn, nil

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -867,6 +867,7 @@ func TestPreexistingConnUnknownDirection(t *testing.T) {
 
 		// packet 3: SYN arrives — sets direction, connection now persistable
 		result = f.runPkt(pb.outgoing(0, 0, 0, SYN))
+		require.Equal(t, ProcessResultStoreConn, result)
 		require.Equal(t, network.OUTGOING, f.conn.Direction)
 	})
 }

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -330,6 +330,14 @@ func (t *ebpfLessTracer) guessConnectionDirection(conn *network.ConnectionStats,
 		}
 	}
 
+	// system ports are always servers
+	if conn.SPort < 1024 {
+		return network.INCOMING, nil
+	}
+	if conn.DPort < 1024 {
+		return network.OUTGOING, nil
+	}
+
 	switch pktType {
 	case unix.PACKET_HOST:
 		return network.INCOMING, nil

--- a/pkg/network/tracer/connection/ebpfless_tracer_test.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer_test.go
@@ -84,7 +84,7 @@ func TestGuessConnectionDirection(t *testing.T) {
 			expectedDir: network.OUTGOING,
 		},
 		{
-			name: "loopback dest port not bound falls through",
+			name: "loopback dest port not bound falls through to unknown for TCP",
 			conn: &network.ConnectionStats{
 				ConnectionTuple: network.ConnectionTuple{
 					Source: loopbackAddr,
@@ -96,7 +96,7 @@ func TestGuessConnectionDirection(t *testing.T) {
 			},
 			pktType:     unix.PACKET_HOST,
 			ports:       mockBoundPortLookup{},
-			expectedDir: network.INCOMING,
+			expectedDir: network.UNKNOWN,
 		},
 		{
 			name: "non-loopback dest port bound is not checked",
@@ -111,7 +111,7 @@ func TestGuessConnectionDirection(t *testing.T) {
 			},
 			pktType:     unix.PACKET_HOST,
 			ports:       mockBoundPortLookup{8080: network.TCP},
-			expectedDir: network.INCOMING,
+			expectedDir: network.UNKNOWN,
 		},
 		{
 			name: "source system port is incoming",
@@ -144,7 +144,7 @@ func TestGuessConnectionDirection(t *testing.T) {
 			expectedDir: network.OUTGOING,
 		},
 		{
-			name: "PACKET_HOST fallback is incoming",
+			name: "TCP PACKET_HOST fallback returns unknown",
 			conn: &network.ConnectionStats{
 				ConnectionTuple: network.ConnectionTuple{
 					Source: remoteAddr,
@@ -156,10 +156,10 @@ func TestGuessConnectionDirection(t *testing.T) {
 			},
 			pktType:     unix.PACKET_HOST,
 			ports:       mockBoundPortLookup{},
-			expectedDir: network.INCOMING,
+			expectedDir: network.UNKNOWN,
 		},
 		{
-			name: "PACKET_OUTGOING fallback is outgoing",
+			name: "TCP PACKET_OUTGOING fallback returns unknown",
 			conn: &network.ConnectionStats{
 				ConnectionTuple: network.ConnectionTuple{
 					Source: remoteAddr,
@@ -167,6 +167,36 @@ func TestGuessConnectionDirection(t *testing.T) {
 					SPort:  12345,
 					DPort:  8080,
 					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_OUTGOING,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.UNKNOWN,
+		},
+		{
+			name: "UDP PACKET_HOST fallback is incoming",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.UDP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "UDP PACKET_OUTGOING fallback is outgoing",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.UDP,
 				},
 			},
 			pktType:     unix.PACKET_OUTGOING,
@@ -181,7 +211,7 @@ func TestGuessConnectionDirection(t *testing.T) {
 					Dest:   remoteAddr,
 					SPort:  12345,
 					DPort:  8080,
-					Type:   network.TCP,
+					Type:   network.UDP,
 				},
 			},
 			pktType:     99,

--- a/pkg/network/tracer/connection/ebpfless_tracer_test.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer_test.go
@@ -1,0 +1,235 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package connection
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+type mockBoundPortLookup map[uint16]network.ConnectionType
+
+func (m mockBoundPortLookup) Find(proto network.ConnectionType, port uint16) bool {
+	foundProto, ok := m[port]
+	return ok && foundProto == proto
+}
+
+func TestGuessConnectionDirection(t *testing.T) {
+	remoteAddr := util.AddressFromString("8.8.8.8")
+	loopbackAddr := util.AddressFromString("127.0.0.1")
+
+	tests := []struct {
+		name        string
+		conn        *network.ConnectionStats
+		pktType     uint8
+		ports       mockBoundPortLookup
+		expectedDir network.ConnectionDirection
+		expectedErr bool
+	}{
+		{
+			name: "already has direction",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source:    remoteAddr,
+					Dest:      remoteAddr,
+					SPort:     12345,
+					DPort:     8080,
+					Type:      network.TCP,
+					Direction: network.OUTGOING,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       nil,
+			expectedDir: network.OUTGOING,
+		},
+		{
+			name: "source port is bound",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  8080,
+					DPort:  12345,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{8080: network.TCP},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "loopback dest port is bound",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: loopbackAddr,
+					Dest:   loopbackAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{8080: network.TCP},
+			expectedDir: network.OUTGOING,
+		},
+		{
+			name: "loopback dest port not bound falls through",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: loopbackAddr,
+					Dest:   loopbackAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "non-loopback dest port bound is not checked",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{8080: network.TCP},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "source system port is incoming",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  80,
+					DPort:  12345,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_OUTGOING,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "dest system port is outgoing",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  443,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.OUTGOING,
+		},
+		{
+			name: "PACKET_HOST fallback is incoming",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "PACKET_OUTGOING fallback is outgoing",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     unix.PACKET_OUTGOING,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.OUTGOING,
+		},
+		{
+			name: "unknown packet type returns error",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  12345,
+					DPort:  8080,
+					Type:   network.TCP,
+				},
+			},
+			pktType:     99,
+			ports:       mockBoundPortLookup{},
+			expectedDir: network.UNKNOWN,
+			expectedErr: true,
+		},
+		{
+			name: "UDP source port bound",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  5353,
+					DPort:  12345,
+					Type:   network.UDP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{5353: network.UDP},
+			expectedDir: network.INCOMING,
+		},
+		{
+			name: "bound port wrong protocol does not match",
+			conn: &network.ConnectionStats{
+				ConnectionTuple: network.ConnectionTuple{
+					Source: remoteAddr,
+					Dest:   remoteAddr,
+					SPort:  8080,
+					DPort:  12345,
+					Type:   network.UDP,
+				},
+			},
+			pktType:     unix.PACKET_HOST,
+			ports:       mockBoundPortLookup{8080: network.TCP},
+			expectedDir: network.INCOMING,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := guessConnectionDirection(tt.conn, tt.pktType, tt.ports)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedDir, dir)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
There is a small chance the tracer could start up mid-UDP connection, which could cause DNS connections to be flipped.  In that case, it would reach the end of `guessConnectionDirection` without finding anything, and guess wrong. This PR makes a few changes:

* Never guess the direction of TCP connections unless you see bound ports
* Recognize system ports as always server-side
* For UDP, recognize their DNS configured ports as server side

### Motivation
Small amount of flipped DNS connections in staging.

### Describe how you validated your changes
Added `ebpfless_tracer_test.go`
