### PR TITLE
[ACTP-1261] Use FQN prefix allowlist for connections auto-creation

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -194,11 +194,9 @@ func performSelfEnrollment(ctx context.Context, log log.Component, ddConfig conf
 	cfg.RunnerId = urnParts.RunnerID
 
 	// Auto-create connections for enrolled runner
-	var actionsAllowlist = make([]string, 0)
-	for _, set := range cfg.ActionsAllowlist {
-		for action := range set {
-			actionsAllowlist = append(actionsAllowlist, action)
-		}
+	var actionsAllowlist = make([]string, 0, len(cfg.ActionsAllowlist))
+	for fqnPrefix := range cfg.ActionsAllowlist {
+		actionsAllowlist = append(actionsAllowlist, fqnPrefix)
 	}
 
 	if len(actionsAllowlist) > 0 {


### PR DESCRIPTION
### Summary
Instead of action name, use FQN prefix allowlist for connections auto-creation.

### Motivation
Connections allowed for auto-creation cannot be matched correctly, and no connection is auto-created.

### Describe how you validated your changes
Ran the agent PAR locally. A script connection was automatically created.
<img width="633" height="480" alt="Screenshot 2026-02-11 at 13 05 14" src="https://github.com/user-attachments/assets/178b4f08-4ef9-4d19-9ebb-19e842e66437" />

