### PR TITLE
fix(ad_endpoints_file): Insert Endpoint to all matching configs 

### DIFF
--- a/comp/core/autodiscovery/providers/kube_endpoints_file.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file.go
@@ -274,28 +274,27 @@ func (s *store) insertEp(ep *v1.Endpoints) bool {
 	defer s.Unlock()
 
 	// Configuration defined using Advanced AD identifiers (exact namespace/name match)
-	epConfig, found := s.epConfigs[epID(ep.Namespace, ep.Name)]
-	if found {
+	epConfig, adFound := s.epConfigs[epID(ep.Namespace, ep.Name)]
+	if adFound {
 		if epConfig.eps == nil {
 			epConfig.eps = make(map[*v1.Endpoints]struct{})
 		}
 		epConfig.eps[ep] = struct{}{}
 		epConfig.shouldCollect = true
-		return true
 	}
 
 	// Endpoint matches any CEL template (CEL Selector based match)
-	if s.matchesAnyCELTemplate(ep) {
+	celFound := s.matchesAnyCELTemplate(ep)
+	if celFound {
 		celEpConfig := s.epConfigs[celEndpointID]
 		if celEpConfig.eps == nil {
 			celEpConfig.eps = make(map[*v1.Endpoints]struct{})
 		}
 		celEpConfig.eps[ep] = struct{}{}
 		celEpConfig.shouldCollect = true
-		return true
 	}
 
-	return false
+	return adFound || celFound
 }
 
 // deleteEp handles endpoint objects deletion.

--- a/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints_file_test.go
@@ -150,6 +150,13 @@ func TestStoreInsertEp(t *testing.T) {
 		}},
 	}
 
+	ns1CelTpl := integration.Config{
+		Name: "check2",
+		CELSelector: workloadfilter.Rules{
+			KubeEndpoints: []string{`kube_endpoint.namespace == "ns1" && kube_endpoint.name == "ep1"`},
+		},
+	}
+
 	ep1 := &v1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "ep1", Namespace: "ns1"}}
 
 	tests := []struct {
@@ -190,6 +197,19 @@ func TestStoreInsertEp(t *testing.T) {
 				},
 				eps: nil,
 			}},
+		},
+		{
+			name: "found and inserts into both AdvancedAD and CEL configurations",
+			epConfigs: map[string]*epConfig{
+				"ns1/ep1":     {templates: []integration.Config{tpl}, eps: nil},
+				celEndpointID: {templates: []integration.Config{ns1CelTpl}, eps: nil},
+			},
+			ep:   ep1,
+			want: true,
+			wantEpConfigs: map[string]*epConfig{
+				"ns1/ep1":     {templates: []integration.Config{tpl}, eps: map[*v1.Endpoints]struct{}{ep1: {}}, shouldCollect: true},
+				celEndpointID: {templates: []integration.Config{ns1CelTpl}, eps: map[*v1.Endpoints]struct{}{ep1: {}}, shouldCollect: true},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Fixes endpoint matching logic to allow endpoints to match both Advanced AD configurations and CEL-based configurations simultaneously. Previously, if an endpoint matched an Advanced AD configuration (exact namespace/name match), it would return early and never check for CEL template matches.

### Describe how you validated your changes

- Added test case ✅ 
