### PR TITLE
dyninst: add capture expressions support

### DIFF
--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -396,6 +396,7 @@ func (ce *captureEvent) MarshalJSONTo(enc *jsontext.Encoder) error {
 	}{
 		{kind: ir.RootExpressionKindArgument, token: jsontext.String("arguments")},
 		{kind: ir.RootExpressionKindLocal, token: jsontext.String("locals")},
+		{kind: ir.RootExpressionKindCaptureExpression, token: jsontext.String("captureExpressions")},
 	} {
 		// We iterate over the 'Expressions' of the EventRoot which contains
 		// metadata and raw bytes of the parameters of this function.

--- a/pkg/dyninst/ir/event_kind_string.go
+++ b/pkg/dyninst/ir/event_kind_string.go
@@ -18,9 +18,9 @@ const _EventKind_name = "EntryReturnLine"
 var _EventKind_index = [...]uint8{0, 5, 11, 15}
 
 func (i EventKind) String() string {
-	i -= 1
-	if i >= EventKind(len(_EventKind_index)-1) {
-		return "EventKind(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_EventKind_index)-1 {
+		return "EventKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _EventKind_name[_EventKind_index[i]:_EventKind_index[i+1]]
+	return _EventKind_name[_EventKind_index[idx]:_EventKind_index[idx+1]]
 }

--- a/pkg/dyninst/ir/issuekind_string.go
+++ b/pkg/dyninst/ir/issuekind_string.go
@@ -21,9 +21,9 @@ const _IssueKind_name = "InvalidProbeDefinitionTargetNotFoundInBinaryUnsupported
 var _IssueKind_index = [...]uint8{0, 22, 44, 62, 81, 93, 110}
 
 func (i IssueKind) String() string {
-	i -= 1
-	if i < 0 || i >= IssueKind(len(_IssueKind_index)-1) {
-		return "IssueKind(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_IssueKind_index)-1 {
+		return "IssueKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _IssueKind_name[_IssueKind_index[i]:_IssueKind_index[i+1]]
+	return _IssueKind_name[_IssueKind_index[idx]:_IssueKind_index[idx+1]]
 }

--- a/pkg/dyninst/ir/probe_definition.go
+++ b/pkg/dyninst/ir/probe_definition.go
@@ -34,6 +34,18 @@ type ProbeDefinition interface {
 	GetThrottleConfig() ThrottleConfig
 	// GetTemplate returns the template of the probe.
 	GetTemplate() TemplateDefinition
+	// GetCaptureExpressions returns the capture expressions of the probe, or
+	// nil if the probe does not have capture expressions.
+	GetCaptureExpressions() []CaptureExpressionDefinition
+}
+
+// CaptureExpressionDefinition defines a single capture expression on a probe.
+type CaptureExpressionDefinition interface {
+	GetName() string
+	GetDSL() string
+	GetJSON() json.RawMessage
+	// GetCaptureConfig returns per-expression capture limits, or nil for probe defaults.
+	GetCaptureConfig() CaptureConfig
 }
 
 // CompareProbeIDs compares two probe definitions by their ID and version.

--- a/pkg/dyninst/ir/probe_kind.go
+++ b/pkg/dyninst/ir/probe_kind.go
@@ -24,6 +24,11 @@ const (
 	// Internally in rcjson these are log probes with capture_snapshot set to
 	// true.
 	ProbeKindSnapshot
+	// ProbeKindCaptureExpression is a probe that captures specific expressions.
+	//
+	// Internally in rcjson these are log probes with captureSnapshot=false and
+	// captureExpressions set.
+	ProbeKindCaptureExpression
 
 	maxProbeKind uint8 = iota
 )

--- a/pkg/dyninst/ir/probe_kind_string.go
+++ b/pkg/dyninst/ir/probe_kind_string.go
@@ -12,16 +12,17 @@ func _() {
 	_ = x[ProbeKindSpan-2]
 	_ = x[ProbeKindMetric-3]
 	_ = x[ProbeKindSnapshot-4]
+	_ = x[ProbeKindCaptureExpression-5]
 }
 
-const _ProbeKind_name = "ProbeKindLogProbeKindSpanProbeKindMetricProbeKindSnapshot"
+const _ProbeKind_name = "ProbeKindLogProbeKindSpanProbeKindMetricProbeKindSnapshotProbeKindCaptureExpression"
 
-var _ProbeKind_index = [...]uint8{0, 12, 25, 40, 57}
+var _ProbeKind_index = [...]uint8{0, 12, 25, 40, 57, 83}
 
 func (i ProbeKind) String() string {
-	i -= 1
-	if i >= ProbeKind(len(_ProbeKind_index)-1) {
-		return "ProbeKind(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	idx := int(i) - 1
+	if i < 1 || idx >= len(_ProbeKind_index)-1 {
+		return "ProbeKind(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
-	return _ProbeKind_name[_ProbeKind_index[i]:_ProbeKind_index[i+1]]
+	return _ProbeKind_name[_ProbeKind_index[idx]:_ProbeKind_index[idx+1]]
 }

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -425,6 +425,9 @@ const (
 	// RootExpressionKindTemplateSegment means that this expression is part of a
 	// template segment.
 	RootExpressionKindTemplateSegment
+	// RootExpressionKindCaptureExpression means that this expression is a
+	// capture expression specified by the user.
+	RootExpressionKindCaptureExpression
 )
 
 func (k RootExpressionKind) String() string {
@@ -435,6 +438,8 @@ func (k RootExpressionKind) String() string {
 		return "local"
 	case RootExpressionKindTemplateSegment:
 		return "template_segment"
+	case RootExpressionKindCaptureExpression:
+		return "capture_expression"
 	default:
 		return fmt.Sprintf("RootExpressionKind(%d)", k)
 	}

--- a/pkg/dyninst/irgen/snapshot_test.go
+++ b/pkg/dyninst/irgen/snapshot_test.go
@@ -100,6 +100,11 @@ func probeConfigsWithMaxReferenceDepth(
 				cfg.Capture = new(rcjson.Capture)
 				cfg.Capture.MaxReferenceDepth = &limit
 			}
+		case *rcjson.CaptureExpressionProbe:
+			if cfg.Capture == nil {
+				cfg.Capture = new(rcjson.Capture)
+				cfg.Capture.MaxReferenceDepth = &limit
+			}
 		}
 	}
 	return probesCfgs

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.stackC]
+          Type: 1332 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xd0a52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1331 EventRootType Probe[main.stackC]Return
+          Type: 1333 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xd0a565", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xd08f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09022", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testAtomicAdd]
+          Type: 1230 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xd07320", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1229 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xd07332", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1351 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1352 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xd0460e"
+              Frameless: false
+            - PC: "0xd04691"
+              Frameless: false
+            - PC: "0xd047d2"
+              Frameless: false
+            - PC: "0xd0485c"
+              Frameless: false
+            - PC: "0xd0492f"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xd0460e"
+              Frameless: false
+            - PC: "0xd04691"
+              Frameless: false
+            - PC: "0xd047d2"
+              Frameless: false
+            - PC: "0xd0485c"
+              Frameless: false
+            - PC: "0xd0492f"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1227 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1228 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xd06f80", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testChannel]
+          Type: 1232 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xd07340", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testCycle]
+          Type: 1240 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xd07720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testEmptySlice]
+          Type: 1320 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xd0a040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xd0a0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testEmptyString]
+          Type: 1346 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xd0a660", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEmptyStruct]
+          Type: 1359 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xd0aae0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xd0ab00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testInlinedBBB]
+          Type: 1366 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xd048a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBCA]
+          Type: 1367 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xd049b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBCB]
+          Type: 1369 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1364 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xd04a66", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xd02932"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedPrint]
+          Type: 1363 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xd0460a"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xd0464a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1359 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xd0460e"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testInlinedSq]
+          Type: 1371 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1366 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xd04ac1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xd04b05"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xd08dee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd08f33", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testLinkedList]
+          Type: 1234 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xd07540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xd09293", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xd094a2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testMassiveString]
+          Type: 1343 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testMassiveString]
+          Type: 1344 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xd0a620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xd09533", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xd0976b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xd098ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xd09976", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xd0904e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xd0926a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xd07100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNamedReturn]
+          Type: 1255 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          Type: 1257 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xd0836a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xd083d5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testNestedPointer]
+          Type: 1355 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testNestedPointer]
+          Type: 1356 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testNestedPointer]
+          Type: 1357 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testNestedPointer]
+          Type: 1358 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xd0aa60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testNilPointer]
+          Type: 1239 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xd076e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testNilSlice]
+          Type: 1327 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xd0a120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xd0a0c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xd0a100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xd0a600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerLoop]
+          Type: 1235 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xd07560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1231 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xd07520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAny]
+          Type: 1251 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xd07fee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xd080a4"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xd07e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xd07ef8"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsArray]
+          Type: 1279 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xd0888a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xd088ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xd0890a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xd0894b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xd0896a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xd089a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xd08a4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xd08aca", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xd08d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xd08dd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsComplex]
+          Type: 1275 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xd0874a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xd087a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsError]
+          Type: 1247 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xd07e2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsError]Return
+          Type: 1248 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xd07e5a"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testReturnsInt]
+          Type: 1241 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xd07c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1240 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xd07c7b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xd07d4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xd07e04", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xd07caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xd07d1b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsInterface]
+          Type: 1253 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xd081ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xd082d1"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xd087ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xd08853", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xd0864e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xd08725", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsMixed]
+          Type: 1291 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xd08baa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xd08c0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xd089ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xd08a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xd08d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xd08d56", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xd08caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xd08cee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xd085ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xd08631", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xd08c2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xd08c8d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xd08aee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xd08b74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleString]
+          Type: 1334 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xd0a580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xd0a160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xd0a060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xd084ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xd0858e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xd0980a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xd0987c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testStringPointer]
+          Type: 1238 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xd076a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testStringSlice]
+          Type: 1325 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xd0a0e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStruct]
+          Type: 1353 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xd0a960", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStruct]Return
+          Type: 1354 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xd0a982", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testStructSlice]
+          Type: 1322 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xd0a080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xd099ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xd09a5a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xd0a820", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xd0a83e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xd0a800", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testSubslices]
+          Type: 1331 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xd0a180", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSubstrings]
+          Type: 1347 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xd0a680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xd0840e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xd084af", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testThreeStrings]
+          Type: 1335 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xd0a5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xd0a5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xd0a5de", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xd0a5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testUintPointer]
+          Type: 1237 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xd075c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testUintSlice]
+          Type: 1319 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xd0a020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testUnitializedString]
+          Type: 1345 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xd0a640", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testUnsafePointer]
+          Type: 1236 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xd07580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xd0a140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xd04cea"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1369 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xd04d30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xd09a8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xd09b0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5648,6 +5779,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0xd06f80..0xd06f81]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xd06f80..0xd06f81
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0xd06f80..0xd06f81
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 16 BaseType float32
+          Locations:
+            - Range: 0xd06f80..0xd06f81
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xd07100..0xd07101]
       InlinePCRanges: []
@@ -5686,7 +5844,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0xd07320..0xd07333]
       InlinePCRanges: []
@@ -5705,7 +5863,7 @@ Subprograms:
             - Range: 0xd07332..0xd07333
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0xd07340..0xd07341]
       InlinePCRanges: []
@@ -5716,7 +5874,7 @@ Subprograms:
             - Range: 0xd07340..0xd07341
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xd07520..0xd07521]
       InlinePCRanges: []
@@ -5727,7 +5885,7 @@ Subprograms:
             - Range: 0xd07520..0xd07521
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xd07540..0xd07541]
       InlinePCRanges: []
@@ -5742,7 +5900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xd07560..0xd07561]
       InlinePCRanges: []
@@ -5753,7 +5911,7 @@ Subprograms:
             - Range: 0xd07560..0xd07561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xd07580..0xd07581]
       InlinePCRanges: []
@@ -5764,7 +5922,7 @@ Subprograms:
             - Range: 0xd07580..0xd07581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xd075c0..0xd075c1]
       InlinePCRanges: []
@@ -5775,7 +5933,7 @@ Subprograms:
             - Range: 0xd075c0..0xd075c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xd076a0..0xd076a1]
       InlinePCRanges: []
@@ -5786,7 +5944,7 @@ Subprograms:
             - Range: 0xd076a0..0xd076a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xd076e0..0xd076e1]
       InlinePCRanges: []
@@ -5803,7 +5961,7 @@ Subprograms:
             - Range: 0xd076e0..0xd076e1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0xd07720..0xd07721]
       InlinePCRanges: []
@@ -5814,7 +5972,7 @@ Subprograms:
             - Range: 0xd07720..0xd07721
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xd07c20..0xd07c92]
       InlinePCRanges: []
@@ -5843,7 +6001,7 @@ Subprograms:
             - Range: 0xd07c45..0xd07c92
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xd07ca0..0xd07d35]
       InlinePCRanges: []
@@ -5874,7 +6032,7 @@ Subprograms:
             - Range: 0xd07cdc..0xd07d35
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xd07d40..0xd07e1e]
       InlinePCRanges: []
@@ -5915,7 +6073,7 @@ Subprograms:
             - Range: 0xd07da7..0xd07e1e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xd07e20..0xd07e7b]
       InlinePCRanges: []
@@ -5948,7 +6106,7 @@ Subprograms:
             - Range: 0xd07e66..0xd07e7b
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xd07e80..0xd07fc6]
       InlinePCRanges: []
@@ -6075,7 +6233,7 @@ Subprograms:
             - Range: 0xd07f17..0xd07f20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xd07fe0..0xd081d4]
       InlinePCRanges: []
@@ -6152,7 +6310,7 @@ Subprograms:
             - Range: 0xd08085..0xd080a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xd081e0..0xd08345]
       InlinePCRanges: []
@@ -6245,7 +6403,7 @@ Subprograms:
             - Range: 0xd082db..0xd08345
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xd08360..0xd083ef]
       InlinePCRanges: []
@@ -6266,7 +6424,7 @@ Subprograms:
             - Range: 0xd083d6..0xd083ef
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xd08400..0xd084c9]
       InlinePCRanges: []
@@ -6297,7 +6455,7 @@ Subprograms:
             - Range: 0xd084b0..0xd084c9
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xd084e0..0xd085a8]
       InlinePCRanges: []
@@ -6340,7 +6498,7 @@ Subprograms:
             - Range: 0xd0858f..0xd085a8
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xd085c0..0xd0863e]
       InlinePCRanges: []
@@ -6425,7 +6583,7 @@ Subprograms:
             - Range: 0xd08632..0xd0863e
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xd08640..0xd08735]
       InlinePCRanges: []
@@ -6510,7 +6668,7 @@ Subprograms:
             - Range: 0xd08726..0xd08735
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xd08740..0xd087b3]
       InlinePCRanges: []
@@ -6523,7 +6681,7 @@ Subprograms:
           Type: 90 BaseType complex128
           Locations: [{Range: 0xd08740..0xd087b3, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xd087c0..0xd08865]
       InlinePCRanges: []
@@ -6538,7 +6696,7 @@ Subprograms:
             - Range: 0xd08854..0xd08865
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xd08880..0xd088fa]
       InlinePCRanges: []
@@ -6553,7 +6711,7 @@ Subprograms:
             - Range: 0xd088ee..0xd088fa
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xd08900..0xd08958]
       InlinePCRanges: []
@@ -6568,7 +6726,7 @@ Subprograms:
             - Range: 0xd0894c..0xd08958
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xd08960..0xd089b3]
       InlinePCRanges: []
@@ -6583,7 +6741,7 @@ Subprograms:
             - Range: 0xd089a7..0xd089b3
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xd089c0..0xd08a27]
       InlinePCRanges: []
@@ -6592,7 +6750,7 @@ Subprograms:
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0xd089c0..0xd08a27, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xd08a40..0xd08ada]
       InlinePCRanges: []
@@ -6687,7 +6845,7 @@ Subprograms:
             - Range: 0xd08acb..0xd08ada
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xd08ae0..0xd08b85]
       InlinePCRanges: []
@@ -6702,7 +6860,7 @@ Subprograms:
             - Range: 0xd08b75..0xd08b85
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xd08ba0..0xd08c19]
       InlinePCRanges: []
@@ -6749,7 +6907,7 @@ Subprograms:
             - Range: 0xd08c0d..0xd08c19
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xd08c20..0xd08c9a]
       InlinePCRanges: []
@@ -6764,7 +6922,7 @@ Subprograms:
             - Range: 0xd08c8e..0xd08c9a
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xd08ca0..0xd08cfb]
       InlinePCRanges: []
@@ -6773,7 +6931,7 @@ Subprograms:
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08ca0..0xd08cfb, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xd08d00..0xd08d67]
       InlinePCRanges: []
@@ -6786,7 +6944,7 @@ Subprograms:
           Type: 17 BaseType float64
           Locations: [{Range: 0xd08d00..0xd08d67, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xd08d80..0xd08ddd]
       InlinePCRanges: []
@@ -6811,7 +6969,7 @@ Subprograms:
             - Range: 0xd08dd1..0xd08ddd
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xd08de0..0xd08f45]
       InlinePCRanges: []
@@ -6832,7 +6990,7 @@ Subprograms:
             - Range: 0xd08f34..0xd08f45
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xd08f60..0xd09032]
       InlinePCRanges: []
@@ -6853,7 +7011,7 @@ Subprograms:
             - Range: 0xd09023..0xd09032
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xd09040..0xd0927a]
       InlinePCRanges: []
@@ -6880,7 +7038,7 @@ Subprograms:
             - Range: 0xd0926b..0xd0927a
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xd09280..0xd0950f]
       InlinePCRanges: []
@@ -6967,7 +7125,7 @@ Subprograms:
             - Range: 0xd094a3..0xd0950f
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xd09520..0xd097ec]
       InlinePCRanges: []
@@ -7056,7 +7214,7 @@ Subprograms:
             - Range: 0xd0976c..0xd097ec
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xd09800..0xd0988c]
       InlinePCRanges: []
@@ -7097,7 +7255,7 @@ Subprograms:
             - Range: 0xd0987d..0xd0988c
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xd098a0..0xd0998a]
       InlinePCRanges: []
@@ -7134,7 +7292,7 @@ Subprograms:
             - Range: 0xd09977..0xd0998a
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xd099a0..0xd09a6b]
       InlinePCRanges: []
@@ -7171,7 +7329,7 @@ Subprograms:
             - Range: 0xd09a26..0xd09a6b
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xd09a80..0xd09b26]
       InlinePCRanges: []
@@ -7212,7 +7370,7 @@ Subprograms:
             - Range: 0xd09b0d..0xd09b26
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xd0a020..0xd0a021]
       InlinePCRanges: []
@@ -7229,7 +7387,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xd0a040..0xd0a041]
       InlinePCRanges: []
@@ -7246,7 +7404,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xd0a060..0xd0a061]
       InlinePCRanges: []
@@ -7263,7 +7421,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xd0a080..0xd0a081]
       InlinePCRanges: []
@@ -7286,7 +7444,7 @@ Subprograms:
             - Range: 0xd0a080..0xd0a081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xd0a0a0..0xd0a0a1]
       InlinePCRanges: []
@@ -7309,7 +7467,7 @@ Subprograms:
             - Range: 0xd0a0a0..0xd0a0a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xd0a0c0..0xd0a0c1]
       InlinePCRanges: []
@@ -7332,7 +7490,7 @@ Subprograms:
             - Range: 0xd0a0c0..0xd0a0c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xd0a0e0..0xd0a0e1]
       InlinePCRanges: []
@@ -7349,7 +7507,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xd0a100..0xd0a101]
       InlinePCRanges: []
@@ -7378,7 +7536,7 @@ Subprograms:
             - Range: 0xd0a100..0xd0a101
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xd0a120..0xd0a121]
       InlinePCRanges: []
@@ -7395,7 +7553,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xd0a140..0xd0a141]
       InlinePCRanges: []
@@ -7412,7 +7570,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xd0a160..0xd0a161]
       InlinePCRanges: []
@@ -7429,7 +7587,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0xd0a180..0xd0a181]
       InlinePCRanges: []
@@ -7470,7 +7628,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0xd0a520..0xd0a572]
       InlinePCRanges: []
@@ -7489,7 +7647,7 @@ Subprograms:
             - Range: 0xd0a566..0xd0a572
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0xd0a580..0xd0a581]
       InlinePCRanges: []
@@ -7504,7 +7662,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xd0a5a0..0xd0a5a1]
       InlinePCRanges: []
@@ -7539,7 +7697,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xd0a5c0..0xd0a5df]
       InlinePCRanges: []
@@ -7562,7 +7720,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xd0a5e0..0xd0a5e1]
       InlinePCRanges: []
@@ -7573,7 +7731,7 @@ Subprograms:
             - Range: 0xd0a5e0..0xd0a5e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xd0a600..0xd0a601]
       InlinePCRanges: []
@@ -7584,7 +7742,7 @@ Subprograms:
             - Range: 0xd0a600..0xd0a601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xd0a620..0xd0a621]
       InlinePCRanges: []
@@ -7599,7 +7757,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xd0a640..0xd0a641]
       InlinePCRanges: []
@@ -7614,7 +7772,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xd0a660..0xd0a661]
       InlinePCRanges: []
@@ -7629,7 +7787,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0xd0a680..0xd0a681]
       InlinePCRanges: []
@@ -7664,7 +7822,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xd0a800..0xd0a801]
       InlinePCRanges: []
@@ -7675,7 +7833,7 @@ Subprograms:
             - Range: 0xd0a800..0xd0a801
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xd0a820..0xd0a83f]
       InlinePCRanges: []
@@ -7698,7 +7856,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0xd0a960..0xd0a983]
       InlinePCRanges: []
@@ -7723,7 +7881,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0xd0aa60..0xd0aa61]
       InlinePCRanges: []
@@ -7734,7 +7892,7 @@ Subprograms:
             - Range: 0xd0aa60..0xd0aa61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xd0aae0..0xd0aae1]
       InlinePCRanges: []
@@ -7743,7 +7901,7 @@ Subprograms:
           Type: 314 StructureType main.emptyStruct
           Locations: [{Range: 0xd0aae0..0xd0aae1, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xd0ab00..0xd0ab01]
       InlinePCRanges: []
@@ -7754,7 +7912,7 @@ Subprograms:
             - Range: 0xd0ab00..0xd0ab01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xd04600..0xd04662]
       InlinePCRanges:
@@ -7783,28 +7941,28 @@ Subprograms:
             - Range: 0xd04920..0xd0493a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd048a6..0xd048de]
           RootRanges: [0xd04840..0xd04905]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd049b3..0xd049f1]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xd04a66..0xd04a9e]
           RootRanges: [0xd049a0..0xd04aae]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7817,7 +7975,7 @@ Subprograms:
             - Range: 0xd04ac0..0xd04ac5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7834,7 +7992,7 @@ Subprograms:
             - Range: 0xd04b8c..0xd04cc5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xd04ce0..0xd04d51]
       InlinePCRanges:
@@ -7871,7 +8029,7 @@ Subprograms:
             - Range: 0xd04d31..0xd04d51
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -10833,10 +10991,10 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1370
+      ID: 1376
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1374
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10848,11 +11006,11 @@ Types:
             Type: 316 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1375
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10864,14 +11022,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -10883,7 +11041,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -10971,7 +11129,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -10983,7 +11141,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -10993,11 +11151,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11009,7 +11167,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11169,7 +11327,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1228
+      ID: 1230
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11181,7 +11339,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11191,11 +11349,11 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1231
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11207,7 +11365,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11292,7 +11450,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1230
+      ID: 1232
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11304,7 +11462,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11314,7 +11472,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11384,7 +11542,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1238
+      ID: 1227
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1228
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1240
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11396,7 +11616,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11406,7 +11626,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11566,7 +11786,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11578,7 +11798,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11588,7 +11808,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11598,7 +11818,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11608,11 +11828,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11624,7 +11844,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11634,11 +11854,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1344
+      ID: 1346
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11650,7 +11870,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11660,11 +11880,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1356
+      ID: 1360
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11676,7 +11896,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11686,11 +11906,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1359
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11702,7 +11922,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11712,7 +11932,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11978,7 +12198,7 @@ Types:
       ID: 1187
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1360
+      ID: 1366
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1184
@@ -12030,16 +12250,16 @@ Types:
       ID: 1185
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1367
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1362
+      ID: 1368
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1369
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1370
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1188
@@ -12048,7 +12268,7 @@ Types:
       ID: 1189
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1357
+      ID: 1363
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12060,7 +12280,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12070,11 +12290,53 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1362
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1365
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12086,7 +12348,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12096,14 +12358,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1364
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1365
+      ID: 1371
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12115,7 +12377,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12125,11 +12387,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1372
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12141,7 +12403,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12151,11 +12413,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1373
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12167,7 +12429,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12177,7 +12439,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12337,7 +12599,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12349,7 +12611,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12359,11 +12621,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12375,11 +12637,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1232
+      ID: 1234
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12391,7 +12653,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12401,7 +12663,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12460,7 +12722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12472,7 +12734,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12482,7 +12744,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12492,7 +12754,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12502,7 +12764,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12512,7 +12774,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12522,7 +12784,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12532,7 +12794,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12542,7 +12804,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12552,7 +12814,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12562,7 +12824,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12572,7 +12834,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12582,7 +12844,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12592,7 +12854,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12602,7 +12864,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12612,7 +12874,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12622,7 +12884,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12632,7 +12894,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12642,11 +12904,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12658,7 +12920,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13182,7 +13444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13194,7 +13456,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13204,11 +13466,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1342
+      ID: 1344
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13220,7 +13482,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13230,11 +13492,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13246,7 +13508,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13256,7 +13518,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13266,7 +13528,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13276,7 +13538,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13286,7 +13548,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13296,7 +13558,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13306,7 +13568,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13316,7 +13578,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13326,7 +13588,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13336,7 +13598,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13346,7 +13608,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13356,7 +13618,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13366,7 +13628,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13376,7 +13638,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13386,7 +13648,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13396,7 +13658,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13406,7 +13668,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13416,11 +13678,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13432,11 +13694,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13448,7 +13710,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13458,7 +13720,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13468,7 +13730,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13478,11 +13740,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13494,7 +13756,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13504,11 +13766,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13520,7 +13782,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13530,7 +13792,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13540,7 +13802,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13550,11 +13812,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13566,11 +13828,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13582,7 +13844,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13592,11 +13854,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13608,7 +13870,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13618,7 +13880,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13628,7 +13890,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13638,23 +13900,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1261
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13670,7 +13916,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13686,11 +13932,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1267
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13702,7 +13964,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13712,11 +13974,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13728,7 +13990,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13738,7 +14000,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13748,7 +14010,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13758,7 +14020,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13768,7 +14030,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13778,33 +14040,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1262
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13820,7 +14056,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13830,7 +14066,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13846,7 +14082,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13856,11 +14092,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1227
+      ID: 1268
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1229
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -13872,7 +14134,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -13882,7 +14144,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -13892,7 +14154,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -13902,7 +14164,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -13912,7 +14174,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -13922,7 +14184,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -13932,7 +14194,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13942,7 +14204,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13952,7 +14214,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -13962,35 +14224,9 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1253
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1255
       Name: Probe[main.testNamedReturn]
@@ -14004,7 +14240,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14014,11 +14250,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1254
+      ID: 1257
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14030,11 +14292,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14046,7 +14308,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14056,11 +14318,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1355
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14072,7 +14334,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14082,11 +14344,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1356
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14098,7 +14360,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14108,10 +14370,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1357
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14123,7 +14385,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14133,7 +14395,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1237
+      ID: 1239
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14145,7 +14407,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14155,7 +14417,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14165,7 +14427,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14175,11 +14437,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14191,7 +14453,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14201,7 +14463,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14211,7 +14473,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14221,11 +14483,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14237,7 +14499,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14247,7 +14509,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14257,7 +14519,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14267,7 +14529,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14277,7 +14539,7 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14287,11 +14549,11 @@ Types:
             Type: 15 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14303,7 +14565,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14313,11 +14575,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14329,7 +14591,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14339,11 +14601,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1235
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14355,7 +14617,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14365,7 +14627,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14395,7 +14657,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1233
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14407,7 +14669,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14417,11 +14679,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1247
+      ID: 1249
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14433,7 +14695,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14443,7 +14705,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14453,7 +14715,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14463,11 +14725,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14479,7 +14741,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14489,446 +14751,12 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1249
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1250
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1279
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1280
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 247 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1281
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1282
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1277
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1278
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 246 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1285
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1286
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1297
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1298
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1273
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1274
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 89 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 90 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1245
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1246
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1244
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1241
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 93 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1239
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1240
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1251
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -14954,6 +14782,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1252
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1282
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1284
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1287
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1288
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1300
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1275
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1276
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 89 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1247
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1245
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1246
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1243
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1244
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 93 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1241
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1242
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1254
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14965,14 +15227,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14984,14 +15246,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15003,7 +15265,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15013,7 +15275,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15023,7 +15285,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15033,7 +15295,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15043,7 +15305,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15053,7 +15315,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15063,7 +15325,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15073,7 +15335,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15083,7 +15345,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15093,7 +15355,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15103,7 +15365,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15113,7 +15375,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15123,7 +15385,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15133,7 +15395,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15143,7 +15405,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15153,7 +15415,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15163,14 +15425,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15182,14 +15444,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15201,7 +15463,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15211,7 +15473,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15221,7 +15483,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15231,7 +15493,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15241,14 +15503,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15260,7 +15522,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15270,14 +15532,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15289,14 +15551,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15308,7 +15570,7 @@ Types:
             Type: 14 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15318,7 +15580,7 @@ Types:
             Type: 97 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15328,7 +15590,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15338,7 +15600,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15348,7 +15610,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15358,7 +15620,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15368,7 +15630,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15378,14 +15640,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15397,14 +15659,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15416,7 +15678,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15726,7 +15988,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15738,7 +16000,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15748,7 +16010,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -15882,7 +16144,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15894,7 +16156,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -15904,11 +16166,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15920,7 +16182,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -15930,7 +16192,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -15960,7 +16222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15972,7 +16234,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -15982,11 +16244,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15998,7 +16260,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16008,7 +16270,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16018,11 +16280,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16034,7 +16296,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16044,11 +16306,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16060,7 +16322,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16070,7 +16332,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16080,7 +16342,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16110,7 +16372,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1236
+      ID: 1238
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16122,7 +16384,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16132,11 +16394,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16148,7 +16410,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16158,7 +16420,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16214,7 +16476,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16226,7 +16488,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16236,7 +16498,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16246,7 +16508,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16256,7 +16518,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16286,7 +16548,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16298,7 +16560,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16308,11 +16570,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16324,7 +16586,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16334,11 +16596,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1349
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16350,7 +16612,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16360,14 +16622,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1348
+      ID: 1350
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1346
+      ID: 1348
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16379,7 +16641,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16389,7 +16651,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16419,7 +16681,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1351
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1353
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16431,7 +16709,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16441,14 +16719,17 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1350
+      ID: 1352
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1329
+      ID: 1354
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1331
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16460,7 +16741,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16470,7 +16751,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16480,7 +16761,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16490,7 +16771,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16500,7 +16781,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16510,11 +16791,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1347
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16526,7 +16807,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16536,7 +16817,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16546,7 +16827,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16556,7 +16837,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16566,7 +16847,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16576,11 +16857,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16592,7 +16873,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16602,11 +16883,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16618,7 +16899,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16631,7 +16912,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16644,14 +16925,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16663,7 +16944,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16673,11 +16954,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16689,7 +16970,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16699,7 +16980,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16709,17 +16990,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1335
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1333
+      ID: 1339
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1335
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16731,7 +17012,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16741,7 +17022,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16751,7 +17032,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16761,7 +17042,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16771,7 +17052,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -16781,7 +17062,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16941,7 +17222,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1237
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16953,7 +17234,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -16963,11 +17244,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16979,7 +17260,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16989,11 +17270,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1343
+      ID: 1345
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17005,7 +17286,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17015,11 +17296,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1234
+      ID: 1236
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17031,7 +17312,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17041,7 +17322,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17071,7 +17352,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17083,7 +17364,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17093,11 +17374,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17109,7 +17390,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17119,11 +17400,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17135,7 +17416,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17145,7 +17426,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17155,7 +17436,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17165,11 +17446,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17181,7 +17462,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17191,7 +17472,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24244,7 +24525,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952224
       GoKind: 5
-MaxTypeID: 1370
+MaxTypeID: 1376
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x175d760", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.stackC]
+          Type: 1507 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcdb96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.stackC]Return
+          Type: 1508 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcdb9a5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcda3ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda462", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testAtomicAdd]
+          Type: 1405 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xcd8800", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1404 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xcd8812", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1526 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1527 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xcd592e"
+              Frameless: false
+            - PC: "0xcd59b1"
+              Frameless: false
+            - PC: "0xcd5af2"
+              Frameless: false
+            - PC: "0xcd5b7c"
+              Frameless: false
+            - PC: "0xcd5c4f"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xcd592e"
+              Frameless: false
+            - PC: "0xcd59b1"
+              Frameless: false
+            - PC: "0xcd5af2"
+              Frameless: false
+            - PC: "0xcd5b7c"
+              Frameless: false
+            - PC: "0xcd5c4f"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1402 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1403 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcd8460", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testChannel]
+          Type: 1407 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcd8820", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testCycle]
+          Type: 1415 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcd8c00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testEmptySlice]
+          Type: 1495 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdb480", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdb4e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testEmptyString]
+          Type: 1521 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcdbaa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testEmptyStruct]
+          Type: 1534 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xcdbf20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xcdbf40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedBBB]
+          Type: 1541 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcd5bc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testInlinedBCA]
+          Type: 1542 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcd5cd3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedBCB]
+          Type: 1544 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1539 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcd5d86", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd3c41"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testInlinedPrint]
+          Type: 1538 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcd592a"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcd596a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcd592e"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testInlinedSq]
+          Type: 1546 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1541 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcd5de1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcd5e25"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcda20e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcda373", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testLinkedList]
+          Type: 1409 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcd8a20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcda6d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcda8e2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testMassiveString]
+          Type: 1518 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testMassiveString]
+          Type: 1519 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcdba60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcda973", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdabab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdacee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdadbe", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcda48e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcda6aa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcd85e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNamedReturn]
+          Type: 1430 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          Type: 1432 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcd978a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcd97f5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testNestedPointer]
+          Type: 1530 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testNestedPointer]
+          Type: 1531 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testNestedPointer]
+          Type: 1532 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testNestedPointer]
+          Type: 1533 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcdbea0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testNilPointer]
+          Type: 1414 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcd8bc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testNilSlice]
+          Type: 1502 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdb560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdb500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdb540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcdba40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerLoop]
+          Type: 1410 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcd8a40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcd8a00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAny]
+          Type: 1426 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcd942e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcd94e4"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcd92ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcd9324"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsArray]
+          Type: 1454 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcd9caa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcd9d0d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcd9d2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcd9d6b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcd9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcd9dc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcd9e6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcd9eea", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcda1aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcda1f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsComplex]
+          Type: 1450 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcd9b6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcd9bc6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsError]
+          Type: 1422 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcd926a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsError]Return
+          Type: 1423 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcd929a"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testReturnsInt]
+          Type: 1416 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcd906a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1415 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcd90bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcd918e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcd9244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcd90ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcd9154", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsInterface]
+          Type: 1428 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcd962e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcd970f"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcd9bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcd9c73", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcd9a6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcd9b47", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsMixed]
+          Type: 1466 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcd9fca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcda02c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcd9dea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcd9e38", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcda12a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcda176", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcda0ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcda10e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcd99ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcd9a51", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcda04a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcda0ad", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcd9f0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcd9f94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testSingleString]
+          Type: 1509 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcdb9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdb5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdb4a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcd990e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcd99ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdac4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdacbc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testStringPointer]
+          Type: 1413 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcd8b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testStringSlice]
+          Type: 1500 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdb520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStruct]
+          Type: 1528 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcdbda0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStruct]Return
+          Type: 1529 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xcdbdc2", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testStructSlice]
+          Type: 1497 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdb4c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdadee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdae9a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcdbc60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xcdbc7e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcdbc40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testSubslices]
+          Type: 1506 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcdb5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSubstrings]
+          Type: 1522 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xcdbac0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcd982e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcd98cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1508 EventRootType Probe[main.testThreeStrings]
+          Type: 1510 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcdb9e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcdba00", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xcdba1e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcdba20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testUintPointer]
+          Type: 1412 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcd8aa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testUintSlice]
+          Type: 1494 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdb460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testUnitializedString]
+          Type: 1520 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcdba80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testUnsafePointer]
+          Type: 1411 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcd8a60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdb580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xcd600a"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xcd6050", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdaece", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdaf4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5648,6 +5779,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0xcd8460..0xcd8461]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcd8460..0xcd8461
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcd8460..0xcd8461
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 17 BaseType float32
+          Locations:
+            - Range: 0xcd8460..0xcd8461
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcd85e0..0xcd85e1]
       InlinePCRanges: []
@@ -5686,7 +5844,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0xcd8800..0xcd8813]
       InlinePCRanges: []
@@ -5705,7 +5863,7 @@ Subprograms:
             - Range: 0xcd8812..0xcd8813
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0xcd8820..0xcd8821]
       InlinePCRanges: []
@@ -5716,7 +5874,7 @@ Subprograms:
             - Range: 0xcd8820..0xcd8821
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcd8a00..0xcd8a01]
       InlinePCRanges: []
@@ -5727,7 +5885,7 @@ Subprograms:
             - Range: 0xcd8a00..0xcd8a01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcd8a20..0xcd8a21]
       InlinePCRanges: []
@@ -5742,7 +5900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcd8a40..0xcd8a41]
       InlinePCRanges: []
@@ -5753,7 +5911,7 @@ Subprograms:
             - Range: 0xcd8a40..0xcd8a41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcd8a60..0xcd8a61]
       InlinePCRanges: []
@@ -5764,7 +5922,7 @@ Subprograms:
             - Range: 0xcd8a60..0xcd8a61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcd8aa0..0xcd8aa1]
       InlinePCRanges: []
@@ -5775,7 +5933,7 @@ Subprograms:
             - Range: 0xcd8aa0..0xcd8aa1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcd8b80..0xcd8b81]
       InlinePCRanges: []
@@ -5786,7 +5944,7 @@ Subprograms:
             - Range: 0xcd8b80..0xcd8b81
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcd8bc0..0xcd8bc1]
       InlinePCRanges: []
@@ -5803,7 +5961,7 @@ Subprograms:
             - Range: 0xcd8bc0..0xcd8bc1
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0xcd8c00..0xcd8c01]
       InlinePCRanges: []
@@ -5814,7 +5972,7 @@ Subprograms:
             - Range: 0xcd8c00..0xcd8c01
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xcd9060..0xcd90d2]
       InlinePCRanges: []
@@ -5843,7 +6001,7 @@ Subprograms:
             - Range: 0xcd9085..0xcd90d2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcd90e0..0xcd916f]
       InlinePCRanges: []
@@ -5874,7 +6032,7 @@ Subprograms:
             - Range: 0xcd9119..0xcd916f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcd9180..0xcd925e]
       InlinePCRanges: []
@@ -5915,7 +6073,7 @@ Subprograms:
             - Range: 0xcd91e7..0xcd925e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcd9260..0xcd92bb]
       InlinePCRanges: []
@@ -5948,7 +6106,7 @@ Subprograms:
             - Range: 0xcd92a6..0xcd92bb
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xcd92c0..0xcd9406]
       InlinePCRanges: []
@@ -6075,7 +6233,7 @@ Subprograms:
             - Range: 0xcd930b..0xcd9311
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xcd9420..0xcd9614]
       InlinePCRanges: []
@@ -6152,7 +6310,7 @@ Subprograms:
             - Range: 0xcd94c5..0xcd94e4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xcd9620..0xcd977d]
       InlinePCRanges: []
@@ -6245,7 +6403,7 @@ Subprograms:
             - Range: 0xcd9719..0xcd977d
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcd9780..0xcd980f]
       InlinePCRanges: []
@@ -6266,7 +6424,7 @@ Subprograms:
             - Range: 0xcd97f6..0xcd980f
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xcd9820..0xcd98e9]
       InlinePCRanges: []
@@ -6297,7 +6455,7 @@ Subprograms:
             - Range: 0xcd98d0..0xcd98e9
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xcd9900..0xcd99c5]
       InlinePCRanges: []
@@ -6340,7 +6498,7 @@ Subprograms:
             - Range: 0xcd99ac..0xcd99c5
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xcd99e0..0xcd9a5e]
       InlinePCRanges: []
@@ -6425,7 +6583,7 @@ Subprograms:
             - Range: 0xcd9a52..0xcd9a5e
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xcd9a60..0xcd9b57]
       InlinePCRanges: []
@@ -6510,7 +6668,7 @@ Subprograms:
             - Range: 0xcd9b48..0xcd9b57
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xcd9b60..0xcd9bd3]
       InlinePCRanges: []
@@ -6523,7 +6681,7 @@ Subprograms:
           Type: 95 BaseType complex128
           Locations: [{Range: 0xcd9b60..0xcd9bd3, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xcd9be0..0xcd9c85]
       InlinePCRanges: []
@@ -6538,7 +6696,7 @@ Subprograms:
             - Range: 0xcd9c74..0xcd9c85
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xcd9ca0..0xcd9d1a]
       InlinePCRanges: []
@@ -6553,7 +6711,7 @@ Subprograms:
             - Range: 0xcd9d0e..0xcd9d1a
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xcd9d20..0xcd9d78]
       InlinePCRanges: []
@@ -6568,7 +6726,7 @@ Subprograms:
             - Range: 0xcd9d6c..0xcd9d78
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xcd9d80..0xcd9dd3]
       InlinePCRanges: []
@@ -6583,7 +6741,7 @@ Subprograms:
             - Range: 0xcd9dc7..0xcd9dd3
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xcd9de0..0xcd9e47]
       InlinePCRanges: []
@@ -6592,7 +6750,7 @@ Subprograms:
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0xcd9de0..0xcd9e47, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xcd9e60..0xcd9efa]
       InlinePCRanges: []
@@ -6687,7 +6845,7 @@ Subprograms:
             - Range: 0xcd9eeb..0xcd9efa
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xcd9f00..0xcd9fa5]
       InlinePCRanges: []
@@ -6702,7 +6860,7 @@ Subprograms:
             - Range: 0xcd9f95..0xcd9fa5
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xcd9fc0..0xcda039]
       InlinePCRanges: []
@@ -6749,7 +6907,7 @@ Subprograms:
             - Range: 0xcda02d..0xcda039
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xcda040..0xcda0ba]
       InlinePCRanges: []
@@ -6764,7 +6922,7 @@ Subprograms:
             - Range: 0xcda0ae..0xcda0ba
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xcda0c0..0xcda11b]
       InlinePCRanges: []
@@ -6773,7 +6931,7 @@ Subprograms:
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda0c0..0xcda11b, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xcda120..0xcda187]
       InlinePCRanges: []
@@ -6786,7 +6944,7 @@ Subprograms:
           Type: 18 BaseType float64
           Locations: [{Range: 0xcda120..0xcda187, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xcda1a0..0xcda1fd]
       InlinePCRanges: []
@@ -6811,7 +6969,7 @@ Subprograms:
             - Range: 0xcda1f1..0xcda1fd
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xcda200..0xcda385]
       InlinePCRanges: []
@@ -6832,7 +6990,7 @@ Subprograms:
             - Range: 0xcda374..0xcda385
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xcda3a0..0xcda472]
       InlinePCRanges: []
@@ -6853,7 +7011,7 @@ Subprograms:
             - Range: 0xcda463..0xcda472
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xcda480..0xcda6ba]
       InlinePCRanges: []
@@ -6880,7 +7038,7 @@ Subprograms:
             - Range: 0xcda6ab..0xcda6ba
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xcda6c0..0xcda94f]
       InlinePCRanges: []
@@ -6967,7 +7125,7 @@ Subprograms:
             - Range: 0xcda8e3..0xcda94f
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xcda960..0xcdac2c]
       InlinePCRanges: []
@@ -7056,7 +7214,7 @@ Subprograms:
             - Range: 0xcdabac..0xcdac2c
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xcdac40..0xcdaccc]
       InlinePCRanges: []
@@ -7097,7 +7255,7 @@ Subprograms:
             - Range: 0xcdacbd..0xcdaccc
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xcdace0..0xcdadce]
       InlinePCRanges: []
@@ -7134,7 +7292,7 @@ Subprograms:
             - Range: 0xcdadbf..0xcdadce
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xcdade0..0xcdaeab]
       InlinePCRanges: []
@@ -7171,7 +7329,7 @@ Subprograms:
             - Range: 0xcdae66..0xcdaeab
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xcdaec0..0xcdaf66]
       InlinePCRanges: []
@@ -7212,7 +7370,7 @@ Subprograms:
             - Range: 0xcdaf4d..0xcdaf66
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdb460..0xcdb461]
       InlinePCRanges: []
@@ -7229,7 +7387,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdb480..0xcdb481]
       InlinePCRanges: []
@@ -7246,7 +7404,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdb4a0..0xcdb4a1]
       InlinePCRanges: []
@@ -7263,7 +7421,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdb4c0..0xcdb4c1]
       InlinePCRanges: []
@@ -7286,7 +7444,7 @@ Subprograms:
             - Range: 0xcdb4c0..0xcdb4c1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdb4e0..0xcdb4e1]
       InlinePCRanges: []
@@ -7309,7 +7467,7 @@ Subprograms:
             - Range: 0xcdb4e0..0xcdb4e1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdb500..0xcdb501]
       InlinePCRanges: []
@@ -7332,7 +7490,7 @@ Subprograms:
             - Range: 0xcdb500..0xcdb501
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcdb520..0xcdb521]
       InlinePCRanges: []
@@ -7349,7 +7507,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcdb540..0xcdb541]
       InlinePCRanges: []
@@ -7378,7 +7536,7 @@ Subprograms:
             - Range: 0xcdb540..0xcdb541
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdb560..0xcdb561]
       InlinePCRanges: []
@@ -7395,7 +7553,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdb580..0xcdb581]
       InlinePCRanges: []
@@ -7412,7 +7570,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xcdb5a0..0xcdb5a1]
       InlinePCRanges: []
@@ -7429,7 +7587,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0xcdb5c0..0xcdb5c1]
       InlinePCRanges: []
@@ -7470,7 +7628,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0xcdb960..0xcdb9b2]
       InlinePCRanges: []
@@ -7489,7 +7647,7 @@ Subprograms:
             - Range: 0xcdb9a6..0xcdb9b2
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0xcdb9c0..0xcdb9c1]
       InlinePCRanges: []
@@ -7504,7 +7662,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcdb9e0..0xcdb9e1]
       InlinePCRanges: []
@@ -7539,7 +7697,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xcdba00..0xcdba1f]
       InlinePCRanges: []
@@ -7562,7 +7720,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xcdba20..0xcdba21]
       InlinePCRanges: []
@@ -7573,7 +7731,7 @@ Subprograms:
             - Range: 0xcdba20..0xcdba21
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcdba40..0xcdba41]
       InlinePCRanges: []
@@ -7584,7 +7742,7 @@ Subprograms:
             - Range: 0xcdba40..0xcdba41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xcdba60..0xcdba61]
       InlinePCRanges: []
@@ -7599,7 +7757,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcdba80..0xcdba81]
       InlinePCRanges: []
@@ -7614,7 +7772,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xcdbaa0..0xcdbaa1]
       InlinePCRanges: []
@@ -7629,7 +7787,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0xcdbac0..0xcdbac1]
       InlinePCRanges: []
@@ -7664,7 +7822,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xcdbc40..0xcdbc41]
       InlinePCRanges: []
@@ -7675,7 +7833,7 @@ Subprograms:
             - Range: 0xcdbc40..0xcdbc41
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xcdbc60..0xcdbc7f]
       InlinePCRanges: []
@@ -7698,7 +7856,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0xcdbda0..0xcdbdc3]
       InlinePCRanges: []
@@ -7723,7 +7881,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0xcdbea0..0xcdbea1]
       InlinePCRanges: []
@@ -7734,7 +7892,7 @@ Subprograms:
             - Range: 0xcdbea0..0xcdbea1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xcdbf20..0xcdbf21]
       InlinePCRanges: []
@@ -7743,7 +7901,7 @@ Subprograms:
           Type: 317 StructureType main.emptyStruct
           Locations: [{Range: 0xcdbf20..0xcdbf21, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xcdbf40..0xcdbf41]
       InlinePCRanges: []
@@ -7754,7 +7912,7 @@ Subprograms:
             - Range: 0xcdbf40..0xcdbf41
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcd5920..0xcd5982]
       InlinePCRanges:
@@ -7783,28 +7941,28 @@ Subprograms:
             - Range: 0xcd5c40..0xcd5c5a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5bc6..0xcd5bfe]
           RootRanges: [0xcd5b60..0xcd5c25]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5cd3..0xcd5d11]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcd5d86..0xcd5dbe]
           RootRanges: [0xcd5cc0..0xcd5dce]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7817,7 +7975,7 @@ Subprograms:
             - Range: 0xcd5de0..0xcd5de5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7834,7 +7992,7 @@ Subprograms:
             - Range: 0xcd5eac..0xcd5fe5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcd6000..0xcd6071]
       InlinePCRanges:
@@ -7871,7 +8029,7 @@ Subprograms:
             - Range: 0xcd6051..0xcd6071
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11138,10 +11296,10 @@ Types:
       GoKind: 22
       Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1545
+      ID: 1551
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1549
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11153,11 +11311,11 @@ Types:
             Type: 319 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1544
+      ID: 1550
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11169,14 +11327,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11188,7 +11346,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11276,7 +11434,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11288,7 +11446,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11298,11 +11456,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11314,7 +11472,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11474,7 +11632,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1403
+      ID: 1405
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11486,7 +11644,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11496,11 +11654,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1406
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11512,7 +11670,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11597,7 +11755,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1405
+      ID: 1407
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11609,7 +11767,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11619,7 +11777,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11689,7 +11847,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1413
+      ID: 1402
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11701,7 +11921,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11711,7 +11931,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11871,7 +12091,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11883,7 +12103,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11893,7 +12113,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11903,7 +12123,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11913,11 +12133,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11929,7 +12149,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11939,11 +12159,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11955,7 +12175,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11965,11 +12185,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1535
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11981,7 +12201,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11991,11 +12211,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1534
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12007,7 +12227,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12017,7 +12237,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12283,7 +12503,7 @@ Types:
       ID: 1362
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1535
+      ID: 1541
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1359
@@ -12335,16 +12555,16 @@ Types:
       ID: 1360
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1536
+      ID: 1542
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1537
+      ID: 1543
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1538
+      ID: 1544
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1539
+      ID: 1545
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1363
@@ -12353,7 +12573,7 @@ Types:
       ID: 1364
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1532
+      ID: 1538
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12365,7 +12585,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12375,11 +12595,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1537
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1540
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12391,7 +12653,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12401,14 +12663,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1539
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1540
+      ID: 1546
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12420,7 +12682,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12430,11 +12692,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1547
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12446,7 +12708,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12456,11 +12718,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1548
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12472,7 +12734,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12482,7 +12744,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12642,7 +12904,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12654,7 +12916,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12664,11 +12926,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12680,11 +12942,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1407
+      ID: 1409
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12696,7 +12958,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12706,7 +12968,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12765,7 +13027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12777,7 +13039,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12787,7 +13049,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12797,7 +13059,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12807,7 +13069,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12817,7 +13079,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12827,7 +13089,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12837,7 +13099,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12847,7 +13109,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12857,7 +13119,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12867,7 +13129,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12877,7 +13139,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12887,7 +13149,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12897,7 +13159,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12907,7 +13169,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12917,7 +13179,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12927,7 +13189,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12937,7 +13199,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12947,11 +13209,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12963,7 +13225,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13487,7 +13749,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13499,7 +13761,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13509,11 +13771,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13525,7 +13787,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13535,11 +13797,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13551,7 +13813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13561,7 +13823,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13571,7 +13833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13581,7 +13843,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13591,7 +13853,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13601,7 +13863,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13611,7 +13873,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13621,7 +13883,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13631,7 +13893,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13641,7 +13903,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13651,7 +13913,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13661,7 +13923,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13671,7 +13933,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13681,7 +13943,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13691,7 +13953,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13701,7 +13963,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13711,7 +13973,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13721,11 +13983,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13737,11 +13999,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13753,7 +14015,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13763,7 +14025,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13773,7 +14035,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13783,11 +14045,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13799,7 +14061,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13809,11 +14071,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13825,7 +14087,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13835,7 +14097,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13845,7 +14107,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13855,11 +14117,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13871,11 +14133,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13887,7 +14149,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13897,11 +14159,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13913,7 +14175,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13923,7 +14185,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13933,7 +14195,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13943,23 +14205,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13975,7 +14221,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13991,11 +14237,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1442
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14007,7 +14269,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14017,11 +14279,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14033,7 +14295,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14043,7 +14305,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14053,7 +14315,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14063,7 +14325,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14073,7 +14335,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14083,33 +14345,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14125,7 +14361,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14135,7 +14371,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14151,7 +14387,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14161,11 +14397,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1443
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1404
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14177,7 +14439,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14187,7 +14449,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14197,7 +14459,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14207,7 +14469,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14217,7 +14479,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14227,7 +14489,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14237,7 +14499,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14247,7 +14509,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14257,7 +14519,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14267,35 +14529,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1428
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testNamedReturn]
@@ -14309,7 +14545,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14319,11 +14555,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1432
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14335,11 +14597,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14351,7 +14613,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14361,11 +14623,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1530
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14377,7 +14639,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14387,11 +14649,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1531
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14403,7 +14665,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14413,10 +14675,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1532
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1533
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14428,7 +14690,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14438,7 +14700,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1412
+      ID: 1414
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14450,7 +14712,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14460,7 +14722,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14470,7 +14732,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14480,11 +14742,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14496,7 +14758,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14506,7 +14768,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14516,7 +14778,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14526,11 +14788,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14542,7 +14804,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14552,7 +14814,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14562,7 +14824,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14572,7 +14834,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14582,7 +14844,7 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14592,11 +14854,11 @@ Types:
             Type: 16 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14608,7 +14870,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14618,11 +14880,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14634,7 +14896,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14644,11 +14906,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1410
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14660,7 +14922,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14670,7 +14932,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14700,7 +14962,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1408
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14712,7 +14974,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14722,11 +14984,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14738,7 +15000,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14748,7 +15010,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14758,7 +15020,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14768,11 +15030,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14784,7 +15046,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14794,446 +15056,12 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1424
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1425
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 250 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1457
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1452
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 249 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1460
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1461
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1448
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1449
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 94 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 95 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1420
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1421
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1418
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1419
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 98 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1414
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1415
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1426
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15259,6 +15087,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1427
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1459
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1420
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1421
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1418
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 98 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1416
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1417
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15270,14 +15532,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15289,14 +15551,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15308,7 +15570,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15318,7 +15580,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15328,7 +15590,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15338,7 +15600,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15348,7 +15610,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15358,7 +15620,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15368,7 +15630,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15378,7 +15640,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15388,7 +15650,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15398,7 +15660,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15408,7 +15670,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15418,7 +15680,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15428,7 +15690,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15438,7 +15700,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15448,7 +15710,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15458,7 +15720,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15468,14 +15730,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15487,14 +15749,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15506,7 +15768,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15516,7 +15778,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15526,7 +15788,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15536,7 +15798,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15546,14 +15808,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15565,7 +15827,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15575,14 +15837,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15594,14 +15856,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15613,7 +15875,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15623,7 +15885,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15633,7 +15895,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15643,7 +15905,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15653,7 +15915,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15663,7 +15925,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15673,7 +15935,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15683,14 +15945,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15702,14 +15964,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15721,7 +15983,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16031,7 +16293,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16043,7 +16305,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16053,7 +16315,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16187,7 +16449,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16199,7 +16461,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16209,11 +16471,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16225,7 +16487,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16235,7 +16497,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16265,7 +16527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16277,7 +16539,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16287,11 +16549,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16303,7 +16565,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16313,7 +16575,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16323,11 +16585,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16339,7 +16601,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16349,11 +16611,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16365,7 +16627,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16375,7 +16637,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16385,7 +16647,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16415,7 +16677,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1411
+      ID: 1413
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16427,7 +16689,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16437,11 +16699,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16453,7 +16715,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16463,7 +16725,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16519,7 +16781,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16531,7 +16793,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16541,7 +16803,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16551,7 +16813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16561,7 +16823,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16591,7 +16853,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16603,7 +16865,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16613,11 +16875,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16629,7 +16891,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16639,11 +16901,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16655,7 +16917,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16665,14 +16927,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16684,7 +16946,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16694,7 +16956,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16724,7 +16986,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1528
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16736,7 +17014,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16746,14 +17024,17 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1504
+      ID: 1529
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1506
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16765,7 +17046,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16775,7 +17056,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16785,7 +17066,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16795,7 +17076,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16805,7 +17086,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16815,11 +17096,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16831,7 +17112,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16841,7 +17122,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16851,7 +17132,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16861,7 +17142,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16871,7 +17152,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16881,11 +17162,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16897,7 +17178,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16907,11 +17188,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16923,7 +17204,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16936,7 +17217,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16949,14 +17230,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16968,7 +17249,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16978,11 +17259,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16994,7 +17275,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17004,7 +17285,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17014,17 +17295,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1510
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1508
+      ID: 1514
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1510
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17036,7 +17317,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17046,7 +17327,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17056,7 +17337,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17066,7 +17347,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17076,7 +17357,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17086,7 +17367,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17246,7 +17527,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1410
+      ID: 1412
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17258,7 +17539,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17268,11 +17549,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17284,7 +17565,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17294,11 +17575,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17310,7 +17591,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17320,11 +17601,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1409
+      ID: 1411
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17336,7 +17617,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17346,7 +17627,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17376,7 +17657,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17388,7 +17669,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17398,11 +17679,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17414,7 +17695,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17424,11 +17705,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17440,7 +17721,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17450,7 +17731,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17460,7 +17741,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17470,11 +17751,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17486,7 +17767,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17496,7 +17777,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26004,7 +26285,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 990432
       GoKind: 5
-MaxTypeID: 1545
+MaxTypeID: 1551
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x18013a0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.stackC]
+          Type: 1526 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xce018a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.stackC]Return
+          Type: 1527 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xce01c5", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xcdebee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdeca2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          Type: 1424 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xcdd080", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xcdd092", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1545 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1546 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xcda20e"
+              Frameless: false
+            - PC: "0xcda291"
+              Frameless: false
+            - PC: "0xcda3d2"
+              Frameless: false
+            - PC: "0xcda45c"
+              Frameless: false
+            - PC: "0xcda52f"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xcda20e"
+              Frameless: false
+            - PC: "0xcda291"
+              Frameless: false
+            - PC: "0xcda3d2"
+              Frameless: false
+            - PC: "0xcda45c"
+              Frameless: false
+            - PC: "0xcda52f"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1421 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xcdcce0", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testChannel]
+          Type: 1426 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xcdd0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testCycle]
+          Type: 1434 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xcdd460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          Type: 1514 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcdfca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcdfd00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
+          Type: 1540 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xce02c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          Type: 1553 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xce0740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xce0760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testInlinedBBB]
+          Type: 1560 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xcda4a6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBCA]
+          Type: 1561 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xcda5b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedBCB]
+          Type: 1563 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xcda65b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1564 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xcd8541"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xcda20a"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xcda24a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xcda20e"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1559 EventRootType Probe[main.testInlinedSq]
+          Type: 1565 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1560 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xcda6c1", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xcda705"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcdea4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdebb3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testLinkedList]
+          Type: 1428 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xcdd280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xcdef13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xcdf122", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
+          Type: 1537 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
+          Type: 1538 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xce0280", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xcdf1b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xcdf3eb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xcdf52e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xcdf5ff", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xcdecce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xcdeeea", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xcdce60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcddfca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcde035", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          Type: 1549 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          Type: 1550 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          Type: 1551 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          Type: 1552 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xce06c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testNilPointer]
+          Type: 1433 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xcdd420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testNilSlice]
+          Type: 1521 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcdfd80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcdfd20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcdfd60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xce0260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          Type: 1429 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xcdd2a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xcdd260", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          Type: 1445 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xcddc6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcddd15"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xcddb0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xcddb64"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          Type: 1473 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcde4ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcde54d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcde56a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcde5ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcde5ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcde606", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcde6ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xcde72a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcde9ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcdea30", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          Type: 1469 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcde3aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcde406", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsError]
+          Type: 1441 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xcddaaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xcddada"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          Type: 1435 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xcdd8aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xcdd8fb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xcdd9ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xcdda84", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xcdd92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xcdd994", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          Type: 1447 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcdde6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcddf3f"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcde42e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcde4b3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcde2ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcde387", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          Type: 1485 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xcde80a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xcde86c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcde62a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcde678", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xcde96a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xcde9b6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xcde90a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xcde94e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcde22a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcde291", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xcde88a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xcde8ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xcde74e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xcde7d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testSingleString]
+          Type: 1528 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xce01e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcdfdc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcdfcc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcde14e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcde1ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xcdf48a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xcdf4fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testStringPointer]
+          Type: 1432 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xcdd3e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testStringSlice]
+          Type: 1519 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcdfd40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
+          Type: 1547 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xce05c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStruct]Return
+          Type: 1548 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0xce05e2", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testStructSlice]
+          Type: 1516 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcdfce0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xcdf62e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xcdf6dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xce0480", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0xce049e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xce0460", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testSubslices]
+          Type: 1525 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcdfde0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
+          Type: 1541 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xce02e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcde06e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcde10f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          Type: 1529 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xce0200", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xce0220", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0xce023e", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xce0240", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testUintPointer]
+          Type: 1431 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xcdd300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testUintSlice]
+          Type: 1513 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcdfc80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          Type: 1539 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xce02a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          Type: 1430 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xcdd2c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcdfda0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xcda8ea"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xcda925", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xcdf70e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcdf78c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5648,6 +5779,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0xcdcce0..0xcdcce1]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xcdcce0..0xcdcce1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xcdcce0..0xcdcce1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 18 BaseType float32
+          Locations:
+            - Range: 0xcdcce0..0xcdcce1
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xcdce60..0xcdce61]
       InlinePCRanges: []
@@ -5686,7 +5844,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0xcdd080..0xcdd093]
       InlinePCRanges: []
@@ -5705,7 +5863,7 @@ Subprograms:
             - Range: 0xcdd092..0xcdd093
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0xcdd0a0..0xcdd0a1]
       InlinePCRanges: []
@@ -5716,7 +5874,7 @@ Subprograms:
             - Range: 0xcdd0a0..0xcdd0a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xcdd260..0xcdd261]
       InlinePCRanges: []
@@ -5727,7 +5885,7 @@ Subprograms:
             - Range: 0xcdd260..0xcdd261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xcdd280..0xcdd281]
       InlinePCRanges: []
@@ -5742,7 +5900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xcdd2a0..0xcdd2a1]
       InlinePCRanges: []
@@ -5753,7 +5911,7 @@ Subprograms:
             - Range: 0xcdd2a0..0xcdd2a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xcdd2c0..0xcdd2c1]
       InlinePCRanges: []
@@ -5764,7 +5922,7 @@ Subprograms:
             - Range: 0xcdd2c0..0xcdd2c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xcdd300..0xcdd301]
       InlinePCRanges: []
@@ -5775,7 +5933,7 @@ Subprograms:
             - Range: 0xcdd300..0xcdd301
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xcdd3e0..0xcdd3e1]
       InlinePCRanges: []
@@ -5786,7 +5944,7 @@ Subprograms:
             - Range: 0xcdd3e0..0xcdd3e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xcdd420..0xcdd421]
       InlinePCRanges: []
@@ -5803,7 +5961,7 @@ Subprograms:
             - Range: 0xcdd420..0xcdd421
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0xcdd460..0xcdd461]
       InlinePCRanges: []
@@ -5814,7 +5972,7 @@ Subprograms:
             - Range: 0xcdd460..0xcdd461
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xcdd8a0..0xcdd912]
       InlinePCRanges: []
@@ -5843,7 +6001,7 @@ Subprograms:
             - Range: 0xcdd8c5..0xcdd912
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xcdd920..0xcdd9af]
       InlinePCRanges: []
@@ -5874,7 +6032,7 @@ Subprograms:
             - Range: 0xcdd959..0xcdd9af
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xcdd9c0..0xcdda9e]
       InlinePCRanges: []
@@ -5915,7 +6073,7 @@ Subprograms:
             - Range: 0xcdda27..0xcdda9e
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xcddaa0..0xcddafb]
       InlinePCRanges: []
@@ -5948,7 +6106,7 @@ Subprograms:
             - Range: 0xcddae6..0xcddafb
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xcddb00..0xcddc46]
       InlinePCRanges: []
@@ -6075,7 +6233,7 @@ Subprograms:
             - Range: 0xcddb4b..0xcddb51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xcddc60..0xcdde4e]
       InlinePCRanges: []
@@ -6152,7 +6310,7 @@ Subprograms:
             - Range: 0xcddd45..0xcddd64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xcdde60..0xcddfb4]
       InlinePCRanges: []
@@ -6245,7 +6403,7 @@ Subprograms:
             - Range: 0xcddf49..0xcddfb4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcddfc0..0xcde04f]
       InlinePCRanges: []
@@ -6266,7 +6424,7 @@ Subprograms:
             - Range: 0xcde036..0xcde04f
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xcde060..0xcde129]
       InlinePCRanges: []
@@ -6297,7 +6455,7 @@ Subprograms:
             - Range: 0xcde110..0xcde129
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xcde140..0xcde207]
       InlinePCRanges: []
@@ -6340,7 +6498,7 @@ Subprograms:
             - Range: 0xcde1ee..0xcde207
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xcde220..0xcde29e]
       InlinePCRanges: []
@@ -6425,7 +6583,7 @@ Subprograms:
             - Range: 0xcde292..0xcde29e
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xcde2a0..0xcde397]
       InlinePCRanges: []
@@ -6510,7 +6668,7 @@ Subprograms:
             - Range: 0xcde388..0xcde397
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xcde3a0..0xcde413]
       InlinePCRanges: []
@@ -6523,7 +6681,7 @@ Subprograms:
           Type: 97 BaseType complex128
           Locations: [{Range: 0xcde3a0..0xcde413, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xcde420..0xcde4c5]
       InlinePCRanges: []
@@ -6538,7 +6696,7 @@ Subprograms:
             - Range: 0xcde4b4..0xcde4c5
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xcde4e0..0xcde55a]
       InlinePCRanges: []
@@ -6553,7 +6711,7 @@ Subprograms:
             - Range: 0xcde54e..0xcde55a
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xcde560..0xcde5b8]
       InlinePCRanges: []
@@ -6568,7 +6726,7 @@ Subprograms:
             - Range: 0xcde5ac..0xcde5b8
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xcde5c0..0xcde613]
       InlinePCRanges: []
@@ -6583,7 +6741,7 @@ Subprograms:
             - Range: 0xcde607..0xcde613
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xcde620..0xcde687]
       InlinePCRanges: []
@@ -6592,7 +6750,7 @@ Subprograms:
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0xcde620..0xcde687, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xcde6a0..0xcde73a]
       InlinePCRanges: []
@@ -6687,7 +6845,7 @@ Subprograms:
             - Range: 0xcde72b..0xcde73a
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xcde740..0xcde7e5]
       InlinePCRanges: []
@@ -6702,7 +6860,7 @@ Subprograms:
             - Range: 0xcde7d5..0xcde7e5
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xcde800..0xcde879]
       InlinePCRanges: []
@@ -6749,7 +6907,7 @@ Subprograms:
             - Range: 0xcde86d..0xcde879
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xcde880..0xcde8fa]
       InlinePCRanges: []
@@ -6764,7 +6922,7 @@ Subprograms:
             - Range: 0xcde8ee..0xcde8fa
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xcde900..0xcde95b]
       InlinePCRanges: []
@@ -6773,7 +6931,7 @@ Subprograms:
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde900..0xcde95b, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xcde960..0xcde9c7]
       InlinePCRanges: []
@@ -6786,7 +6944,7 @@ Subprograms:
           Type: 15 BaseType float64
           Locations: [{Range: 0xcde960..0xcde9c7, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xcde9e0..0xcdea3d]
       InlinePCRanges: []
@@ -6811,7 +6969,7 @@ Subprograms:
             - Range: 0xcdea31..0xcdea3d
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xcdea40..0xcdebc5]
       InlinePCRanges: []
@@ -6832,7 +6990,7 @@ Subprograms:
             - Range: 0xcdebb4..0xcdebc5
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xcdebe0..0xcdecb2]
       InlinePCRanges: []
@@ -6853,7 +7011,7 @@ Subprograms:
             - Range: 0xcdeca3..0xcdecb2
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xcdecc0..0xcdeefa]
       InlinePCRanges: []
@@ -6880,7 +7038,7 @@ Subprograms:
             - Range: 0xcdeeeb..0xcdeefa
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xcdef00..0xcdf18f]
       InlinePCRanges: []
@@ -6967,7 +7125,7 @@ Subprograms:
             - Range: 0xcdf123..0xcdf18f
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xcdf1a0..0xcdf46c]
       InlinePCRanges: []
@@ -7056,7 +7214,7 @@ Subprograms:
             - Range: 0xcdf3ec..0xcdf46c
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xcdf480..0xcdf50c]
       InlinePCRanges: []
@@ -7097,7 +7255,7 @@ Subprograms:
             - Range: 0xcdf4fd..0xcdf50c
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xcdf520..0xcdf60f]
       InlinePCRanges: []
@@ -7134,7 +7292,7 @@ Subprograms:
             - Range: 0xcdf600..0xcdf60f
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xcdf620..0xcdf6ec]
       InlinePCRanges: []
@@ -7171,7 +7329,7 @@ Subprograms:
             - Range: 0xcdf6a6..0xcdf6ec
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xcdf700..0xcdf7a6]
       InlinePCRanges: []
@@ -7212,7 +7370,7 @@ Subprograms:
             - Range: 0xcdf78d..0xcdf7a6
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcdfc80..0xcdfc81]
       InlinePCRanges: []
@@ -7229,7 +7387,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcdfca0..0xcdfca1]
       InlinePCRanges: []
@@ -7246,7 +7404,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcdfcc0..0xcdfcc1]
       InlinePCRanges: []
@@ -7263,7 +7421,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcdfce0..0xcdfce1]
       InlinePCRanges: []
@@ -7286,7 +7444,7 @@ Subprograms:
             - Range: 0xcdfce0..0xcdfce1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcdfd00..0xcdfd01]
       InlinePCRanges: []
@@ -7309,7 +7467,7 @@ Subprograms:
             - Range: 0xcdfd00..0xcdfd01
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcdfd20..0xcdfd21]
       InlinePCRanges: []
@@ -7332,7 +7490,7 @@ Subprograms:
             - Range: 0xcdfd20..0xcdfd21
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcdfd40..0xcdfd41]
       InlinePCRanges: []
@@ -7349,7 +7507,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcdfd60..0xcdfd61]
       InlinePCRanges: []
@@ -7378,7 +7536,7 @@ Subprograms:
             - Range: 0xcdfd60..0xcdfd61
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcdfd80..0xcdfd81]
       InlinePCRanges: []
@@ -7395,7 +7553,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcdfda0..0xcdfda1]
       InlinePCRanges: []
@@ -7412,7 +7570,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xcdfdc0..0xcdfdc1]
       InlinePCRanges: []
@@ -7429,7 +7587,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0xcdfde0..0xcdfde1]
       InlinePCRanges: []
@@ -7470,7 +7628,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0xce0180..0xce01d2]
       InlinePCRanges: []
@@ -7489,7 +7647,7 @@ Subprograms:
             - Range: 0xce01c6..0xce01d2
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0xce01e0..0xce01e1]
       InlinePCRanges: []
@@ -7504,7 +7662,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xce0200..0xce0201]
       InlinePCRanges: []
@@ -7539,7 +7697,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xce0220..0xce023f]
       InlinePCRanges: []
@@ -7562,7 +7720,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xce0240..0xce0241]
       InlinePCRanges: []
@@ -7573,7 +7731,7 @@ Subprograms:
             - Range: 0xce0240..0xce0241
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xce0260..0xce0261]
       InlinePCRanges: []
@@ -7584,7 +7742,7 @@ Subprograms:
             - Range: 0xce0260..0xce0261
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xce0280..0xce0281]
       InlinePCRanges: []
@@ -7599,7 +7757,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xce02a0..0xce02a1]
       InlinePCRanges: []
@@ -7614,7 +7772,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xce02c0..0xce02c1]
       InlinePCRanges: []
@@ -7629,7 +7787,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0xce02e0..0xce02e1]
       InlinePCRanges: []
@@ -7664,7 +7822,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xce0460..0xce0461]
       InlinePCRanges: []
@@ -7675,7 +7833,7 @@ Subprograms:
             - Range: 0xce0460..0xce0461
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xce0480..0xce049f]
       InlinePCRanges: []
@@ -7698,7 +7856,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0xce05c0..0xce05e3]
       InlinePCRanges: []
@@ -7723,7 +7881,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0xce06c0..0xce06c1]
       InlinePCRanges: []
@@ -7734,7 +7892,7 @@ Subprograms:
             - Range: 0xce06c0..0xce06c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xce0740..0xce0741]
       InlinePCRanges: []
@@ -7743,7 +7901,7 @@ Subprograms:
           Type: 319 StructureType main.emptyStruct
           Locations: [{Range: 0xce0740..0xce0741, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xce0760..0xce0761]
       InlinePCRanges: []
@@ -7754,7 +7912,7 @@ Subprograms:
             - Range: 0xce0760..0xce0761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xcda200..0xcda262]
       InlinePCRanges:
@@ -7783,28 +7941,28 @@ Subprograms:
             - Range: 0xcda520..0xcda53a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda4a6..0xcda4de]
           RootRanges: [0xcda440..0xcda505]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda5b3..0xcda5f1]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xcda65b..0xcda693]
           RootRanges: [0xcda5a0..0xcda6a5]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7817,7 +7975,7 @@ Subprograms:
             - Range: 0xcda6c0..0xcda6c5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7834,7 +7992,7 @@ Subprograms:
             - Range: 0xcda78c..0xcda8c5
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xcda8e0..0xcda946]
       InlinePCRanges:
@@ -7865,7 +8023,7 @@ Subprograms:
             - Range: 0xcda926..0xcda946
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11199,10 +11357,10 @@ Types:
       GoKind: 22
       Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1564
+      ID: 1570
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1568
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11214,11 +11372,11 @@ Types:
             Type: 321 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1563
+      ID: 1569
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11230,14 +11388,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11249,7 +11407,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11337,7 +11495,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11349,7 +11507,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11359,11 +11517,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11375,7 +11533,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11535,7 +11693,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11547,7 +11705,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11557,11 +11715,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11573,7 +11731,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11658,7 +11816,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11670,7 +11828,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11680,7 +11838,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11750,7 +11908,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1432
+      ID: 1421
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11762,7 +11982,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11772,7 +11992,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11932,7 +12152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11944,7 +12164,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11954,7 +12174,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11964,7 +12184,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11974,11 +12194,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11990,7 +12210,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12000,11 +12220,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12016,7 +12236,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12026,11 +12246,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1554
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12042,7 +12262,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12052,11 +12272,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1553
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12068,7 +12288,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12078,7 +12298,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12344,7 +12564,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1554
+      ID: 1560
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12396,16 +12616,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1561
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1556
+      ID: 1562
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1557
+      ID: 1563
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1564
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12414,7 +12634,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1551
+      ID: 1557
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12426,7 +12646,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12436,11 +12656,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1556
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1559
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12452,7 +12714,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12462,14 +12724,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1552
+      ID: 1558
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1559
+      ID: 1565
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12481,7 +12743,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12491,11 +12753,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1560
+      ID: 1566
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12507,7 +12769,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12517,11 +12779,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1567
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12533,7 +12795,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12543,7 +12805,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12703,7 +12965,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12715,7 +12977,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12725,11 +12987,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12741,11 +13003,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12757,7 +13019,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12767,7 +13029,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12826,7 +13088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12838,7 +13100,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12848,7 +13110,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12858,7 +13120,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12868,7 +13130,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12878,7 +13140,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12888,7 +13150,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12898,7 +13160,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12908,7 +13170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12918,7 +13180,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12928,7 +13190,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12938,7 +13200,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12948,7 +13210,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12958,7 +13220,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12968,7 +13230,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12978,7 +13240,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12988,7 +13250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12998,7 +13260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13008,11 +13270,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13024,7 +13286,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13548,7 +13810,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13560,7 +13822,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13570,11 +13832,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13586,7 +13848,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13596,11 +13858,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13612,7 +13874,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13622,7 +13884,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13632,7 +13894,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13642,7 +13904,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13652,7 +13914,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13662,7 +13924,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13672,7 +13934,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13682,7 +13944,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13692,7 +13954,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13702,7 +13964,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13712,7 +13974,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13722,7 +13984,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13732,7 +13994,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13742,7 +14004,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13752,7 +14014,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13762,7 +14024,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13772,7 +14034,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13782,11 +14044,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13798,11 +14060,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13814,7 +14076,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13824,7 +14086,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13834,7 +14096,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13844,11 +14106,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13860,7 +14122,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13870,11 +14132,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13886,7 +14148,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13896,7 +14158,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13906,7 +14168,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13916,11 +14178,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13932,11 +14194,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13948,7 +14210,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13958,11 +14220,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13974,7 +14236,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13984,7 +14246,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13994,7 +14256,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14004,23 +14266,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14036,7 +14282,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14052,11 +14298,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1461
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14068,7 +14330,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14078,11 +14340,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14094,7 +14356,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14104,7 +14366,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14114,7 +14376,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14124,7 +14386,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14134,7 +14396,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14144,33 +14406,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14186,7 +14422,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14196,7 +14432,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14212,7 +14448,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14222,11 +14458,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1462
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14238,7 +14500,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14248,7 +14510,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14258,7 +14520,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14268,7 +14530,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14278,7 +14540,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14288,7 +14550,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14298,7 +14560,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14308,7 +14570,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14318,7 +14580,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14328,35 +14590,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testNamedReturn]
@@ -14370,7 +14606,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14380,11 +14616,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1451
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14396,11 +14658,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14412,7 +14674,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14422,11 +14684,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1549
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14438,7 +14700,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14448,11 +14710,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1546
+      ID: 1550
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14464,7 +14726,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14474,10 +14736,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1551
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1552
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14489,7 +14751,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14499,7 +14761,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14511,7 +14773,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14521,7 +14783,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14531,7 +14793,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14541,11 +14803,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14557,7 +14819,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14567,7 +14829,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14577,7 +14839,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14587,11 +14849,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14603,7 +14865,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14613,7 +14875,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14623,7 +14885,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14633,7 +14895,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14643,7 +14905,7 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14653,11 +14915,11 @@ Types:
             Type: 17 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14669,7 +14931,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14679,11 +14941,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14695,7 +14957,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14705,11 +14967,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14721,7 +14983,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14731,7 +14993,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14761,7 +15023,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14773,7 +15035,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14783,11 +15045,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14799,7 +15061,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14809,7 +15071,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14819,7 +15081,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14829,11 +15091,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14845,7 +15107,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14855,446 +15117,12 @@ Types:
             Type: 13 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1443
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1444
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 252 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1475
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1476
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1479
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1480
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1491
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1492
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1467
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1468
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 96 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 97 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1439
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1440
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 15 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1445
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15320,6 +15148,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1446
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1478
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1494
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 15 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15331,14 +15593,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15350,14 +15612,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15369,7 +15631,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15379,7 +15641,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15389,7 +15651,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15399,7 +15661,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15409,7 +15671,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15419,7 +15681,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15429,7 +15691,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15439,7 +15701,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15449,7 +15711,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15459,7 +15721,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15469,7 +15731,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15479,7 +15741,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15489,7 +15751,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15499,7 +15761,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15509,7 +15771,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15519,7 +15781,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15529,14 +15791,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15548,14 +15810,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15567,7 +15829,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15577,7 +15839,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15587,7 +15849,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15597,7 +15859,7 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15607,14 +15869,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15626,7 +15888,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15636,14 +15898,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15655,14 +15917,14 @@ Types:
             Type: 15 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15674,7 +15936,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15684,7 +15946,7 @@ Types:
             Type: 104 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15694,7 +15956,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15704,7 +15966,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15714,7 +15976,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15724,7 +15986,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15734,7 +15996,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15744,14 +16006,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15763,14 +16025,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15782,7 +16044,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16092,7 +16354,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16104,7 +16366,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16114,7 +16376,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16248,7 +16510,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16260,7 +16522,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16270,11 +16532,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16286,7 +16548,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16296,7 +16558,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16326,7 +16588,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16338,7 +16600,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16348,11 +16610,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16364,7 +16626,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16374,7 +16636,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16384,11 +16646,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16400,7 +16662,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16410,11 +16672,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16426,7 +16688,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16436,7 +16698,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16446,7 +16708,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16476,7 +16738,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16488,7 +16750,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16498,11 +16760,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16514,7 +16776,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16524,7 +16786,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16580,7 +16842,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16592,7 +16854,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16602,7 +16864,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16612,7 +16874,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16622,7 +16884,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16652,7 +16914,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16664,7 +16926,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16674,11 +16936,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16690,7 +16952,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16700,11 +16962,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16716,7 +16978,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16726,14 +16988,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16745,7 +17007,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16755,7 +17017,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16785,7 +17047,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1547
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16797,7 +17075,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16807,14 +17085,17 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1548
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1525
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16826,7 +17107,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16836,7 +17117,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16846,7 +17127,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16856,7 +17137,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16866,7 +17147,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16876,11 +17157,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16892,7 +17173,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16902,7 +17183,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16912,7 +17193,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16922,7 +17203,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16932,7 +17213,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16942,11 +17223,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16958,7 +17239,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16968,11 +17249,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16984,7 +17265,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16997,7 +17278,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17010,14 +17291,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17029,7 +17310,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17039,11 +17320,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17055,7 +17336,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17065,7 +17346,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17075,17 +17356,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1529
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1527
+      ID: 1533
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1529
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17097,7 +17378,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17107,7 +17388,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17117,7 +17398,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17127,7 +17408,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17137,7 +17418,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17147,7 +17428,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17307,7 +17588,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17319,7 +17600,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17329,11 +17610,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17345,7 +17626,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17355,11 +17636,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17371,7 +17652,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17381,11 +17662,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17397,7 +17678,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17407,7 +17688,7 @@ Types:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17437,7 +17718,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17449,7 +17730,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17459,11 +17740,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17475,7 +17756,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17485,11 +17766,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17501,7 +17782,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17511,7 +17792,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17521,7 +17802,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17531,11 +17812,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17547,7 +17828,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17557,7 +17838,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26225,7 +26506,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994944
       GoKind: 5
-MaxTypeID: 1564
+MaxTypeID: 1570
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1805520", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.stackC]
+          Type: 1526 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0xcec4ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.stackC]Return
+          Type: 1527 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0xcec505", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0xceaeee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0xceafaa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          Type: 1424 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0xce9380", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0xce9392", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -306,6 +306,133 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1542 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0xcec900", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xce656e"
+              Frameless: false
+            - PC: "0xce65f1"
+              Frameless: false
+            - PC: "0xce6732"
+              Frameless: false
+            - PC: "0xce67bc"
+              Frameless: false
+            - PC: "0xce688f"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0xce656e"
+              Frameless: false
+            - PC: "0xce65f1"
+              Frameless: false
+            - PC: "0xce6732"
+              Frameless: false
+            - PC: "0xce67bc"
+              Frameless: false
+            - PC: "0xce688f"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1421 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0xce8fe0", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -314,10 +441,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testChannel]
+          Type: 1426 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0xce93a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -374,10 +501,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testCycle]
+          Type: 1434 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0xce9760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -521,10 +648,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          Type: 1514 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0xcec020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -547,10 +674,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0xcec080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -574,10 +701,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testEmptyString]
+          Type: 1538 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0xcec600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -595,10 +722,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testEmptyStruct]
+          Type: 1548 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0xceca40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -615,10 +742,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0xceca60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -866,10 +993,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testInlinedBBB]
+          Type: 1555 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0xce6806", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -904,10 +1031,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedBCA]
+          Type: 1556 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -924,10 +1051,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1552 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0xce6913", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -941,10 +1068,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedBCB]
+          Type: 1558 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -961,10 +1088,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0xce69bb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -978,10 +1105,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0xce4881"
               Frameless: true
@@ -1000,10 +1127,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testInlinedPrint]
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0xce656a"
               Frameless: false
@@ -1017,7 +1144,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0xce65aa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1038,10 +1165,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1549 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0xce656e"
               Frameless: false
@@ -1069,10 +1196,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedSq]
+          Type: 1560 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1093,10 +1220,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0xce6a21", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1115,10 +1242,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0xce6a6d"
               Frameless: false
@@ -1265,14 +1392,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0xcead6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0xceaecd", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1290,10 +1417,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testLinkedList]
+          Type: 1428 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0xce9580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1398,14 +1525,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0xceb213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0xceb442", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1889,10 +2016,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testMassiveString]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1911,10 +2038,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testMassiveString]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0xcec5c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1957,14 +2084,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0xceb4d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0xceb702", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2026,14 +2153,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0xceb84e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0xceb91d", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,14 +2187,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0xceafce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0xceb1eb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,14 +2216,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2128,10 +2255,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0xce9160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2168,14 +2295,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,14 +2325,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0xcea2ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0xcea33b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2229,10 +2356,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testNestedPointer]
+          Type: 1544 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2253,10 +2380,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testNestedPointer]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2283,10 +2410,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testNestedPointer]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2307,10 +2434,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0xcec9c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2333,10 +2460,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testNilPointer]
+          Type: 1433 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0xce9720", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2359,10 +2486,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testNilSlice]
+          Type: 1521 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0xcec100", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2385,10 +2512,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0xcec0a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2419,10 +2546,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0xcec0e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2450,10 +2577,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0xcec5a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,10 +2598,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          Type: 1429 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0xce95a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2513,10 +2640,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0xce9560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2534,14 +2661,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          Type: 1445 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0xce9f6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0xcea015"
               Frameless: false
@@ -2572,14 +2699,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0xce9e0e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0xce9e64"
               Frameless: false
@@ -2609,14 +2736,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          Type: 1473 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0xcea7ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0xcea84f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2629,14 +2756,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0xcea86a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0xcea8ab", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2649,14 +2776,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0xcea8ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0xcea906", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2669,14 +2796,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0xcea9ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0xceaa2a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2689,14 +2816,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0xcead0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0xcead50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2709,14 +2836,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          Type: 1469 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0xcea6aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0xcea706", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2730,14 +2857,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsError]
+          Type: 1441 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0xce9d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0xce9dc4"
               Frameless: false
@@ -2758,14 +2885,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          Type: 1435 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0xce9b8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0xce9bdb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2782,14 +2909,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0xce9cae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0xce9d65", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2806,14 +2933,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0xce9c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0xce9c74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2831,14 +2958,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          Type: 1447 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0xcea16e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0xcea23d"
               Frameless: false
@@ -2859,14 +2986,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0xcea72e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0xcea7c3", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2879,14 +3006,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0xcea5ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0xcea687", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2899,14 +3026,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          Type: 1485 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0xceab2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0xceab8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2919,14 +3046,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0xcea92a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0xcea978", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2939,14 +3066,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0xceac8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0xceacd6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2959,14 +3086,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0xceac2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0xceac6e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2979,14 +3106,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0xcea52a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0xcea591", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2999,14 +3126,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0xceabaa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0xceac0f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3019,14 +3146,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0xceaa4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0xceaaf2", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3074,14 +3201,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3350,10 +3477,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testSingleString]
+          Type: 1528 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0xcec520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3476,10 +3603,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0xcec140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3497,10 +3624,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0xcec040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3538,14 +3665,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0xcea44e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0xcea4ed", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3562,14 +3689,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0xceb7aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0xceb81e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3608,10 +3735,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testStringPointer]
+          Type: 1432 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0xce96e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3629,10 +3756,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testStringSlice]
+          Type: 1519 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0xcec0c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3692,10 +3819,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStruct]
+          Type: 1543 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0xcec900", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3718,10 +3845,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testStructSlice]
+          Type: 1516 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0xcec060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3764,14 +3891,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0xceb94e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0xceba04", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3789,10 +3916,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0xcec7c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,10 +3936,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0xcec7a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3866,10 +3993,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testSubslices]
+          Type: 1525 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0xcec160", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3905,10 +4032,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testSubstrings]
+          Type: 1539 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0xcec620", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3937,14 +4064,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3961,14 +4088,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3987,14 +4114,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0xcea36e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0xcea40f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4019,10 +4146,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          Type: 1529 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0xcec540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4050,10 +4177,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4079,10 +4206,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0xcec560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4110,10 +4237,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4139,10 +4266,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0xcec580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4296,10 +4423,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testUintPointer]
+          Type: 1431 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0xce9600", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4317,10 +4444,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testUintSlice]
+          Type: 1513 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0xcec000", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4338,10 +4465,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testUnitializedString]
+          Type: 1537 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0xcec5e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4359,10 +4486,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          Type: 1430 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0xce95c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4401,10 +4528,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4422,10 +4549,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0xcec120", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4569,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0xce6c4a"
               Frameless: false
@@ -4453,7 +4580,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1559 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0xce6c85", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4471,14 +4598,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0xceba2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0xcebaac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5630,6 +5757,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0xce8fe0..0xce8fe1]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0xce8fe0..0xce8fe1
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xce8fe0..0xce8fe1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 17 BaseType float32
+          Locations:
+            - Range: 0xce8fe0..0xce8fe1
+              Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0xce9160..0xce9161]
       InlinePCRanges: []
@@ -5668,7 +5822,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0xce9380..0xce9393]
       InlinePCRanges: []
@@ -5687,7 +5841,7 @@ Subprograms:
             - Range: 0xce9392..0xce9393
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0xce93a0..0xce93a1]
       InlinePCRanges: []
@@ -5698,7 +5852,7 @@ Subprograms:
             - Range: 0xce93a0..0xce93a1
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0xce9560..0xce9561]
       InlinePCRanges: []
@@ -5709,7 +5863,7 @@ Subprograms:
             - Range: 0xce9560..0xce9561
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0xce9580..0xce9581]
       InlinePCRanges: []
@@ -5724,7 +5878,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0xce95a0..0xce95a1]
       InlinePCRanges: []
@@ -5735,7 +5889,7 @@ Subprograms:
             - Range: 0xce95a0..0xce95a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0xce95c0..0xce95c1]
       InlinePCRanges: []
@@ -5746,7 +5900,7 @@ Subprograms:
             - Range: 0xce95c0..0xce95c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0xce9600..0xce9601]
       InlinePCRanges: []
@@ -5757,7 +5911,7 @@ Subprograms:
             - Range: 0xce9600..0xce9601
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0xce96e0..0xce96e1]
       InlinePCRanges: []
@@ -5768,7 +5922,7 @@ Subprograms:
             - Range: 0xce96e0..0xce96e1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0xce9720..0xce9721]
       InlinePCRanges: []
@@ -5785,7 +5939,7 @@ Subprograms:
             - Range: 0xce9720..0xce9721
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0xce9760..0xce9761]
       InlinePCRanges: []
@@ -5796,7 +5950,7 @@ Subprograms:
             - Range: 0xce9760..0xce9761
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0xce9b80..0xce9bf2]
       InlinePCRanges: []
@@ -5825,7 +5979,7 @@ Subprograms:
             - Range: 0xce9ba5..0xce9bf2
               Pieces: [{Size: 8, Op: {CfaOffset: -40}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0xce9c00..0xce9c8f]
       InlinePCRanges: []
@@ -5856,7 +6010,7 @@ Subprograms:
             - Range: 0xce9c39..0xce9c8f
               Pieces: [{Size: 8, Op: {CfaOffset: -24}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0xce9ca0..0xce9d7f]
       InlinePCRanges: []
@@ -5897,7 +6051,7 @@ Subprograms:
             - Range: 0xce9d08..0xce9d7f
               Pieces: [{Size: 8, Op: {CfaOffset: -72}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0xce9d80..0xce9de4]
       InlinePCRanges: []
@@ -5930,7 +6084,7 @@ Subprograms:
             - Range: 0xce9dcf..0xce9de4
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0xce9e00..0xce9f5c]
       InlinePCRanges: []
@@ -6057,7 +6211,7 @@ Subprograms:
             - Range: 0xce9e4b..0xce9e51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0xce9f60..0xcea15d]
       InlinePCRanges: []
@@ -6134,7 +6288,7 @@ Subprograms:
             - Range: 0xcea045..0xcea064
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0xcea160..0xcea2b4]
       InlinePCRanges: []
@@ -6227,7 +6381,7 @@ Subprograms:
             - Range: 0xcea247..0xcea2b4
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0xcea2c0..0xcea355]
       InlinePCRanges: []
@@ -6248,7 +6402,7 @@ Subprograms:
             - Range: 0xcea33c..0xcea355
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0xcea360..0xcea429]
       InlinePCRanges: []
@@ -6279,7 +6433,7 @@ Subprograms:
             - Range: 0xcea410..0xcea429
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0xcea440..0xcea507]
       InlinePCRanges: []
@@ -6322,7 +6476,7 @@ Subprograms:
             - Range: 0xcea4ee..0xcea507
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0xcea520..0xcea59e]
       InlinePCRanges: []
@@ -6407,7 +6561,7 @@ Subprograms:
             - Range: 0xcea592..0xcea59e
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0xcea5a0..0xcea697]
       InlinePCRanges: []
@@ -6492,7 +6646,7 @@ Subprograms:
             - Range: 0xcea688..0xcea697
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0xcea6a0..0xcea713]
       InlinePCRanges: []
@@ -6505,7 +6659,7 @@ Subprograms:
           Type: 18 BaseType complex128
           Locations: [{Range: 0xcea6a0..0xcea713, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0xcea720..0xcea7d3]
       InlinePCRanges: []
@@ -6520,7 +6674,7 @@ Subprograms:
             - Range: 0xcea7c4..0xcea7d3
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0xcea7e0..0xcea85c]
       InlinePCRanges: []
@@ -6535,7 +6689,7 @@ Subprograms:
             - Range: 0xcea850..0xcea85c
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0xcea860..0xcea8b8]
       InlinePCRanges: []
@@ -6550,7 +6704,7 @@ Subprograms:
             - Range: 0xcea8ac..0xcea8b8
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0xcea8c0..0xcea913]
       InlinePCRanges: []
@@ -6565,7 +6719,7 @@ Subprograms:
             - Range: 0xcea907..0xcea913
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0xcea920..0xcea987]
       InlinePCRanges: []
@@ -6574,7 +6728,7 @@ Subprograms:
           Type: 260 StructureType main.mixedStruct
           Locations: [{Range: 0xcea920..0xcea987, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0xcea9a0..0xceaa3a]
       InlinePCRanges: []
@@ -6669,7 +6823,7 @@ Subprograms:
             - Range: 0xceaa2b..0xceaa3a
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0xceaa40..0xceab05]
       InlinePCRanges: []
@@ -6684,7 +6838,7 @@ Subprograms:
             - Range: 0xceaaf3..0xceab05
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0xceab20..0xceab99]
       InlinePCRanges: []
@@ -6731,7 +6885,7 @@ Subprograms:
             - Range: 0xceab8d..0xceab99
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0xceaba0..0xceac1c]
       InlinePCRanges: []
@@ -6746,7 +6900,7 @@ Subprograms:
             - Range: 0xceac10..0xceac1c
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0xceac20..0xceac7b]
       InlinePCRanges: []
@@ -6755,7 +6909,7 @@ Subprograms:
           Type: 13 BaseType float64
           Locations: [{Range: 0xceac20..0xceac7b, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0xceac80..0xceace7]
       InlinePCRanges: []
@@ -6768,7 +6922,7 @@ Subprograms:
           Type: 13 BaseType float64
           Locations: [{Range: 0xceac80..0xceace7, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0xcead00..0xcead5d]
       InlinePCRanges: []
@@ -6793,7 +6947,7 @@ Subprograms:
             - Range: 0xcead51..0xcead5d
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0xcead60..0xceaedd]
       InlinePCRanges: []
@@ -6814,7 +6968,7 @@ Subprograms:
             - Range: 0xceaece..0xceaedd
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0xceaee0..0xceafba]
       InlinePCRanges: []
@@ -6835,7 +6989,7 @@ Subprograms:
             - Range: 0xceafab..0xceafba
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0xceafc0..0xceb1fb]
       InlinePCRanges: []
@@ -6862,7 +7016,7 @@ Subprograms:
             - Range: 0xceb1ec..0xceb1fb
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0xceb200..0xceb4af]
       InlinePCRanges: []
@@ -6949,7 +7103,7 @@ Subprograms:
             - Range: 0xceb443..0xceb4af
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0xceb4c0..0xceb785]
       InlinePCRanges: []
@@ -7038,7 +7192,7 @@ Subprograms:
             - Range: 0xceb703..0xceb785
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0xceb7a0..0xceb82e]
       InlinePCRanges: []
@@ -7079,7 +7233,7 @@ Subprograms:
             - Range: 0xceb81f..0xceb82e
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0xceb840..0xceb92d]
       InlinePCRanges: []
@@ -7116,7 +7270,7 @@ Subprograms:
             - Range: 0xceb91e..0xceb92d
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0xceb940..0xceba14]
       InlinePCRanges: []
@@ -7153,7 +7307,7 @@ Subprograms:
             - Range: 0xceb9ce..0xceba14
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0xceba20..0xcebac6]
       InlinePCRanges: []
@@ -7194,7 +7348,7 @@ Subprograms:
             - Range: 0xcebaad..0xcebac6
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0xcec000..0xcec001]
       InlinePCRanges: []
@@ -7211,7 +7365,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0xcec020..0xcec021]
       InlinePCRanges: []
@@ -7228,7 +7382,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0xcec040..0xcec041]
       InlinePCRanges: []
@@ -7245,7 +7399,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0xcec060..0xcec061]
       InlinePCRanges: []
@@ -7268,7 +7422,7 @@ Subprograms:
             - Range: 0xcec060..0xcec061
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0xcec080..0xcec081]
       InlinePCRanges: []
@@ -7291,7 +7445,7 @@ Subprograms:
             - Range: 0xcec080..0xcec081
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0xcec0a0..0xcec0a1]
       InlinePCRanges: []
@@ -7314,7 +7468,7 @@ Subprograms:
             - Range: 0xcec0a0..0xcec0a1
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0xcec0c0..0xcec0c1]
       InlinePCRanges: []
@@ -7331,7 +7485,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0xcec0e0..0xcec0e1]
       InlinePCRanges: []
@@ -7360,7 +7514,7 @@ Subprograms:
             - Range: 0xcec0e0..0xcec0e1
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0xcec100..0xcec101]
       InlinePCRanges: []
@@ -7377,7 +7531,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0xcec120..0xcec121]
       InlinePCRanges: []
@@ -7394,7 +7548,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0xcec140..0xcec141]
       InlinePCRanges: []
@@ -7411,7 +7565,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0xcec160..0xcec161]
       InlinePCRanges: []
@@ -7452,7 +7606,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 11, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0xcec4c0..0xcec512]
       InlinePCRanges: []
@@ -7471,7 +7625,7 @@ Subprograms:
             - Range: 0xcec506..0xcec512
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0xcec520..0xcec521]
       InlinePCRanges: []
@@ -7486,7 +7640,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0xcec540..0xcec541]
       InlinePCRanges: []
@@ -7521,7 +7675,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0xcec560..0xcec561]
       InlinePCRanges: []
@@ -7544,7 +7698,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0xcec580..0xcec581]
       InlinePCRanges: []
@@ -7555,7 +7709,7 @@ Subprograms:
             - Range: 0xcec580..0xcec581
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0xcec5a0..0xcec5a1]
       InlinePCRanges: []
@@ -7566,7 +7720,7 @@ Subprograms:
             - Range: 0xcec5a0..0xcec5a1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0xcec5c0..0xcec5c1]
       InlinePCRanges: []
@@ -7581,7 +7735,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0xcec5e0..0xcec5e1]
       InlinePCRanges: []
@@ -7596,7 +7750,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0xcec600..0xcec601]
       InlinePCRanges: []
@@ -7611,7 +7765,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0xcec620..0xcec621]
       InlinePCRanges: []
@@ -7646,7 +7800,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0xcec7a0..0xcec7a1]
       InlinePCRanges: []
@@ -7657,7 +7811,7 @@ Subprograms:
             - Range: 0xcec7a0..0xcec7a1
               Pieces: [{Size: 144, Op: {CfaOffset: 0}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0xcec7c0..0xcec7c1]
       InlinePCRanges: []
@@ -7680,7 +7834,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0xcec900..0xcec901]
       InlinePCRanges: []
@@ -7705,7 +7859,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 9, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0xcec9c0..0xcec9c1]
       InlinePCRanges: []
@@ -7716,7 +7870,7 @@ Subprograms:
             - Range: 0xcec9c0..0xcec9c1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0xceca40..0xceca41]
       InlinePCRanges: []
@@ -7725,7 +7879,7 @@ Subprograms:
           Type: 325 StructureType main.emptyStruct
           Locations: [{Range: 0xceca40..0xceca41, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0xceca60..0xceca61]
       InlinePCRanges: []
@@ -7736,7 +7890,7 @@ Subprograms:
             - Range: 0xceca60..0xceca61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0xce6560..0xce65c2]
       InlinePCRanges:
@@ -7765,28 +7919,28 @@ Subprograms:
             - Range: 0xce6880..0xce689a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6806..0xce683e]
           RootRanges: [0xce67a0..0xce6865]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce6913..0xce6951]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0xce69bb..0xce69f3]
           RootRanges: [0xce6900..0xce6a05]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7799,7 +7953,7 @@ Subprograms:
             - Range: 0xce6a20..0xce6a25
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -7816,7 +7970,7 @@ Subprograms:
             - Range: 0xce6ae7..0xce6c25
               Pieces: [{Size: 40, Op: {CfaOffset: -128}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0xce6c40..0xce6ca6]
       InlinePCRanges:
@@ -7847,7 +8001,7 @@ Subprograms:
             - Range: 0xce6c86..0xce6ca6
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11190,10 +11344,10 @@ Types:
       GoKind: 22
       Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1560
+      ID: 1565
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1563
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11205,11 +11359,11 @@ Types:
             Type: 327 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1559
+      ID: 1564
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11221,14 +11375,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11240,7 +11394,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11328,7 +11482,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11340,7 +11494,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11350,11 +11504,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11366,7 +11520,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11526,7 +11680,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11538,7 +11692,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11548,11 +11702,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11564,7 +11718,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11646,7 +11800,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11658,7 +11812,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11668,7 +11822,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11738,7 +11892,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1432
+      ID: 1421
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11750,7 +11966,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11760,7 +11976,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11920,7 +12136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11932,7 +12148,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11942,7 +12158,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11952,7 +12168,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11962,11 +12178,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11978,7 +12194,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11988,11 +12204,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12004,7 +12220,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12014,11 +12230,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1549
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12030,7 +12246,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12040,11 +12256,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1548
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12056,7 +12272,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12066,7 +12282,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12332,7 +12548,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1550
+      ID: 1555
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12384,16 +12600,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1551
+      ID: 1556
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1557
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1553
+      ID: 1558
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1559
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12402,7 +12618,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1547
+      ID: 1552
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12414,7 +12630,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12424,11 +12640,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1551
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12440,7 +12698,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12450,14 +12708,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1560
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12469,7 +12727,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12479,11 +12737,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1561
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12495,7 +12753,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12505,11 +12763,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1557
+      ID: 1562
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12521,7 +12779,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12531,7 +12789,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12691,7 +12949,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12703,7 +12961,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12713,11 +12971,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12729,11 +12987,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12745,7 +13003,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12755,7 +13013,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12834,7 +13092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12846,7 +13104,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12856,7 +13114,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12866,7 +13124,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12876,7 +13134,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12886,7 +13144,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12896,7 +13154,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12906,7 +13164,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12916,7 +13174,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12926,7 +13184,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12936,7 +13194,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12946,7 +13204,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12956,7 +13214,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12966,7 +13224,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12976,7 +13234,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12986,7 +13244,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12996,7 +13254,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13006,7 +13264,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13016,11 +13274,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13032,7 +13290,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13556,7 +13814,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13568,7 +13826,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13578,11 +13836,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13594,7 +13852,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13604,11 +13862,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13620,7 +13878,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13630,7 +13888,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13640,7 +13898,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13650,7 +13908,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13660,7 +13918,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13670,7 +13928,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13680,7 +13938,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13690,7 +13948,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13700,7 +13958,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13710,7 +13968,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13720,7 +13978,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13730,7 +13988,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13740,7 +13998,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13750,7 +14008,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13760,7 +14018,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13770,7 +14028,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13780,7 +14038,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13790,11 +14048,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13806,11 +14064,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13822,7 +14080,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13832,7 +14090,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13842,7 +14100,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13852,11 +14110,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13868,7 +14126,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13878,11 +14136,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13894,7 +14152,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13904,7 +14162,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13914,7 +14172,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13924,11 +14182,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13940,11 +14198,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13956,7 +14214,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13966,11 +14224,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13982,7 +14240,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13992,7 +14250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14002,7 +14260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14012,23 +14270,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14044,7 +14286,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14060,11 +14302,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1461
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14076,7 +14334,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14086,11 +14344,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14102,7 +14360,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14112,7 +14370,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14122,7 +14380,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14132,7 +14390,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14142,7 +14400,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14152,33 +14410,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14194,7 +14426,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14204,7 +14436,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14220,7 +14452,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14230,11 +14462,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1462
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14246,7 +14504,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14256,7 +14514,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14266,7 +14524,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14276,7 +14534,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14286,7 +14544,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14296,7 +14554,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14306,7 +14564,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14316,7 +14574,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14326,7 +14584,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14336,35 +14594,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testNamedReturn]
@@ -14378,7 +14610,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14388,11 +14620,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1451
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14404,11 +14662,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14420,7 +14678,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14430,11 +14688,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1544
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14446,7 +14704,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14456,11 +14714,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14472,7 +14730,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14482,10 +14740,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1546
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1547
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14497,7 +14755,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14507,7 +14765,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14519,7 +14777,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14529,7 +14787,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14539,7 +14797,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14549,11 +14807,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14565,7 +14823,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14575,7 +14833,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14585,7 +14843,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14595,11 +14853,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14611,7 +14869,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14621,7 +14879,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14631,7 +14889,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14641,7 +14899,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14651,7 +14909,7 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14661,11 +14919,11 @@ Types:
             Type: 14 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14677,7 +14935,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14687,11 +14945,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14703,7 +14961,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14713,11 +14971,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14729,7 +14987,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14739,7 +14997,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14769,7 +15027,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14781,7 +15039,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14791,11 +15049,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14807,7 +15065,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14817,7 +15075,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14827,7 +15085,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14837,11 +15095,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14853,7 +15111,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14863,446 +15121,12 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1443
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1444
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 258 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1475
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1476
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 257 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1479
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1480
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1491
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1492
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1467
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1468
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 102 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1439
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1440
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 13 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 104 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1445
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15328,6 +15152,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1446
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 258 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1478
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 257 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1494
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 102 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 13 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 104 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15339,14 +15597,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15358,14 +15616,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15377,7 +15635,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15387,7 +15645,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15397,7 +15655,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15407,7 +15665,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15417,7 +15675,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15427,7 +15685,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15437,7 +15695,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15447,7 +15705,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15457,7 +15715,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15467,7 +15725,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15477,7 +15735,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15487,7 +15745,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15497,7 +15755,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15507,7 +15765,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15517,7 +15775,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15527,7 +15785,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15537,14 +15795,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15556,14 +15814,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15575,7 +15833,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15585,7 +15843,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15595,7 +15853,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15605,7 +15863,7 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15615,14 +15873,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15634,7 +15892,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15644,14 +15902,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15663,14 +15921,14 @@ Types:
             Type: 13 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15682,7 +15940,7 @@ Types:
             Type: 20 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15692,7 +15950,7 @@ Types:
             Type: 109 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15702,7 +15960,7 @@ Types:
             Type: 10 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15712,7 +15970,7 @@ Types:
             Type: 12 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15722,7 +15980,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15732,7 +15990,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15742,7 +16000,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15752,14 +16010,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15771,14 +16029,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15790,7 +16048,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16100,7 +16358,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16112,7 +16370,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16122,7 +16380,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16256,7 +16514,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16268,7 +16526,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16278,11 +16536,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16294,7 +16552,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16304,7 +16562,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16334,7 +16592,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16346,7 +16604,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16356,11 +16614,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16372,7 +16630,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16382,7 +16640,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16392,11 +16650,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16408,7 +16666,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16418,11 +16676,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16434,7 +16692,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16444,7 +16702,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16454,7 +16712,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16484,7 +16742,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16496,7 +16754,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16506,11 +16764,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16522,7 +16780,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16532,7 +16790,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16588,7 +16846,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16600,7 +16858,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16610,7 +16868,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16620,7 +16878,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16630,7 +16888,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16660,7 +16918,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16672,7 +16930,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16682,11 +16940,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16698,7 +16956,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16708,11 +16966,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16724,7 +16982,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16734,11 +16992,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16750,7 +17008,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16760,7 +17018,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16790,7 +17048,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16802,7 +17076,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16812,11 +17086,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16828,7 +17102,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16838,7 +17112,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16848,7 +17122,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16858,7 +17132,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16868,7 +17142,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16878,11 +17152,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16894,7 +17168,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16904,7 +17178,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16914,7 +17188,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16924,7 +17198,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16934,7 +17208,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16944,11 +17218,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16960,7 +17234,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16970,11 +17244,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16986,7 +17260,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16999,7 +17273,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17012,14 +17286,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17031,7 +17305,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17041,11 +17315,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17057,7 +17331,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17067,7 +17341,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17077,11 +17351,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17093,7 +17367,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17103,7 +17377,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17113,7 +17387,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17123,7 +17397,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17133,7 +17407,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17143,7 +17417,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17303,7 +17577,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17315,7 +17589,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17325,11 +17599,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17341,7 +17615,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17351,11 +17625,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17367,7 +17641,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17377,11 +17651,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17393,7 +17667,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17403,7 +17677,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17433,7 +17707,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17445,7 +17719,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17455,11 +17729,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17471,7 +17745,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17481,11 +17755,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17497,7 +17771,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17507,7 +17781,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17517,7 +17791,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17527,11 +17801,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17543,7 +17817,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17553,7 +17827,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26215,7 +26489,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.004e+06
       GoKind: 5
-MaxTypeID: 1560
+MaxTypeID: 1565
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1853d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1330 EventRootType Probe[main.stackC]
+          Type: 1332 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x892908", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1331 EventRootType Probe[main.stackC]Return
+          Type: 1333 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x89293c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1301 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1303 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x89166c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1302 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1304 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x891704", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1228 EventRootType Probe[main.testAtomicAdd]
+          Type: 1230 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x88fb40", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1229 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1231 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x88fb7c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1351 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x892c60", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1352 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1361 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x88d608"
+              Frameless: false
+            - PC: "0x88d67c"
+              Frameless: false
+            - PC: "0x88d7c8"
+              Frameless: false
+            - PC: "0x88d844"
+              Frameless: false
+            - PC: "0x88d90c"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1362 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x88d608"
+              Frameless: false
+            - PC: "0x88d67c"
+              Frameless: false
+            - PC: "0x88d7c8"
+              Frameless: false
+            - PC: "0x88d844"
+              Frameless: false
+            - PC: "0x88d90c"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1227 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1228 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x88f8e0", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1230 EventRootType Probe[main.testChannel]
+          Type: 1232 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x88fb80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1238 EventRootType Probe[main.testCycle]
+          Type: 1240 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x88fe30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1318 EventRootType Probe[main.testEmptySlice]
+          Type: 1320 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x892530", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1321 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1323 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x892560", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1344 EventRootType Probe[main.testEmptyString]
+          Type: 1346 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x8929e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1355 EventRootType Probe[main.testEmptyStruct]
+          Type: 1359 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x892d60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1356 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1360 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x892d70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1360 EventRootType Probe[main.testInlinedBBB]
+          Type: 1366 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x88d888", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1361 EventRootType Probe[main.testInlinedBCA]
+          Type: 1367 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1362 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1368 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x88d98c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1363 EventRootType Probe[main.testInlinedBCB]
+          Type: 1369 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1364 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1370 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x88da40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1370 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1376 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x88bd84"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1357 EventRootType Probe[main.testInlinedPrint]
+          Type: 1363 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1358 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1364 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x88d640", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1359 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1365 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x88d608"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1365 EventRootType Probe[main.testInlinedSq]
+          Type: 1371 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1366 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1372 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x88da94", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1367 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1373 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x88dac4"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1299 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1301 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x891490", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1300 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1302 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x8915e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1232 EventRootType Probe[main.testLinkedList]
+          Type: 1234 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x88fd40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1305 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1307 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x89199c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1306 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1308 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x891b0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1341 EventRootType Probe[main.testMassiveString]
+          Type: 1343 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1342 EventRootType Probe[main.testMassiveString]
+          Type: 1344 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x8929c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1307 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1309 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x891b90", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1308 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1310 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x891d40", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1311 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1313 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x891e6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1312 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1314 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x891f10", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1303 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1305 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x891740", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1304 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1306 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x891910", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1257 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1258 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1227 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1229 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x88f9a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1253 EventRootType Probe[main.testNamedReturn]
+          Type: 1255 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1254 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1255 EventRootType Probe[main.testNamedReturn]
+          Type: 1257 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x8909b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1256 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1258 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x890a18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1351 EventRootType Probe[main.testNestedPointer]
+          Type: 1355 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1352 EventRootType Probe[main.testNestedPointer]
+          Type: 1356 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1353 EventRootType Probe[main.testNestedPointer]
+          Type: 1357 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1354 EventRootType Probe[main.testNestedPointer]
+          Type: 1358 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x892d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1237 EventRootType Probe[main.testNilPointer]
+          Type: 1239 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x88fe10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1325 EventRootType Probe[main.testNilSlice]
+          Type: 1327 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x8925a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1322 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1324 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x892570", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1324 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1326 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x892590", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1340 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1342 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x8929b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1233 EventRootType Probe[main.testPointerLoop]
+          Type: 1235 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x88fd50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1231 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1233 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x88fd30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1249 EventRootType Probe[main.testReturnsAny]
+          Type: 1251 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x890648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1250 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1252 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x8906e8"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1247 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1249 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x8904c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1248 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1250 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x890534"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1277 EventRootType Probe[main.testReturnsArray]
+          Type: 1279 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x890e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1278 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1280 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x890ef0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1279 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1281 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x890f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1280 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1282 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x890f64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1281 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1283 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x890f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1282 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1284 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x890fd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1285 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1287 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x891088", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1286 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1288 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x8910ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1297 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1299 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x891418", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1298 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1300 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x891458", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1273 EventRootType Probe[main.testReturnsComplex]
+          Type: 1275 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x890d48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1274 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1276 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x890d94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1245 EventRootType Probe[main.testReturnsError]
+          Type: 1247 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x890448", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1246 EventRootType Probe[main.testReturnsError]Return
+          Type: 1248 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x890478"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1239 EventRootType Probe[main.testReturnsInt]
+          Type: 1241 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x890258", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1240 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1242 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x89029c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1243 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1245 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x890378", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1244 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1246 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x890410", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1241 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1243 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x8902d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1242 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1244 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x89033c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1251 EventRootType Probe[main.testReturnsInterface]
+          Type: 1253 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x890848", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1252 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1254 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x890918"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1275 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1277 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x890dd0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1276 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1278 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x890e64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1271 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1273 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x890c88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1272 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1274 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x890d0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1289 EventRootType Probe[main.testReturnsMixed]
+          Type: 1291 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x891208", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1290 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1292 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x891260", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1283 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1285 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x891008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1284 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1286 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x891050", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1295 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1297 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x891398", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1296 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1298 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x8913dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1293 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1295 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x891328", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1294 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1296 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x891368", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1269 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1271 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x890bf8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1270 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1272 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x890c50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1291 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1293 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x89129c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1292 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1294 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x8912f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1287 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1289 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x891130", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1288 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1290 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x8911d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1259 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1260 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1332 EventRootType Probe[main.testSingleString]
+          Type: 1334 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x892960", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1328 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1330 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x8925c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1319 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1321 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x892540", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1267 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1269 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x890b28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1268 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1270 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x890bb4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1309 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1311 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x891dc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1310 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1312 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x891e2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1236 EventRootType Probe[main.testStringPointer]
+          Type: 1238 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x88fdf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1323 EventRootType Probe[main.testStringSlice]
+          Type: 1325 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x892580", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1349 EventRootType Probe[main.testStruct]
+          Type: 1353 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x892c60", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1350 EventRootType Probe[main.testStruct]Return
+          Type: 1354 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x892c7c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1320 EventRootType Probe[main.testStructSlice]
+          Type: 1322 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x892550", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1313 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1315 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x891f4c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1314 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1316 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x891fdc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1347 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1349 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x892b70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1348 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1350 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x892b88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1346 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1348 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x892b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1329 EventRootType Probe[main.testSubslices]
+          Type: 1331 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x8925d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1345 EventRootType Probe[main.testSubstrings]
+          Type: 1347 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x8929f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1261 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1262 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1263 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1264 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1265 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1267 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x890a58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1266 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1268 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x890ae4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1333 EventRootType Probe[main.testThreeStrings]
+          Type: 1335 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x892970", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1334 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1335 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1336 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1338 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x892980", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1337 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1339 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x892998", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1338 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1340 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1339 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1341 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x8929a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1235 EventRootType Probe[main.testUintPointer]
+          Type: 1237 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x88fd80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1317 EventRootType Probe[main.testUintSlice]
+          Type: 1319 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x892520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1343 EventRootType Probe[main.testUnitializedString]
+          Type: 1345 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x8929d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1234 EventRootType Probe[main.testUnsafePointer]
+          Type: 1236 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x88fd60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1326 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1328 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1327 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1329 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8925b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1368 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1374 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x88dc68"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1369 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1375 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x88dca0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1315 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1317 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x892018", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1316 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1318 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x892084", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5650,6 +5781,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x88f8e0..0x88f8f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x88f8e0..0x88f8f0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 11 GoStringHeaderType string
+          Locations:
+            - Range: 0x88f8e0..0x88f8f0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 16 BaseType float32
+          Locations:
+            - Range: 0x88f8e0..0x88f8f0
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x88f9a0..0x88f9b0]
       InlinePCRanges: []
@@ -5688,7 +5846,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0x88fb40..0x88fb80]
       InlinePCRanges: []
@@ -5709,7 +5867,7 @@ Subprograms:
             - Range: 0x88fb7d..0x88fb80
               Pieces: []
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0x88fb80..0x88fb90]
       InlinePCRanges: []
@@ -5720,7 +5878,7 @@ Subprograms:
             - Range: 0x88fb80..0x88fb90
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x88fd30..0x88fd40]
       InlinePCRanges: []
@@ -5731,7 +5889,7 @@ Subprograms:
             - Range: 0x88fd30..0x88fd40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x88fd40..0x88fd50]
       InlinePCRanges: []
@@ -5746,7 +5904,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x88fd50..0x88fd60]
       InlinePCRanges: []
@@ -5757,7 +5915,7 @@ Subprograms:
             - Range: 0x88fd50..0x88fd60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x88fd60..0x88fd70]
       InlinePCRanges: []
@@ -5768,7 +5926,7 @@ Subprograms:
             - Range: 0x88fd60..0x88fd70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x88fd80..0x88fd90]
       InlinePCRanges: []
@@ -5779,7 +5937,7 @@ Subprograms:
             - Range: 0x88fd80..0x88fd90
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x88fdf0..0x88fe00]
       InlinePCRanges: []
@@ -5790,7 +5948,7 @@ Subprograms:
             - Range: 0x88fdf0..0x88fe00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x88fe10..0x88fe20]
       InlinePCRanges: []
@@ -5807,7 +5965,7 @@ Subprograms:
             - Range: 0x88fe10..0x88fe20
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0x88fe30..0x88fe40]
       InlinePCRanges: []
@@ -5818,7 +5976,7 @@ Subprograms:
             - Range: 0x88fe30..0x88fe40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x890240..0x8902c0]
       InlinePCRanges: []
@@ -5847,7 +6005,7 @@ Subprograms:
             - Range: 0x890268..0x8902c0
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x8902c0..0x890360]
       InlinePCRanges: []
@@ -5878,7 +6036,7 @@ Subprograms:
             - Range: 0x890304..0x890360
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x890360..0x890430]
       InlinePCRanges: []
@@ -5919,7 +6077,7 @@ Subprograms:
             - Range: 0x8903bc..0x890430
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x890430..0x8904b0]
       InlinePCRanges: []
@@ -5952,7 +6110,7 @@ Subprograms:
             - Range: 0x89048d..0x8904b0
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x8904b0..0x890630]
       InlinePCRanges: []
@@ -6079,7 +6237,7 @@ Subprograms:
             - Range: 0x890564..0x89056c
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x890630..0x890830]
       InlinePCRanges: []
@@ -6156,7 +6314,7 @@ Subprograms:
             - Range: 0x8906cc..0x8906e8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x890830..0x8909a0]
       InlinePCRanges: []
@@ -6249,7 +6407,7 @@ Subprograms:
             - Range: 0x89092c..0x8909a0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x8909a0..0x890a40]
       InlinePCRanges: []
@@ -6270,7 +6428,7 @@ Subprograms:
             - Range: 0x890a19..0x890a40
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x890a40..0x890b10]
       InlinePCRanges: []
@@ -6301,7 +6459,7 @@ Subprograms:
             - Range: 0x890ae5..0x890b10
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x890b10..0x890be0]
       InlinePCRanges: []
@@ -6344,7 +6502,7 @@ Subprograms:
             - Range: 0x890bb5..0x890be0
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x890be0..0x890c70]
       InlinePCRanges: []
@@ -6429,7 +6587,7 @@ Subprograms:
             - Range: 0x890c51..0x890c70
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x890c70..0x890d30]
       InlinePCRanges: []
@@ -6508,7 +6666,7 @@ Subprograms:
             - Range: 0x890d0d..0x890d30
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x890d30..0x890db0]
       InlinePCRanges: []
@@ -6521,7 +6679,7 @@ Subprograms:
           Type: 91 BaseType complex128
           Locations: [{Range: 0x890d30..0x890db0, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x890db0..0x890e80]
       InlinePCRanges: []
@@ -6556,7 +6714,7 @@ Subprograms:
             - Range: 0x890e65..0x890e80
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x890e80..0x890f10]
       InlinePCRanges: []
@@ -6571,7 +6729,7 @@ Subprograms:
             - Range: 0x890ef1..0x890f10
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x890f10..0x890f80]
       InlinePCRanges: []
@@ -6586,7 +6744,7 @@ Subprograms:
             - Range: 0x890f65..0x890f80
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x890f80..0x890ff0]
       InlinePCRanges: []
@@ -6601,7 +6759,7 @@ Subprograms:
             - Range: 0x890fd1..0x890ff0
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x890ff0..0x891070]
       InlinePCRanges: []
@@ -6610,7 +6768,7 @@ Subprograms:
           Type: 249 StructureType main.mixedStruct
           Locations: [{Range: 0x890ff0..0x891070, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x891070..0x891110]
       InlinePCRanges: []
@@ -6709,7 +6867,7 @@ Subprograms:
             - Range: 0x8910ed..0x891110
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x891110..0x8911f0]
       InlinePCRanges: []
@@ -6746,7 +6904,7 @@ Subprograms:
             - Range: 0x8911d5..0x8911f0
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x8911f0..0x891280]
       InlinePCRanges: []
@@ -6793,7 +6951,7 @@ Subprograms:
             - Range: 0x891261..0x891280
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x891280..0x891310]
       InlinePCRanges: []
@@ -6808,7 +6966,7 @@ Subprograms:
             - Range: 0x8912f1..0x891310
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x891310..0x891380]
       InlinePCRanges: []
@@ -6817,7 +6975,7 @@ Subprograms:
           Type: 17 BaseType float64
           Locations: [{Range: 0x891310..0x891380, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x891380..0x891400]
       InlinePCRanges: []
@@ -6830,7 +6988,7 @@ Subprograms:
           Type: 17 BaseType float64
           Locations: [{Range: 0x891380..0x891400, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x891400..0x891470]
       InlinePCRanges: []
@@ -6855,7 +7013,7 @@ Subprograms:
             - Range: 0x891459..0x891470
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x891470..0x891650]
       InlinePCRanges: []
@@ -6960,7 +7118,7 @@ Subprograms:
             - Range: 0x8915e9..0x891650
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x891650..0x891720]
       InlinePCRanges: []
@@ -6981,7 +7139,7 @@ Subprograms:
             - Range: 0x891705..0x891720
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x891720..0x891980]
       InlinePCRanges: []
@@ -7092,7 +7250,7 @@ Subprograms:
             - Range: 0x891911..0x891980
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x891980..0x891b70]
       InlinePCRanges: []
@@ -7179,7 +7337,7 @@ Subprograms:
             - Range: 0x891b0d..0x891b70
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x891b70..0x891db0]
       InlinePCRanges: []
@@ -7294,7 +7452,7 @@ Subprograms:
             - Range: 0x891d41..0x891db0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x891db0..0x891e50]
       InlinePCRanges: []
@@ -7335,7 +7493,7 @@ Subprograms:
             - Range: 0x891e2d..0x891e50
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x891e50..0x891f30]
       InlinePCRanges: []
@@ -7372,7 +7530,7 @@ Subprograms:
             - Range: 0x891f11..0x891f30
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x891f30..0x892000]
       InlinePCRanges: []
@@ -7409,7 +7567,7 @@ Subprograms:
             - Range: 0x891fb0..0x892000
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x892000..0x8920b0]
       InlinePCRanges: []
@@ -7450,7 +7608,7 @@ Subprograms:
             - Range: 0x892085..0x8920b0
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x892520..0x892530]
       InlinePCRanges: []
@@ -7467,7 +7625,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x892530..0x892540]
       InlinePCRanges: []
@@ -7484,7 +7642,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x892540..0x892550]
       InlinePCRanges: []
@@ -7501,7 +7659,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x892550..0x892560]
       InlinePCRanges: []
@@ -7524,7 +7682,7 @@ Subprograms:
             - Range: 0x892550..0x892560
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x892560..0x892570]
       InlinePCRanges: []
@@ -7547,7 +7705,7 @@ Subprograms:
             - Range: 0x892560..0x892570
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x892570..0x892580]
       InlinePCRanges: []
@@ -7570,7 +7728,7 @@ Subprograms:
             - Range: 0x892570..0x892580
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x892580..0x892590]
       InlinePCRanges: []
@@ -7587,7 +7745,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x892590..0x8925a0]
       InlinePCRanges: []
@@ -7616,7 +7774,7 @@ Subprograms:
             - Range: 0x892590..0x8925a0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x8925a0..0x8925b0]
       InlinePCRanges: []
@@ -7633,7 +7791,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8925b0..0x8925c0]
       InlinePCRanges: []
@@ -7650,7 +7808,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x8925c0..0x8925d0]
       InlinePCRanges: []
@@ -7667,7 +7825,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0x8925d0..0x8925e0]
       InlinePCRanges: []
@@ -7708,7 +7866,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0x8928f0..0x892960]
       InlinePCRanges: []
@@ -7727,7 +7885,7 @@ Subprograms:
             - Range: 0x89293d..0x892960
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0x892960..0x892970]
       InlinePCRanges: []
@@ -7742,7 +7900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x892970..0x892980]
       InlinePCRanges: []
@@ -7777,7 +7935,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x892980..0x8929a0]
       InlinePCRanges: []
@@ -7800,7 +7958,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x8929a0..0x8929b0]
       InlinePCRanges: []
@@ -7811,7 +7969,7 @@ Subprograms:
             - Range: 0x8929a0..0x8929b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x8929b0..0x8929c0]
       InlinePCRanges: []
@@ -7822,7 +7980,7 @@ Subprograms:
             - Range: 0x8929b0..0x8929c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x8929c0..0x8929d0]
       InlinePCRanges: []
@@ -7837,7 +7995,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x8929d0..0x8929e0]
       InlinePCRanges: []
@@ -7852,7 +8010,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x8929e0..0x8929f0]
       InlinePCRanges: []
@@ -7867,7 +8025,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0x8929f0..0x892a00]
       InlinePCRanges: []
@@ -7902,7 +8060,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x892b60..0x892b70]
       InlinePCRanges: []
@@ -7913,7 +8071,7 @@ Subprograms:
             - Range: 0x892b60..0x892b70
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x892b70..0x892b90]
       InlinePCRanges: []
@@ -7936,7 +8094,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0x892c60..0x892c80]
       InlinePCRanges: []
@@ -7961,7 +8119,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0x892d00..0x892d10]
       InlinePCRanges: []
@@ -7972,7 +8130,7 @@ Subprograms:
             - Range: 0x892d00..0x892d10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x892d60..0x892d70]
       InlinePCRanges: []
@@ -7981,7 +8139,7 @@ Subprograms:
           Type: 314 StructureType main.emptyStruct
           Locations: [{Range: 0x892d60..0x892d70, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x892d70..0x892d80]
       InlinePCRanges: []
@@ -7992,7 +8150,7 @@ Subprograms:
             - Range: 0x892d70..0x892d80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x88d5f0..0x88d660]
       InlinePCRanges:
@@ -8021,28 +8179,28 @@ Subprograms:
             - Range: 0x88d8f0..0x88d914
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d888..0x88d8c0]
           RootRanges: [0x88d820..0x88d8f0]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88d98c..0x88d9d0]
           RootRanges: [0x88d970..0x88da90]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x88da40..0x88da78]
           RootRanges: [0x88d970..0x88da90]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8055,7 +8213,7 @@ Subprograms:
             - Range: 0x88da90..0x88da98
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8072,7 +8230,7 @@ Subprograms:
             - Range: 0x88db48..0x88dc50
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x88dc50..0x88dcd0]
       InlinePCRanges:
@@ -8109,7 +8267,7 @@ Subprograms:
             - Range: 0x88dca1..0x88dcd0
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11071,10 +11229,10 @@ Types:
       GoKind: 22
       Pointee: 674 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1370
+      ID: 1376
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1368
+      ID: 1374
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11086,11 +11244,11 @@ Types:
             Type: 316 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1369
+      ID: 1375
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11102,14 +11260,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1330
+      ID: 1332
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1331
+      ID: 1333
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11121,7 +11279,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11209,7 +11367,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1301
+      ID: 1303
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11221,7 +11379,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11231,11 +11389,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1302
+      ID: 1304
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11247,7 +11405,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11407,7 +11565,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1228
+      ID: 1230
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11419,7 +11577,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11429,11 +11587,11 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1229
+      ID: 1231
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11445,7 +11603,7 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11530,7 +11688,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1230
+      ID: 1232
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11542,7 +11700,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11552,7 +11710,7 @@ Types:
             Type: 238 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11622,7 +11780,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1238
+      ID: 1227
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1228
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1240
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11634,7 +11854,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11644,7 +11864,7 @@ Types:
             Type: 243 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11804,7 +12024,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1321
+      ID: 1323
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -11816,7 +12036,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -11826,7 +12046,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -11836,7 +12056,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -11846,11 +12066,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1318
+      ID: 1320
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11862,7 +12082,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -11872,11 +12092,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1344
+      ID: 1346
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -11888,7 +12108,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -11898,11 +12118,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1356
+      ID: 1360
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11914,7 +12134,7 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -11924,11 +12144,11 @@ Types:
             Type: 315 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1355
+      ID: 1359
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11940,7 +12160,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -11950,7 +12170,7 @@ Types:
             Type: 314 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12216,7 +12436,7 @@ Types:
       ID: 1187
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1360
+      ID: 1366
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1184
@@ -12268,16 +12488,16 @@ Types:
       ID: 1185
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1361
+      ID: 1367
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1362
+      ID: 1368
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1363
+      ID: 1369
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1364
+      ID: 1370
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1188
@@ -12286,7 +12506,7 @@ Types:
       ID: 1189
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1357
+      ID: 1363
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12298,7 +12518,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12308,11 +12528,53 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1359
+      ID: 1361
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1362
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1365
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12324,7 +12586,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12334,14 +12596,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1358
+      ID: 1364
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1365
+      ID: 1371
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12353,7 +12615,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12363,11 +12625,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1366
+      ID: 1372
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12379,7 +12641,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12389,11 +12651,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1367
+      ID: 1373
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12405,7 +12667,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12415,7 +12677,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12575,7 +12837,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1299
+      ID: 1301
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12587,7 +12849,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12597,11 +12859,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1300
+      ID: 1302
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12613,11 +12875,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1232
+      ID: 1234
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12629,7 +12891,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12639,7 +12901,7 @@ Types:
             Type: 241 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -12698,7 +12960,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1305
+      ID: 1307
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -12710,7 +12972,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12720,7 +12982,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12730,7 +12992,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -12740,7 +13002,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12750,7 +13012,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -12760,7 +13022,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12770,7 +13032,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -12780,7 +13042,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12790,7 +13052,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12800,7 +13062,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12810,7 +13072,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -12820,7 +13082,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12830,7 +13092,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -12840,7 +13102,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12850,7 +13112,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -12860,7 +13122,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12870,7 +13132,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -12880,11 +13142,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1306
+      ID: 1308
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12896,7 +13158,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13420,7 +13682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1341
+      ID: 1343
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13432,7 +13694,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13442,11 +13704,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1342
+      ID: 1344
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13458,7 +13720,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13468,11 +13730,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1307
+      ID: 1309
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13484,7 +13746,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13494,7 +13756,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13504,7 +13766,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13514,7 +13776,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13524,7 +13786,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13534,7 +13796,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13544,7 +13806,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13554,7 +13816,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13564,7 +13826,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13574,7 +13836,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13584,7 +13846,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13594,7 +13856,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13604,7 +13866,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13614,7 +13876,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13624,7 +13886,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13634,7 +13896,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13644,7 +13906,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13654,11 +13916,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1308
+      ID: 1310
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13670,11 +13932,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1311
+      ID: 1313
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13686,7 +13948,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13696,7 +13958,7 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -13706,7 +13968,7 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -13716,11 +13978,11 @@ Types:
             Type: 246 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1312
+      ID: 1314
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -13732,7 +13994,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -13742,11 +14004,11 @@ Types:
             Type: 106 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1303
+      ID: 1305
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -13758,7 +14020,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -13768,7 +14030,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13778,7 +14040,7 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -13788,11 +14050,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1304
+      ID: 1306
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13804,11 +14066,11 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1257
+      ID: 1259
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13820,7 +14082,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13830,11 +14092,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1259
+      ID: 1261
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13846,7 +14108,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13856,7 +14118,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13866,7 +14128,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13876,23 +14138,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1261
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13908,7 +14154,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -13924,11 +14170,27 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1258
+      ID: 1267
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1260
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13940,7 +14202,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13950,11 +14212,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1260
+      ID: 1262
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -13966,7 +14228,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13976,7 +14238,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -13986,7 +14248,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -13996,7 +14258,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14006,7 +14268,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14016,33 +14278,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1262
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14058,7 +14294,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14068,7 +14304,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14084,7 +14320,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14094,11 +14330,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1227
+      ID: 1268
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1229
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14110,7 +14372,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14120,7 +14382,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14130,7 +14392,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14140,7 +14402,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14150,7 +14412,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14160,7 +14422,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14170,7 +14432,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14180,7 +14442,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14190,7 +14452,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14200,35 +14462,9 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1253
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1255
       Name: Probe[main.testNamedReturn]
@@ -14242,7 +14478,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14252,11 +14488,37 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1254
+      ID: 1257
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1256
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14268,11 +14530,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1256
+      ID: 1258
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14284,7 +14546,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14294,11 +14556,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1351
+      ID: 1355
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14310,7 +14572,7 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14320,11 +14582,11 @@ Types:
             Type: 312 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1352
+      ID: 1356
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14336,7 +14598,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14346,10 +14608,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1353
+      ID: 1357
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1354
+      ID: 1358
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14361,7 +14623,7 @@ Types:
             Type: 116 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14371,7 +14633,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1237
+      ID: 1239
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14383,7 +14645,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14393,7 +14655,7 @@ Types:
             Type: 5 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14403,7 +14665,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14413,11 +14675,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1322
+      ID: 1324
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14429,7 +14691,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14439,7 +14701,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14449,7 +14711,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14459,11 +14721,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1324
+      ID: 1326
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14475,7 +14737,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14485,7 +14747,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14495,7 +14757,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14505,7 +14767,7 @@ Types:
             Type: 259 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14515,7 +14777,7 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14525,11 +14787,11 @@ Types:
             Type: 12 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1325
+      ID: 1327
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14541,7 +14803,7 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14551,11 +14813,11 @@ Types:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1340
+      ID: 1342
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14567,7 +14829,7 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14577,11 +14839,11 @@ Types:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1233
+      ID: 1235
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14593,7 +14855,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14603,7 +14865,7 @@ Types:
             Type: 242 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14633,7 +14895,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1231
+      ID: 1233
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14645,7 +14907,7 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14655,11 +14917,11 @@ Types:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1247
+      ID: 1249
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14671,7 +14933,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14681,7 +14943,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14691,7 +14953,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -14701,11 +14963,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1248
+      ID: 1250
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14717,7 +14979,7 @@ Types:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -14727,446 +14989,12 @@ Types:
             Type: 18 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1249
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1250
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1279
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1280
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 247 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1281
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1282
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1277
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1278
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 246 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1285
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1286
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1297
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1298
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1273
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1274
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 90 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 91 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1245
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1246
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1243
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1244
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 17 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1241
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1242
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 94 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1239
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1240
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1251
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15192,6 +15020,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1252
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1281
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1282
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 247 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1283
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1284
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1279
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1280
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 246 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1287
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1288
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1299
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1300
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1275
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1276
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 90 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 91 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1247
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1248
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1245
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1246
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 17 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1243
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1244
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 94 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1241
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1242
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1253
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1254
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15203,14 +15465,14 @@ Types:
             Type: 157 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1275
+      ID: 1277
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1276
+      ID: 1278
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15222,14 +15484,14 @@ Types:
             Type: 245 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1271
+      ID: 1273
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1272
+      ID: 1274
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15241,7 +15503,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15251,7 +15513,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15261,7 +15523,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15271,7 +15533,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15281,7 +15543,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15291,7 +15553,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15301,7 +15563,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15311,7 +15573,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15321,7 +15583,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15331,7 +15593,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15341,7 +15603,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15351,7 +15613,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15361,7 +15623,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15371,7 +15633,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15381,7 +15643,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15391,7 +15653,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15401,14 +15663,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1283
+      ID: 1285
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1284
+      ID: 1286
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15420,14 +15682,14 @@ Types:
             Type: 249 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1289
+      ID: 1291
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1290
+      ID: 1292
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15439,7 +15701,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15449,7 +15711,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15459,7 +15721,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15469,7 +15731,7 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15479,14 +15741,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1295
+      ID: 1297
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1296
+      ID: 1298
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15498,7 +15760,7 @@ Types:
             Type: 16 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15508,14 +15770,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1293
+      ID: 1295
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1294
+      ID: 1296
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15527,14 +15789,14 @@ Types:
             Type: 17 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1269
+      ID: 1271
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1270
+      ID: 1272
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15546,7 +15808,7 @@ Types:
             Type: 15 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15556,7 +15818,7 @@ Types:
             Type: 89 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15566,7 +15828,7 @@ Types:
             Type: 13 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15576,7 +15838,7 @@ Types:
             Type: 14 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15586,7 +15848,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15596,7 +15858,7 @@ Types:
             Type: 7 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15606,7 +15868,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15616,14 +15878,14 @@ Types:
             Type: 10 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1291
+      ID: 1293
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1292
+      ID: 1294
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15635,14 +15897,14 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1287
+      ID: 1289
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1288
+      ID: 1290
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15654,7 +15916,7 @@ Types:
             Type: 250 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -15964,7 +16226,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1332
+      ID: 1334
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15976,7 +16238,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -15986,7 +16248,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16120,7 +16382,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1328
+      ID: 1330
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16132,7 +16394,7 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16142,11 +16404,11 @@ Types:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1319
+      ID: 1321
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16158,7 +16420,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16168,7 +16430,7 @@ Types:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16198,7 +16460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1267
+      ID: 1269
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16210,7 +16472,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16220,11 +16482,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1268
+      ID: 1270
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16236,7 +16498,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16246,7 +16508,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16256,11 +16518,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1309
+      ID: 1311
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16272,7 +16534,7 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16282,11 +16544,11 @@ Types:
             Type: 156 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1310
+      ID: 1312
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16298,7 +16560,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16308,7 +16570,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16318,7 +16580,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16348,7 +16610,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1236
+      ID: 1238
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16360,7 +16622,7 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16370,11 +16632,11 @@ Types:
             Type: 88 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1323
+      ID: 1325
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16386,7 +16648,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16396,7 +16658,7 @@ Types:
             Type: 258 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16452,7 +16714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1320
+      ID: 1322
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16464,7 +16726,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16474,7 +16736,7 @@ Types:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16484,7 +16746,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16494,7 +16756,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16524,7 +16786,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1313
+      ID: 1315
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16536,7 +16798,7 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16546,11 +16808,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1314
+      ID: 1316
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16562,7 +16824,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16572,11 +16834,11 @@ Types:
             Type: 251 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1347
+      ID: 1349
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16588,7 +16850,7 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16598,14 +16860,14 @@ Types:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1348
+      ID: 1350
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1346
+      ID: 1348
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16617,7 +16879,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16627,7 +16889,7 @@ Types:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16657,7 +16919,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1349
+      ID: 1351
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1353
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16669,7 +16947,7 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16679,14 +16957,17 @@ Types:
             Type: 311 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1350
+      ID: 1352
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1329
+      ID: 1354
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1331
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -16698,7 +16979,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -16708,7 +16989,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16718,7 +16999,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -16728,7 +17009,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16738,7 +17019,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -16748,11 +17029,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1345
+      ID: 1347
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16764,7 +17045,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -16774,7 +17055,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16784,7 +17065,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -16794,7 +17075,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16804,7 +17085,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -16814,11 +17095,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1338
+      ID: 1340
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16830,7 +17111,7 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16840,11 +17121,11 @@ Types:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1339
+      ID: 1341
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16856,7 +17137,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16869,7 +17150,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -16882,14 +17163,14 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1334
+      ID: 1336
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16901,7 +17182,7 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16911,11 +17192,11 @@ Types:
             Type: 263 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1336
+      ID: 1338
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16927,7 +17208,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -16937,7 +17218,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -16947,17 +17228,17 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1335
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1333
+      ID: 1339
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1335
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16969,7 +17250,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16979,7 +17260,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16989,7 +17270,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -16999,7 +17280,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17009,7 +17290,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17019,7 +17300,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17179,7 +17460,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1235
+      ID: 1237
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17191,7 +17472,7 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17201,11 +17482,11 @@ Types:
             Type: 100 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1317
+      ID: 1319
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17217,7 +17498,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17227,11 +17508,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1343
+      ID: 1345
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17243,7 +17524,7 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17253,11 +17534,11 @@ Types:
             Type: 11 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1234
+      ID: 1236
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17269,7 +17550,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17279,7 +17560,7 @@ Types:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17309,7 +17590,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1326
+      ID: 1328
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17321,7 +17602,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17331,11 +17612,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1327
+      ID: 1329
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17347,7 +17628,7 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17357,11 +17638,11 @@ Types:
             Type: 252 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1315
+      ID: 1317
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17373,7 +17654,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17383,7 +17664,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17393,7 +17674,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17403,11 +17684,11 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1316
+      ID: 1318
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17419,7 +17700,7 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17429,7 +17710,7 @@ Types:
             Type: 248 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -24482,7 +24763,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 952416
       GoKind: 5
-MaxTypeID: 1370
+MaxTypeID: 1376
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12cd8e0", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.stackC]
+          Type: 1507 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x84fef8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.stackC]Return
+          Type: 1508 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x84ff2c", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1476 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1478 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x84ecfc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1477 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1479 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ed94", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1403 EventRootType Probe[main.testAtomicAdd]
+          Type: 1405 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x84d2e0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1404 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1406 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x84d31c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1526 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x850250", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1527 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x85026c", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1536 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x84ad18"
+              Frameless: false
+            - PC: "0x84ad8c"
+              Frameless: false
+            - PC: "0x84aed8"
+              Frameless: false
+            - PC: "0x84af54"
+              Frameless: false
+            - PC: "0x84b00c"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1537 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x84ad18"
+              Frameless: false
+            - PC: "0x84ad8c"
+              Frameless: false
+            - PC: "0x84aed8"
+              Frameless: false
+            - PC: "0x84af54"
+              Frameless: false
+            - PC: "0x84b00c"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1402 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x84d080", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1403 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x84d080", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1405 EventRootType Probe[main.testChannel]
+          Type: 1407 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x84d320", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1413 EventRootType Probe[main.testCycle]
+          Type: 1415 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x84d5d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testEmptySlice]
+          Type: 1495 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x84fb20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1496 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1498 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x84fb50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testEmptyString]
+          Type: 1521 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x84ffd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testEmptyStruct]
+          Type: 1534 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x850350", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1535 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x850360", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testInlinedBBB]
+          Type: 1541 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x84af98", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testInlinedBCA]
+          Type: 1542 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1537 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1543 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x84b08c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testInlinedBCB]
+          Type: 1544 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1539 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1545 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x84b140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1551 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x8494b8"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testInlinedPrint]
+          Type: 1538 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1533 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1539 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x84ad50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1534 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1540 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x84ad18"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testInlinedSq]
+          Type: 1546 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1541 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1547 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x84b194", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1548 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x84b1c4"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1474 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1476 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x84eb40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1475 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1477 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84ec98", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1407 EventRootType Probe[main.testLinkedList]
+          Type: 1409 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x84d4e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1480 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1482 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x84effc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1481 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1483 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x84f168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testMassiveString]
+          Type: 1518 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testMassiveString]
+          Type: 1519 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x84ffb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1482 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1484 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x84f1d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1483 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1485 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x84f37c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1486 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1488 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x84f47c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1487 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1489 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x84f524", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1478 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1480 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x84edd0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1479 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1481 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x84efa0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1433 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1402 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1404 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x84d140", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testNamedReturn]
+          Type: 1430 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1429 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testNamedReturn]
+          Type: 1432 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x84e078", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1431 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1433 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x84e0d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testNestedPointer]
+          Type: 1530 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testNestedPointer]
+          Type: 1531 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testNestedPointer]
+          Type: 1532 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testNestedPointer]
+          Type: 1533 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x8502f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1412 EventRootType Probe[main.testNilPointer]
+          Type: 1414 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x84d5b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1500 EventRootType Probe[main.testNilSlice]
+          Type: 1502 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x84fb90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1499 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x84fb60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1501 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x84fb80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1517 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x84ffa0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1408 EventRootType Probe[main.testPointerLoop]
+          Type: 1410 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x84d4f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1406 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1408 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x84d4d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testReturnsAny]
+          Type: 1426 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x84dd18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1425 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1427 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x84ddb4"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1424 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x84db98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1425 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x84dbec"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1452 EventRootType Probe[main.testReturnsArray]
+          Type: 1454 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x84e54c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1453 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1455 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x84e5a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1454 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1456 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x84e5d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1455 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1457 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x84e614", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1456 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1458 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x84e648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1457 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1459 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x84e680", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1460 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1462 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x84e738", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1461 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1463 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x84e79c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1472 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1474 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x84eac8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1473 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1475 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x84eb08", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1448 EventRootType Probe[main.testReturnsComplex]
+          Type: 1450 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x84e3f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1449 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1451 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x84e444", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1420 EventRootType Probe[main.testReturnsError]
+          Type: 1422 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x84db18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1421 EventRootType Probe[main.testReturnsError]Return
+          Type: 1423 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x84db48"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1414 EventRootType Probe[main.testReturnsInt]
+          Type: 1416 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x84d928", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1415 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1417 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x84d96c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1418 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1420 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x84da48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1419 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1421 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x84dae0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1416 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1418 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x84d9a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1417 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1419 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x84da08", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testReturnsInterface]
+          Type: 1428 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x84df18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1427 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1429 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x84dfe4"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1450 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1452 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x84e480", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1451 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1453 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x84e514", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1446 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1448 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x84e338", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1447 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1449 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x84e3bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1464 EventRootType Probe[main.testReturnsMixed]
+          Type: 1466 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x84e8b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1465 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1467 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x84e910", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1458 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1460 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x84e6b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1459 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1461 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x84e700", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1470 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1472 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x84ea48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1471 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1473 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x84ea8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1468 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1470 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x84e9d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1469 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1471 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x84ea18", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1444 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1446 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x84e2a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1445 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1447 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x84e300", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1466 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1468 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x84e94c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1467 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1469 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x84e9a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1462 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1464 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x84e7e0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1463 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1465 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x84e884", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1434 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1435 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testSingleString]
+          Type: 1509 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x84ff50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1505 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x84fbb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1494 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1496 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x84fb30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1442 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1444 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x84e1e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1443 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1445 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x84e270", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1484 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1486 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x84f3d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1485 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1487 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x84f43c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1411 EventRootType Probe[main.testStringPointer]
+          Type: 1413 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x84d590", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1498 EventRootType Probe[main.testStringSlice]
+          Type: 1500 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x84fb70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.testStruct]
+          Type: 1528 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x850250", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.testStruct]Return
+          Type: 1529 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x85026c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testStructSlice]
+          Type: 1497 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x84fb40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1488 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1490 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x84f55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1489 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1491 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x84f5ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1524 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x850160", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1523 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1525 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x850178", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1523 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x850150", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1504 EventRootType Probe[main.testSubslices]
+          Type: 1506 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x84fbc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testSubstrings]
+          Type: 1522 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x84ffe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1436 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1437 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1438 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1439 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1440 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1442 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x84e118", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1441 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1443 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x84e1a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1508 EventRootType Probe[main.testThreeStrings]
+          Type: 1510 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x84ff60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1513 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x84ff70", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1512 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1514 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x84ff88", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1515 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1516 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x84ff90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1410 EventRootType Probe[main.testUintPointer]
+          Type: 1412 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x84d520", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1492 EventRootType Probe[main.testUintSlice]
+          Type: 1494 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x84fb10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testUnitializedString]
+          Type: 1520 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x84ffc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1409 EventRootType Probe[main.testUnsafePointer]
+          Type: 1411 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x84d500", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1503 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1502 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1504 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x84fba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1549 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x84b368"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1550 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x84b3a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1490 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1492 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x84f628", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1491 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1493 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x84f690", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5650,6 +5781,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x84d080..0x84d090]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x84d080..0x84d090
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x84d080..0x84d090
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 17 BaseType float32
+          Locations:
+            - Range: 0x84d080..0x84d090
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x84d140..0x84d150]
       InlinePCRanges: []
@@ -5688,7 +5846,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0x84d2e0..0x84d320]
       InlinePCRanges: []
@@ -5709,7 +5867,7 @@ Subprograms:
             - Range: 0x84d31d..0x84d320
               Pieces: []
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0x84d320..0x84d330]
       InlinePCRanges: []
@@ -5720,7 +5878,7 @@ Subprograms:
             - Range: 0x84d320..0x84d330
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x84d4d0..0x84d4e0]
       InlinePCRanges: []
@@ -5731,7 +5889,7 @@ Subprograms:
             - Range: 0x84d4d0..0x84d4e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x84d4e0..0x84d4f0]
       InlinePCRanges: []
@@ -5746,7 +5904,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x84d4f0..0x84d500]
       InlinePCRanges: []
@@ -5757,7 +5915,7 @@ Subprograms:
             - Range: 0x84d4f0..0x84d500
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x84d500..0x84d510]
       InlinePCRanges: []
@@ -5768,7 +5926,7 @@ Subprograms:
             - Range: 0x84d500..0x84d510
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x84d520..0x84d530]
       InlinePCRanges: []
@@ -5779,7 +5937,7 @@ Subprograms:
             - Range: 0x84d520..0x84d530
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x84d590..0x84d5a0]
       InlinePCRanges: []
@@ -5790,7 +5948,7 @@ Subprograms:
             - Range: 0x84d590..0x84d5a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x84d5b0..0x84d5c0]
       InlinePCRanges: []
@@ -5807,7 +5965,7 @@ Subprograms:
             - Range: 0x84d5b0..0x84d5c0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0x84d5d0..0x84d5e0]
       InlinePCRanges: []
@@ -5818,7 +5976,7 @@ Subprograms:
             - Range: 0x84d5d0..0x84d5e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x84d910..0x84d990]
       InlinePCRanges: []
@@ -5847,7 +6005,7 @@ Subprograms:
             - Range: 0x84d938..0x84d990
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x84d990..0x84da30]
       InlinePCRanges: []
@@ -5878,7 +6036,7 @@ Subprograms:
             - Range: 0x84d9d0..0x84da30
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x84da30..0x84db00]
       InlinePCRanges: []
@@ -5919,7 +6077,7 @@ Subprograms:
             - Range: 0x84da8c..0x84db00
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x84db00..0x84db80]
       InlinePCRanges: []
@@ -5952,7 +6110,7 @@ Subprograms:
             - Range: 0x84db5d..0x84db80
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x84db80..0x84dd00]
       InlinePCRanges: []
@@ -6079,7 +6237,7 @@ Subprograms:
             - Range: 0x84dbd0..0x84dbd8
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x84dd00..0x84df00]
       InlinePCRanges: []
@@ -6156,7 +6314,7 @@ Subprograms:
             - Range: 0x84dd98..0x84ddb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x84df00..0x84e060]
       InlinePCRanges: []
@@ -6249,7 +6407,7 @@ Subprograms:
             - Range: 0x84dff8..0x84e060
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x84e060..0x84e100]
       InlinePCRanges: []
@@ -6270,7 +6428,7 @@ Subprograms:
             - Range: 0x84e0d9..0x84e100
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x84e100..0x84e1d0]
       InlinePCRanges: []
@@ -6301,7 +6459,7 @@ Subprograms:
             - Range: 0x84e1a5..0x84e1d0
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x84e1d0..0x84e290]
       InlinePCRanges: []
@@ -6344,7 +6502,7 @@ Subprograms:
             - Range: 0x84e271..0x84e290
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x84e290..0x84e320]
       InlinePCRanges: []
@@ -6429,7 +6587,7 @@ Subprograms:
             - Range: 0x84e301..0x84e320
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x84e320..0x84e3e0]
       InlinePCRanges: []
@@ -6508,7 +6666,7 @@ Subprograms:
             - Range: 0x84e3bd..0x84e3e0
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x84e3e0..0x84e460]
       InlinePCRanges: []
@@ -6521,7 +6679,7 @@ Subprograms:
           Type: 96 BaseType complex128
           Locations: [{Range: 0x84e3e0..0x84e460, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x84e460..0x84e530]
       InlinePCRanges: []
@@ -6556,7 +6714,7 @@ Subprograms:
             - Range: 0x84e515..0x84e530
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x84e530..0x84e5c0]
       InlinePCRanges: []
@@ -6571,7 +6729,7 @@ Subprograms:
             - Range: 0x84e5a1..0x84e5c0
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x84e5c0..0x84e630]
       InlinePCRanges: []
@@ -6586,7 +6744,7 @@ Subprograms:
             - Range: 0x84e615..0x84e630
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x84e630..0x84e6a0]
       InlinePCRanges: []
@@ -6601,7 +6759,7 @@ Subprograms:
             - Range: 0x84e681..0x84e6a0
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x84e6a0..0x84e720]
       InlinePCRanges: []
@@ -6610,7 +6768,7 @@ Subprograms:
           Type: 252 StructureType main.mixedStruct
           Locations: [{Range: 0x84e6a0..0x84e720, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x84e720..0x84e7c0]
       InlinePCRanges: []
@@ -6709,7 +6867,7 @@ Subprograms:
             - Range: 0x84e79d..0x84e7c0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x84e7c0..0x84e8a0]
       InlinePCRanges: []
@@ -6746,7 +6904,7 @@ Subprograms:
             - Range: 0x84e885..0x84e8a0
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x84e8a0..0x84e930]
       InlinePCRanges: []
@@ -6793,7 +6951,7 @@ Subprograms:
             - Range: 0x84e911..0x84e930
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x84e930..0x84e9c0]
       InlinePCRanges: []
@@ -6808,7 +6966,7 @@ Subprograms:
             - Range: 0x84e9a1..0x84e9c0
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x84e9c0..0x84ea30]
       InlinePCRanges: []
@@ -6817,7 +6975,7 @@ Subprograms:
           Type: 18 BaseType float64
           Locations: [{Range: 0x84e9c0..0x84ea30, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x84ea30..0x84eab0]
       InlinePCRanges: []
@@ -6830,7 +6988,7 @@ Subprograms:
           Type: 18 BaseType float64
           Locations: [{Range: 0x84ea30..0x84eab0, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x84eab0..0x84eb20]
       InlinePCRanges: []
@@ -6855,7 +7013,7 @@ Subprograms:
             - Range: 0x84eb09..0x84eb20
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x84eb20..0x84ece0]
       InlinePCRanges: []
@@ -6960,7 +7118,7 @@ Subprograms:
             - Range: 0x84ec99..0x84ece0
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x84ece0..0x84edb0]
       InlinePCRanges: []
@@ -6981,7 +7139,7 @@ Subprograms:
             - Range: 0x84ed95..0x84edb0
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x84edb0..0x84efe0]
       InlinePCRanges: []
@@ -7092,7 +7250,7 @@ Subprograms:
             - Range: 0x84efa1..0x84efe0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x84efe0..0x84f1b0]
       InlinePCRanges: []
@@ -7179,7 +7337,7 @@ Subprograms:
             - Range: 0x84f169..0x84f1b0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x84f1b0..0x84f3c0]
       InlinePCRanges: []
@@ -7294,7 +7452,7 @@ Subprograms:
             - Range: 0x84f37d..0x84f3c0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x84f3c0..0x84f460]
       InlinePCRanges: []
@@ -7335,7 +7493,7 @@ Subprograms:
             - Range: 0x84f43d..0x84f460
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x84f460..0x84f540]
       InlinePCRanges: []
@@ -7372,7 +7530,7 @@ Subprograms:
             - Range: 0x84f525..0x84f540
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x84f540..0x84f610]
       InlinePCRanges: []
@@ -7409,7 +7567,7 @@ Subprograms:
             - Range: 0x84f5c0..0x84f610
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x84f610..0x84f6b0]
       InlinePCRanges: []
@@ -7450,7 +7608,7 @@ Subprograms:
             - Range: 0x84f691..0x84f6b0
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x84fb10..0x84fb20]
       InlinePCRanges: []
@@ -7467,7 +7625,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x84fb20..0x84fb30]
       InlinePCRanges: []
@@ -7484,7 +7642,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x84fb30..0x84fb40]
       InlinePCRanges: []
@@ -7501,7 +7659,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x84fb40..0x84fb50]
       InlinePCRanges: []
@@ -7524,7 +7682,7 @@ Subprograms:
             - Range: 0x84fb40..0x84fb50
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x84fb50..0x84fb60]
       InlinePCRanges: []
@@ -7547,7 +7705,7 @@ Subprograms:
             - Range: 0x84fb50..0x84fb60
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x84fb60..0x84fb70]
       InlinePCRanges: []
@@ -7570,7 +7728,7 @@ Subprograms:
             - Range: 0x84fb60..0x84fb70
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x84fb70..0x84fb80]
       InlinePCRanges: []
@@ -7587,7 +7745,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x84fb80..0x84fb90]
       InlinePCRanges: []
@@ -7616,7 +7774,7 @@ Subprograms:
             - Range: 0x84fb80..0x84fb90
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x84fb90..0x84fba0]
       InlinePCRanges: []
@@ -7633,7 +7791,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x84fba0..0x84fbb0]
       InlinePCRanges: []
@@ -7650,7 +7808,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x84fbb0..0x84fbc0]
       InlinePCRanges: []
@@ -7667,7 +7825,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0x84fbc0..0x84fbd0]
       InlinePCRanges: []
@@ -7708,7 +7866,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0x84fee0..0x84ff50]
       InlinePCRanges: []
@@ -7727,7 +7885,7 @@ Subprograms:
             - Range: 0x84ff2d..0x84ff50
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0x84ff50..0x84ff60]
       InlinePCRanges: []
@@ -7742,7 +7900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x84ff60..0x84ff70]
       InlinePCRanges: []
@@ -7777,7 +7935,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x84ff70..0x84ff90]
       InlinePCRanges: []
@@ -7800,7 +7958,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x84ff90..0x84ffa0]
       InlinePCRanges: []
@@ -7811,7 +7969,7 @@ Subprograms:
             - Range: 0x84ff90..0x84ffa0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x84ffa0..0x84ffb0]
       InlinePCRanges: []
@@ -7822,7 +7980,7 @@ Subprograms:
             - Range: 0x84ffa0..0x84ffb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x84ffb0..0x84ffc0]
       InlinePCRanges: []
@@ -7837,7 +7995,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x84ffc0..0x84ffd0]
       InlinePCRanges: []
@@ -7852,7 +8010,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x84ffd0..0x84ffe0]
       InlinePCRanges: []
@@ -7867,7 +8025,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0x84ffe0..0x84fff0]
       InlinePCRanges: []
@@ -7902,7 +8060,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x850150..0x850160]
       InlinePCRanges: []
@@ -7913,7 +8071,7 @@ Subprograms:
             - Range: 0x850150..0x850160
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x850160..0x850180]
       InlinePCRanges: []
@@ -7936,7 +8094,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0x850250..0x850270]
       InlinePCRanges: []
@@ -7961,7 +8119,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0x8502f0..0x850300]
       InlinePCRanges: []
@@ -7972,7 +8130,7 @@ Subprograms:
             - Range: 0x8502f0..0x850300
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x850350..0x850360]
       InlinePCRanges: []
@@ -7981,7 +8139,7 @@ Subprograms:
           Type: 317 StructureType main.emptyStruct
           Locations: [{Range: 0x850350..0x850360, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x850360..0x850370]
       InlinePCRanges: []
@@ -7992,7 +8150,7 @@ Subprograms:
             - Range: 0x850360..0x850370
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x84ad00..0x84ad70]
       InlinePCRanges:
@@ -8021,28 +8179,28 @@ Subprograms:
             - Range: 0x84aff0..0x84b014
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84af98..0x84afd0]
           RootRanges: [0x84af30..0x84aff0]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b08c..0x84b0d0]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x84b140..0x84b178]
           RootRanges: [0x84b070..0x84b190]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8055,7 +8213,7 @@ Subprograms:
             - Range: 0x84b190..0x84b198
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8072,7 +8230,7 @@ Subprograms:
             - Range: 0x84b248..0x84b350
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x84b350..0x84b3c0]
       InlinePCRanges:
@@ -8109,7 +8267,7 @@ Subprograms:
             - Range: 0x84b3a1..0x84b3c0
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11376,10 +11534,10 @@ Types:
       GoKind: 22
       Pointee: 811 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1545
+      ID: 1551
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1543
+      ID: 1549
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11391,11 +11549,11 @@ Types:
             Type: 319 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1544
+      ID: 1550
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11407,14 +11565,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11426,7 +11584,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11514,7 +11672,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1476
+      ID: 1478
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11526,7 +11684,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11536,11 +11694,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11552,7 +11710,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11712,7 +11870,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1403
+      ID: 1405
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11724,7 +11882,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11734,11 +11892,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1404
+      ID: 1406
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11750,7 +11908,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11835,7 +11993,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1405
+      ID: 1407
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11847,7 +12005,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11857,7 +12015,7 @@ Types:
             Type: 241 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -11927,7 +12085,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1413
+      ID: 1402
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1403
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1415
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11939,7 +12159,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -11949,7 +12169,7 @@ Types:
             Type: 246 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -12109,7 +12329,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12121,7 +12341,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12131,7 +12351,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12141,7 +12361,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12151,11 +12371,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12167,7 +12387,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12177,11 +12397,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12193,7 +12413,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12203,11 +12423,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1531
+      ID: 1535
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12219,7 +12439,7 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12229,11 +12449,11 @@ Types:
             Type: 318 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1530
+      ID: 1534
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12245,7 +12465,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12255,7 +12475,7 @@ Types:
             Type: 317 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12521,7 +12741,7 @@ Types:
       ID: 1362
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1535
+      ID: 1541
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1359
@@ -12573,16 +12793,16 @@ Types:
       ID: 1360
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1536
+      ID: 1542
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1537
+      ID: 1543
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1538
+      ID: 1544
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1539
+      ID: 1545
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1363
@@ -12591,7 +12811,7 @@ Types:
       ID: 1364
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1532
+      ID: 1538
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12603,7 +12823,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12613,11 +12833,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1537
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1540
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12629,7 +12891,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12639,14 +12901,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1539
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1540
+      ID: 1546
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12658,7 +12920,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12668,11 +12930,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1547
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12684,7 +12946,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12694,11 +12956,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1548
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12710,7 +12972,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12720,7 +12982,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12880,7 +13142,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1474
+      ID: 1476
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12892,7 +13154,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12902,11 +13164,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1475
+      ID: 1477
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12918,11 +13180,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1407
+      ID: 1409
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12934,7 +13196,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -12944,7 +13206,7 @@ Types:
             Type: 244 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13003,7 +13265,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1480
+      ID: 1482
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13015,7 +13277,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13025,7 +13287,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13035,7 +13297,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13045,7 +13307,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13055,7 +13317,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13065,7 +13327,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13075,7 +13337,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13085,7 +13347,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13095,7 +13357,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13105,7 +13367,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13115,7 +13377,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13125,7 +13387,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13135,7 +13397,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13145,7 +13407,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13155,7 +13417,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13165,7 +13427,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13175,7 +13437,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13185,11 +13447,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13201,7 +13463,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13725,7 +13987,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13737,7 +13999,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13747,11 +14009,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13763,7 +14025,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13773,11 +14035,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13789,7 +14051,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13799,7 +14061,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13809,7 +14071,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13819,7 +14081,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13829,7 +14091,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13839,7 +14101,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13849,7 +14111,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13859,7 +14121,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13869,7 +14131,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13879,7 +14141,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13889,7 +14151,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13899,7 +14161,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13909,7 +14171,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13919,7 +14181,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13929,7 +14191,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13939,7 +14201,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -13949,7 +14211,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -13959,11 +14221,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13975,11 +14237,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13991,7 +14253,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14001,7 +14263,7 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14011,7 +14273,7 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14021,11 +14283,11 @@ Types:
             Type: 249 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14037,7 +14299,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14047,11 +14309,11 @@ Types:
             Type: 111 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14063,7 +14325,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14073,7 +14335,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14083,7 +14345,7 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14093,11 +14355,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1479
+      ID: 1481
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14109,11 +14371,11 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1432
+      ID: 1434
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14125,7 +14387,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14135,11 +14397,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1434
+      ID: 1436
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14151,7 +14413,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14161,7 +14423,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14171,7 +14433,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14181,23 +14443,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14213,7 +14459,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14229,11 +14475,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1433
+      ID: 1442
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14245,7 +14507,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14255,11 +14517,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1435
+      ID: 1437
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14271,7 +14533,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14281,7 +14543,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14291,7 +14553,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14301,7 +14563,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14311,7 +14573,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14321,33 +14583,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14363,7 +14599,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14373,7 +14609,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14389,7 +14625,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14399,11 +14635,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1402
+      ID: 1443
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1404
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14415,7 +14677,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14425,7 +14687,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14435,7 +14697,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14445,7 +14707,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14455,7 +14717,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14465,7 +14727,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14475,7 +14737,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14485,7 +14747,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14495,7 +14757,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14505,35 +14767,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1428
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1430
       Name: Probe[main.testNamedReturn]
@@ -14547,7 +14783,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14557,11 +14793,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1429
+      ID: 1432
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1431
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14573,11 +14835,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14589,7 +14851,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14599,11 +14861,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1526
+      ID: 1530
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14615,7 +14877,7 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14625,11 +14887,11 @@ Types:
             Type: 315 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1527
+      ID: 1531
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14641,7 +14903,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14651,10 +14913,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1532
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1529
+      ID: 1533
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14666,7 +14928,7 @@ Types:
             Type: 121 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14676,7 +14938,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1412
+      ID: 1414
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14688,7 +14950,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14698,7 +14960,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14708,7 +14970,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14718,11 +14980,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14734,7 +14996,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14744,7 +15006,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14754,7 +15016,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14764,11 +15026,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14780,7 +15042,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14790,7 +15052,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14800,7 +15062,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14810,7 +15072,7 @@ Types:
             Type: 262 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14820,7 +15082,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14830,11 +15092,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14846,7 +15108,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14856,11 +15118,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14872,7 +15134,7 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14882,11 +15144,11 @@ Types:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1408
+      ID: 1410
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14898,7 +15160,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14908,7 +15170,7 @@ Types:
             Type: 245 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14938,7 +15200,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1406
+      ID: 1408
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14950,7 +15212,7 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14960,11 +15222,11 @@ Types:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -14976,7 +15238,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -14986,7 +15248,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -14996,7 +15258,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15006,11 +15268,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15022,7 +15284,7 @@ Types:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15032,446 +15294,12 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1424
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1425
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1454
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 250 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1457
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1452
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1453
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 249 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1460
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1461
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1448
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1449
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 95 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 96 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1420
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1421
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1418
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1419
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1416
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1417
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 99 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1414
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1415
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1426
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15497,6 +15325,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1427
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1456
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1457
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 250 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1458
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1459
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1454
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1455
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 249 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1462
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1463
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1451
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 95 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 96 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1423
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1420
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1421
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1418
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1419
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 99 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1416
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1417
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1428
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1429
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15508,14 +15770,14 @@ Types:
             Type: 160 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15527,14 +15789,14 @@ Types:
             Type: 248 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1446
+      ID: 1448
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1447
+      ID: 1449
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15546,7 +15808,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15556,7 +15818,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15566,7 +15828,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15576,7 +15838,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15586,7 +15848,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15596,7 +15858,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15606,7 +15868,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15616,7 +15878,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15626,7 +15888,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15636,7 +15898,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15646,7 +15908,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15656,7 +15918,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15666,7 +15928,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15676,7 +15938,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15686,7 +15948,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15696,7 +15958,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15706,14 +15968,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1458
+      ID: 1460
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1459
+      ID: 1461
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15725,14 +15987,14 @@ Types:
             Type: 252 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15744,7 +16006,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15754,7 +16016,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15764,7 +16026,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15774,7 +16036,7 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15784,14 +16046,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1471
+      ID: 1473
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15803,7 +16065,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15813,14 +16075,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1468
+      ID: 1470
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15832,14 +16094,14 @@ Types:
             Type: 18 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1444
+      ID: 1446
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1445
+      ID: 1447
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15851,7 +16113,7 @@ Types:
             Type: 16 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15861,7 +16123,7 @@ Types:
             Type: 94 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15871,7 +16133,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15881,7 +16143,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15891,7 +16153,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15901,7 +16163,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -15911,7 +16173,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -15921,14 +16183,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1467
+      ID: 1469
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15940,14 +16202,14 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -15959,7 +16221,7 @@ Types:
             Type: 253 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16269,7 +16531,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16281,7 +16543,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16291,7 +16553,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16425,7 +16687,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16437,7 +16699,7 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16447,11 +16709,11 @@ Types:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16463,7 +16725,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16473,7 +16735,7 @@ Types:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16503,7 +16765,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16515,7 +16777,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16525,11 +16787,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1443
+      ID: 1445
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16541,7 +16803,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16551,7 +16813,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16561,11 +16823,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16577,7 +16839,7 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16587,11 +16849,11 @@ Types:
             Type: 159 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16603,7 +16865,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16613,7 +16875,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16623,7 +16885,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16653,7 +16915,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1411
+      ID: 1413
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16665,7 +16927,7 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16675,11 +16937,11 @@ Types:
             Type: 93 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16691,7 +16953,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16701,7 +16963,7 @@ Types:
             Type: 261 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16757,7 +17019,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16769,7 +17031,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16779,7 +17041,7 @@ Types:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16789,7 +17051,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16799,7 +17061,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16829,7 +17091,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16841,7 +17103,7 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16851,11 +17113,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16867,7 +17129,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16877,11 +17139,11 @@ Types:
             Type: 254 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16893,7 +17155,7 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16903,14 +17165,14 @@ Types:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -16922,7 +17184,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -16932,7 +17194,7 @@ Types:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -16962,7 +17224,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1528
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -16974,7 +17252,7 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -16984,14 +17262,17 @@ Types:
             Type: 314 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1504
+      ID: 1529
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1506
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17003,7 +17284,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17013,7 +17294,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17023,7 +17304,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17033,7 +17314,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17043,7 +17324,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17053,11 +17334,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17069,7 +17350,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17079,7 +17360,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17089,7 +17370,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17099,7 +17380,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17109,7 +17390,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17119,11 +17400,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17135,7 +17416,7 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17145,11 +17426,11 @@ Types:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17161,7 +17442,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17174,7 +17455,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17187,14 +17468,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17206,7 +17487,7 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17216,11 +17497,11 @@ Types:
             Type: 266 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17232,7 +17513,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17242,7 +17523,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17252,17 +17533,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1510
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1508
+      ID: 1514
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1510
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17274,7 +17555,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17284,7 +17565,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17294,7 +17575,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17304,7 +17585,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17314,7 +17595,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17324,7 +17605,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17484,7 +17765,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1410
+      ID: 1412
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17496,7 +17777,7 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17506,11 +17787,11 @@ Types:
             Type: 105 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1492
+      ID: 1494
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17522,7 +17803,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17532,11 +17813,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17548,7 +17829,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17558,11 +17839,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1409
+      ID: 1411
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17574,7 +17855,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17584,7 +17865,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17614,7 +17895,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17626,7 +17907,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17636,11 +17917,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17652,7 +17933,7 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17662,11 +17943,11 @@ Types:
             Type: 255 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17678,7 +17959,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17688,7 +17969,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17698,7 +17979,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17708,11 +17989,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1491
+      ID: 1493
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17724,7 +18005,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17734,7 +18015,7 @@ Types:
             Type: 251 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26242,7 +26523,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 989760
       GoKind: 5
-MaxTypeID: 1545
+MaxTypeID: 1551
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x132d360", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.stackC]
+          Type: 1526 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x80c388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.stackC]Return
+          Type: 1527 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x80c3b8", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x80b29c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b328", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          Type: 1424 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x8099d0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x809a0c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -310,6 +310,137 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1545 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x80c670", Frameless: true}]
+          Condition: null
+        - Kind: Return
+          Type: 1546 EventRootType Probe[main.testStruct]Return
+          InjectionPoints: [{PC: "0x80c680", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1555 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x807538"
+              Frameless: false
+            - PC: "0x8075ac"
+              Frameless: false
+            - PC: "0x8076e8"
+              Frameless: false
+            - PC: "0x807764"
+              Frameless: false
+            - PC: "0x80781c"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1556 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x807538"
+              Frameless: false
+            - PC: "0x8075ac"
+              Frameless: false
+            - PC: "0x8076e8"
+              Frameless: false
+            - PC: "0x807764"
+              Frameless: false
+            - PC: "0x80781c"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1421 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x809770", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x809770", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -318,10 +449,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testChannel]
+          Type: 1426 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x809a10", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -378,10 +509,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testCycle]
+          Type: 1434 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x809ca0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -525,10 +656,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          Type: 1514 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x80bfe0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -551,10 +682,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x80c010", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -578,10 +709,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testEmptyString]
+          Type: 1540 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x80c440", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -599,10 +730,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1549 EventRootType Probe[main.testEmptyStruct]
+          Type: 1553 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x80c740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -619,10 +750,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1554 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x80c750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -870,10 +1001,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1554 EventRootType Probe[main.testInlinedBBB]
+          Type: 1560 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x8077a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -908,10 +1039,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedBCA]
+          Type: 1561 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -928,10 +1059,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1562 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x80788c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -945,10 +1076,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedBCB]
+          Type: 1563 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -965,10 +1096,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1558 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1564 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x807930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -982,10 +1113,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1564 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1570 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x805df8"
               Frameless: true
@@ -1004,10 +1135,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedPrint]
+          Type: 1557 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -1021,7 +1152,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1552 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1558 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x80756c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1042,10 +1173,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1553 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1559 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x807538"
               Frameless: false
@@ -1073,10 +1204,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1559 EventRootType Probe[main.testInlinedSq]
+          Type: 1565 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1097,10 +1228,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1560 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1566 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x807984", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1119,10 +1250,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1561 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1567 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8079b4"
               Frameless: false
@@ -1269,14 +1400,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x80b110", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80b238", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1294,10 +1425,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testLinkedList]
+          Type: 1428 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x809bb0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1402,14 +1533,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x80b56c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x80b6ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1893,10 +2024,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testMassiveString]
+          Type: 1537 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1915,10 +2046,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testMassiveString]
+          Type: 1538 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x80c420", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1961,14 +2092,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x80b710", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x80b898", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2030,14 +2161,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x80b98c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x80ba24", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2064,14 +2195,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x80b360", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x80b504", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2093,14 +2224,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2132,10 +2263,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x809830", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2172,14 +2303,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2202,14 +2333,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x80a6d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x80a730", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2233,10 +2364,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testNestedPointer]
+          Type: 1549 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2257,10 +2388,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testNestedPointer]
+          Type: 1550 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2287,10 +2418,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testNestedPointer]
+          Type: 1551 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2311,10 +2442,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1548 EventRootType Probe[main.testNestedPointer]
+          Type: 1552 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x80c700", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2337,10 +2468,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testNilPointer]
+          Type: 1433 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x809c80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2363,10 +2494,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testNilSlice]
+          Type: 1521 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x80c050", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2389,10 +2520,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x80c020", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2423,10 +2554,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x80c040", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2454,10 +2585,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1536 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x80c410", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2475,10 +2606,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          Type: 1429 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x809bc0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2517,10 +2648,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x809ba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2538,14 +2669,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          Type: 1445 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x80a3a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x80a430"
               Frameless: false
@@ -2576,14 +2707,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x80a238", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80a28c"
               Frameless: false
@@ -2613,14 +2744,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          Type: 1473 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80ab6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x80abb8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2633,14 +2764,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x80abe8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x80ac20", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2653,14 +2784,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x80ac58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x80ac8c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2673,14 +2804,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x80ad48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x80ada8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2693,14 +2824,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x80b098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x80b0d4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2713,14 +2844,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          Type: 1469 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x80aa28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x80aa70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2734,14 +2865,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsError]
+          Type: 1441 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x80a1b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x80a1e4"
               Frameless: false
@@ -2762,14 +2893,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          Type: 1435 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x809fc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x80a008", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2786,14 +2917,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x80a0e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x80a174", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2810,14 +2941,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x80a048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x80a0a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2835,14 +2966,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          Type: 1447 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x80a588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x80a640"
               Frameless: false
@@ -2863,14 +2994,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x80aab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x80ab2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2883,14 +3014,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x80a978", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x80a9f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2903,14 +3034,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          Type: 1485 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x80aea8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80aefc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2923,14 +3054,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x80acc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80ad0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2943,14 +3074,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x80b028", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x80b068", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2963,14 +3094,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x80afb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x80aff4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2983,14 +3114,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x80a8e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80a93c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3003,14 +3134,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80af3c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x80af88", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3023,14 +3154,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x80ade0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x80ae6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3078,14 +3209,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3354,10 +3485,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testSingleString]
+          Type: 1528 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x80c3d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3480,10 +3611,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x80c070", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3501,10 +3632,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x80bff0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3542,14 +3673,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x80a828", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x80a8ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3566,14 +3697,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x80b8f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x80b950", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3612,10 +3743,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testStringPointer]
+          Type: 1432 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x809c60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3633,10 +3764,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testStringSlice]
+          Type: 1519 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x80c030", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3696,14 +3827,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testStruct]
+          Type: 1547 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x80c670", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1544 EventRootType Probe[main.testStruct]Return
+          Type: 1548 EventRootType Probe[main.testStruct]Return
           InjectionPoints: [{PC: "0x80c680", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3726,10 +3857,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testStructSlice]
+          Type: 1516 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x80c000", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3772,14 +3903,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x80ba5c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x80bae0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3797,14 +3928,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1543 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x80c5c0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1542 EventRootType Probe[main.testStructWithCyclicMaps]Return
+          Type: 1544 EventRootType Probe[main.testStructWithCyclicMaps]Return
           InjectionPoints: [{PC: "0x80c5cc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3821,10 +3952,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1542 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x80c5b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3878,10 +4009,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testSubslices]
+          Type: 1525 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x80c080", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3917,10 +4048,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testSubstrings]
+          Type: 1541 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x80c450", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3949,14 +4080,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3973,14 +4104,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3999,14 +4130,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x80a768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x80a7e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4031,10 +4162,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          Type: 1529 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x80c3e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4062,14 +4193,14 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4095,14 +4226,14 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x80c3f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]Return
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStruct]Return
           InjectionPoints: [{PC: "0x80c3fc", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4130,10 +4261,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1534 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4159,10 +4290,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1535 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x80c400", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4316,10 +4447,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testUintPointer]
+          Type: 1431 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x809bf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4337,10 +4468,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testUintSlice]
+          Type: 1513 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x80bfd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4358,10 +4489,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testUnitializedString]
+          Type: 1539 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x80c430", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4379,10 +4510,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          Type: 1430 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x809bd0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4421,10 +4552,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4573,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x80c060", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4462,10 +4593,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1562 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1568 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x807b38"
               Frameless: false
@@ -4473,7 +4604,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1569 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x807b60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4491,14 +4622,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x80bb18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x80bb78", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5646,6 +5777,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x809770..0x809780]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x809770..0x809780
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x809770..0x809780
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 18 BaseType float32
+          Locations:
+            - Range: 0x809770..0x809780
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x809830..0x809840]
       InlinePCRanges: []
@@ -5684,7 +5842,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0x8099d0..0x809a10]
       InlinePCRanges: []
@@ -5705,7 +5863,7 @@ Subprograms:
             - Range: 0x809a0d..0x809a10
               Pieces: []
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0x809a10..0x809a20]
       InlinePCRanges: []
@@ -5716,7 +5874,7 @@ Subprograms:
             - Range: 0x809a10..0x809a20
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x809ba0..0x809bb0]
       InlinePCRanges: []
@@ -5727,7 +5885,7 @@ Subprograms:
             - Range: 0x809ba0..0x809bb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x809bb0..0x809bc0]
       InlinePCRanges: []
@@ -5742,7 +5900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x809bc0..0x809bd0]
       InlinePCRanges: []
@@ -5753,7 +5911,7 @@ Subprograms:
             - Range: 0x809bc0..0x809bd0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x809bd0..0x809be0]
       InlinePCRanges: []
@@ -5764,7 +5922,7 @@ Subprograms:
             - Range: 0x809bd0..0x809be0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x809bf0..0x809c00]
       InlinePCRanges: []
@@ -5775,7 +5933,7 @@ Subprograms:
             - Range: 0x809bf0..0x809c00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x809c60..0x809c70]
       InlinePCRanges: []
@@ -5786,7 +5944,7 @@ Subprograms:
             - Range: 0x809c60..0x809c70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x809c80..0x809c90]
       InlinePCRanges: []
@@ -5803,7 +5961,7 @@ Subprograms:
             - Range: 0x809c80..0x809c90
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0x809ca0..0x809cb0]
       InlinePCRanges: []
@@ -5814,7 +5972,7 @@ Subprograms:
             - Range: 0x809ca0..0x809cb0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x809fb0..0x80a030]
       InlinePCRanges: []
@@ -5843,7 +6001,7 @@ Subprograms:
             - Range: 0x809fd8..0x80a030
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x80a030..0x80a0d0]
       InlinePCRanges: []
@@ -5874,7 +6032,7 @@ Subprograms:
             - Range: 0x80a070..0x80a0d0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x80a0d0..0x80a1a0]
       InlinePCRanges: []
@@ -5915,7 +6073,7 @@ Subprograms:
             - Range: 0x80a128..0x80a1a0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x80a1a0..0x80a220]
       InlinePCRanges: []
@@ -5948,7 +6106,7 @@ Subprograms:
             - Range: 0x80a1f9..0x80a220
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x80a220..0x80a390]
       InlinePCRanges: []
@@ -6069,7 +6227,7 @@ Subprograms:
             - Range: 0x80a270..0x80a278
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x80a390..0x80a570]
       InlinePCRanges: []
@@ -6146,7 +6304,7 @@ Subprograms:
             - Range: 0x80a468..0x80a484
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x80a570..0x80a6c0]
       InlinePCRanges: []
@@ -6239,7 +6397,7 @@ Subprograms:
             - Range: 0x80a654..0x80a6c0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x80a6c0..0x80a750]
       InlinePCRanges: []
@@ -6260,7 +6418,7 @@ Subprograms:
             - Range: 0x80a731..0x80a750
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x80a750..0x80a810]
       InlinePCRanges: []
@@ -6291,7 +6449,7 @@ Subprograms:
             - Range: 0x80a7e9..0x80a810
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x80a810..0x80a8d0]
       InlinePCRanges: []
@@ -6334,7 +6492,7 @@ Subprograms:
             - Range: 0x80a8ad..0x80a8d0
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x80a8d0..0x80a960]
       InlinePCRanges: []
@@ -6419,7 +6577,7 @@ Subprograms:
             - Range: 0x80a93d..0x80a960
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x80a960..0x80aa10]
       InlinePCRanges: []
@@ -6498,7 +6656,7 @@ Subprograms:
             - Range: 0x80a9f9..0x80aa10
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x80aa10..0x80aa90]
       InlinePCRanges: []
@@ -6511,7 +6669,7 @@ Subprograms:
           Type: 98 BaseType complex128
           Locations: [{Range: 0x80aa10..0x80aa90, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x80aa90..0x80ab50]
       InlinePCRanges: []
@@ -6546,7 +6704,7 @@ Subprograms:
             - Range: 0x80ab2d..0x80ab50
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x80ab50..0x80abd0]
       InlinePCRanges: []
@@ -6561,7 +6719,7 @@ Subprograms:
             - Range: 0x80abb9..0x80abd0
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x80abd0..0x80ac40]
       InlinePCRanges: []
@@ -6576,7 +6734,7 @@ Subprograms:
             - Range: 0x80ac21..0x80ac40
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x80ac40..0x80acb0]
       InlinePCRanges: []
@@ -6591,7 +6749,7 @@ Subprograms:
             - Range: 0x80ac8d..0x80acb0
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x80acb0..0x80ad30]
       InlinePCRanges: []
@@ -6600,7 +6758,7 @@ Subprograms:
           Type: 254 StructureType main.mixedStruct
           Locations: [{Range: 0x80acb0..0x80ad30, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x80ad30..0x80adc0]
       InlinePCRanges: []
@@ -6699,7 +6857,7 @@ Subprograms:
             - Range: 0x80ada9..0x80adc0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x80adc0..0x80ae90]
       InlinePCRanges: []
@@ -6736,7 +6894,7 @@ Subprograms:
             - Range: 0x80ae6d..0x80ae90
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x80ae90..0x80af20]
       InlinePCRanges: []
@@ -6783,7 +6941,7 @@ Subprograms:
             - Range: 0x80aefd..0x80af20
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x80af20..0x80afa0]
       InlinePCRanges: []
@@ -6798,7 +6956,7 @@ Subprograms:
             - Range: 0x80af89..0x80afa0
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x80afa0..0x80b010]
       InlinePCRanges: []
@@ -6807,7 +6965,7 @@ Subprograms:
           Type: 16 BaseType float64
           Locations: [{Range: 0x80afa0..0x80b010, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x80b010..0x80b080]
       InlinePCRanges: []
@@ -6820,7 +6978,7 @@ Subprograms:
           Type: 16 BaseType float64
           Locations: [{Range: 0x80b010..0x80b080, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x80b080..0x80b0f0]
       InlinePCRanges: []
@@ -6845,7 +7003,7 @@ Subprograms:
             - Range: 0x80b0d5..0x80b0f0
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x80b0f0..0x80b280]
       InlinePCRanges: []
@@ -6972,7 +7130,7 @@ Subprograms:
             - Range: 0x80b239..0x80b280
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x80b280..0x80b340]
       InlinePCRanges: []
@@ -6993,7 +7151,7 @@ Subprograms:
             - Range: 0x80b329..0x80b340
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x80b340..0x80b550]
       InlinePCRanges: []
@@ -7126,7 +7284,7 @@ Subprograms:
             - Range: 0x80b505..0x80b550
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x80b550..0x80b6f0]
       InlinePCRanges: []
@@ -7213,7 +7371,7 @@ Subprograms:
             - Range: 0x80b6ad..0x80b6f0
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x80b6f0..0x80b8e0]
       InlinePCRanges: []
@@ -7328,7 +7486,7 @@ Subprograms:
             - Range: 0x80b899..0x80b8e0
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x80b8e0..0x80b970]
       InlinePCRanges: []
@@ -7369,7 +7527,7 @@ Subprograms:
             - Range: 0x80b951..0x80b970
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x80b970..0x80ba40]
       InlinePCRanges: []
@@ -7406,7 +7564,7 @@ Subprograms:
             - Range: 0x80ba25..0x80ba40
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x80ba40..0x80bb00]
       InlinePCRanges: []
@@ -7443,7 +7601,7 @@ Subprograms:
             - Range: 0x80bab8..0x80bb00
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x80bb00..0x80bba0]
       InlinePCRanges: []
@@ -7484,7 +7642,7 @@ Subprograms:
             - Range: 0x80bb79..0x80bba0
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x80bfd0..0x80bfe0]
       InlinePCRanges: []
@@ -7501,7 +7659,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x80bfe0..0x80bff0]
       InlinePCRanges: []
@@ -7518,7 +7676,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x80bff0..0x80c000]
       InlinePCRanges: []
@@ -7535,7 +7693,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x80c000..0x80c010]
       InlinePCRanges: []
@@ -7558,7 +7716,7 @@ Subprograms:
             - Range: 0x80c000..0x80c010
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x80c010..0x80c020]
       InlinePCRanges: []
@@ -7581,7 +7739,7 @@ Subprograms:
             - Range: 0x80c010..0x80c020
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x80c020..0x80c030]
       InlinePCRanges: []
@@ -7604,7 +7762,7 @@ Subprograms:
             - Range: 0x80c020..0x80c030
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x80c030..0x80c040]
       InlinePCRanges: []
@@ -7621,7 +7779,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x80c040..0x80c050]
       InlinePCRanges: []
@@ -7650,7 +7808,7 @@ Subprograms:
             - Range: 0x80c040..0x80c050
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x80c050..0x80c060]
       InlinePCRanges: []
@@ -7667,7 +7825,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x80c060..0x80c070]
       InlinePCRanges: []
@@ -7684,7 +7842,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x80c070..0x80c080]
       InlinePCRanges: []
@@ -7701,7 +7859,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0x80c080..0x80c090]
       InlinePCRanges: []
@@ -7742,7 +7900,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0x80c370..0x80c3d0]
       InlinePCRanges: []
@@ -7761,7 +7919,7 @@ Subprograms:
             - Range: 0x80c3b9..0x80c3d0
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0x80c3d0..0x80c3e0]
       InlinePCRanges: []
@@ -7776,7 +7934,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x80c3e0..0x80c3f0]
       InlinePCRanges: []
@@ -7811,7 +7969,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x80c3f0..0x80c400]
       InlinePCRanges: []
@@ -7834,7 +7992,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x80c400..0x80c410]
       InlinePCRanges: []
@@ -7845,7 +8003,7 @@ Subprograms:
             - Range: 0x80c400..0x80c410
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x80c410..0x80c420]
       InlinePCRanges: []
@@ -7856,7 +8014,7 @@ Subprograms:
             - Range: 0x80c410..0x80c420
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x80c420..0x80c430]
       InlinePCRanges: []
@@ -7871,7 +8029,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x80c430..0x80c440]
       InlinePCRanges: []
@@ -7886,7 +8044,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x80c440..0x80c450]
       InlinePCRanges: []
@@ -7901,7 +8059,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0x80c450..0x80c460]
       InlinePCRanges: []
@@ -7936,7 +8094,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x80c5b0..0x80c5c0]
       InlinePCRanges: []
@@ -7947,7 +8105,7 @@ Subprograms:
             - Range: 0x80c5b0..0x80c5c0
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x80c5c0..0x80c5d0]
       InlinePCRanges: []
@@ -7970,7 +8128,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0x80c670..0x80c690]
       InlinePCRanges: []
@@ -7995,7 +8153,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0x80c700..0x80c710]
       InlinePCRanges: []
@@ -8006,7 +8164,7 @@ Subprograms:
             - Range: 0x80c700..0x80c710
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x80c740..0x80c750]
       InlinePCRanges: []
@@ -8015,7 +8173,7 @@ Subprograms:
           Type: 319 StructureType main.emptyStruct
           Locations: [{Range: 0x80c740..0x80c750, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x80c750..0x80c760]
       InlinePCRanges: []
@@ -8026,7 +8184,7 @@ Subprograms:
             - Range: 0x80c750..0x80c760
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x807520..0x807590]
       InlinePCRanges:
@@ -8055,28 +8213,28 @@ Subprograms:
             - Range: 0x807800..0x807824
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x8077a4..0x8077d8]
           RootRanges: [0x807740..0x807800]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x80788c..0x8078c0, 0x8078c8..0x8078cc]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x807930..0x807964]
           RootRanges: [0x807870..0x807980]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8089,7 +8247,7 @@ Subprograms:
             - Range: 0x807980..0x807988
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8106,7 +8264,7 @@ Subprograms:
             - Range: 0x807a28..0x807b20
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x807b20..0x807b80]
       InlinePCRanges:
@@ -8137,7 +8295,7 @@ Subprograms:
             - Range: 0x807b61..0x807b80
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11471,10 +11629,10 @@ Types:
       GoKind: 22
       Pointee: 824 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1564
+      ID: 1570
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1562
+      ID: 1568
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11486,11 +11644,11 @@ Types:
             Type: 321 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1563
+      ID: 1569
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11502,14 +11660,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11521,7 +11679,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11609,7 +11767,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11621,7 +11779,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11631,11 +11789,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11647,7 +11805,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11807,7 +11965,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11819,7 +11977,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11829,11 +11987,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11845,7 +12003,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11930,7 +12088,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11942,7 +12100,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11952,7 +12110,7 @@ Types:
             Type: 243 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12022,7 +12180,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1432
+      ID: 1421
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12034,7 +12254,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -12044,7 +12264,7 @@ Types:
             Type: 248 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -12204,7 +12424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12216,7 +12436,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12226,7 +12446,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12236,7 +12456,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12246,11 +12466,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12262,7 +12482,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12272,11 +12492,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12288,7 +12508,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12298,11 +12518,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1550
+      ID: 1554
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12314,7 +12534,7 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12324,11 +12544,11 @@ Types:
             Type: 320 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1553
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12340,7 +12560,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12350,7 +12570,7 @@ Types:
             Type: 319 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12616,7 +12836,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1554
+      ID: 1560
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12668,16 +12888,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1561
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1556
+      ID: 1562
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1557
+      ID: 1563
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1564
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12686,7 +12906,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1551
+      ID: 1557
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12698,7 +12918,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12708,11 +12928,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1553
+      ID: 1555
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1556
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1559
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12724,7 +12986,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12734,14 +12996,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1552
+      ID: 1558
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1559
+      ID: 1565
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12753,7 +13015,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12763,11 +13025,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1560
+      ID: 1566
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12779,7 +13041,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12789,11 +13051,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1561
+      ID: 1567
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12805,7 +13067,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12815,7 +13077,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12975,7 +13237,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12987,7 +13249,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12997,11 +13259,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -13013,11 +13275,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13029,7 +13291,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13039,7 +13301,7 @@ Types:
             Type: 246 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13098,7 +13360,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13110,7 +13372,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13120,7 +13382,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13130,7 +13392,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13140,7 +13402,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13150,7 +13412,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13160,7 +13422,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13170,7 +13432,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13180,7 +13442,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13190,7 +13452,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13200,7 +13462,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13210,7 +13472,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13220,7 +13482,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13230,7 +13492,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13240,7 +13502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13250,7 +13512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13260,7 +13522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13270,7 +13532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13280,11 +13542,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13296,7 +13558,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13820,7 +14082,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13832,7 +14094,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13842,11 +14104,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13858,7 +14120,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13868,11 +14130,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13884,7 +14146,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13894,7 +14156,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13904,7 +14166,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13914,7 +14176,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13924,7 +14186,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13934,7 +14196,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13944,7 +14206,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13954,7 +14216,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13964,7 +14226,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13974,7 +14236,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13984,7 +14246,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13994,7 +14256,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14004,7 +14266,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14014,7 +14276,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14024,7 +14286,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14034,7 +14296,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14044,7 +14306,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14054,11 +14316,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14070,11 +14332,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14086,7 +14348,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14096,7 +14358,7 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14106,7 +14368,7 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14116,11 +14378,11 @@ Types:
             Type: 251 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14132,7 +14394,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14142,11 +14404,11 @@ Types:
             Type: 113 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14158,7 +14420,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14168,7 +14430,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14178,7 +14440,7 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14188,11 +14450,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14204,11 +14466,11 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14220,7 +14482,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14230,11 +14492,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14246,7 +14508,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14256,7 +14518,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14266,7 +14528,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14276,23 +14538,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14308,7 +14554,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14324,11 +14570,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1461
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14340,7 +14602,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14350,11 +14612,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14366,7 +14628,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14376,7 +14638,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14386,7 +14648,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14396,7 +14658,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14406,7 +14668,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14416,33 +14678,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14458,7 +14694,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14468,7 +14704,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14484,7 +14720,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14494,11 +14730,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1462
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14510,7 +14772,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14520,7 +14782,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14530,7 +14792,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14540,7 +14802,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14550,7 +14812,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14560,7 +14822,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14570,7 +14832,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14580,7 +14842,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14590,7 +14852,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14600,35 +14862,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testNamedReturn]
@@ -14642,7 +14878,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14652,11 +14888,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1451
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14668,11 +14930,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14684,7 +14946,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14694,11 +14956,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1549
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14710,7 +14972,7 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14720,11 +14982,11 @@ Types:
             Type: 317 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1546
+      ID: 1550
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14736,7 +14998,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14746,10 +15008,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1547
+      ID: 1551
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1548
+      ID: 1552
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14761,7 +15023,7 @@ Types:
             Type: 123 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14771,7 +15033,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14783,7 +15045,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14793,7 +15055,7 @@ Types:
             Type: 11 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14803,7 +15065,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14813,11 +15075,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14829,7 +15091,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14839,7 +15101,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14849,7 +15111,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14859,11 +15121,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14875,7 +15137,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14885,7 +15147,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14895,7 +15157,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14905,7 +15167,7 @@ Types:
             Type: 264 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14915,7 +15177,7 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14925,11 +15187,11 @@ Types:
             Type: 10 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14941,7 +15203,7 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14951,11 +15213,11 @@ Types:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14967,7 +15229,7 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14977,11 +15239,11 @@ Types:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14993,7 +15255,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15003,7 +15265,7 @@ Types:
             Type: 247 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -15033,7 +15295,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15045,7 +15307,7 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15055,11 +15317,11 @@ Types:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15071,7 +15333,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15081,7 +15343,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15091,7 +15353,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15101,11 +15363,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15117,7 +15379,7 @@ Types:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15127,446 +15389,12 @@ Types:
             Type: 14 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1443
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1444
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 252 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1475
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1476
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 251 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1479
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1480
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1491
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1492
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1467
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1468
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 97 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 98 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1439
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1440
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 16 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 100 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1445
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15592,6 +15420,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1446
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 252 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1478
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 251 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1494
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 97 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 98 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 16 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 100 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15603,14 +15865,14 @@ Types:
             Type: 162 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15622,14 +15884,14 @@ Types:
             Type: 250 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15641,7 +15903,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15651,7 +15913,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15661,7 +15923,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15671,7 +15933,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15681,7 +15943,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15691,7 +15953,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15701,7 +15963,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15711,7 +15973,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15721,7 +15983,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15731,7 +15993,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15741,7 +16003,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15751,7 +16013,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15761,7 +16023,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15771,7 +16033,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15781,7 +16043,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15791,7 +16053,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15801,14 +16063,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15820,14 +16082,14 @@ Types:
             Type: 254 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15839,7 +16101,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15849,7 +16111,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15859,7 +16121,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15869,7 +16131,7 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15879,14 +16141,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15898,7 +16160,7 @@ Types:
             Type: 18 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15908,14 +16170,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15927,14 +16189,14 @@ Types:
             Type: 16 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15946,7 +16208,7 @@ Types:
             Type: 17 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15956,7 +16218,7 @@ Types:
             Type: 96 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15966,7 +16228,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15976,7 +16238,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15986,7 +16248,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15996,7 +16258,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16006,7 +16268,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16016,14 +16278,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16035,14 +16297,14 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16054,7 +16316,7 @@ Types:
             Type: 255 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16364,7 +16626,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16376,7 +16638,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16386,7 +16648,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16520,7 +16782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16532,7 +16794,7 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16542,11 +16804,11 @@ Types:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16558,7 +16820,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16568,7 +16830,7 @@ Types:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16598,7 +16860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16610,7 +16872,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16620,11 +16882,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16636,7 +16898,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16646,7 +16908,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16656,11 +16918,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16672,7 +16934,7 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16682,11 +16944,11 @@ Types:
             Type: 161 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16698,7 +16960,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16708,7 +16970,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16718,7 +16980,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16748,7 +17010,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16760,7 +17022,7 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16770,11 +17032,11 @@ Types:
             Type: 95 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16786,7 +17048,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16796,7 +17058,7 @@ Types:
             Type: 263 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16852,7 +17114,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16864,7 +17126,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16874,7 +17136,7 @@ Types:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16884,7 +17146,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16894,7 +17156,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16924,7 +17186,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16936,7 +17198,7 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16946,11 +17208,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16962,7 +17224,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16972,11 +17234,11 @@ Types:
             Type: 256 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1541
+      ID: 1543
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16988,7 +17250,7 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16998,14 +17260,14 @@ Types:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1542
+      ID: 1544
       Name: Probe[main.testStructWithCyclicMaps]Return
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17017,7 +17279,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17027,7 +17289,7 @@ Types:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -17057,7 +17319,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1543
+      ID: 1545
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1547
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17069,7 +17347,7 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17079,14 +17357,17 @@ Types:
             Type: 316 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1544
+      ID: 1546
       Name: Probe[main.testStruct]Return
     - __kind: EventRootType
-      ID: 1523
+      ID: 1548
+      Name: Probe[main.testStruct]Return
+    - __kind: EventRootType
+      ID: 1525
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17098,7 +17379,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17108,7 +17389,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17118,7 +17399,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17128,7 +17409,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17138,7 +17419,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17148,11 +17429,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17164,7 +17445,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17174,7 +17455,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17184,7 +17465,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17194,7 +17475,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17204,7 +17485,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17214,11 +17495,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17230,7 +17511,7 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17240,11 +17521,11 @@ Types:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17256,7 +17537,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17269,7 +17550,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17282,14 +17563,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17301,7 +17582,7 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17311,11 +17592,11 @@ Types:
             Type: 268 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17327,7 +17608,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17337,7 +17618,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17347,17 +17628,17 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1529
-      Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStringsInStruct]Return
     - __kind: EventRootType
-      ID: 1527
+      ID: 1533
+      Name: Probe[main.testThreeStringsInStruct]Return
+    - __kind: EventRootType
+      ID: 1529
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17369,7 +17650,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17379,7 +17660,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17389,7 +17670,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17399,7 +17680,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17409,7 +17690,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17419,7 +17700,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17579,7 +17860,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17591,7 +17872,7 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17601,11 +17882,11 @@ Types:
             Type: 107 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17617,7 +17898,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17627,11 +17908,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17643,7 +17924,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17653,11 +17934,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17669,7 +17950,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17679,7 +17960,7 @@ Types:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17709,7 +17990,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17721,7 +18002,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17731,11 +18012,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17747,7 +18028,7 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17757,11 +18038,11 @@ Types:
             Type: 257 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17773,7 +18054,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17783,7 +18064,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17793,7 +18074,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17803,11 +18084,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17819,7 +18100,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17829,7 +18110,7 @@ Types:
             Type: 253 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26497,7 +26778,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 994240
       GoKind: 5
-MaxTypeID: 1564
+MaxTypeID: 1570
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x12ed500", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -8,14 +8,14 @@ Probes:
       template: stackC
       segments: [stackC]
       captureSnapshot: true
-      subprogram: {subprogram: 141}
+      subprogram: {subprogram: 142}
       events:
         - Kind: Entry
-          Type: 1524 EventRootType Probe[main.stackC]
+          Type: 1526 EventRootType Probe[main.stackC]
           InjectionPoints: [{PC: "0x808ad8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1525 EventRootType Probe[main.stackC]Return
+          Type: 1527 EventRootType Probe[main.stackC]Return
           InjectionPoints: [{PC: "0x808b08", Frameless: false}]
           Condition: null
       probeTemplate: {TemplateString: stackC, Segments: [stackC]}
@@ -76,14 +76,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 121}
+      subprogram: {subprogram: 122}
       events:
         - Kind: Entry
-          Type: 1495 EventRootType Probe[main.testArrayArgAndReturn]
+          Type: 1497 EventRootType Probe[main.testArrayArgAndReturn]
           InjectionPoints: [{PC: "0x8079dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1496 EventRootType Probe[main.testArrayArgAndReturn]Return
+          Type: 1498 EventRootType Probe[main.testArrayArgAndReturn]Return
           InjectionPoints: [{PC: "0x807a70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -226,14 +226,14 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 85}
+      subprogram: {subprogram: 86}
       events:
         - Kind: Entry
-          Type: 1422 EventRootType Probe[main.testAtomicAdd]
+          Type: 1424 EventRootType Probe[main.testAtomicAdd]
           InjectionPoints: [{PC: "0x8060f0", Frameless: true}]
           Condition: null
         - Kind: Return
-          Type: 1423 EventRootType Probe[main.testAtomicAdd]Return
+          Type: 1425 EventRootType Probe[main.testAtomicAdd]Return
           InjectionPoints: [{PC: "0x80612c", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -306,6 +306,133 @@ Probes:
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 1
+    - id: testCaptureExprGetmember
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testStruct}
+      tags: ['version_diff:go1.26rc1']
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x.aString
+          expr:
+            dsl: x.aString
+            json: {getmember: [{ref: x}, aString]}
+      subprogram: {subprogram: 154}
+      events:
+        - Kind: Entry
+          Type: 1542 EventRootType Probe[main.testStruct]
+          InjectionPoints: [{PC: "0x808da0", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprLine
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1550 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x803c78"
+              Frameless: false
+            - PC: "0x803cec"
+              Frameless: false
+            - PC: "0x803e20"
+              Frameless: false
+            - PC: "0x803ea4"
+              Frameless: false
+            - PC: "0x803f5c"
+              Frameless: false
+          Condition: null
+    - id: testCaptureExprLineWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where:
+        methodName: main.testInlinedPrint
+        sourceFile: inlined.go
+        lines: ["14"]
+      sampling: {snapshotsPerSecond: 100}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions: [{name: x_val, expr: {dsl: x, json: {ref: x}}}]
+      subprogram: {subprogram: 158}
+      events:
+        - Kind: Line
+          Type: 1551 EventRootType Probe[main.testInlinedPrint]Line
+          InjectionPoints:
+            - PC: "0x803c78"
+              Frameless: false
+            - PC: "0x803cec"
+              Frameless: false
+            - PC: "0x803e20"
+              Frameless: false
+            - PC: "0x803ea4"
+              Frameless: false
+            - PC: "0x803f5c"
+              Frameless: false
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Line
+              EventExpressionIndex: 0
+    - id: testCaptureExprSimple
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1421 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x805e90", Frameless: true}]
+          Condition: null
+    - id: testCaptureExprWithTemplate
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.testCombinedString}
+      template: x={x}
+      segments: [x=, {json: {ref: x}, dsl: x}]
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_val
+          expr: {dsl: x, json: {ref: x}}
+        - name: w_val
+          expr: {dsl: w, json: {ref: w}}
+      subprogram: {subprogram: 84}
+      events:
+        - Kind: Entry
+          Type: 1422 EventRootType Probe[main.testCombinedString]
+          InjectionPoints: [{PC: "0x805e90", Frameless: true}]
+          Condition: null
+      probeTemplate:
+        TemplateString: x={x}
+        Segments:
+            - x=
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: testChannel
       version: 0
       type: LOG_PROBE
@@ -314,10 +441,10 @@ Probes:
       template: '{c}'
       segments: [{json: {ref: c}, dsl: c}]
       captureSnapshot: true
-      subprogram: {subprogram: 86}
+      subprogram: {subprogram: 87}
       events:
         - Kind: Entry
-          Type: 1424 EventRootType Probe[main.testChannel]
+          Type: 1426 EventRootType Probe[main.testChannel]
           InjectionPoints: [{PC: "0x806130", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -374,10 +501,10 @@ Probes:
       template: '{t}'
       segments: [{json: {ref: t}, dsl: t}]
       captureSnapshot: true
-      subprogram: {subprogram: 94}
+      subprogram: {subprogram: 95}
       events:
         - Kind: Entry
-          Type: 1432 EventRootType Probe[main.testCycle]
+          Type: 1434 EventRootType Probe[main.testCycle]
           InjectionPoints: [{PC: "0x8063b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -521,10 +648,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 130}
+      subprogram: {subprogram: 131}
       events:
         - Kind: Entry
-          Type: 1512 EventRootType Probe[main.testEmptySlice]
+          Type: 1514 EventRootType Probe[main.testEmptySlice]
           InjectionPoints: [{PC: "0x808750", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -547,10 +674,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 133}
+      subprogram: {subprogram: 134}
       events:
         - Kind: Entry
-          Type: 1515 EventRootType Probe[main.testEmptySliceOfStructs]
+          Type: 1517 EventRootType Probe[main.testEmptySliceOfStructs]
           InjectionPoints: [{PC: "0x808780", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -574,10 +701,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 149}
+      subprogram: {subprogram: 150}
       events:
         - Kind: Entry
-          Type: 1536 EventRootType Probe[main.testEmptyString]
+          Type: 1538 EventRootType Probe[main.testEmptyString]
           InjectionPoints: [{PC: "0x808b90", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -595,10 +722,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 155}
+      subprogram: {subprogram: 156}
       events:
         - Kind: Entry
-          Type: 1545 EventRootType Probe[main.testEmptyStruct]
+          Type: 1548 EventRootType Probe[main.testEmptyStruct]
           InjectionPoints: [{PC: "0x808e40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -615,10 +742,10 @@ Probes:
       template: '{e}'
       segments: [{json: {ref: e}, dsl: e}]
       captureSnapshot: true
-      subprogram: {subprogram: 156}
+      subprogram: {subprogram: 157}
       events:
         - Kind: Entry
-          Type: 1546 EventRootType Probe[main.testEmptyStructPointer]
+          Type: 1549 EventRootType Probe[main.testEmptyStructPointer]
           InjectionPoints: [{PC: "0x808e50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -866,10 +993,10 @@ Probes:
       template: testInlinedBBB
       segments: [testInlinedBBB]
       captureSnapshot: true
-      subprogram: {subprogram: 158}
+      subprogram: {subprogram: 159}
       events:
         - Kind: Entry
-          Type: 1550 EventRootType Probe[main.testInlinedBBB]
+          Type: 1555 EventRootType Probe[main.testInlinedBBB]
           InjectionPoints: [{PC: "0x803ee4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -904,10 +1031,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Entry
-          Type: 1551 EventRootType Probe[main.testInlinedBCA]
+          Type: 1556 EventRootType Probe[main.testInlinedBCA]
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -924,10 +1051,10 @@ Probes:
       template: testInlinedBCA
       segments: [testInlinedBCA]
       captureSnapshot: true
-      subprogram: {subprogram: 159}
+      subprogram: {subprogram: 160}
       events:
         - Kind: Line
-          Type: 1552 EventRootType Probe[main.testInlinedBCA]Line
+          Type: 1557 EventRootType Probe[main.testInlinedBCA]Line
           InjectionPoints: [{PC: "0x803fcc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -941,10 +1068,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Entry
-          Type: 1553 EventRootType Probe[main.testInlinedBCB]
+          Type: 1558 EventRootType Probe[main.testInlinedBCB]
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -961,10 +1088,10 @@ Probes:
       template: testInlinedBCB
       segments: [testInlinedBCB]
       captureSnapshot: true
-      subprogram: {subprogram: 160}
+      subprogram: {subprogram: 161}
       events:
         - Kind: Line
-          Type: 1554 EventRootType Probe[main.testInlinedBCB]Line
+          Type: 1559 EventRootType Probe[main.testInlinedBCB]Line
           InjectionPoints: [{PC: "0x804070", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -978,10 +1105,10 @@ Probes:
       template: testInlinedFuncFromOtherPackage
       segments: [testInlinedFuncFromOtherPackage]
       captureSnapshot: true
-      subprogram: {subprogram: 164}
+      subprogram: {subprogram: 165}
       events:
         - Kind: Entry
-          Type: 1560 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
+          Type: 1565 EventRootType Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
           InjectionPoints:
             - PC: "0x802568"
               Frameless: true
@@ -1000,10 +1127,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Entry
-          Type: 1547 EventRootType Probe[main.testInlinedPrint]
+          Type: 1552 EventRootType Probe[main.testInlinedPrint]
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -1017,7 +1144,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1548 EventRootType Probe[main.testInlinedPrint]Return
+          Type: 1553 EventRootType Probe[main.testInlinedPrint]Return
           InjectionPoints: [{PC: "0x803cac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1038,10 +1165,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 157}
+      subprogram: {subprogram: 158}
       events:
         - Kind: Line
-          Type: 1549 EventRootType Probe[main.testInlinedPrint]Line
+          Type: 1554 EventRootType Probe[main.testInlinedPrint]Line
           InjectionPoints:
             - PC: "0x803c78"
               Frameless: false
@@ -1069,10 +1196,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Entry
-          Type: 1555 EventRootType Probe[main.testInlinedSq]
+          Type: 1560 EventRootType Probe[main.testInlinedSq]
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1093,10 +1220,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 161}
+      subprogram: {subprogram: 162}
       events:
         - Kind: Line
-          Type: 1556 EventRootType Probe[main.testInlinedSq]Line
+          Type: 1561 EventRootType Probe[main.testInlinedSq]Line
           InjectionPoints: [{PC: "0x8040c4", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1115,10 +1242,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 162}
+      subprogram: {subprogram: 163}
       events:
         - Kind: Entry
-          Type: 1557 EventRootType Probe[main.testInlinedSumArray]
+          Type: 1562 EventRootType Probe[main.testInlinedSumArray]
           InjectionPoints:
             - PC: "0x8040f4"
               Frameless: false
@@ -1265,14 +1392,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 120}
+      subprogram: {subprogram: 121}
       events:
         - Kind: Entry
-          Type: 1493 EventRootType Probe[main.testLargeArgAndReturn]
+          Type: 1495 EventRootType Probe[main.testLargeArgAndReturn]
           InjectionPoints: [{PC: "0x807850", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1494 EventRootType Probe[main.testLargeArgAndReturn]Return
+          Type: 1496 EventRootType Probe[main.testLargeArgAndReturn]Return
           InjectionPoints: [{PC: "0x807980", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1290,10 +1417,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 88}
+      subprogram: {subprogram: 89}
       events:
         - Kind: Entry
-          Type: 1426 EventRootType Probe[main.testLinkedList]
+          Type: 1428 EventRootType Probe[main.testLinkedList]
           InjectionPoints: [{PC: "0x8062c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1398,14 +1525,14 @@ Probes:
         - json: {ref: i}
           dsl: i
       captureSnapshot: true
-      subprogram: {subprogram: 123}
+      subprogram: {subprogram: 124}
       events:
         - Kind: Entry
-          Type: 1499 EventRootType Probe[main.testManyArgsArrayReturn]
+          Type: 1501 EventRootType Probe[main.testManyArgsArrayReturn]
           InjectionPoints: [{PC: "0x807cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1500 EventRootType Probe[main.testManyArgsArrayReturn]Return
+          Type: 1502 EventRootType Probe[main.testManyArgsArrayReturn]Return
           InjectionPoints: [{PC: "0x807e10", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1889,10 +2016,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1533 EventRootType Probe[main.testMassiveString]
+          Type: 1535 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1911,10 +2038,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 147}
+      subprogram: {subprogram: 148}
       events:
         - Kind: Entry
-          Type: 1534 EventRootType Probe[main.testMassiveString]
+          Type: 1536 EventRootType Probe[main.testMassiveString]
           InjectionPoints: [{PC: "0x808b70", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -1957,14 +2084,14 @@ Probes:
         - json: {ref: s}
           dsl: s
       captureSnapshot: true
-      subprogram: {subprogram: 124}
+      subprogram: {subprogram: 125}
       events:
         - Kind: Entry
-          Type: 1501 EventRootType Probe[main.testMixedArgsStackReturn]
+          Type: 1503 EventRootType Probe[main.testMixedArgsStackReturn]
           InjectionPoints: [{PC: "0x807e70", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1502 EventRootType Probe[main.testMixedArgsStackReturn]Return
+          Type: 1504 EventRootType Probe[main.testMixedArgsStackReturn]Return
           InjectionPoints: [{PC: "0x807ffc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2026,14 +2153,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 126}
+      subprogram: {subprogram: 127}
       events:
         - Kind: Entry
-          Type: 1505 EventRootType Probe[main.testMultipleArrayArgs]
+          Type: 1507 EventRootType Probe[main.testMultipleArrayArgs]
           InjectionPoints: [{PC: "0x8080ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1506 EventRootType Probe[main.testMultipleArrayArgs]Return
+          Type: 1508 EventRootType Probe[main.testMultipleArrayArgs]Return
           InjectionPoints: [{PC: "0x808188", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,14 +2187,14 @@ Probes:
         - json: {ref: s2}
           dsl: s2
       captureSnapshot: true
-      subprogram: {subprogram: 122}
+      subprogram: {subprogram: 123}
       events:
         - Kind: Entry
-          Type: 1497 EventRootType Probe[main.testMultipleLargeArgs]
+          Type: 1499 EventRootType Probe[main.testMultipleLargeArgs]
           InjectionPoints: [{PC: "0x807ab0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1498 EventRootType Probe[main.testMultipleLargeArgs]Return
+          Type: 1500 EventRootType Probe[main.testMultipleLargeArgs]Return
           InjectionPoints: [{PC: "0x807c58", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,14 +2216,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1451 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1452 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2128,10 +2255,10 @@ Probes:
         - json: {ref: e}
           dsl: e
       captureSnapshot: true
-      subprogram: {subprogram: 84}
+      subprogram: {subprogram: 85}
       events:
         - Kind: Entry
-          Type: 1421 EventRootType Probe[main.testMultipleSimpleParams]
+          Type: 1423 EventRootType Probe[main.testMultipleSimpleParams]
           InjectionPoints: [{PC: "0x805f50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2168,14 +2295,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1447 EventRootType Probe[main.testNamedReturn]
+          Type: 1449 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1448 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2198,14 +2325,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 102}
+      subprogram: {subprogram: 103}
       events:
         - Kind: Entry
-          Type: 1449 EventRootType Probe[main.testNamedReturn]
+          Type: 1451 EventRootType Probe[main.testNamedReturn]
           InjectionPoints: [{PC: "0x806de8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1450 EventRootType Probe[main.testNamedReturn]Return
+          Type: 1452 EventRootType Probe[main.testNamedReturn]Return
           InjectionPoints: [{PC: "0x806e44", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2229,10 +2356,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1541 EventRootType Probe[main.testNestedPointer]
+          Type: 1544 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2253,10 +2380,10 @@ Probes:
             getmember: [{getmember: [{ref: x}, nested]}, anotherString]
           dsl: x.nested.anotherString
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1542 EventRootType Probe[main.testNestedPointer]
+          Type: 1545 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2283,10 +2410,10 @@ Probes:
         - json: {getmember: [{ref: x}, notAMember]}
           dsl: x.notAMember
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1543 EventRootType Probe[main.testNestedPointer]
+          Type: 1546 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2307,10 +2434,10 @@ Probes:
         - json: {getmember: [{ref: x}, nested]}
           dsl: x.nested
       captureSnapshot: false
-      subprogram: {subprogram: 154}
+      subprogram: {subprogram: 155}
       events:
         - Kind: Entry
-          Type: 1544 EventRootType Probe[main.testNestedPointer]
+          Type: 1547 EventRootType Probe[main.testNestedPointer]
           InjectionPoints: [{PC: "0x808e00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2333,10 +2460,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 93}
+      subprogram: {subprogram: 94}
       events:
         - Kind: Entry
-          Type: 1431 EventRootType Probe[main.testNilPointer]
+          Type: 1433 EventRootType Probe[main.testNilPointer]
           InjectionPoints: [{PC: "0x806390", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2359,10 +2486,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 137}
+      subprogram: {subprogram: 138}
       events:
         - Kind: Entry
-          Type: 1519 EventRootType Probe[main.testNilSlice]
+          Type: 1521 EventRootType Probe[main.testNilSlice]
           InjectionPoints: [{PC: "0x8087c0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2385,10 +2512,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 134}
+      subprogram: {subprogram: 135}
       events:
         - Kind: Entry
-          Type: 1516 EventRootType Probe[main.testNilSliceOfStructs]
+          Type: 1518 EventRootType Probe[main.testNilSliceOfStructs]
           InjectionPoints: [{PC: "0x808790", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2419,10 +2546,10 @@ Probes:
         - json: {ref: x}
           dsl: x
       captureSnapshot: true
-      subprogram: {subprogram: 136}
+      subprogram: {subprogram: 137}
       events:
         - Kind: Entry
-          Type: 1518 EventRootType Probe[main.testNilSliceWithOtherParams]
+          Type: 1520 EventRootType Probe[main.testNilSliceWithOtherParams]
           InjectionPoints: [{PC: "0x8087b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2450,10 +2577,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 146}
+      subprogram: {subprogram: 147}
       events:
         - Kind: Entry
-          Type: 1532 EventRootType Probe[main.testOneStringInStructPointer]
+          Type: 1534 EventRootType Probe[main.testOneStringInStructPointer]
           InjectionPoints: [{PC: "0x808b60", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2471,10 +2598,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 89}
+      subprogram: {subprogram: 90}
       events:
         - Kind: Entry
-          Type: 1427 EventRootType Probe[main.testPointerLoop]
+          Type: 1429 EventRootType Probe[main.testPointerLoop]
           InjectionPoints: [{PC: "0x8062d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2513,10 +2640,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 87}
+      subprogram: {subprogram: 88}
       events:
         - Kind: Entry
-          Type: 1425 EventRootType Probe[main.testPointerToSimpleStruct]
+          Type: 1427 EventRootType Probe[main.testPointerToSimpleStruct]
           InjectionPoints: [{PC: "0x8062b0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -2534,14 +2661,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 100}
+      subprogram: {subprogram: 101}
       events:
         - Kind: Entry
-          Type: 1443 EventRootType Probe[main.testReturnsAny]
+          Type: 1445 EventRootType Probe[main.testReturnsAny]
           InjectionPoints: [{PC: "0x806ab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1444 EventRootType Probe[main.testReturnsAny]Return
+          Type: 1446 EventRootType Probe[main.testReturnsAny]Return
           InjectionPoints:
             - PC: "0x806b40"
               Frameless: false
@@ -2572,14 +2699,14 @@ Probes:
         - json: {ref: failed}
           dsl: failed
       captureSnapshot: true
-      subprogram: {subprogram: 99}
+      subprogram: {subprogram: 100}
       events:
         - Kind: Entry
-          Type: 1441 EventRootType Probe[main.testReturnsAnyAndError]
+          Type: 1443 EventRootType Probe[main.testReturnsAnyAndError]
           InjectionPoints: [{PC: "0x806938", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1442 EventRootType Probe[main.testReturnsAnyAndError]Return
+          Type: 1444 EventRootType Probe[main.testReturnsAnyAndError]Return
           InjectionPoints:
             - PC: "0x80698c"
               Frameless: false
@@ -2609,14 +2736,14 @@ Probes:
       template: testReturnsArray
       segments: [testReturnsArray]
       captureSnapshot: true
-      subprogram: {subprogram: 109}
+      subprogram: {subprogram: 110}
       events:
         - Kind: Entry
-          Type: 1471 EventRootType Probe[main.testReturnsArray]
+          Type: 1473 EventRootType Probe[main.testReturnsArray]
           InjectionPoints: [{PC: "0x80728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1472 EventRootType Probe[main.testReturnsArray]Return
+          Type: 1474 EventRootType Probe[main.testReturnsArray]Return
           InjectionPoints: [{PC: "0x8072dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2629,14 +2756,14 @@ Probes:
       template: testReturnsArrayOne
       segments: [testReturnsArrayOne]
       captureSnapshot: true
-      subprogram: {subprogram: 110}
+      subprogram: {subprogram: 111}
       events:
         - Kind: Entry
-          Type: 1473 EventRootType Probe[main.testReturnsArrayOne]
+          Type: 1475 EventRootType Probe[main.testReturnsArrayOne]
           InjectionPoints: [{PC: "0x807318", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1474 EventRootType Probe[main.testReturnsArrayOne]Return
+          Type: 1476 EventRootType Probe[main.testReturnsArrayOne]Return
           InjectionPoints: [{PC: "0x807350", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2649,14 +2776,14 @@ Probes:
       template: testReturnsArrayZero
       segments: [testReturnsArrayZero]
       captureSnapshot: true
-      subprogram: {subprogram: 111}
+      subprogram: {subprogram: 112}
       events:
         - Kind: Entry
-          Type: 1475 EventRootType Probe[main.testReturnsArrayZero]
+          Type: 1477 EventRootType Probe[main.testReturnsArrayZero]
           InjectionPoints: [{PC: "0x807388", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1476 EventRootType Probe[main.testReturnsArrayZero]Return
+          Type: 1478 EventRootType Probe[main.testReturnsArrayZero]Return
           InjectionPoints: [{PC: "0x8073bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2669,14 +2796,14 @@ Probes:
       template: testReturnsBacktrackInt
       segments: [testReturnsBacktrackInt]
       captureSnapshot: true
-      subprogram: {subprogram: 113}
+      subprogram: {subprogram: 114}
       events:
         - Kind: Entry
-          Type: 1479 EventRootType Probe[main.testReturnsBacktrackInt]
+          Type: 1481 EventRootType Probe[main.testReturnsBacktrackInt]
           InjectionPoints: [{PC: "0x807478", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1480 EventRootType Probe[main.testReturnsBacktrackInt]Return
+          Type: 1482 EventRootType Probe[main.testReturnsBacktrackInt]Return
           InjectionPoints: [{PC: "0x8074d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2689,14 +2816,14 @@ Probes:
       template: testReturnsBoolAndUintptr
       segments: [testReturnsBoolAndUintptr]
       captureSnapshot: true
-      subprogram: {subprogram: 119}
+      subprogram: {subprogram: 120}
       events:
         - Kind: Entry
-          Type: 1491 EventRootType Probe[main.testReturnsBoolAndUintptr]
+          Type: 1493 EventRootType Probe[main.testReturnsBoolAndUintptr]
           InjectionPoints: [{PC: "0x8077d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1492 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
+          Type: 1494 EventRootType Probe[main.testReturnsBoolAndUintptr]Return
           InjectionPoints: [{PC: "0x807814", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2709,14 +2836,14 @@ Probes:
       template: testReturnsComplex
       segments: [testReturnsComplex]
       captureSnapshot: true
-      subprogram: {subprogram: 107}
+      subprogram: {subprogram: 108}
       events:
         - Kind: Entry
-          Type: 1467 EventRootType Probe[main.testReturnsComplex]
+          Type: 1469 EventRootType Probe[main.testReturnsComplex]
           InjectionPoints: [{PC: "0x807148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1468 EventRootType Probe[main.testReturnsComplex]Return
+          Type: 1470 EventRootType Probe[main.testReturnsComplex]Return
           InjectionPoints: [{PC: "0x807190", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2730,14 +2857,14 @@ Probes:
       template: '{failed}'
       segments: [{json: {ref: failed}, dsl: failed}]
       captureSnapshot: true
-      subprogram: {subprogram: 98}
+      subprogram: {subprogram: 99}
       events:
         - Kind: Entry
-          Type: 1439 EventRootType Probe[main.testReturnsError]
+          Type: 1441 EventRootType Probe[main.testReturnsError]
           InjectionPoints: [{PC: "0x8068b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1440 EventRootType Probe[main.testReturnsError]Return
+          Type: 1442 EventRootType Probe[main.testReturnsError]Return
           InjectionPoints:
             - PC: "0x8068ec"
               Frameless: false
@@ -2758,14 +2885,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 95}
+      subprogram: {subprogram: 96}
       events:
         - Kind: Entry
-          Type: 1433 EventRootType Probe[main.testReturnsInt]
+          Type: 1435 EventRootType Probe[main.testReturnsInt]
           InjectionPoints: [{PC: "0x8066c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1434 EventRootType Probe[main.testReturnsInt]Return
+          Type: 1436 EventRootType Probe[main.testReturnsInt]Return
           InjectionPoints: [{PC: "0x806708", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2782,14 +2909,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 97}
+      subprogram: {subprogram: 98}
       events:
         - Kind: Entry
-          Type: 1437 EventRootType Probe[main.testReturnsIntAndFloat]
+          Type: 1439 EventRootType Probe[main.testReturnsIntAndFloat]
           InjectionPoints: [{PC: "0x8067e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1438 EventRootType Probe[main.testReturnsIntAndFloat]Return
+          Type: 1440 EventRootType Probe[main.testReturnsIntAndFloat]Return
           InjectionPoints: [{PC: "0x806878", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2806,14 +2933,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 96}
+      subprogram: {subprogram: 97}
       events:
         - Kind: Entry
-          Type: 1435 EventRootType Probe[main.testReturnsIntPointer]
+          Type: 1437 EventRootType Probe[main.testReturnsIntPointer]
           InjectionPoints: [{PC: "0x806748", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1436 EventRootType Probe[main.testReturnsIntPointer]Return
+          Type: 1438 EventRootType Probe[main.testReturnsIntPointer]Return
           InjectionPoints: [{PC: "0x8067a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2831,14 +2958,14 @@ Probes:
       template: '{v}'
       segments: [{json: {ref: v}, dsl: v}]
       captureSnapshot: true
-      subprogram: {subprogram: 101}
+      subprogram: {subprogram: 102}
       events:
         - Kind: Entry
-          Type: 1445 EventRootType Probe[main.testReturnsInterface]
+          Type: 1447 EventRootType Probe[main.testReturnsInterface]
           InjectionPoints: [{PC: "0x806c98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1446 EventRootType Probe[main.testReturnsInterface]Return
+          Type: 1448 EventRootType Probe[main.testReturnsInterface]Return
           InjectionPoints:
             - PC: "0x806d50"
               Frameless: false
@@ -2859,14 +2986,14 @@ Probes:
       template: testReturnsLargeStruct
       segments: [testReturnsLargeStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 108}
+      subprogram: {subprogram: 109}
       events:
         - Kind: Entry
-          Type: 1469 EventRootType Probe[main.testReturnsLargeStruct]
+          Type: 1471 EventRootType Probe[main.testReturnsLargeStruct]
           InjectionPoints: [{PC: "0x8071d0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1470 EventRootType Probe[main.testReturnsLargeStruct]Return
+          Type: 1472 EventRootType Probe[main.testReturnsLargeStruct]Return
           InjectionPoints: [{PC: "0x807250", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2879,14 +3006,14 @@ Probes:
       template: testReturnsManyFloats
       segments: [testReturnsManyFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 106}
+      subprogram: {subprogram: 107}
       events:
         - Kind: Entry
-          Type: 1465 EventRootType Probe[main.testReturnsManyFloats]
+          Type: 1467 EventRootType Probe[main.testReturnsManyFloats]
           InjectionPoints: [{PC: "0x807098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1466 EventRootType Probe[main.testReturnsManyFloats]Return
+          Type: 1468 EventRootType Probe[main.testReturnsManyFloats]Return
           InjectionPoints: [{PC: "0x807118", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2899,14 +3026,14 @@ Probes:
       template: testReturnsMixed
       segments: [testReturnsMixed]
       captureSnapshot: true
-      subprogram: {subprogram: 115}
+      subprogram: {subprogram: 116}
       events:
         - Kind: Entry
-          Type: 1483 EventRootType Probe[main.testReturnsMixed]
+          Type: 1485 EventRootType Probe[main.testReturnsMixed]
           InjectionPoints: [{PC: "0x8075d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1484 EventRootType Probe[main.testReturnsMixed]Return
+          Type: 1486 EventRootType Probe[main.testReturnsMixed]Return
           InjectionPoints: [{PC: "0x80762c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2919,14 +3046,14 @@ Probes:
       template: testReturnsMixedStruct
       segments: [testReturnsMixedStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 112}
+      subprogram: {subprogram: 113}
       events:
         - Kind: Entry
-          Type: 1477 EventRootType Probe[main.testReturnsMixedStruct]
+          Type: 1479 EventRootType Probe[main.testReturnsMixedStruct]
           InjectionPoints: [{PC: "0x8073f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1478 EventRootType Probe[main.testReturnsMixedStruct]Return
+          Type: 1480 EventRootType Probe[main.testReturnsMixedStruct]Return
           InjectionPoints: [{PC: "0x80743c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2939,14 +3066,14 @@ Probes:
       template: testReturnsMultipleFloats
       segments: [testReturnsMultipleFloats]
       captureSnapshot: true
-      subprogram: {subprogram: 118}
+      subprogram: {subprogram: 119}
       events:
         - Kind: Entry
-          Type: 1489 EventRootType Probe[main.testReturnsMultipleFloats]
+          Type: 1491 EventRootType Probe[main.testReturnsMultipleFloats]
           InjectionPoints: [{PC: "0x807768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1490 EventRootType Probe[main.testReturnsMultipleFloats]Return
+          Type: 1492 EventRootType Probe[main.testReturnsMultipleFloats]Return
           InjectionPoints: [{PC: "0x8077a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2959,14 +3086,14 @@ Probes:
       template: testReturnsOnlyFloat
       segments: [testReturnsOnlyFloat]
       captureSnapshot: true
-      subprogram: {subprogram: 117}
+      subprogram: {subprogram: 118}
       events:
         - Kind: Entry
-          Type: 1487 EventRootType Probe[main.testReturnsOnlyFloat]
+          Type: 1489 EventRootType Probe[main.testReturnsOnlyFloat]
           InjectionPoints: [{PC: "0x8076f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1488 EventRootType Probe[main.testReturnsOnlyFloat]Return
+          Type: 1490 EventRootType Probe[main.testReturnsOnlyFloat]Return
           InjectionPoints: [{PC: "0x807734", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2979,14 +3106,14 @@ Probes:
       template: testReturnsPrimitives
       segments: [testReturnsPrimitives]
       captureSnapshot: true
-      subprogram: {subprogram: 105}
+      subprogram: {subprogram: 106}
       events:
         - Kind: Entry
-          Type: 1463 EventRootType Probe[main.testReturnsPrimitives]
+          Type: 1465 EventRootType Probe[main.testReturnsPrimitives]
           InjectionPoints: [{PC: "0x807008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1464 EventRootType Probe[main.testReturnsPrimitives]Return
+          Type: 1466 EventRootType Probe[main.testReturnsPrimitives]Return
           InjectionPoints: [{PC: "0x80705c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2999,14 +3126,14 @@ Probes:
       template: testReturnsStructWithArray
       segments: [testReturnsStructWithArray]
       captureSnapshot: true
-      subprogram: {subprogram: 116}
+      subprogram: {subprogram: 117}
       events:
         - Kind: Entry
-          Type: 1485 EventRootType Probe[main.testReturnsStructWithArray]
+          Type: 1487 EventRootType Probe[main.testReturnsStructWithArray]
           InjectionPoints: [{PC: "0x80766c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1486 EventRootType Probe[main.testReturnsStructWithArray]Return
+          Type: 1488 EventRootType Probe[main.testReturnsStructWithArray]Return
           InjectionPoints: [{PC: "0x8076bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3019,14 +3146,14 @@ Probes:
       template: testReturnsWideStruct
       segments: [testReturnsWideStruct]
       captureSnapshot: true
-      subprogram: {subprogram: 114}
+      subprogram: {subprogram: 115}
       events:
         - Kind: Entry
-          Type: 1481 EventRootType Probe[main.testReturnsWideStruct]
+          Type: 1483 EventRootType Probe[main.testReturnsWideStruct]
           InjectionPoints: [{PC: "0x807510", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1482 EventRootType Probe[main.testReturnsWideStruct]Return
+          Type: 1484 EventRootType Probe[main.testReturnsWideStruct]Return
           InjectionPoints: [{PC: "0x8075a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3074,14 +3201,14 @@ Probes:
         - json: {ref: result}
           dsl: result
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1453 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1454 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3350,10 +3477,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 142}
+      subprogram: {subprogram: 143}
       events:
         - Kind: Entry
-          Type: 1526 EventRootType Probe[main.testSingleString]
+          Type: 1528 EventRootType Probe[main.testSingleString]
           InjectionPoints: [{PC: "0x808b20", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3476,10 +3603,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 139}
+      subprogram: {subprogram: 140}
       events:
         - Kind: Entry
-          Type: 1522 EventRootType Probe[main.testSliceEmptyStructs]
+          Type: 1524 EventRootType Probe[main.testSliceEmptyStructs]
           InjectionPoints: [{PC: "0x8087e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3497,10 +3624,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 131}
+      subprogram: {subprogram: 132}
       events:
         - Kind: Entry
-          Type: 1513 EventRootType Probe[main.testSliceOfSlices]
+          Type: 1515 EventRootType Probe[main.testSliceOfSlices]
           InjectionPoints: [{PC: "0x808760", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3538,14 +3665,14 @@ Probes:
       template: '{i}'
       segments: [{json: {ref: i}, dsl: i}]
       captureSnapshot: true
-      subprogram: {subprogram: 104}
+      subprogram: {subprogram: 105}
       events:
         - Kind: Entry
-          Type: 1461 EventRootType Probe[main.testSomeNamedReturn]
+          Type: 1463 EventRootType Probe[main.testSomeNamedReturn]
           InjectionPoints: [{PC: "0x806f48", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1462 EventRootType Probe[main.testSomeNamedReturn]Return
+          Type: 1464 EventRootType Probe[main.testSomeNamedReturn]Return
           InjectionPoints: [{PC: "0x806fd0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3562,14 +3689,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 125}
+      subprogram: {subprogram: 126}
       events:
         - Kind: Entry
-          Type: 1503 EventRootType Probe[main.testStackArgRegReturns]
+          Type: 1505 EventRootType Probe[main.testStackArgRegReturns]
           InjectionPoints: [{PC: "0x808058", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1504 EventRootType Probe[main.testStackArgRegReturns]Return
+          Type: 1506 EventRootType Probe[main.testStackArgRegReturns]Return
           InjectionPoints: [{PC: "0x8080b4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3608,10 +3735,10 @@ Probes:
       template: '{z}'
       segments: [{json: {ref: z}, dsl: z}]
       captureSnapshot: true
-      subprogram: {subprogram: 92}
+      subprogram: {subprogram: 93}
       events:
         - Kind: Entry
-          Type: 1430 EventRootType Probe[main.testStringPointer]
+          Type: 1432 EventRootType Probe[main.testStringPointer]
           InjectionPoints: [{PC: "0x806370", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3629,10 +3756,10 @@ Probes:
       template: '{s}'
       segments: [{json: {ref: s}, dsl: s}]
       captureSnapshot: true
-      subprogram: {subprogram: 135}
+      subprogram: {subprogram: 136}
       events:
         - Kind: Entry
-          Type: 1517 EventRootType Probe[main.testStringSlice]
+          Type: 1519 EventRootType Probe[main.testStringSlice]
           InjectionPoints: [{PC: "0x8087a0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3692,10 +3819,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 153}
+      subprogram: {subprogram: 154}
       events:
         - Kind: Entry
-          Type: 1540 EventRootType Probe[main.testStruct]
+          Type: 1543 EventRootType Probe[main.testStruct]
           InjectionPoints: [{PC: "0x808da0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3718,10 +3845,10 @@ Probes:
         - json: {ref: a}
           dsl: a
       captureSnapshot: true
-      subprogram: {subprogram: 132}
+      subprogram: {subprogram: 133}
       events:
         - Kind: Entry
-          Type: 1514 EventRootType Probe[main.testStructSlice]
+          Type: 1516 EventRootType Probe[main.testStructSlice]
           InjectionPoints: [{PC: "0x808770", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3764,14 +3891,14 @@ Probes:
       template: '{arg}'
       segments: [{json: {ref: arg}, dsl: arg}]
       captureSnapshot: true
-      subprogram: {subprogram: 127}
+      subprogram: {subprogram: 128}
       events:
         - Kind: Entry
-          Type: 1507 EventRootType Probe[main.testStructWithArrayArg]
+          Type: 1509 EventRootType Probe[main.testStructWithArrayArg]
           InjectionPoints: [{PC: "0x8081bc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1508 EventRootType Probe[main.testStructWithArrayArg]Return
+          Type: 1510 EventRootType Probe[main.testStructWithArrayArg]Return
           InjectionPoints: [{PC: "0x808244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3789,10 +3916,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 152}
+      subprogram: {subprogram: 153}
       events:
         - Kind: Entry
-          Type: 1539 EventRootType Probe[main.testStructWithCyclicMaps]
+          Type: 1541 EventRootType Probe[main.testStructWithCyclicMaps]
           InjectionPoints: [{PC: "0x808d00", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3809,10 +3936,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 151}
+      subprogram: {subprogram: 152}
       events:
         - Kind: Entry
-          Type: 1538 EventRootType Probe[main.testStructWithCyclicSlices]
+          Type: 1540 EventRootType Probe[main.testStructWithCyclicSlices]
           InjectionPoints: [{PC: "0x808cf0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3866,10 +3993,10 @@ Probes:
         - json: {ref: cs}
           dsl: cs
       captureSnapshot: true
-      subprogram: {subprogram: 140}
+      subprogram: {subprogram: 141}
       events:
         - Kind: Entry
-          Type: 1523 EventRootType Probe[main.testSubslices]
+          Type: 1525 EventRootType Probe[main.testSubslices]
           InjectionPoints: [{PC: "0x8087f0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3905,10 +4032,10 @@ Probes:
         - json: {ref: c}
           dsl: c
       captureSnapshot: true
-      subprogram: {subprogram: 150}
+      subprogram: {subprogram: 151}
       events:
         - Kind: Entry
-          Type: 1537 EventRootType Probe[main.testSubstrings]
+          Type: 1539 EventRootType Probe[main.testSubstrings]
           InjectionPoints: [{PC: "0x808ba0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -3937,14 +4064,14 @@ Probes:
         - json: {ref: nonexistentVariable}
           dsl: nonexistentVariable
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1455 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1456 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3961,14 +4088,14 @@ Probes:
         - json: {foobar: unsupportedExpression}
           dsl: unsupportedExpression
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1457 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1458 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -3987,14 +4114,14 @@ Probes:
           dsl: '@duration'
         - ms
       captureSnapshot: true
-      subprogram: {subprogram: 103}
+      subprogram: {subprogram: 104}
       events:
         - Kind: Entry
-          Type: 1459 EventRootType Probe[main.testMultipleNamedReturn]
+          Type: 1461 EventRootType Probe[main.testMultipleNamedReturn]
           InjectionPoints: [{PC: "0x806e88", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1460 EventRootType Probe[main.testMultipleNamedReturn]Return
+          Type: 1462 EventRootType Probe[main.testMultipleNamedReturn]Return
           InjectionPoints: [{PC: "0x806f0c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4019,10 +4146,10 @@ Probes:
         - json: {ref: z}
           dsl: z
       captureSnapshot: true
-      subprogram: {subprogram: 143}
+      subprogram: {subprogram: 144}
       events:
         - Kind: Entry
-          Type: 1527 EventRootType Probe[main.testThreeStrings]
+          Type: 1529 EventRootType Probe[main.testThreeStrings]
           InjectionPoints: [{PC: "0x808b30", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4050,10 +4177,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1528 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1530 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4079,10 +4206,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: t.c
       captureSnapshot: false
-      subprogram: {subprogram: 144}
+      subprogram: {subprogram: 145}
       events:
         - Kind: Entry
-          Type: 1529 EventRootType Probe[main.testThreeStringsInStruct]
+          Type: 1531 EventRootType Probe[main.testThreeStringsInStruct]
           InjectionPoints: [{PC: "0x808b40", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4110,10 +4237,10 @@ Probes:
       template: '{a}'
       segments: [{json: {ref: a}, dsl: a}]
       captureSnapshot: true
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1530 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1532 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4139,10 +4266,10 @@ Probes:
         - json: {getmember: [{ref: a}, c]}
           dsl: a.c
       captureSnapshot: false
-      subprogram: {subprogram: 145}
+      subprogram: {subprogram: 146}
       events:
         - Kind: Entry
-          Type: 1531 EventRootType Probe[main.testThreeStringsInStructPointer]
+          Type: 1533 EventRootType Probe[main.testThreeStringsInStructPointer]
           InjectionPoints: [{PC: "0x808b50", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4296,10 +4423,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 91}
+      subprogram: {subprogram: 92}
       events:
         - Kind: Entry
-          Type: 1429 EventRootType Probe[main.testUintPointer]
+          Type: 1431 EventRootType Probe[main.testUintPointer]
           InjectionPoints: [{PC: "0x806300", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4317,10 +4444,10 @@ Probes:
       template: '{u}'
       segments: [{json: {ref: u}, dsl: u}]
       captureSnapshot: true
-      subprogram: {subprogram: 129}
+      subprogram: {subprogram: 130}
       events:
         - Kind: Entry
-          Type: 1511 EventRootType Probe[main.testUintSlice]
+          Type: 1513 EventRootType Probe[main.testUintSlice]
           InjectionPoints: [{PC: "0x808740", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4338,10 +4465,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 148}
+      subprogram: {subprogram: 149}
       events:
         - Kind: Entry
-          Type: 1535 EventRootType Probe[main.testUnitializedString]
+          Type: 1537 EventRootType Probe[main.testUnitializedString]
           InjectionPoints: [{PC: "0x808b80", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4359,10 +4486,10 @@ Probes:
       template: '{x}'
       segments: [{json: {ref: x}, dsl: x}]
       captureSnapshot: true
-      subprogram: {subprogram: 90}
+      subprogram: {subprogram: 91}
       events:
         - Kind: Entry
-          Type: 1428 EventRootType Probe[main.testUnsafePointer]
+          Type: 1430 EventRootType Probe[main.testUnsafePointer]
           InjectionPoints: [{PC: "0x8062e0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4401,10 +4528,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1520 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1522 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4422,10 +4549,10 @@ Probes:
       template: '{xs}'
       segments: [{json: {ref: xs}, dsl: xs}]
       captureSnapshot: true
-      subprogram: {subprogram: 138}
+      subprogram: {subprogram: 139}
       events:
         - Kind: Entry
-          Type: 1521 EventRootType Probe[main.testVeryLargeSlice]
+          Type: 1523 EventRootType Probe[main.testVeryLargeSlice]
           InjectionPoints: [{PC: "0x8087d0", Frameless: true}]
           Condition: null
       probeTemplate:
@@ -4442,10 +4569,10 @@ Probes:
       template: testWhollyInlinedSubroutine
       segments: [testWhollyInlinedSubroutine]
       captureSnapshot: true
-      subprogram: {subprogram: 163}
+      subprogram: {subprogram: 164}
       events:
         - Kind: Entry
-          Type: 1558 EventRootType Probe[main.firstBehavior.DoSomething]
+          Type: 1563 EventRootType Probe[main.firstBehavior.DoSomething]
           InjectionPoints:
             - PC: "0x804278"
               Frameless: false
@@ -4453,7 +4580,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 1559 EventRootType Probe[main.firstBehavior.DoSomething]Return
+          Type: 1564 EventRootType Probe[main.firstBehavior.DoSomething]Return
           InjectionPoints: [{PC: "0x8042a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -4471,14 +4598,14 @@ Probes:
         - json: {ref: b}
           dsl: b
       captureSnapshot: true
-      subprogram: {subprogram: 128}
+      subprogram: {subprogram: 129}
       events:
         - Kind: Entry
-          Type: 1509 EventRootType Probe[main.testZeroSizeArgAndReturn]
+          Type: 1511 EventRootType Probe[main.testZeroSizeArgAndReturn]
           InjectionPoints: [{PC: "0x808278", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 1510 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
+          Type: 1512 EventRootType Probe[main.testZeroSizeArgAndReturn]Return
           InjectionPoints: [{PC: "0x8082dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -5618,6 +5745,33 @@ Subprograms:
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
     - ID: 84
+      Name: main.testCombinedString
+      OutOfLinePCRanges: [0x805e90..0x805ea0]
+      InlinePCRanges: []
+      Variables:
+        - Name: w
+          Type: 3 BaseType uint8
+          Locations:
+            - Range: 0x805e90..0x805ea0
+              Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
+          Role: Parameter
+        - Name: x
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x805e90..0x805ea0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+          Role: Parameter
+        - Name: y
+          Type: 17 BaseType float32
+          Locations:
+            - Range: 0x805e90..0x805ea0
+              Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
+          Role: Parameter
+    - ID: 85
       Name: main.testMultipleSimpleParams
       OutOfLinePCRanges: [0x805f50..0x805f60]
       InlinePCRanges: []
@@ -5656,7 +5810,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 85
+    - ID: 86
       Name: main.testAtomicAdd
       OutOfLinePCRanges: [0x8060f0..0x806130]
       InlinePCRanges: []
@@ -5677,7 +5831,7 @@ Subprograms:
             - Range: 0x80612d..0x806130
               Pieces: []
           Role: Return
-    - ID: 86
+    - ID: 87
       Name: main.testChannel
       OutOfLinePCRanges: [0x806130..0x806140]
       InlinePCRanges: []
@@ -5688,7 +5842,7 @@ Subprograms:
             - Range: 0x806130..0x806140
               Pieces: [{Size: 0, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 87
+    - ID: 88
       Name: main.testPointerToSimpleStruct
       OutOfLinePCRanges: [0x8062b0..0x8062c0]
       InlinePCRanges: []
@@ -5699,7 +5853,7 @@ Subprograms:
             - Range: 0x8062b0..0x8062c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 88
+    - ID: 89
       Name: main.testLinkedList
       OutOfLinePCRanges: [0x8062c0..0x8062d0]
       InlinePCRanges: []
@@ -5714,7 +5868,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 89
+    - ID: 90
       Name: main.testPointerLoop
       OutOfLinePCRanges: [0x8062d0..0x8062e0]
       InlinePCRanges: []
@@ -5725,7 +5879,7 @@ Subprograms:
             - Range: 0x8062d0..0x8062e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 90
+    - ID: 91
       Name: main.testUnsafePointer
       OutOfLinePCRanges: [0x8062e0..0x8062f0]
       InlinePCRanges: []
@@ -5736,7 +5890,7 @@ Subprograms:
             - Range: 0x8062e0..0x8062f0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 91
+    - ID: 92
       Name: main.testUintPointer
       OutOfLinePCRanges: [0x806300..0x806310]
       InlinePCRanges: []
@@ -5747,7 +5901,7 @@ Subprograms:
             - Range: 0x806300..0x806310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 92
+    - ID: 93
       Name: main.testStringPointer
       OutOfLinePCRanges: [0x806370..0x806380]
       InlinePCRanges: []
@@ -5758,7 +5912,7 @@ Subprograms:
             - Range: 0x806370..0x806380
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 93
+    - ID: 94
       Name: main.testNilPointer
       OutOfLinePCRanges: [0x806390..0x8063a0]
       InlinePCRanges: []
@@ -5775,7 +5929,7 @@ Subprograms:
             - Range: 0x806390..0x8063a0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
-    - ID: 94
+    - ID: 95
       Name: main.testCycle
       OutOfLinePCRanges: [0x8063b0..0x8063c0]
       InlinePCRanges: []
@@ -5786,7 +5940,7 @@ Subprograms:
             - Range: 0x8063b0..0x8063c0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 95
+    - ID: 96
       Name: main.testReturnsInt
       OutOfLinePCRanges: [0x8066b0..0x806730]
       InlinePCRanges: []
@@ -5815,7 +5969,7 @@ Subprograms:
             - Range: 0x8066d8..0x806730
               Pieces: [{Size: 8, Op: {CfaOffset: -32}}]
           Role: Local
-    - ID: 96
+    - ID: 97
       Name: main.testReturnsIntPointer
       OutOfLinePCRanges: [0x806730..0x8067d0]
       InlinePCRanges: []
@@ -5846,7 +6000,7 @@ Subprograms:
             - Range: 0x806770..0x8067d0
               Pieces: [{Size: 8, Op: {CfaOffset: -16}}]
           Role: Local
-    - ID: 97
+    - ID: 98
       Name: main.testReturnsIntAndFloat
       OutOfLinePCRanges: [0x8067d0..0x8068a0]
       InlinePCRanges: []
@@ -5887,7 +6041,7 @@ Subprograms:
             - Range: 0x80682c..0x8068a0
               Pieces: [{Size: 8, Op: {CfaOffset: -64}}]
           Role: Local
-    - ID: 98
+    - ID: 99
       Name: main.testReturnsError
       OutOfLinePCRanges: [0x8068a0..0x806920]
       InlinePCRanges: []
@@ -5920,7 +6074,7 @@ Subprograms:
             - Range: 0x806901..0x806920
               Pieces: []
           Role: Return
-    - ID: 99
+    - ID: 100
       Name: main.testReturnsAnyAndError
       OutOfLinePCRanges: [0x806920..0x806aa0]
       InlinePCRanges: []
@@ -6041,7 +6195,7 @@ Subprograms:
             - Range: 0x806970..0x806978
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Local
-    - ID: 100
+    - ID: 101
       Name: main.testReturnsAny
       OutOfLinePCRanges: [0x806aa0..0x806c80]
       InlinePCRanges: []
@@ -6118,7 +6272,7 @@ Subprograms:
             - Range: 0x806b78..0x806b94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 101
+    - ID: 102
       Name: main.testReturnsInterface
       OutOfLinePCRanges: [0x806c80..0x806dd0]
       InlinePCRanges: []
@@ -6211,7 +6365,7 @@ Subprograms:
             - Range: 0x806d64..0x806dd0
               Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
           Role: Local
-    - ID: 102
+    - ID: 103
       Name: main.testNamedReturn
       OutOfLinePCRanges: [0x806dd0..0x806e70]
       InlinePCRanges: []
@@ -6232,7 +6386,7 @@ Subprograms:
             - Range: 0x806e45..0x806e70
               Pieces: []
           Role: Return
-    - ID: 103
+    - ID: 104
       Name: main.testMultipleNamedReturn
       OutOfLinePCRanges: [0x806e70..0x806f30]
       InlinePCRanges: []
@@ -6263,7 +6417,7 @@ Subprograms:
             - Range: 0x806f0d..0x806f30
               Pieces: []
           Role: Return
-    - ID: 104
+    - ID: 105
       Name: main.testSomeNamedReturn
       OutOfLinePCRanges: [0x806f30..0x806ff0]
       InlinePCRanges: []
@@ -6306,7 +6460,7 @@ Subprograms:
             - Range: 0x806fd1..0x806ff0
               Pieces: []
           Role: Return
-    - ID: 105
+    - ID: 106
       Name: main.testReturnsPrimitives
       OutOfLinePCRanges: [0x806ff0..0x807080]
       InlinePCRanges: []
@@ -6391,7 +6545,7 @@ Subprograms:
             - Range: 0x80705d..0x807080
               Pieces: []
           Role: Return
-    - ID: 106
+    - ID: 107
       Name: main.testReturnsManyFloats
       OutOfLinePCRanges: [0x807080..0x807130]
       InlinePCRanges: []
@@ -6470,7 +6624,7 @@ Subprograms:
             - Range: 0x807119..0x807130
               Pieces: []
           Role: Return
-    - ID: 107
+    - ID: 108
       Name: main.testReturnsComplex
       OutOfLinePCRanges: [0x807130..0x8071b0]
       InlinePCRanges: []
@@ -6483,7 +6637,7 @@ Subprograms:
           Type: 18 BaseType complex128
           Locations: [{Range: 0x807130..0x8071b0, Pieces: []}]
           Role: Return
-    - ID: 108
+    - ID: 109
       Name: main.testReturnsLargeStruct
       OutOfLinePCRanges: [0x8071b0..0x807270]
       InlinePCRanges: []
@@ -6518,7 +6672,7 @@ Subprograms:
             - Range: 0x807251..0x807270
               Pieces: []
           Role: Return
-    - ID: 109
+    - ID: 110
       Name: main.testReturnsArray
       OutOfLinePCRanges: [0x807270..0x807300]
       InlinePCRanges: []
@@ -6533,7 +6687,7 @@ Subprograms:
             - Range: 0x8072dd..0x807300
               Pieces: []
           Role: Return
-    - ID: 110
+    - ID: 111
       Name: main.testReturnsArrayOne
       OutOfLinePCRanges: [0x807300..0x807370]
       InlinePCRanges: []
@@ -6548,7 +6702,7 @@ Subprograms:
             - Range: 0x807351..0x807370
               Pieces: []
           Role: Return
-    - ID: 111
+    - ID: 112
       Name: main.testReturnsArrayZero
       OutOfLinePCRanges: [0x807370..0x8073e0]
       InlinePCRanges: []
@@ -6563,7 +6717,7 @@ Subprograms:
             - Range: 0x8073bd..0x8073e0
               Pieces: []
           Role: Return
-    - ID: 112
+    - ID: 113
       Name: main.testReturnsMixedStruct
       OutOfLinePCRanges: [0x8073e0..0x807460]
       InlinePCRanges: []
@@ -6572,7 +6726,7 @@ Subprograms:
           Type: 260 StructureType main.mixedStruct
           Locations: [{Range: 0x8073e0..0x807460, Pieces: []}]
           Role: Return
-    - ID: 113
+    - ID: 114
       Name: main.testReturnsBacktrackInt
       OutOfLinePCRanges: [0x807460..0x8074f0]
       InlinePCRanges: []
@@ -6671,7 +6825,7 @@ Subprograms:
             - Range: 0x8074d9..0x8074f0
               Pieces: []
           Role: Return
-    - ID: 114
+    - ID: 115
       Name: main.testReturnsWideStruct
       OutOfLinePCRanges: [0x8074f0..0x8075c0]
       InlinePCRanges: []
@@ -6708,7 +6862,7 @@ Subprograms:
             - Range: 0x8075a1..0x8075c0
               Pieces: []
           Role: Return
-    - ID: 115
+    - ID: 116
       Name: main.testReturnsMixed
       OutOfLinePCRanges: [0x8075c0..0x807650]
       InlinePCRanges: []
@@ -6755,7 +6909,7 @@ Subprograms:
             - Range: 0x80762d..0x807650
               Pieces: []
           Role: Return
-    - ID: 116
+    - ID: 117
       Name: main.testReturnsStructWithArray
       OutOfLinePCRanges: [0x807650..0x8076e0]
       InlinePCRanges: []
@@ -6770,7 +6924,7 @@ Subprograms:
             - Range: 0x8076bd..0x8076e0
               Pieces: []
           Role: Return
-    - ID: 117
+    - ID: 118
       Name: main.testReturnsOnlyFloat
       OutOfLinePCRanges: [0x8076e0..0x807750]
       InlinePCRanges: []
@@ -6779,7 +6933,7 @@ Subprograms:
           Type: 14 BaseType float64
           Locations: [{Range: 0x8076e0..0x807750, Pieces: []}]
           Role: Return
-    - ID: 118
+    - ID: 119
       Name: main.testReturnsMultipleFloats
       OutOfLinePCRanges: [0x807750..0x8077c0]
       InlinePCRanges: []
@@ -6792,7 +6946,7 @@ Subprograms:
           Type: 14 BaseType float64
           Locations: [{Range: 0x807750..0x8077c0, Pieces: []}]
           Role: Return
-    - ID: 119
+    - ID: 120
       Name: main.testReturnsBoolAndUintptr
       OutOfLinePCRanges: [0x8077c0..0x807830]
       InlinePCRanges: []
@@ -6817,7 +6971,7 @@ Subprograms:
             - Range: 0x807815..0x807830
               Pieces: []
           Role: Return
-    - ID: 120
+    - ID: 121
       Name: main.testLargeArgAndReturn
       OutOfLinePCRanges: [0x807830..0x8079c0]
       InlinePCRanges: []
@@ -6944,7 +7098,7 @@ Subprograms:
             - Range: 0x807981..0x8079c0
               Pieces: []
           Role: Return
-    - ID: 121
+    - ID: 122
       Name: main.testArrayArgAndReturn
       OutOfLinePCRanges: [0x8079c0..0x807a90]
       InlinePCRanges: []
@@ -6965,7 +7119,7 @@ Subprograms:
             - Range: 0x807a71..0x807a90
               Pieces: []
           Role: Return
-    - ID: 122
+    - ID: 123
       Name: main.testMultipleLargeArgs
       OutOfLinePCRanges: [0x807a90..0x807ca0]
       InlinePCRanges: []
@@ -7098,7 +7252,7 @@ Subprograms:
             - Range: 0x807c59..0x807ca0
               Pieces: []
           Role: Return
-    - ID: 123
+    - ID: 124
       Name: main.testManyArgsArrayReturn
       OutOfLinePCRanges: [0x807ca0..0x807e50]
       InlinePCRanges: []
@@ -7185,7 +7339,7 @@ Subprograms:
             - Range: 0x807e11..0x807e50
               Pieces: []
           Role: Return
-    - ID: 124
+    - ID: 125
       Name: main.testMixedArgsStackReturn
       OutOfLinePCRanges: [0x807e50..0x808040]
       InlinePCRanges: []
@@ -7300,7 +7454,7 @@ Subprograms:
             - Range: 0x807ffd..0x808040
               Pieces: []
           Role: Return
-    - ID: 125
+    - ID: 126
       Name: main.testStackArgRegReturns
       OutOfLinePCRanges: [0x808040..0x8080d0]
       InlinePCRanges: []
@@ -7341,7 +7495,7 @@ Subprograms:
             - Range: 0x8080b5..0x8080d0
               Pieces: []
           Role: Return
-    - ID: 126
+    - ID: 127
       Name: main.testMultipleArrayArgs
       OutOfLinePCRanges: [0x8080d0..0x8081a0]
       InlinePCRanges: []
@@ -7378,7 +7532,7 @@ Subprograms:
             - Range: 0x808189..0x8081a0
               Pieces: []
           Role: Return
-    - ID: 127
+    - ID: 128
       Name: main.testStructWithArrayArg
       OutOfLinePCRanges: [0x8081a0..0x808260]
       InlinePCRanges: []
@@ -7415,7 +7569,7 @@ Subprograms:
             - Range: 0x808220..0x808260
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
-    - ID: 128
+    - ID: 129
       Name: main.testZeroSizeArgAndReturn
       OutOfLinePCRanges: [0x808260..0x808300]
       InlinePCRanges: []
@@ -7456,7 +7610,7 @@ Subprograms:
             - Range: 0x8082dd..0x808300
               Pieces: []
           Role: Return
-    - ID: 129
+    - ID: 130
       Name: main.testUintSlice
       OutOfLinePCRanges: [0x808740..0x808750]
       InlinePCRanges: []
@@ -7473,7 +7627,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 130
+    - ID: 131
       Name: main.testEmptySlice
       OutOfLinePCRanges: [0x808750..0x808760]
       InlinePCRanges: []
@@ -7490,7 +7644,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 131
+    - ID: 132
       Name: main.testSliceOfSlices
       OutOfLinePCRanges: [0x808760..0x808770]
       InlinePCRanges: []
@@ -7507,7 +7661,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 132
+    - ID: 133
       Name: main.testStructSlice
       OutOfLinePCRanges: [0x808770..0x808780]
       InlinePCRanges: []
@@ -7530,7 +7684,7 @@ Subprograms:
             - Range: 0x808770..0x808780
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 133
+    - ID: 134
       Name: main.testEmptySliceOfStructs
       OutOfLinePCRanges: [0x808780..0x808790]
       InlinePCRanges: []
@@ -7553,7 +7707,7 @@ Subprograms:
             - Range: 0x808780..0x808790
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 134
+    - ID: 135
       Name: main.testNilSliceOfStructs
       OutOfLinePCRanges: [0x808790..0x8087a0]
       InlinePCRanges: []
@@ -7576,7 +7730,7 @@ Subprograms:
             - Range: 0x808790..0x8087a0
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
-    - ID: 135
+    - ID: 136
       Name: main.testStringSlice
       OutOfLinePCRanges: [0x8087a0..0x8087b0]
       InlinePCRanges: []
@@ -7593,7 +7747,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 136
+    - ID: 137
       Name: main.testNilSliceWithOtherParams
       OutOfLinePCRanges: [0x8087b0..0x8087c0]
       InlinePCRanges: []
@@ -7622,7 +7776,7 @@ Subprograms:
             - Range: 0x8087b0..0x8087c0
               Pieces: [{Size: 8, Op: {RegNo: 4, Shift: 0}}]
           Role: Parameter
-    - ID: 137
+    - ID: 138
       Name: main.testNilSlice
       OutOfLinePCRanges: [0x8087c0..0x8087d0]
       InlinePCRanges: []
@@ -7639,7 +7793,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 138
+    - ID: 139
       Name: main.testVeryLargeSlice
       OutOfLinePCRanges: [0x8087d0..0x8087e0]
       InlinePCRanges: []
@@ -7656,7 +7810,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 139
+    - ID: 140
       Name: main.testSliceEmptyStructs
       OutOfLinePCRanges: [0x8087e0..0x8087f0]
       InlinePCRanges: []
@@ -7673,7 +7827,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
           Role: Parameter
-    - ID: 140
+    - ID: 141
       Name: main.testSubslices
       OutOfLinePCRanges: [0x8087f0..0x808800]
       InlinePCRanges: []
@@ -7714,7 +7868,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 8, Shift: 0}
           Role: Parameter
-    - ID: 141
+    - ID: 142
       Name: main.stackC
       OutOfLinePCRanges: [0x808ac0..0x808b20]
       InlinePCRanges: []
@@ -7733,7 +7887,7 @@ Subprograms:
             - Range: 0x808b09..0x808b20
               Pieces: []
           Role: Return
-    - ID: 142
+    - ID: 143
       Name: main.testSingleString
       OutOfLinePCRanges: [0x808b20..0x808b30]
       InlinePCRanges: []
@@ -7748,7 +7902,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 143
+    - ID: 144
       Name: main.testThreeStrings
       OutOfLinePCRanges: [0x808b30..0x808b40]
       InlinePCRanges: []
@@ -7783,7 +7937,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 144
+    - ID: 145
       Name: main.testThreeStringsInStruct
       OutOfLinePCRanges: [0x808b40..0x808b50]
       InlinePCRanges: []
@@ -7806,7 +7960,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 145
+    - ID: 146
       Name: main.testThreeStringsInStructPointer
       OutOfLinePCRanges: [0x808b50..0x808b60]
       InlinePCRanges: []
@@ -7817,7 +7971,7 @@ Subprograms:
             - Range: 0x808b50..0x808b60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 146
+    - ID: 147
       Name: main.testOneStringInStructPointer
       OutOfLinePCRanges: [0x808b60..0x808b70]
       InlinePCRanges: []
@@ -7828,7 +7982,7 @@ Subprograms:
             - Range: 0x808b60..0x808b70
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 147
+    - ID: 148
       Name: main.testMassiveString
       OutOfLinePCRanges: [0x808b70..0x808b80]
       InlinePCRanges: []
@@ -7843,7 +7997,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 148
+    - ID: 149
       Name: main.testUnitializedString
       OutOfLinePCRanges: [0x808b80..0x808b90]
       InlinePCRanges: []
@@ -7858,7 +8012,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 149
+    - ID: 150
       Name: main.testEmptyString
       OutOfLinePCRanges: [0x808b90..0x808ba0]
       InlinePCRanges: []
@@ -7873,7 +8027,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
           Role: Parameter
-    - ID: 150
+    - ID: 151
       Name: main.testSubstrings
       OutOfLinePCRanges: [0x808ba0..0x808bb0]
       InlinePCRanges: []
@@ -7908,7 +8062,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 151
+    - ID: 152
       Name: main.testStructWithCyclicSlices
       OutOfLinePCRanges: [0x808cf0..0x808d00]
       InlinePCRanges: []
@@ -7919,7 +8073,7 @@ Subprograms:
             - Range: 0x808cf0..0x808d00
               Pieces: [{Size: 144, Op: {CfaOffset: 8}}]
           Role: Parameter
-    - ID: 152
+    - ID: 153
       Name: main.testStructWithCyclicMaps
       OutOfLinePCRanges: [0x808d00..0x808d10]
       InlinePCRanges: []
@@ -7942,7 +8096,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
           Role: Parameter
-    - ID: 153
+    - ID: 154
       Name: main.testStruct
       OutOfLinePCRanges: [0x808da0..0x808db0]
       InlinePCRanges: []
@@ -7967,7 +8121,7 @@ Subprograms:
                 - Size: 8
                   Op: {RegNo: 6, Shift: 0}
           Role: Parameter
-    - ID: 154
+    - ID: 155
       Name: main.testNestedPointer
       OutOfLinePCRanges: [0x808e00..0x808e10]
       InlinePCRanges: []
@@ -7978,7 +8132,7 @@ Subprograms:
             - Range: 0x808e00..0x808e10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 155
+    - ID: 156
       Name: main.testEmptyStruct
       OutOfLinePCRanges: [0x808e40..0x808e50]
       InlinePCRanges: []
@@ -7987,7 +8141,7 @@ Subprograms:
           Type: 325 StructureType main.emptyStruct
           Locations: [{Range: 0x808e40..0x808e50, Pieces: []}]
           Role: Parameter
-    - ID: 156
+    - ID: 157
       Name: main.testEmptyStructPointer
       OutOfLinePCRanges: [0x808e50..0x808e60]
       InlinePCRanges: []
@@ -7998,7 +8152,7 @@ Subprograms:
             - Range: 0x808e50..0x808e60
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 157
+    - ID: 158
       Name: main.testInlinedPrint
       OutOfLinePCRanges: [0x803c60..0x803cd0]
       InlinePCRanges:
@@ -8027,28 +8181,28 @@ Subprograms:
             - Range: 0x803f40..0x803f64
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 158
+    - ID: 159
       Name: main.testInlinedBBB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803ee4..0x803f18]
           RootRanges: [0x803e80..0x803f40]
       Variables: []
-    - ID: 159
+    - ID: 160
       Name: main.testInlinedBCA
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x803fcc..0x804000, 0x804008..0x80400c]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 160
+    - ID: 161
       Name: main.testInlinedBCB
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x804070..0x8040a4]
           RootRanges: [0x803fb0..0x8040c0]
       Variables: []
-    - ID: 161
+    - ID: 162
       Name: main.testInlinedSq
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8061,7 +8215,7 @@ Subprograms:
             - Range: 0x8040c0..0x8040c8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 162
+    - ID: 163
       Name: main.testInlinedSumArray
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -8078,7 +8232,7 @@ Subprograms:
             - Range: 0x804168..0x804260
               Pieces: [{Size: 40, Op: {CfaOffset: -120}}]
           Role: Parameter
-    - ID: 163
+    - ID: 164
       Name: main.firstBehavior.DoSomething
       OutOfLinePCRanges: [0x804260..0x8042c0]
       InlinePCRanges:
@@ -8109,7 +8263,7 @@ Subprograms:
             - Range: 0x8042a1..0x8042c0
               Pieces: []
           Role: Return
-    - ID: 164
+    - ID: 165
       Name: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -11452,10 +11606,10 @@ Types:
       GoKind: 22
       Pointee: 826 BaseType vendor/golang.org/x/net/idna.runeError
     - __kind: EventRootType
-      ID: 1560
+      ID: 1565
       Name: Probe[github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.InlinedFunc]
     - __kind: EventRootType
-      ID: 1558
+      ID: 1563
       Name: Probe[main.firstBehavior.DoSomething]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11467,11 +11621,11 @@ Types:
             Type: 327 StructureType main.firstBehavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 0, name: b}
+                  Variable: {subprogram: 164, index: 0, name: b}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1559
+      ID: 1564
       Name: Probe[main.firstBehavior.DoSomething]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11483,14 +11637,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 163, index: 1, name: ~r0}
+                  Variable: {subprogram: 164, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1524
+      ID: 1526
       Name: Probe[main.stackC]
     - __kind: EventRootType
-      ID: 1525
+      ID: 1527
       Name: Probe[main.stackC]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11502,7 +11656,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 141, index: 0, name: ~r0}
+                  Variable: {subprogram: 142, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -11590,7 +11744,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1495
+      ID: 1497
       Name: Probe[main.testArrayArgAndReturn]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -11602,7 +11756,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -11612,11 +11766,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 0, name: arg}
+                  Variable: {subprogram: 122, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1496
+      ID: 1498
       Name: Probe[main.testArrayArgAndReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -11628,7 +11782,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 121, index: 1, name: ~r0}
+                  Variable: {subprogram: 122, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -11788,7 +11942,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1422
+      ID: 1424
       Name: Probe[main.testAtomicAdd]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -11800,7 +11954,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -11810,11 +11964,11 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 0, name: x}
+                  Variable: {subprogram: 86, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1423
+      ID: 1425
       Name: Probe[main.testAtomicAdd]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -11826,7 +11980,7 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 85, index: 1, name: ~r0}
+                  Variable: {subprogram: 86, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -11908,7 +12062,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
     - __kind: EventRootType
-      ID: 1424
+      ID: 1426
       Name: Probe[main.testChannel]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -11920,7 +12074,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
         - Name: c
@@ -11930,7 +12084,7 @@ Types:
             Type: 249 GoChannelType chan bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: c}
+                  Variable: {subprogram: 87, index: 0, name: c}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12000,7 +12154,69 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1432
+      ID: 1421
+      Name: Probe[main.testCombinedString]
+      ByteSize: 18
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1422
+      Name: Probe[main.testCombinedString]
+      ByteSize: 34
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: x_val
+          Offset: 17
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 1, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: w_val
+          Offset: 33
+          Kind: capture_expression
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1434
       Name: Probe[main.testCycle]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12012,7 +12228,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
         - Name: t
@@ -12022,7 +12238,7 @@ Types:
             Type: 254 PointerType *main.t
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 94, index: 0, name: t}
+                  Variable: {subprogram: 95, index: 0, name: t}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -12182,7 +12398,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1515
+      ID: 1517
       Name: Probe[main.testEmptySliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -12194,7 +12410,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -12204,7 +12420,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 0, name: xs}
+                  Variable: {subprogram: 134, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -12214,7 +12430,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -12224,11 +12440,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 133, index: 1, name: a}
+                  Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1512
+      ID: 1514
       Name: Probe[main.testEmptySlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -12240,7 +12456,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -12250,11 +12466,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: u}
+                  Variable: {subprogram: 131, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1536
+      ID: 1538
       Name: Probe[main.testEmptyString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -12266,7 +12482,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -12276,11 +12492,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 149, index: 0, name: x}
+                  Variable: {subprogram: 150, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1546
+      ID: 1549
       Name: Probe[main.testEmptyStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12292,7 +12508,7 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -12302,11 +12518,11 @@ Types:
             Type: 326 PointerType *main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 156, index: 0, name: e}
+                  Variable: {subprogram: 157, index: 0, name: e}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1545
+      ID: 1548
       Name: Probe[main.testEmptyStruct]
       ByteSize: 1
       PresenceBitsetSize: 1
@@ -12318,7 +12534,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
         - Name: e
@@ -12328,7 +12544,7 @@ Types:
             Type: 325 StructureType main.emptyStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 155, index: 0, name: e}
+                  Variable: {subprogram: 156, index: 0, name: e}
                   Offset: 0
                   ByteSize: 0
     - __kind: EventRootType
@@ -12594,7 +12810,7 @@ Types:
       ID: 1381
       Name: Probe[main.testInlinedBBA]Return
     - __kind: EventRootType
-      ID: 1550
+      ID: 1555
       Name: Probe[main.testInlinedBBB]
     - __kind: EventRootType
       ID: 1378
@@ -12646,16 +12862,16 @@ Types:
       ID: 1379
       Name: Probe[main.testInlinedBB]Return
     - __kind: EventRootType
-      ID: 1551
+      ID: 1556
       Name: Probe[main.testInlinedBCA]
     - __kind: EventRootType
-      ID: 1552
+      ID: 1557
       Name: Probe[main.testInlinedBCA]Line
     - __kind: EventRootType
-      ID: 1553
+      ID: 1558
       Name: Probe[main.testInlinedBCB]
     - __kind: EventRootType
-      ID: 1554
+      ID: 1559
       Name: Probe[main.testInlinedBCB]Line
     - __kind: EventRootType
       ID: 1382
@@ -12664,7 +12880,7 @@ Types:
       ID: 1383
       Name: Probe[main.testInlinedBC]Return
     - __kind: EventRootType
-      ID: 1547
+      ID: 1552
       Name: Probe[main.testInlinedPrint]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12676,7 +12892,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12686,11 +12902,53 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1549
+      ID: 1550
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_val
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1551
+      Name: Probe[main.testInlinedPrint]Line
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: x_val
+          Offset: 9
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 158, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1554
       Name: Probe[main.testInlinedPrint]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12702,7 +12960,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12712,14 +12970,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 157, index: 0, name: x}
+                  Variable: {subprogram: 158, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1548
+      ID: 1553
       Name: Probe[main.testInlinedPrint]Return
     - __kind: EventRootType
-      ID: 1555
+      ID: 1560
       Name: Probe[main.testInlinedSq]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12731,7 +12989,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12741,11 +12999,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1556
+      ID: 1561
       Name: Probe[main.testInlinedSq]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -12757,7 +13015,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -12767,11 +13025,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 161, index: 0, name: x}
+                  Variable: {subprogram: 162, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1557
+      ID: 1562
       Name: Probe[main.testInlinedSumArray]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12783,7 +13041,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
         - Name: a
@@ -12793,7 +13051,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 162, index: 0, name: a}
+                  Variable: {subprogram: 163, index: 0, name: a}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
@@ -12953,7 +13211,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1493
+      ID: 1495
       Name: Probe[main.testLargeArgAndReturn]
       ByteSize: 161
       PresenceBitsetSize: 1
@@ -12965,7 +13223,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
         - Name: arg
@@ -12975,11 +13233,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 0, name: arg}
+                  Variable: {subprogram: 121, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1494
+      ID: 1496
       Name: Probe[main.testLargeArgAndReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -12991,11 +13249,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 120, index: 1, name: ~r0}
+                  Variable: {subprogram: 121, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1426
+      ID: 1428
       Name: Probe[main.testLinkedList]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13007,7 +13265,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -13017,7 +13275,7 @@ Types:
             Type: 252 StructureType main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 88, index: 0, name: a}
+                  Variable: {subprogram: 89, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13096,7 +13354,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1499
+      ID: 1501
       Name: Probe[main.testManyArgsArrayReturn]
       ByteSize: 147
       PresenceBitsetSize: 3
@@ -13108,7 +13366,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13118,7 +13376,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 0, name: a}
+                  Variable: {subprogram: 124, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13128,7 +13386,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13138,7 +13396,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 1, name: b}
+                  Variable: {subprogram: 124, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13148,7 +13406,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13158,7 +13416,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 2, name: c}
+                  Variable: {subprogram: 124, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13168,7 +13426,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13178,7 +13436,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 3, name: d}
+                  Variable: {subprogram: 124, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13188,7 +13446,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13198,7 +13456,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 4, name: e}
+                  Variable: {subprogram: 124, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13208,7 +13466,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13218,7 +13476,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 5, name: f}
+                  Variable: {subprogram: 124, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13228,7 +13486,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -13238,7 +13496,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 6, name: g}
+                  Variable: {subprogram: 124, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13248,7 +13506,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -13258,7 +13516,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 7, name: h}
+                  Variable: {subprogram: 124, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13268,7 +13526,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -13278,11 +13536,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 8, name: i}
+                  Variable: {subprogram: 124, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1500
+      ID: 1502
       Name: Probe[main.testManyArgsArrayReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -13294,7 +13552,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 123, index: 9, name: ~r0}
+                  Variable: {subprogram: 124, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -13818,7 +14076,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1533
+      ID: 1535
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13830,7 +14088,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13840,11 +14098,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1534
+      ID: 1536
       Name: Probe[main.testMassiveString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -13856,7 +14114,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -13866,11 +14124,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 147, index: 0, name: x}
+                  Variable: {subprogram: 148, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1501
+      ID: 1503
       Name: Probe[main.testMixedArgsStackReturn]
       ByteSize: 163
       PresenceBitsetSize: 3
@@ -13882,7 +14140,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -13892,7 +14150,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13902,7 +14160,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -13912,7 +14170,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13922,7 +14180,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: c
@@ -13932,7 +14190,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13942,7 +14200,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -13952,7 +14210,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13962,7 +14220,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -13972,7 +14230,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 4, name: e}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13982,7 +14240,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: f
@@ -13992,7 +14250,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 5, name: f}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14002,7 +14260,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: g
@@ -14012,7 +14270,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 6, name: g}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14022,7 +14280,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: h
@@ -14032,7 +14290,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 7, name: h}
+                  Variable: {subprogram: 125, index: 7, name: h}
                   Offset: 0
                   ByteSize: 8
         - Name: s
@@ -14042,7 +14300,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
         - Name: s
@@ -14052,11 +14310,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 8, name: s}
+                  Variable: {subprogram: 125, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1502
+      ID: 1504
       Name: Probe[main.testMixedArgsStackReturn]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14068,11 +14326,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 9, name: ~r0}
+                  Variable: {subprogram: 125, index: 9, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1505
+      ID: 1507
       Name: Probe[main.testMultipleArrayArgs]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14084,7 +14342,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -14094,7 +14352,7 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 127, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -14104,7 +14362,7 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
         - Name: b
@@ -14114,11 +14372,11 @@ Types:
             Type: 257 ArrayType [3]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 127, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1506
+      ID: 1508
       Name: Probe[main.testMultipleArrayArgs]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14130,7 +14388,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: ~r0}
+                  Variable: {subprogram: 127, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -14140,11 +14398,11 @@ Types:
             Type: 119 ArrayType [2]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: ~r1}
+                  Variable: {subprogram: 127, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1497
+      ID: 1499
       Name: Probe[main.testMultipleLargeArgs]
       ByteSize: 321
       PresenceBitsetSize: 1
@@ -14156,7 +14414,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s1
@@ -14166,7 +14424,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 0, name: s1}
+                  Variable: {subprogram: 123, index: 0, name: s1}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14176,7 +14434,7 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
         - Name: s2
@@ -14186,11 +14444,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 1, name: s2}
+                  Variable: {subprogram: 123, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1498
+      ID: 1500
       Name: Probe[main.testMultipleLargeArgs]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -14202,11 +14460,11 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 122, index: 2, name: ~r0}
+                  Variable: {subprogram: 123, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1451
+      ID: 1453
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14218,7 +14476,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14228,11 +14486,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1453
+      ID: 1455
       Name: Probe[main.testMultipleNamedReturn]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14244,7 +14502,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14254,7 +14512,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14264,7 +14522,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14274,23 +14532,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1455
-      Name: Probe[main.testMultipleNamedReturn]
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14306,7 +14548,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14322,11 +14564,27 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 0, name: i}
+                  Variable: {subprogram: 104, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1452
+      ID: 1461
+      Name: Probe[main.testMultipleNamedReturn]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1454
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14338,7 +14596,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14348,11 +14606,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1454
+      ID: 1456
       Name: Probe[main.testMultipleNamedReturn]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14364,7 +14622,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14374,7 +14632,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14384,7 +14642,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14394,7 +14652,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14404,7 +14662,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14414,33 +14672,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1456
-      Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: result
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14456,7 +14688,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14466,7 +14698,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -14482,7 +14714,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 1, name: result}
+                  Variable: {subprogram: 104, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -14492,11 +14724,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 103, index: 2, name: result2}
+                  Variable: {subprogram: 104, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1421
+      ID: 1462
+      Name: Probe[main.testMultipleNamedReturn]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: result
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 1, name: result}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1423
       Name: Probe[main.testMultipleSimpleParams]
       ByteSize: 62
       PresenceBitsetSize: 2
@@ -14508,7 +14766,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14518,7 +14776,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: a}
+                  Variable: {subprogram: 85, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14528,7 +14786,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: b
@@ -14538,7 +14796,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 1, name: b}
+                  Variable: {subprogram: 85, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
         - Name: c
@@ -14548,7 +14806,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: c
@@ -14558,7 +14816,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 2, name: c}
+                  Variable: {subprogram: 85, index: 2, name: c}
                   Offset: 0
                   ByteSize: 4
         - Name: d
@@ -14568,7 +14826,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: d
@@ -14578,7 +14836,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 3, name: d}
+                  Variable: {subprogram: 85, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
         - Name: e
@@ -14588,7 +14846,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
         - Name: e
@@ -14598,35 +14856,9 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 4, name: e}
+                  Variable: {subprogram: 85, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1447
-      Name: Probe[main.testNamedReturn]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testNamedReturn]
@@ -14640,7 +14872,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -14650,11 +14882,37 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 0, name: i}
+                  Variable: {subprogram: 103, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1448
+      ID: 1451
+      Name: Probe[main.testNamedReturn]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 103, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1450
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -14666,11 +14924,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1450
+      ID: 1452
       Name: Probe[main.testNamedReturn]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14682,7 +14940,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
         - Name: result
@@ -14692,11 +14950,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 102, index: 1, name: result}
+                  Variable: {subprogram: 103, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1541
+      ID: 1544
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14708,7 +14966,7 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14718,11 +14976,11 @@ Types:
             Type: 323 PointerType *main.anotherStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1542
+      ID: 1545
       Name: Probe[main.testNestedPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14734,7 +14992,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14744,10 +15002,10 @@ Types:
                   Bias: 8
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1543
+      ID: 1546
       Name: Probe[main.testNestedPointer]
     - __kind: EventRootType
-      ID: 1544
+      ID: 1547
       Name: Probe[main.testNestedPointer]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -14759,7 +15017,7 @@ Types:
             Type: 129 StructureType main.nestedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 154, index: 0, name: x}
+                  Variable: {subprogram: 155, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -14769,7 +15027,7 @@ Types:
                   Bias: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1431
+      ID: 1433
       Name: Probe[main.testNilPointer]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -14781,7 +15039,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -14791,7 +15049,7 @@ Types:
             Type: 10 PointerType *bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 0, name: z}
+                  Variable: {subprogram: 94, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14801,7 +15059,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14811,11 +15069,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 93, index: 1, name: a}
+                  Variable: {subprogram: 94, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1516
+      ID: 1518
       Name: Probe[main.testNilSliceOfStructs]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -14827,7 +15085,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14837,7 +15095,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Variable: {subprogram: 135, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -14847,7 +15105,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14857,11 +15115,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 1, name: a}
+                  Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1518
+      ID: 1520
       Name: Probe[main.testNilSliceWithOtherParams]
       ByteSize: 67
       PresenceBitsetSize: 1
@@ -14873,7 +15131,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: a
@@ -14883,7 +15141,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: a}
+                  Variable: {subprogram: 137, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
         - Name: s
@@ -14893,7 +15151,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -14903,7 +15161,7 @@ Types:
             Type: 270 GoSliceHeaderType []bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 1, name: s}
+                  Variable: {subprogram: 137, index: 1, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: x
@@ -14913,7 +15171,7 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -14923,11 +15181,11 @@ Types:
             Type: 11 BaseType uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 2, name: x}
+                  Variable: {subprogram: 137, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1519
+      ID: 1521
       Name: Probe[main.testNilSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -14939,7 +15197,7 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -14949,11 +15207,11 @@ Types:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 137, index: 0, name: xs}
+                  Variable: {subprogram: 138, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1532
+      ID: 1534
       Name: Probe[main.testOneStringInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14965,7 +15223,7 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -14975,11 +15233,11 @@ Types:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 146, index: 0, name: a}
+                  Variable: {subprogram: 147, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1427
+      ID: 1429
       Name: Probe[main.testPointerLoop]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -14991,7 +15249,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15001,7 +15259,7 @@ Types:
             Type: 253 PointerType *main.node
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 89, index: 0, name: a}
+                  Variable: {subprogram: 90, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -15031,7 +15289,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1425
+      ID: 1427
       Name: Probe[main.testPointerToSimpleStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15043,7 +15301,7 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -15053,11 +15311,11 @@ Types:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 87, index: 0, name: a}
+                  Variable: {subprogram: 88, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1441
+      ID: 1443
       Name: Probe[main.testReturnsAnyAndError]
       ByteSize: 35
       PresenceBitsetSize: 1
@@ -15069,7 +15327,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: v
@@ -15079,7 +15337,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 0, name: v}
+                  Variable: {subprogram: 100, index: 0, name: v}
                   Offset: 0
                   ByteSize: 16
         - Name: failed
@@ -15089,7 +15347,7 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
         - Name: failed
@@ -15099,11 +15357,11 @@ Types:
             Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 1, name: failed}
+                  Variable: {subprogram: 100, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
     - __kind: EventRootType
-      ID: 1442
+      ID: 1444
       Name: Probe[main.testReturnsAnyAndError]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -15115,7 +15373,7 @@ Types:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 2, name: ~r0}
+                  Variable: {subprogram: 100, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 16
         - Name: ~r1
@@ -15125,446 +15383,12 @@ Types:
             Type: 15 GoInterfaceType error
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 99, index: 3, name: ~r1}
+                  Variable: {subprogram: 100, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 1443
-      Name: Probe[main.testReturnsAny]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: v
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
-          Kind: template_segment
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1444
-      Name: Probe[main.testReturnsAny]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 100, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1473
-      Name: Probe[main.testReturnsArrayOne]
-    - __kind: EventRootType
-      ID: 1474
-      Name: Probe[main.testReturnsArrayOne]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 258 ArrayType [1]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 110, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1475
-      Name: Probe[main.testReturnsArrayZero]
-    - __kind: EventRootType
-      ID: 1476
-      Name: Probe[main.testReturnsArrayZero]Return
-      ByteSize: 1
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 111, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 0
-    - __kind: EventRootType
-      ID: 1471
-      Name: Probe[main.testReturnsArray]
-    - __kind: EventRootType
-      ID: 1472
-      Name: Probe[main.testReturnsArray]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 257 ArrayType [3]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 109, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 24
-    - __kind: EventRootType
-      ID: 1479
-      Name: Probe[main.testReturnsBacktrackInt]
-    - __kind: EventRootType
-      ID: 1480
-      Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
-      Expressions:
-        - Name: ~r0
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 10
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r2
-          Offset: 18
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 2, name: ~r2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r3
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 3, name: ~r3}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r4
-          Offset: 34
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 4, name: ~r4}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r5
-          Offset: 42
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 5, name: ~r5}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r6
-          Offset: 50
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 6, name: ~r6}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r7
-          Offset: 58
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 7, name: ~r7}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r8
-          Offset: 66
-          Kind: local
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 113, index: 8, name: ~r8}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1491
-      Name: Probe[main.testReturnsBoolAndUintptr]
-    - __kind: EventRootType
-      ID: 1492
-      Name: Probe[main.testReturnsBoolAndUintptr]Return
-      ByteSize: 10
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: ~r1
-          Offset: 2
-          Kind: local
-          Expression:
-            Type: 1 BaseType uintptr
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 119, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1467
-      Name: Probe[main.testReturnsComplex]
-    - __kind: EventRootType
-      ID: 1468
-      Name: Probe[main.testReturnsComplex]Return
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 103 BaseType complex64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 0, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 18 BaseType complex128
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 107, index: 1, name: ~r1}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1439
-      Name: Probe[main.testReturnsError]
-      ByteSize: 3
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: failed
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: failed
-          Offset: 2
-          Kind: template_segment
-          Expression:
-            Type: 4 BaseType bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 0, name: failed}
-                  Offset: 0
-                  ByteSize: 1
-    - __kind: EventRootType
-      ID: 1440
-      Name: Probe[main.testReturnsError]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 98, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 1437
-      Name: Probe[main.testReturnsIntAndFloat]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1438
-      Name: Probe[main.testReturnsIntAndFloat]Return
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: ~r1
-          Offset: 9
-          Kind: local
-          Expression:
-            Type: 14 BaseType float64
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 97, index: 2, name: ~r1}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1435
-      Name: Probe[main.testReturnsIntPointer]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1436
-      Name: Probe[main.testReturnsIntPointer]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 105 PointerType *int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 96, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1433
-      Name: Probe[main.testReturnsInt]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: i
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: i
-          Offset: 9
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: i}
-                  Offset: 0
-                  ByteSize: 8
-    - __kind: EventRootType
-      ID: 1434
-      Name: Probe[main.testReturnsInt]Return
-      ByteSize: 9
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: ~r0
-          Offset: 1
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 1, name: ~r0}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 1445
-      Name: Probe[main.testReturnsInterface]
+      Name: Probe[main.testReturnsAny]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -15590,6 +15414,440 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 1446
+      Name: Probe[main.testReturnsAny]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1475
+      Name: Probe[main.testReturnsArrayOne]
+    - __kind: EventRootType
+      ID: 1476
+      Name: Probe[main.testReturnsArrayOne]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 258 ArrayType [1]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 111, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1477
+      Name: Probe[main.testReturnsArrayZero]
+    - __kind: EventRootType
+      ID: 1478
+      Name: Probe[main.testReturnsArrayZero]Return
+      ByteSize: 1
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 0
+    - __kind: EventRootType
+      ID: 1473
+      Name: Probe[main.testReturnsArray]
+    - __kind: EventRootType
+      ID: 1474
+      Name: Probe[main.testReturnsArray]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 257 ArrayType [3]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 110, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 24
+    - __kind: EventRootType
+      ID: 1481
+      Name: Probe[main.testReturnsBacktrackInt]
+    - __kind: EventRootType
+      ID: 1482
+      Name: Probe[main.testReturnsBacktrackInt]Return
+      ByteSize: 82
+      PresenceBitsetSize: 2
+      Expressions:
+        - Name: ~r0
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 10
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r2
+          Offset: 18
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 2, name: ~r2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r3
+          Offset: 26
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 3, name: ~r3}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r4
+          Offset: 34
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 4, name: ~r4}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r5
+          Offset: 42
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 5, name: ~r5}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r6
+          Offset: 50
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 6, name: ~r6}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r7
+          Offset: 58
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 7, name: ~r7}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r8
+          Offset: 66
+          Kind: local
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 114, index: 8, name: ~r8}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1493
+      Name: Probe[main.testReturnsBoolAndUintptr]
+    - __kind: EventRootType
+      ID: 1494
+      Name: Probe[main.testReturnsBoolAndUintptr]Return
+      ByteSize: 10
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: ~r1
+          Offset: 2
+          Kind: local
+          Expression:
+            Type: 1 BaseType uintptr
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 120, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1469
+      Name: Probe[main.testReturnsComplex]
+    - __kind: EventRootType
+      ID: 1470
+      Name: Probe[main.testReturnsComplex]Return
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 103 BaseType complex64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 18 BaseType complex128
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 108, index: 1, name: ~r1}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1441
+      Name: Probe[main.testReturnsError]
+      ByteSize: 3
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: failed
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: failed
+          Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 0, name: failed}
+                  Offset: 0
+                  ByteSize: 1
+    - __kind: EventRootType
+      ID: 1442
+      Name: Probe[main.testReturnsError]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 99, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1439
+      Name: Probe[main.testReturnsIntAndFloat]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1440
+      Name: Probe[main.testReturnsIntAndFloat]Return
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: ~r1
+          Offset: 9
+          Kind: local
+          Expression:
+            Type: 14 BaseType float64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 98, index: 2, name: ~r1}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1437
+      Name: Probe[main.testReturnsIntPointer]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1438
+      Name: Probe[main.testReturnsIntPointer]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 105 PointerType *int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 97, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1435
+      Name: Probe[main.testReturnsInt]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: i
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: i
+          Offset: 9
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 0, name: i}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1436
+      Name: Probe[main.testReturnsInt]Return
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: ~r0
+          Offset: 1
+          Kind: local
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 96, index: 1, name: ~r0}
+                  Offset: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 1447
+      Name: Probe[main.testReturnsInterface]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: v
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: v
+          Offset: 17
+          Kind: template_segment
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 102, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1448
       Name: Probe[main.testReturnsInterface]Return
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -15601,14 +15859,14 @@ Types:
             Type: 168 GoInterfaceType main.behavior
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 1, name: ~r0}
+                  Variable: {subprogram: 102, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1469
+      ID: 1471
       Name: Probe[main.testReturnsLargeStruct]
     - __kind: EventRootType
-      ID: 1470
+      ID: 1472
       Name: Probe[main.testReturnsLargeStruct]Return
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -15620,14 +15878,14 @@ Types:
             Type: 256 StructureType main.largeStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 108, index: 0, name: ~r0}
+                  Variable: {subprogram: 109, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 80
     - __kind: EventRootType
-      ID: 1465
+      ID: 1467
       Name: Probe[main.testReturnsManyFloats]
     - __kind: EventRootType
-      ID: 1466
+      ID: 1468
       Name: Probe[main.testReturnsManyFloats]Return
       ByteSize: 139
       PresenceBitsetSize: 3
@@ -15639,7 +15897,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 0, name: ~r0}
+                  Variable: {subprogram: 107, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15649,7 +15907,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 1, name: ~r1}
+                  Variable: {subprogram: 107, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15659,7 +15917,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 2, name: ~r2}
+                  Variable: {subprogram: 107, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15669,7 +15927,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 3, name: ~r3}
+                  Variable: {subprogram: 107, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15679,7 +15937,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 4, name: ~r4}
+                  Variable: {subprogram: 107, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
@@ -15689,7 +15947,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 5, name: ~r5}
+                  Variable: {subprogram: 107, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
@@ -15699,7 +15957,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 6, name: ~r6}
+                  Variable: {subprogram: 107, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
@@ -15709,7 +15967,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 7, name: ~r7}
+                  Variable: {subprogram: 107, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
@@ -15719,7 +15977,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 8, name: ~r8}
+                  Variable: {subprogram: 107, index: 8, name: ~r8}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
@@ -15729,7 +15987,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 9, name: ~r9}
+                  Variable: {subprogram: 107, index: 9, name: ~r9}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
@@ -15739,7 +15997,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 10, name: ~r10}
+                  Variable: {subprogram: 107, index: 10, name: ~r10}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
@@ -15749,7 +16007,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 11, name: ~r11}
+                  Variable: {subprogram: 107, index: 11, name: ~r11}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
@@ -15759,7 +16017,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 12, name: ~r12}
+                  Variable: {subprogram: 107, index: 12, name: ~r12}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
@@ -15769,7 +16027,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 13, name: ~r13}
+                  Variable: {subprogram: 107, index: 13, name: ~r13}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
@@ -15779,7 +16037,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 14, name: ~r14}
+                  Variable: {subprogram: 107, index: 14, name: ~r14}
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
@@ -15789,7 +16047,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 15, name: onlyOnAmd64_16}
+                  Variable: {subprogram: 107, index: 15, name: onlyOnAmd64_16}
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
@@ -15799,14 +16057,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 106, index: 16, name: bothArmAndAmd64}
+                  Variable: {subprogram: 107, index: 16, name: bothArmAndAmd64}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1477
+      ID: 1479
       Name: Probe[main.testReturnsMixedStruct]
     - __kind: EventRootType
-      ID: 1478
+      ID: 1480
       Name: Probe[main.testReturnsMixedStruct]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -15818,14 +16076,14 @@ Types:
             Type: 260 StructureType main.mixedStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 112, index: 0, name: ~r0}
+                  Variable: {subprogram: 113, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1483
+      ID: 1485
       Name: Probe[main.testReturnsMixed]
     - __kind: EventRootType
-      ID: 1484
+      ID: 1486
       Name: Probe[main.testReturnsMixed]Return
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -15837,7 +16095,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 0, name: ~r0}
+                  Variable: {subprogram: 116, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -15847,7 +16105,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 1, name: ~r1}
+                  Variable: {subprogram: 116, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -15857,7 +16115,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 2, name: ~r2}
+                  Variable: {subprogram: 116, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
@@ -15867,7 +16125,7 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 3, name: ~r3}
+                  Variable: {subprogram: 116, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15877,14 +16135,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 115, index: 4, name: ~r4}
+                  Variable: {subprogram: 116, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1489
+      ID: 1491
       Name: Probe[main.testReturnsMultipleFloats]
     - __kind: EventRootType
-      ID: 1490
+      ID: 1492
       Name: Probe[main.testReturnsMultipleFloats]Return
       ByteSize: 13
       PresenceBitsetSize: 1
@@ -15896,7 +16154,7 @@ Types:
             Type: 17 BaseType float32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 0, name: ~r0}
+                  Variable: {subprogram: 119, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r1
@@ -15906,14 +16164,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 118, index: 1, name: ~r1}
+                  Variable: {subprogram: 119, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1487
+      ID: 1489
       Name: Probe[main.testReturnsOnlyFloat]
     - __kind: EventRootType
-      ID: 1488
+      ID: 1490
       Name: Probe[main.testReturnsOnlyFloat]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -15925,14 +16183,14 @@ Types:
             Type: 14 BaseType float64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 117, index: 0, name: ~r0}
+                  Variable: {subprogram: 118, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1463
+      ID: 1465
       Name: Probe[main.testReturnsPrimitives]
     - __kind: EventRootType
-      ID: 1464
+      ID: 1466
       Name: Probe[main.testReturnsPrimitives]Return
       ByteSize: 31
       PresenceBitsetSize: 1
@@ -15944,7 +16202,7 @@ Types:
             Type: 19 BaseType int8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 0, name: ~r0}
+                  Variable: {subprogram: 106, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
@@ -15954,7 +16212,7 @@ Types:
             Type: 102 BaseType int16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 1, name: ~r1}
+                  Variable: {subprogram: 106, index: 1, name: ~r1}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
@@ -15964,7 +16222,7 @@ Types:
             Type: 12 BaseType int32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: ~r2}
+                  Variable: {subprogram: 106, index: 2, name: ~r2}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
@@ -15974,7 +16232,7 @@ Types:
             Type: 13 BaseType int64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 3, name: ~r3}
+                  Variable: {subprogram: 106, index: 3, name: ~r3}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
@@ -15984,7 +16242,7 @@ Types:
             Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 4, name: ~r4}
+                  Variable: {subprogram: 106, index: 4, name: ~r4}
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
@@ -15994,7 +16252,7 @@ Types:
             Type: 6 BaseType uint16
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 5, name: ~r5}
+                  Variable: {subprogram: 106, index: 5, name: ~r5}
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
@@ -16004,7 +16262,7 @@ Types:
             Type: 2 BaseType uint32
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 6, name: ~r6}
+                  Variable: {subprogram: 106, index: 6, name: ~r6}
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
@@ -16014,14 +16272,14 @@ Types:
             Type: 8 BaseType uint64
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 7, name: ~r7}
+                  Variable: {subprogram: 106, index: 7, name: ~r7}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1485
+      ID: 1487
       Name: Probe[main.testReturnsStructWithArray]
     - __kind: EventRootType
-      ID: 1486
+      ID: 1488
       Name: Probe[main.testReturnsStructWithArray]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16033,14 +16291,14 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 116, index: 0, name: ~r0}
+                  Variable: {subprogram: 117, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1481
+      ID: 1483
       Name: Probe[main.testReturnsWideStruct]
     - __kind: EventRootType
-      ID: 1482
+      ID: 1484
       Name: Probe[main.testReturnsWideStruct]Return
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -16052,7 +16310,7 @@ Types:
             Type: 261 StructureType main.wideStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 114, index: 0, name: ~r0}
+                  Variable: {subprogram: 115, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 88
     - __kind: EventRootType
@@ -16362,7 +16620,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
     - __kind: EventRootType
-      ID: 1526
+      ID: 1528
       Name: Probe[main.testSingleString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16374,7 +16632,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -16384,7 +16642,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: x}
+                  Variable: {subprogram: 143, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -16518,7 +16776,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1522
+      ID: 1524
       Name: Probe[main.testSliceEmptyStructs]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16530,7 +16788,7 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16540,11 +16798,11 @@ Types:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 139, index: 0, name: xs}
+                  Variable: {subprogram: 140, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1513
+      ID: 1515
       Name: Probe[main.testSliceOfSlices]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16556,7 +16814,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -16566,7 +16824,7 @@ Types:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 131, index: 0, name: u}
+                  Variable: {subprogram: 132, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16596,7 +16854,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1461
+      ID: 1463
       Name: Probe[main.testSomeNamedReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16608,7 +16866,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
         - Name: i
@@ -16618,11 +16876,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 0, name: i}
+                  Variable: {subprogram: 105, index: 0, name: i}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1462
+      ID: 1464
       Name: Probe[main.testSomeNamedReturn]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16634,7 +16892,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 1, name: ~r0}
+                  Variable: {subprogram: 105, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: result2
@@ -16644,7 +16902,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 2, name: result2}
+                  Variable: {subprogram: 105, index: 2, name: result2}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16654,11 +16912,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 104, index: 3, name: ~r2}
+                  Variable: {subprogram: 105, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1503
+      ID: 1505
       Name: Probe[main.testStackArgRegReturns]
       ByteSize: 81
       PresenceBitsetSize: 1
@@ -16670,7 +16928,7 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
         - Name: arg
@@ -16680,11 +16938,11 @@ Types:
             Type: 167 ArrayType [5]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: arg}
+                  Variable: {subprogram: 126, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 40
     - __kind: EventRootType
-      ID: 1504
+      ID: 1506
       Name: Probe[main.testStackArgRegReturns]Return
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -16696,7 +16954,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: ~r0}
+                  Variable: {subprogram: 126, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16706,7 +16964,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: ~r1}
+                  Variable: {subprogram: 126, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
@@ -16716,7 +16974,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: ~r2}
+                  Variable: {subprogram: 126, index: 3, name: ~r2}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16746,7 +17004,7 @@ Types:
                   Offset: 0
                   ByteSize: 32
     - __kind: EventRootType
-      ID: 1430
+      ID: 1432
       Name: Probe[main.testStringPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -16758,7 +17016,7 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
         - Name: z
@@ -16768,11 +17026,11 @@ Types:
             Type: 101 PointerType *string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 92, index: 0, name: z}
+                  Variable: {subprogram: 93, index: 0, name: z}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1517
+      ID: 1519
       Name: Probe[main.testStringSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16784,7 +17042,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
         - Name: s
@@ -16794,7 +17052,7 @@ Types:
             Type: 269 GoSliceHeaderType []string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: s}
+                  Variable: {subprogram: 136, index: 0, name: s}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
@@ -16850,7 +17108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1514
+      ID: 1516
       Name: Probe[main.testStructSlice]
       ByteSize: 65
       PresenceBitsetSize: 1
@@ -16862,7 +17120,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -16872,7 +17130,7 @@ Types:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 0, name: xs}
+                  Variable: {subprogram: 133, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: a
@@ -16882,7 +17140,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -16892,7 +17150,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 132, index: 1, name: a}
+                  Variable: {subprogram: 133, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -16922,7 +17180,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1507
+      ID: 1509
       Name: Probe[main.testStructWithArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -16934,7 +17192,7 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
         - Name: arg
@@ -16944,11 +17202,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 0, name: arg}
+                  Variable: {subprogram: 128, index: 0, name: arg}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1508
+      ID: 1510
       Name: Probe[main.testStructWithArrayArg]Return
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -16960,7 +17218,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 1, name: ~r0}
+                  Variable: {subprogram: 128, index: 1, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -16970,11 +17228,11 @@ Types:
             Type: 262 StructureType main.structWithArray
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 127, index: 2, name: ~r1}
+                  Variable: {subprogram: 128, index: 2, name: ~r1}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1539
+      ID: 1541
       Name: Probe[main.testStructWithCyclicMaps]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -16986,7 +17244,7 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -16996,11 +17254,11 @@ Types:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
+                  Variable: {subprogram: 153, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1538
+      ID: 1540
       Name: Probe[main.testStructWithCyclicSlices]
       ByteSize: 289
       PresenceBitsetSize: 1
@@ -17012,7 +17270,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
         - Name: a
@@ -17022,7 +17280,7 @@ Types:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 151, index: 0, name: a}
+                  Variable: {subprogram: 152, index: 0, name: a}
                   Offset: 0
                   ByteSize: 144
     - __kind: EventRootType
@@ -17052,7 +17310,23 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1540
+      ID: 1542
+      Name: Probe[main.testStruct]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x.aString
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 154, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 1543
       Name: Probe[main.testStruct]
       ByteSize: 113
       PresenceBitsetSize: 1
@@ -17064,7 +17338,7 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
         - Name: x
@@ -17074,11 +17348,11 @@ Types:
             Type: 322 StructureType main.aStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 153, index: 0, name: x}
+                  Variable: {subprogram: 154, index: 0, name: x}
                   Offset: 0
                   ByteSize: 56
     - __kind: EventRootType
-      ID: 1523
+      ID: 1525
       Name: Probe[main.testSubslices]
       ByteSize: 145
       PresenceBitsetSize: 1
@@ -17090,7 +17364,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: as
@@ -17100,7 +17374,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 0, name: as}
+                  Variable: {subprogram: 141, index: 0, name: as}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17110,7 +17384,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: bs
@@ -17120,7 +17394,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 1, name: bs}
+                  Variable: {subprogram: 141, index: 1, name: bs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17130,7 +17404,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
         - Name: cs
@@ -17140,11 +17414,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 140, index: 2, name: cs}
+                  Variable: {subprogram: 141, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1537
+      ID: 1539
       Name: Probe[main.testSubstrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17156,7 +17430,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: a
@@ -17166,7 +17440,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 0, name: a}
+                  Variable: {subprogram: 151, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17176,7 +17450,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: b
@@ -17186,7 +17460,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 1, name: b}
+                  Variable: {subprogram: 151, index: 1, name: b}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17196,7 +17470,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
         - Name: c
@@ -17206,11 +17480,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 150, index: 2, name: c}
+                  Variable: {subprogram: 151, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1530
+      ID: 1532
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17222,7 +17496,7 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
         - Name: a
@@ -17232,11 +17506,11 @@ Types:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1531
+      ID: 1533
       Name: Probe[main.testThreeStringsInStructPointer]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17248,7 +17522,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17261,7 +17535,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
@@ -17274,14 +17548,14 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: a}
+                  Variable: {subprogram: 146, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
                 - __kind: DereferenceOp
                   Bias: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1528
+      ID: 1530
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17293,7 +17567,7 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
         - Name: a
@@ -17303,11 +17577,11 @@ Types:
             Type: 274 StructureType main.threeStringStruct
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 1529
+      ID: 1531
       Name: Probe[main.testThreeStringsInStruct]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17319,7 +17593,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 0
                   ByteSize: 16
         - Name: t.b
@@ -17329,7 +17603,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 16
                   ByteSize: 16
         - Name: t.c
@@ -17339,11 +17613,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 144, index: 0, name: a}
+                  Variable: {subprogram: 145, index: 0, name: a}
                   Offset: 32
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1527
+      ID: 1529
       Name: Probe[main.testThreeStrings]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -17355,7 +17629,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17365,7 +17639,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 0, name: x}
+                  Variable: {subprogram: 144, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17375,7 +17649,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: y
@@ -17385,7 +17659,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 1, name: y}
+                  Variable: {subprogram: 144, index: 1, name: y}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17395,7 +17669,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
         - Name: z
@@ -17405,7 +17679,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 143, index: 2, name: z}
+                  Variable: {subprogram: 144, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
@@ -17565,7 +17839,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1429
+      ID: 1431
       Name: Probe[main.testUintPointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17577,7 +17851,7 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17587,11 +17861,11 @@ Types:
             Type: 112 PointerType *uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 91, index: 0, name: x}
+                  Variable: {subprogram: 92, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1511
+      ID: 1513
       Name: Probe[main.testUintSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17603,7 +17877,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
         - Name: u
@@ -17613,11 +17887,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 129, index: 0, name: u}
+                  Variable: {subprogram: 130, index: 0, name: u}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1535
+      ID: 1537
       Name: Probe[main.testUnitializedString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -17629,7 +17903,7 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
         - Name: x
@@ -17639,11 +17913,11 @@ Types:
             Type: 9 GoStringHeaderType string
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 148, index: 0, name: x}
+                  Variable: {subprogram: 149, index: 0, name: x}
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 1428
+      ID: 1430
       Name: Probe[main.testUnsafePointer]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17655,7 +17929,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
         - Name: x
@@ -17665,7 +17939,7 @@ Types:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 90, index: 0, name: x}
+                  Variable: {subprogram: 91, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
@@ -17695,7 +17969,7 @@ Types:
                   Offset: 0
                   ByteSize: 800
     - __kind: EventRootType
-      ID: 1520
+      ID: 1522
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17707,7 +17981,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17717,11 +17991,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1521
+      ID: 1523
       Name: Probe[main.testVeryLargeSlice]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -17733,7 +18007,7 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
         - Name: xs
@@ -17743,11 +18017,11 @@ Types:
             Type: 263 GoSliceHeaderType []uint
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: xs}
+                  Variable: {subprogram: 139, index: 0, name: xs}
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 1509
+      ID: 1511
       Name: Probe[main.testZeroSizeArgAndReturn]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -17759,7 +18033,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: a
@@ -17769,7 +18043,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
+                  Variable: {subprogram: 129, index: 0, name: a}
                   Offset: 0
                   ByteSize: 0
         - Name: b
@@ -17779,7 +18053,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
         - Name: b
@@ -17789,11 +18063,11 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 1, name: b}
+                  Variable: {subprogram: 129, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 1510
+      ID: 1512
       Name: Probe[main.testZeroSizeArgAndReturn]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -17805,7 +18079,7 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 2, name: ~r0}
+                  Variable: {subprogram: 129, index: 2, name: ~r0}
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
@@ -17815,7 +18089,7 @@ Types:
             Type: 259 ArrayType [0]int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 3, name: ~r1}
+                  Variable: {subprogram: 129, index: 3, name: ~r1}
                   Offset: 0
                   ByteSize: 0
     - __kind: ArrayType
@@ -26477,7 +26751,7 @@ Types:
       ByteSize: 4
       GoRuntimeType: 1.003232e+06
       GoKind: 5
-MaxTypeID: 1560
+MaxTypeID: 1565
 Issues: []
 GoModuledataInfo: {FirstModuledataAddr: "0x1321d00", TypesOffset: 296}
 CommonTypes:

--- a/pkg/dyninst/irprinter/json.go
+++ b/pkg/dyninst/irprinter/json.go
@@ -156,7 +156,7 @@ func PrintJSON(p *ir.Program) ([]byte, error) {
 		encode(v.Subprogram)
 		writeToken(jsontext.String("events"))
 		encode(v.Events)
-		if v.Template.TemplateString != "" {
+		if v.Template != nil && v.Template.TemplateString != "" {
 			writeToken(jsontext.String("probeTemplate"))
 			encode(v.Template)
 		}

--- a/pkg/dyninst/module/diagnostics_test.go
+++ b/pkg/dyninst/module/diagnostics_test.go
@@ -283,4 +283,8 @@ func (p testProbeDefinition) GetTemplate() ir.TemplateDefinition {
 	return nil
 }
 
+func (p testProbeDefinition) GetCaptureExpressions() []ir.CaptureExpressionDefinition {
+	return nil
+}
+
 var _ ir.ProbeDefinition = testProbeDefinition{}

--- a/pkg/dyninst/rcjson/rcjson_test.go
+++ b/pkg/dyninst/rcjson/rcjson_test.go
@@ -241,6 +241,85 @@ var testCases = []testCase{
 		},
 	},
 	{
+		name: "capture expression probe",
+		input: `{
+				"id": "capture-expr-1",
+				"type": "LOG_PROBE",
+				"version": 1,
+				"where": {
+					"methodName": "MyMethod"
+				},
+				"captureSnapshot": false,
+				"captureExpressions": [
+					{
+						"name": "x_val",
+						"expr": {"dsl": "x", "json": {"ref": "x"}}
+					},
+					{
+						"name": "y_val",
+						"expr": {"dsl": "y", "json": {"ref": "y"}},
+						"capture": {"maxReferenceDepth": 2}
+					}
+				]
+			}`,
+		want: &CaptureExpressionProbe{
+			LogProbeCommon: LogProbeCommon{
+				ProbeCommon: ProbeCommon{
+					ID:      "capture-expr-1",
+					Version: 1,
+					Type:    TypeLogProbe.String(),
+					Where: &Where{
+						MethodName: "MyMethod",
+					},
+				},
+			},
+			RawCaptureExpressions: []*CaptureExpressionEntry{
+				{
+					Name: "x_val",
+					Expr: CaptureExprJSON{
+						DSL:  "x",
+						JSON: json.RawMessage(`{"ref": "x"}`),
+					},
+				},
+				{
+					Name: "y_val",
+					Expr: CaptureExprJSON{
+						DSL:  "y",
+						JSON: json.RawMessage(`{"ref": "y"}`),
+					},
+					Capture: &Capture{MaxReferenceDepth: intPtr(2)},
+				},
+			},
+		},
+	},
+	{
+		name: "capture expression probe without expressions",
+		input: `{
+				"id": "capture-expr-2",
+				"type": "LOG_PROBE",
+				"version": 1,
+				"where": {
+					"methodName": "MyMethod"
+				},
+				"captureSnapshot": false,
+				"captureExpressions": []
+			}`,
+		want: &CaptureExpressionProbe{
+			LogProbeCommon: LogProbeCommon{
+				ProbeCommon: ProbeCommon{
+					ID:      "capture-expr-2",
+					Version: 1,
+					Type:    TypeLogProbe.String(),
+					Where: &Where{
+						MethodName: "MyMethod",
+					},
+				},
+			},
+			RawCaptureExpressions: []*CaptureExpressionEntry{},
+		},
+		validationErr: `captureExpressions must be non-empty`,
+	},
+	{
 		name:         "invalid json",
 		input:        `{invalid json}`,
 		unmarshalErr: `failed to parse json: .*`,

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember.json
@@ -1,0 +1,65 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 84
+          },
+          {
+            "function": "main.executeStructFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 143
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprGetmember",
+          "location": {
+            "method": "main.testStruct"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x.aString": {
+                "type": "string",
+                "value": "one"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprGetmember_geq_go1.26rc1.json
@@ -1,0 +1,70 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 84
+          },
+          {
+            "function": "main.executeStructFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/structs.go",
+            "lineNumber": 143
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 32
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprGetmember",
+          "location": {
+            "method": "main.testStruct"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x.aString": {
+                "type": "string",
+                "value": "one"
+              }
+            }
+          }
+        }
+      },
+      "evaluationErrors": [
+        {
+          "expr": "@duration",
+          "message": "not available: function has no body"
+        }
+      ]
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLine.json
@@ -1,0 +1,377 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 101
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "25"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "3"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 39
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "150"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 45
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "150"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.forceOutOfLine",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 103
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLine",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprLineWithTemplate.json
@@ -1,0 +1,382 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 18
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 101
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLineWithTemplate",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "25"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "message": "x=25"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 22
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLineWithTemplate",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "3"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "message": "x=3"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 39
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLineWithTemplate",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "150"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "message": "x=150"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.testInlinedBBA",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 45
+          },
+          {
+            "function": "main.testInlinedBB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 40
+          },
+          {
+            "function": "main.testInlinedB",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 23
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLineWithTemplate",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "150"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "message": "x=150"
+  },
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testInlinedPrint",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testInlinedPrint",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 14
+          },
+          {
+            "function": "main.forceOutOfLine",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 29
+          },
+          {
+            "function": "main.executeInlined",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/inlined.go",
+            "lineNumber": 103
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 34
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprLineWithTemplate",
+          "location": {
+            "method": "main.testInlinedPrint",
+            "file": "inlined.go",
+            "line": 14
+          }
+        },
+        "captures": {
+          "lines": {
+            "14": {
+              "captureExpressions": {
+                "x_val": {
+                  "type": "int",
+                  "value": "1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "message": "x=1"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprSimple.json
@@ -1,0 +1,74 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testCombinedString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testCombinedString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.executeMultiParamFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 28
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprSimple",
+          "location": {
+            "method": "main.testCombinedString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x_val": {
+                "type": "string",
+                "value": "boo"
+              },
+              "w_val": {
+                "type": "uint8",
+                "value": "2"
+              }
+            }
+          }
+        }
+      },
+      "evaluationErrors": [
+        {
+          "expr": "@duration",
+          "message": "not available: function has no body"
+        }
+      ]
+    },
+    "timestamp": "[ts]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
+++ b/pkg/dyninst/testdata/decoded/sample/testCaptureExprWithTemplate.json
@@ -1,0 +1,75 @@
+[
+  {
+    "service": "sample",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.testCombinedString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.testCombinedString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 30
+          },
+          {
+            "function": "main.executeMultiParamFuncs",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/multi_params.go",
+            "lineNumber": 102
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/main.go",
+            "lineNumber": 28
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "testCaptureExprWithTemplate",
+          "location": {
+            "method": "main.testCombinedString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x_val": {
+                "type": "string",
+                "value": "boo"
+              },
+              "w_val": {
+                "type": "uint8",
+                "value": "2"
+              }
+            }
+          }
+        }
+      },
+      "evaluationErrors": [
+        {
+          "expr": "@duration",
+          "message": "not available: function has no body"
+        }
+      ]
+    },
+    "timestamp": "[ts]",
+    "message": "x=boo"
+  }
+]

--- a/pkg/dyninst/testprogs/testdata/probes/sample.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/sample.yaml
@@ -2342,3 +2342,95 @@ probes:
     segments:
       - str: "testWhollyInlinedSubroutine"
     captureSnapshot: true
+  # Capture expression probes
+  - id: testCaptureExprSimple
+    type: LOG_PROBE
+    where:
+      methodName: main.testCombinedString
+    captureSnapshot: false
+    captureExpressions:
+      - name: "x_val"
+        expr:
+          dsl: "x"
+          json:
+            ref: "x"
+      - name: "w_val"
+        expr:
+          dsl: "w"
+          json:
+            ref: "w"
+  - id: testCaptureExprGetmember
+    type: LOG_PROBE
+    tags:
+      - "version_diff:go1.26rc1"
+    where:
+      methodName: main.testStruct
+    captureSnapshot: false
+    captureExpressions:
+      - name: "x.aString"
+        expr:
+          dsl: "x.aString"
+          json:
+            getmember:
+              - ref: "x"
+              - "aString"
+  - id: testCaptureExprWithTemplate
+    type: LOG_PROBE
+    where:
+      methodName: main.testCombinedString
+    template: "x={x}"
+    segments:
+      - str: "x="
+      - json:
+          ref: "x"
+        dsl: "x"
+    captureSnapshot: false
+    captureExpressions:
+      - name: "x_val"
+        expr:
+          dsl: "x"
+          json:
+            ref: "x"
+      - name: "w_val"
+        expr:
+          dsl: "w"
+          json:
+            ref: "w"
+  - id: testCaptureExprLine
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedPrint
+      sourceFile: inlined.go
+      lines:
+        - "14"
+    captureSnapshot: false
+    captureExpressions:
+      - name: "x_val"
+        expr:
+          dsl: "x"
+          json:
+            ref: "x"
+    sampling:
+      snapshotsPerSecond: 100
+  - id: testCaptureExprLineWithTemplate
+    type: LOG_PROBE
+    where:
+      methodName: main.testInlinedPrint
+      sourceFile: inlined.go
+      lines:
+        - "14"
+    template: "x={x}"
+    segments:
+      - str: "x="
+      - json:
+          ref: "x"
+        dsl: "x"
+    captureSnapshot: false
+    captureExpressions:
+      - name: "x_val"
+        expr:
+          dsl: "x"
+          json:
+            ref: "x"
+    sampling:
+      snapshotsPerSecond: 100


### PR DESCRIPTION


### What does this PR do?

Implements `captureExpression` probes for Go. 

### Motivation

Capture expressions let users specify exactly which variables to capture in a probe instead of a full snapshot. When `captureExpressions` is present on a LOG_PROBE with `captureSnapshot: false`, only those expressions are captured.

Per-expression capture depth configs are supported in the probe definition, but the eBPF compiler currently applies a single depth limit per probe. As a shortcut, irgen takes the max depth across all expressions as the probe-level budget. This should be revisited when per-expression depth is supported in eBPF.

### Describe how you validated your changes

There's end-to-end testing

### Additional Notes

Resolves https://datadoghq.atlassian.net/browse/DEBUG-5010

