### PR TITLE
CONTINT-5040 - expose cluster api-resources to new metric

### DIFF
--- a/pkg/util/kubernetes/apiserver/resourcetypes_test.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes_test.go
@@ -192,12 +192,22 @@ func TestPrepopulateCache(t *testing.T) {
 				{Kind: "Deployment", Name: "deployments"},
 			},
 		},
+		{
+			GroupVersion: "v1",
+			APIResources: []v1.APIResource{
+				{Kind: "Node", Name: "nodes", Namespaced: false},
+				{Kind: "Namespace", Name: "namespaces", Namespaced: false},
+				{Kind: "CustomResource", Name: "customresources/status", Namespaced: false},
+				{Kind: "InvalidClusterSubresource", Name: "invalidclusterresource/notvalid", Namespaced: false},
+			},
+		},
 	}
 
 	resourceCache = &ResourceTypeCache{
-		kindGroupToType: make(map[string]string),
-		typeGroupToKind: make(map[string]string),
-		discoveryClient: fakeDiscoveryClient,
+		kindGroupToType:  make(map[string]string),
+		typeGroupToKind:  make(map[string]string),
+		clusterResources: make(map[string]ClusterResource),
+		discoveryClient:  fakeDiscoveryClient,
 	}
 
 	err := resourceCache.prepopulateCache()
@@ -212,6 +222,10 @@ func TestPrepopulateCache(t *testing.T) {
 	assert.Equal(t, "Secret", resourceCache.typeGroupToKind["secrets"])
 	assert.Equal(t, "ConfigMap", resourceCache.typeGroupToKind["configmaps"])
 	assert.Equal(t, "Deployment", resourceCache.typeGroupToKind["deployments/apps"])
+
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "Node"}, resourceCache.clusterResources["nodes"])
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "Namespace"}, resourceCache.clusterResources["namespaces"])
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "CustomResource"}, resourceCache.clusterResources["customresources"])
 }
 
 type blockingDiscovery struct {

--- a/releasenotes/notes/expose-cluster-wide-api-resources-0be3022888aa9051.yaml
+++ b/releasenotes/notes/expose-cluster-wide-api-resources-0be3022888aa9051.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Expose a new metric ``kube_apiserver.api_resource`` that holds the ``name``, ``kind``, ``group``, and ``version``
+    of all known cluster-wide (non namespaced) resources on the cluster.

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -95,6 +95,21 @@ func (suite *kindSuite) TestControlPlane() {
 		},
 	})
 
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "kube_apiserver.api_resource",
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
+				`^api_resource_kind:.*`,
+				`^api_resource_group:.*`,
+				`^api_resource_version:.*`,
+				`^api_resource_name:.*`,
+			},
+			AcceptUnexpectedTags: true,
+		},
+	})
+
 	// Test `kube_controller_manager` check is properly working
 	suite.testMetric(&testMetricArgs{
 		Filter: testMetricFilterArgs{


### PR DESCRIPTION
### What does this PR do?

Expose a new metric under the `kubernetes_apiserver` check.

The metric exposes a dummy value of 1, and a tag with the existing, clusre wide resource name, kind, group and version.

- metric name: `kube_apiserver.api_resource`
- tags:
  - `kind`: the resource kind
  - `group`: the resource group
  - `version`: the current version for that group
  - `name`: the name of the that resource.
- value: always 1, we are interested in the existence of the tags, not the value.

### Motivation

[CONTINT-5040](https://datadoghq.atlassian.net/browse/CONTINT-5040)

### Describe how you validated your changes

Added basic unit tests, run the custom image and read the metric from the console.

Next step: open PR, deploy to stagging, validate changes on staging. 

### Additional Notes


[CONTINT-5040]: https://datadoghq.atlassian.net/browse/CONTINT-5040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ