### PR TITLE
[WINA-2111] Add PAR to GO_BINARIES

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -326,6 +326,9 @@ if windows_target?
   if not fips_mode?
     # TODO(AGENTCFG-XXX): SGC is not supported in FIPS mode
     GO_BINARIES << "#{install_dir}\\bin\\agent\\secret-generic-connector.exe"
+
+    # TODO(ACTP-XXX): PAR is not enabled in Gov yet
+    GO_BINARIES << "#{install_dir}\\bin\\agent\\privateactionrunner.exe"
   end
 
   if not windows_arch_i386? and ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?


### PR DESCRIPTION
### What does this PR do?
Adds the Private Action Runner binary to the `GO_BINARIES` const

### Motivation
This should put the PAR binary through the sign & strip process at build time.

### Describe how you validated your changes
Unsure how to actually validate! The binaries compile and run.

### Additional Notes
