### PR TITLE
[ACTP] One time self enrollment for PAR in DCA

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -719,10 +719,15 @@ func startPrivateActionRunner(
 	if err != nil {
 		return nil, err
 	}
-	err = app.Start(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// Start the private action runner asynchronously
+	errChan := app.StartAsync(ctx)
+
+	go func() {
+		// We could ignore this error but it's better to log it for debugging purposes
+		if err := <-errChan; err != nil {
+			log.Errorf("Failed to start private action runner: %v", err)
+		}
+	}()
 	return func() {
 		if err := app.Stop(context.Background()); err != nil {
 			log.Errorf("Error stopping private action runner: %v", err)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -557,11 +557,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
-<<<<<<< HEAD
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, log, taggerComp, tracerouteComp, eventPlatform)
-=======
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp)
->>>>>>> 9266f4b7d6 (leader election and unique par identity)
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -704,9 +700,6 @@ func startPrivateActionRunner(
 	if rcClient == nil {
 		return nil, errors.New("Remote config is disabled or failed to initialize, remote config is a required dependency for private action runner")
 	}
-<<<<<<< HEAD
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
-=======
 	if !config.GetBool("leader_election") {
 		return nil, errors.New("leader election is not enabled on the Cluster Agent. The private action runner needs leader election for identity coordination across replicas")
 	}
@@ -714,8 +707,7 @@ func startPrivateActionRunner(
 	if err != nil {
 		log.Warnf("Leader election failed: %v", err)
 	}
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp)
->>>>>>> 9266f4b7d6 (leader election and unique par identity)
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -557,7 +557,11 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
+<<<<<<< HEAD
 		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, log, taggerComp, tracerouteComp, eventPlatform)
+=======
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp)
+>>>>>>> 9266f4b7d6 (leader election and unique par identity)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -691,6 +695,7 @@ func startPrivateActionRunner(
 	config config.Component,
 	hostnameGetter hostnameinterface.Component,
 	rcClient *rcclient.Client,
+	le *leaderelection.LeaderEngine,
 	log log.Component,
 	tagger tagger.Component,
 	tracerouteComp traceroute.Component,
@@ -699,7 +704,18 @@ func startPrivateActionRunner(
 	if rcClient == nil {
 		return nil, errors.New("Remote config is disabled or failed to initialize, remote config is a required dependency for private action runner")
 	}
+<<<<<<< HEAD
 	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
+=======
+	if !config.GetBool("leader_election") {
+		return nil, errors.New("leader election is not enabled on the Cluster Agent. The private action runner needs leader election for identity coordination across replicas")
+	}
+	err := le.EnsureLeaderElectionRuns()
+	if err != nil {
+		return nil, err
+	}
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp)
+>>>>>>> 9266f4b7d6 (leader election and unique par identity)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -703,10 +703,7 @@ func startPrivateActionRunner(
 	if !config.GetBool("leader_election") {
 		return nil, errors.New("leader election is not enabled on the Cluster Agent. The private action runner needs leader election for identity coordination across replicas")
 	}
-	err := le.EnsureLeaderElectionRuns()
-	if err != nil {
-		log.Warnf("Leader election failed: %v", err)
-	}
+	le.StartLeaderElectionRun()
 	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
 	if err != nil {
 		return nil, err

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -712,7 +712,7 @@ func startPrivateActionRunner(
 	}
 	err := le.EnsureLeaderElectionRuns()
 	if err != nil {
-		return nil, err
+		log.Warnf("Leader election failed: %v", err)
 	}
 	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp)
 >>>>>>> 9266f4b7d6 (leader election and unique par identity)

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -43,6 +43,8 @@ const (
 	parSelfEnroll = "private_action_runner.self_enroll"
 	parPrivateKey = "private_action_runner.private_key"
 	parUrn        = "private_action_runner.urn"
+
+	maxStartupWaitTimeout = 15 * time.Second
 )
 
 // isEnabled checks if the private action runner is enabled in the configuration
@@ -79,9 +81,10 @@ type PrivateActionRunner struct {
 	workflowRunner *runners.WorkflowRunner
 	commonRunner   *runners.CommonRunner
 
-	startOnce sync.Once
-	startDone chan struct{}
-	drain     func()
+	started     bool
+	startOnce   sync.Once
+	startChan   chan struct{}
+	cancelStart context.CancelFunc
 }
 
 // NewComponent creates a new privateactionrunner component
@@ -121,8 +124,7 @@ func NewPrivateActionRunner(
 		tagger:         taggerComp,
 		traceroute:     tracerouteComp,
 		eventPlatform:  eventPlatform,
-		startDone:      make(chan struct{}),
-		drain:          func() {},
+		startChan:      make(chan struct{}),
 	}, nil
 }
 
@@ -159,8 +161,9 @@ func (p *PrivateActionRunner) getRunnerConfig(ctx context.Context) (*parconfig.C
 
 func (p *PrivateActionRunner) Start(ctx context.Context) error {
 	var err error
+	p.started = true
 	p.startOnce.Do(func() {
-		defer close(p.startDone)
+		defer close(p.startChan)
 		err = p.start(ctx)
 	})
 	return err
@@ -176,6 +179,9 @@ func (p *PrivateActionRunner) StartAsync(ctx context.Context) <-chan error {
 }
 
 func (p *PrivateActionRunner) start(ctx context.Context) error {
+	// Any cancellation from the parent context will be propagated to the start process
+	// But we want to control cancellation in case Stop is called unexpectedly
+	ctx, p.cancelStart = context.WithCancel(ctx)
 	cfg, err := p.getRunnerConfig(ctx)
 	if err != nil {
 		return err
@@ -194,19 +200,26 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 		return err
 	}
 	p.commonRunner = runners.NewCommonRunner(cfg)
-	// Use background context to avoid inheriting any deadlines from component lifecycle which stop the PAR loop
-	ctx, mainCtxCancel := context.WithCancel(context.Background())
-	p.drain = mainCtxCancel
-	err = p.commonRunner.Start(ctx)
+	err = p.workflowRunner.Start(ctx)
 	if err != nil {
 		return err
 	}
-	return p.workflowRunner.Start(ctx)
+	return p.commonRunner.Start(ctx)
 }
 
 func (p *PrivateActionRunner) Stop(ctx context.Context) error {
-	// Wait for startup to complete before stopping
-	<-p.startDone
+	if !p.started {
+		return nil // Never started, nothing to stop
+	}
+
+	p.cancelStart()
+	waitCtx, cancelWaitCtx := context.WithTimeout(ctx, maxStartupWaitTimeout)
+	defer cancelWaitCtx()
+	err := p.waitForStartup(waitCtx)
+	if err != nil {
+		p.logger.Warn("PAR startup did not complete in time, forcing cleanup")
+		// Don't return - continue to cleanup what we can
+	}
 
 	if p.workflowRunner != nil {
 		err := p.workflowRunner.Stop(ctx)
@@ -220,7 +233,16 @@ func (p *PrivateActionRunner) Stop(ctx context.Context) error {
 			return err
 		}
 	}
-	p.drain()
+	return nil
+}
+
+func (p *PrivateActionRunner) waitForStartup(ctx context.Context) error {
+	select {
+	case <-p.startChan:
+		// Startup completed normally
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	return nil
 }
 

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -14,11 +14,12 @@ const (
 	PARLogFile = "private_action_runner.log_file"
 
 	// Identity / enrollment configuration
-	PARSelfEnroll         = "private_action_runner.self_enroll"
-	PARIdentityFilePath   = "private_action_runner.identity_file_path"
-	PARIdentitySecretName = "private_action_runner.identity_secret_name"
-	PARPrivateKey         = "private_action_runner.private_key"
-	PARUrn                = "private_action_runner.urn"
+	PARSelfEnroll           = "private_action_runner.self_enroll"
+	PARIdentityFilePath     = "private_action_runner.identity_file_path"
+	PARIdentityUseK8sSecret = "private_action_runner.identity_use_k8s_secret"
+	PARIdentitySecretName   = "private_action_runner.identity_secret_name"
+	PARPrivateKey           = "private_action_runner.private_key"
+	PARUrn                  = "private_action_runner.urn"
 
 	// General config
 	PARTaskConcurrency    = "private_action_runner.task_concurrency"
@@ -42,6 +43,7 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	// Identity / enrollment configuration
 	config.BindEnvAndSetDefault(PARSelfEnroll, true)
 	config.BindEnvAndSetDefault(PARIdentityFilePath, "")
+	config.BindEnvAndSetDefault(PARIdentityUseK8sSecret, true)
 	config.BindEnvAndSetDefault(PARIdentitySecretName, "private-action-runner-identity")
 	config.BindEnvAndSetDefault(PARPrivateKey, "")
 	config.BindEnvAndSetDefault(PARUrn, "")

--- a/pkg/privateactionrunner/enrollment/storage.go
+++ b/pkg/privateactionrunner/enrollment/storage.go
@@ -23,7 +23,7 @@ import (
 
 // GetIdentityFromPreviousEnrollment retrieves PAR identity from either K8s secret or file based on configuration
 func GetIdentityFromPreviousEnrollment(ctx context.Context, cfg configModel.Reader) (*PersistedIdentity, error) {
-	if cfg.GetBool("cluster_agent.enabled") && flavor.GetFlavor() == flavor.ClusterAgent {
+	if cfg.GetBool(setup.PARIdentityUseK8sSecret) && flavor.GetFlavor() == flavor.ClusterAgent {
 		return getIdentityFromK8sSecret(ctx, cfg)
 	}
 	return getIdentityFromFile(cfg)
@@ -31,7 +31,7 @@ func GetIdentityFromPreviousEnrollment(ctx context.Context, cfg configModel.Read
 
 // PersistIdentity persists identity to either K8s secret or file based on configuration
 func PersistIdentity(ctx context.Context, cfg configModel.Reader, result *Result) error {
-	if cfg.GetBool("cluster_agent.enabled") && flavor.GetFlavor() == flavor.ClusterAgent {
+	if cfg.GetBool(setup.PARIdentityUseK8sSecret) && flavor.GetFlavor() == flavor.ClusterAgent {
 		return persistIdentityToK8sSecret(ctx, cfg, result)
 	}
 	return persistIdentityToFile(cfg, result)

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -191,7 +191,6 @@ func (le *LeaderEngine) init() error {
 func (le *LeaderEngine) StartLeaderElectionRun() {
 	le.once.Do(
 		func() {
-			log.Infof("Starting leader election goroutine for %q", le.HolderIdentity)
 			go le.runLeaderElection()
 		},
 	)
@@ -210,20 +209,14 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 
 	le.StartLeaderElectionRun()
 
-	log.Infof("Waiting for leader election to determine a leader (timeout: %s)...", getLeaderTimeout)
 	timeout := time.After(getLeaderTimeout)
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
 	for {
+		log.Tracef("Waiting for new leader identity...")
 		select {
 		case <-tick.C:
-			// Query Kubernetes directly to see current leader, don't wait for callback
-			leaderIdentity, err := le.getCurrentLeader()
-			if err != nil {
-				log.Warnf("Error querying current leader: %v", err)
-				continue
-			}
-			log.Infof("Polling for leader: current leader identity = %q", leaderIdentity)
+			leaderIdentity := le.GetLeader()
 			if leaderIdentity != "" {
 				log.Infof("Leader election running, current leader is %q", leaderIdentity)
 				le.running = true

--- a/releasenotes/notes/par-k8s-identity-in-dca-09d00e972c674fda.yaml
+++ b/releasenotes/notes/par-k8s-identity-in-dca-09d00e972c674fda.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The Private Action Runner (PAR) now runs in the Datadog Cluster Agent with
+    improved identity management for Kubernetes environments. PAR identity (URN
+    and private key) is now stored in a Kubernetes secret and shared across all
+    DCA replicas using leader election. The leader replica handles enrollment and
+    secret creation, while follower replicas wait for and read the shared identity.
+    This enables multiple DCA replicas to execute PAR tasks using a single cluster
+    identity, eliminating the need for per-replica enrollment.


### PR DESCRIPTION
## What does this PR do?

Adds leader election coordination to ensure PAR identity is created once and shared across all cluster agent replicas, preventing duplicate enrollments when running multiple replicas.

**Key changes:**
- Use leaderelection (Subscribe + Wait Loop) for enrollment coordination
  - Leader replica creates and persists PAR identity to Kubernetes secret
  - Follower replicas wait for and reuse the leader's identity

## Motivation

**Problem:** When running multiple cluster agent replicas with PAR enabled, each replica would independently self-enroll, creating multiple PAR identities instead of sharing one.

This causes:
- Multiple PAR runners registered for the same cluster
- Confusion about which runner is active
- Wasted API calls and resources

**Solution:** Use leader election to coordinate identity creation:

1. Leader replica self-enrolls and persists identity to K8s secret
2. Follower replicas wait for the secret and reuse the identity
3. All replicas run PAR with the same shared identity

## Describe how you validated your changes

**Test scenario:** Deploy cluster agent with 4 replicas, PAR enabled, no existing identity

For more instructions see https://datadoghq.atlassian.net/wiki/spaces/ACT/pages/5394760254/PAR+in+agent+dev+setup#Private-runner-in-Datadog-Cluster-Agent-(DCA)

✅ **Leader behavior:**
- Leader election completes within 1 second
- Leader self-enrolls and creates new PAR identity
- Identity persisted to `private-action-runner-identity` secret
- PAR starts successfully with new URN

✅ **Follower behavior:**
- Follower detects leader within 1 second (via direct K8s query)
- Waits for leader to create secret (~5 seconds)
- Loads identity from secret created by leader
- PAR starts successfully with same URN as leader

✅ **Leadership transitions:**
- Deleted leader pod while secret doesn't exist
- New leader takes over and creates the secret
- Follower successfully loads the secret

✅ **Existing identity:**
- Both replicas immediately load existing secret
- No re-enrollment occurs
- Both start with identical identity

## Additional Notes
- Follows same pattern as AppSec Injector and Admission Controller
- Uses `le.Subscribe()` for leadership change notifications
- Polls Kubernetes every 1 second for secret appearance
- No timeout - waits indefinitely (safe because PAR runs in background goroutine)
