### PR TITLE
Fix fuzzer build for ebpf target

### DIFF
--- a/.gitlab/test/fuzz/infra.yml
+++ b/.gitlab/test/fuzz/infra.yml
@@ -1,4 +1,5 @@
 test_fuzz:
+  extends: .bazel:defs:cache:ephemeral
   rules:
     - !reference [.on_scheduled_main]
     - !reference [.manual]

--- a/.gitlab/test/fuzz/infra.yml
+++ b/.gitlab/test/fuzz/infra.yml
@@ -9,4 +9,5 @@ test_fuzz:
   allow_failure: true
   script:
     - dda self dep sync -f legacy-tasks
+    - dda inv -- -e system-probe.object-files
     - dda inv -- build-and-upload-fuzz

--- a/tasks/fuzz_infra.py
+++ b/tasks/fuzz_infra.py
@@ -155,6 +155,10 @@ def search_fuzz_tests(directory):
     for file in os.listdir(directory):
         path = os.path.join(directory, file)
         if os.path.isdir(path):
+            # Skip hidden directories (.cache, .git, etc.) to avoid picking up
+            # files from the bazel cache or other non-source directories.
+            if file.startswith('.'):
+                continue
             yield from search_fuzz_tests(path)
         else:
             if not file.endswith('_test.go'):


### PR DESCRIPTION
### What does this PR do?

This adds the missing steps to generate object/c files embeded in the Go code.
Fix: `../ebpf/kernelbugs/kernel_bugs_amd64.go:32:12: pattern c/detect-seccomp-bug: no matching files found`

### Motivation

Allow 100% of the fuzzers to be build correctly

### Describe how you validated your changes

Run the [manual test_fuzz job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1416318586)

### Additional Notes
