### PR TITLE
enable secret-backend (SGC) fips for windows

### DIFF
--- a/.gitlab/deploy/container_build/docker_windows.yml
+++ b/.gitlab/deploy/container_build/docker_windows.yml
@@ -23,8 +23,7 @@
     # Omnibus uses a slightly different path than the actual install
     # TODO: This overwrites an extra agent.exe, we should also remove it from the zip
     - mv "Datadog Agent\bin\agent\agent.exe" "Datadog Agent\bin\agent.exe" -Force
-    # TODO(AGENTCFG-XXX): SGC is not supported in FIPS mode
-    - if (Test-Path "Datadog Agent\bin\agent\secret-generic-connector.exe") { mv "Datadog Agent\bin\agent\secret-generic-connector.exe" "Datadog Agent\bin\secret-generic-connector.exe" -Force }
+    - mv "Datadog Agent\bin\agent\secret-generic-connector.exe" "Datadog Agent\bin\secret-generic-connector.exe" -Force
     - popd
 
     - get-childitem ${BUILD_CONTEXT}

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -323,10 +323,9 @@ if windows_target?
     "#{install_dir}\\datadog-installer.exe"
   ]
 
-  if not fips_mode?
-    # TODO(AGENTCFG-XXX): SGC is not supported in FIPS mode
-    GO_BINARIES << "#{install_dir}\\bin\\agent\\secret-generic-connector.exe"
+  GO_BINARIES << "#{install_dir}\\bin\\agent\\secret-generic-connector.exe"
 
+  if not fips_mode?
     # TODO(ACTP-XXX): PAR is not enabled in Gov yet
     GO_BINARIES << "#{install_dir}\\bin\\agent\\privateactionrunner.exe"
   end

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -320,10 +320,9 @@ if windows_target?
     "#{install_dir}\\bin\\agent\\trace-agent.exe",
     "#{install_dir}\\bin\\agent\\process-agent.exe",
     "#{install_dir}\\bin\\agent\\system-probe.exe",
+    "#{install_dir}\\bin\\agent\\secret-generic-connector.exe",
     "#{install_dir}\\datadog-installer.exe"
   ]
-
-  GO_BINARIES << "#{install_dir}\\bin\\agent\\secret-generic-connector.exe"
 
   if not fips_mode?
     # TODO(ACTP-XXX): PAR is not enabled in Gov yet

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -645,10 +645,9 @@ namespace WixSetup.Datadog_Agent
                 ),
                 scriptsBinDir
             );
-            // TODO(AGENTCFG-XXX): SGC is not supported in FIPS mode
+            targetBinFolder.AddFile(new WixSharp.File(_agentBinaries.SecretGenericConnector));
             if (_agentFlavor.FlavorName != Constants.FipsFlavor)
             {
-                targetBinFolder.AddFile(new WixSharp.File(_agentBinaries.SecretGenericConnector));
                 targetBinFolder.AddFile(new WixSharp.File(_agentBinaries.DdCompilePolicy));
             }
 


### PR DESCRIPTION
### What does this PR do?
As the datadog-secret-backend (SGC) is now shipped inside the agent repo and fips is enabled, this TODO should be resolved without issue. https://github.com/DataDog/datadog-agent/pull/44866/changes

### Motivation
enable FIPS support

### Describe how you validated your changes
CI

### Additional Notes
