### PR TITLE
sd-agent: config: check for enabled keys values

### DIFF
--- a/pkg/discovery/module/rust/src/config.rs
+++ b/pkg/discovery/module/rust/src/config.rs
@@ -1158,7 +1158,10 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::FallbackToSystemProbe);
+            assert_eq!(
+                determine_action(&config),
+                FallbackDecision::FallbackToSystemProbe
+            );
         });
     }
 
@@ -1173,7 +1176,10 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::FallbackToSystemProbe);
+            assert_eq!(
+                determine_action(&config),
+                FallbackDecision::FallbackToSystemProbe
+            );
         });
     }
 
@@ -1242,7 +1248,10 @@ system_probe_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::FallbackToSystemProbe);
+            assert_eq!(
+                determine_action(&config),
+                FallbackDecision::FallbackToSystemProbe
+            );
         });
     }
 
@@ -1276,7 +1285,10 @@ event_monitoring_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::FallbackToSystemProbe);
+            assert_eq!(
+                determine_action(&config),
+                FallbackDecision::FallbackToSystemProbe
+            );
         });
     }
 
@@ -1292,7 +1304,10 @@ event_monitoring_config:
 "#;
             let config_file = create_test_config(yaml);
             let config = load_config(Some(config_file.path().to_path_buf()));
-            assert_eq!(determine_action(&config), FallbackDecision::FallbackToSystemProbe);
+            assert_eq!(
+                determine_action(&config),
+                FallbackDecision::FallbackToSystemProbe
+            );
         });
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR changes how sd-agent parses system-probe config to do its fallback decision. It now explicitly checks for the "enabled" keys values of the various system-probe feature.

### Motivation

Helm chart support: the Helm chart always generate full config files with default values. This means that we will all the system-probe features yaml sections in it even when unused, causing sd-agent to always fallback to system-probe.

### Describe how you validated your changes

Covered by unit tests. Added additional "full config" tests.

### Additional Notes
