### PR TITLE
Remove rule to always trigger test on some team specific tests

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -320,7 +320,6 @@ new-e2e-remote-config:
   extends: .new_e2e_template_needs_deb_x64
   rules:
     - !reference [.on_rc_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/remote-config
@@ -452,7 +451,6 @@ new-e2e-language-detection:
   extends: .new_e2e_template_needs_deb_x64
   rules:
     - !reference [.on_language-detection_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/language-detection
@@ -637,7 +635,6 @@ new-e2e-discovery:
     - qa_agent_linux
   rules:
     - !reference [.on_discovery_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/discovery
@@ -670,7 +667,6 @@ new-e2e-process:
     - qa_dca
   rules:
     - !reference [.on_process_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     EXTRA_PARAMS: --skip TestECSFargateCoreAgentTestSuite|TestECSFargateTestSuite|TestECSEC2CoreAgentSuite|TestECSEC2TestSuite
@@ -694,7 +690,6 @@ new-e2e-orchestrator:
   extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_orchestrator_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     EXTRA_PARAMS: --skip TestECSSuite
@@ -856,7 +851,6 @@ new-e2e-ndm-snmp:
   extends: .new_e2e_template
   rules:
     - !reference [.on_ndm_snmp_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
@@ -871,7 +865,6 @@ new-e2e-ha-agent:
   extends: .new_e2e_template_needs_deb_x64
   rules:
     - !reference [.on_ha_agent_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/ha-agent
@@ -897,7 +890,6 @@ new-e2e-netpath:
   extends: .new_e2e_template_needs_deb_windows_x64
   rules:
     - !reference [.on_netpath_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/netpath
@@ -996,7 +988,6 @@ new-e2e-ssi:
   extends: .new_e2e_template
   rules:
     - !reference [.on_ssi_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
@@ -1044,7 +1035,6 @@ new-e2e-cspm:
   extends: .new_e2e_template
   rules:
     - !reference [.on_cspm_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
@@ -1060,7 +1050,6 @@ new-e2e-gpu:
   extends: .new_e2e_template_needs_container_deploy_linux
   rules:
     - !reference [.on_gpu_or_e2e_changes]
-    - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job
     - !reference [.manual]
   variables:
     TARGETS: ./tests/gpu # the target path where tests are


### PR DESCRIPTION
### What does this PR do?

Remove rule that would always run the e2e tests and let dynamic tests skipping them on some team specific tests, that used to have scoped rules.

### Motivation

To reduce the duration of the CI we agreed that taking some risk on e2e tests was fine, the goal is run less tests on PR. Catching those issues on main will be handled by an automatic revert system.

### Describe how you validated your changes

### Additional Notes
