### PR TITLE
[WINA-2115][ACTP-1280] add PAR pwsh script template as read-only

### DIFF
--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -5,7 +5,10 @@ package(default_visibility = ["//packages:__subpackages__"])
 
 pkg_files(
     name = "all_files",
-    srcs = ["script-config.yaml"],
+    srcs = select({
+        "@platforms//os:windows": ["powershell-script-config.yaml"],
+        "//conditions:default": ["script-config.yaml"],
+    }),
     attributes = pkg_attributes(
         group = "root",
         mode = "0644",

--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -14,7 +14,10 @@ pkg_files(
         mode = "0644",
         owner = "root",
     ),
-    prefix = "etc/datadog-agent/private-action-runner",
+    prefix = select({
+        "@platforms//os:windows": "ProgramData/Datadog/private-action-runner",
+        "//conditions:default": "etc/datadog-agent/private-action-runner",
+    }),
 )
 
 pkg_install(

--- a/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
+++ b/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
@@ -1,0 +1,18 @@
+schemaId: powershell-script-credentials-v1
+runPredefinedPowershellScript:
+  helloWorld:
+    command:
+    - Write-Output
+    - "Hello World"
+  
+  # Example with parameters
+  greet:
+    command:
+      - Write-Output
+      - "Call parameter {{ parameters.name }} !"
+    parameterSchema:
+      properties:
+        name:
+          type: string
+      required:
+        - name

--- a/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
+++ b/pkg/privateactionrunner/autoconnections/conf/powershell-script-config.yaml
@@ -1,4 +1,4 @@
-schemaId: powershell-script-credentials-v1
+schemaId: script-credentials-v1
 runPredefinedPowershellScript:
   helloWorld:
     command:

--- a/pkg/privateactionrunner/bundles/script/credentials.go
+++ b/pkg/privateactionrunner/bundles/script/credentials.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	schemaIdV1 = "script-credentials-v1"
+	schemaIdV1           = "script-credentials-v1"
+	schemaIdPowershellV1 = "powershell-script-credentials-v1"
 )
 
 type ScriptBundleConfig struct {
@@ -37,8 +38,13 @@ func parseCredentials(credentials *privateconnection.PrivateCredentials) (*Scrip
 	if err != nil {
 		return nil, err
 	}
-	if scriptConfig.SchemaId != schemaIdV1 {
-		return nil, fmt.Errorf("unexpected schemaId: %s, supported schemaId: %s", scriptConfig.SchemaId, schemaIdV1)
+	if scriptConfig.SchemaId != schemaIdV1 && scriptConfig.SchemaId != schemaIdPowershellV1 {
+		return nil, fmt.Errorf(
+			"unexpected schemaId: %s, supported schemaId: %s, %s",
+			scriptConfig.SchemaId,
+			schemaIdV1,
+			schemaIdPowershellV1,
+		)
 	}
 
 	return scriptConfig, nil

--- a/pkg/privateactionrunner/bundles/script/credentials.go
+++ b/pkg/privateactionrunner/bundles/script/credentials.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	schemaIdV1           = "script-credentials-v1"
-	schemaIdPowershellV1 = "powershell-script-credentials-v1"
+	schemaIdV1 = "script-credentials-v1"
 )
 
 type ScriptBundleConfig struct {
@@ -38,13 +37,8 @@ func parseCredentials(credentials *privateconnection.PrivateCredentials) (*Scrip
 	if err != nil {
 		return nil, err
 	}
-	if scriptConfig.SchemaId != schemaIdV1 && scriptConfig.SchemaId != schemaIdPowershellV1 {
-		return nil, fmt.Errorf(
-			"unexpected schemaId: %s, supported schemaId: %s, %s",
-			scriptConfig.SchemaId,
-			schemaIdV1,
-			schemaIdPowershellV1,
-		)
+	if scriptConfig.SchemaId != schemaIdV1 {
+		return nil, fmt.Errorf("unexpected schemaId: %s, supported schemaId: %s", scriptConfig.SchemaId, schemaIdV1)
 	}
 
 	return scriptConfig, nil

--- a/releasenotes/notes/private-action-runner-powershell-example-config.yaml
+++ b/releasenotes/notes/private-action-runner-powershell-example-config.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Added a Windows PowerShell example config for private action runner scripts.
+

--- a/releasenotes/notes/private-action-runner-powershell-example-config.yaml
+++ b/releasenotes/notes/private-action-runner-powershell-example-config.yaml
@@ -1,4 +1,4 @@
 features:
   - |
-    Added a Windows PowerShell example config for private action runner scripts.
+    Add a Windows PowerShell example config for private action runner scripts.
 

--- a/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
+++ b/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
@@ -1,5 +1,5 @@
 features:
   - |
     On Windows, stop the private action runner service during MSI upgrades and
-    fleet-driven stop-all operations so it is shut down alongside the agent.
+    fleet-driven stop-all operations so it is shut down alongside the Agent.
 

--- a/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
+++ b/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
@@ -1,0 +1,5 @@
+features:
+  - |
+    On Windows, stop the private action runner service during MSI upgrades and
+    fleet-driven stop-all operations so it is shut down alongside the agent.
+


### PR DESCRIPTION
### What does this PR do?
This PR adds a predefined script example for powershell script action with root owner.
This script is required to auto-create script connections (see [this PR](https://github.com/DataDog/datadog-agent/pull/46021) adding it for linux PAR)

### Motivation
This change is part of the Private Action Runner integration with Agent on Windows. 
While integrating, we need to move local storage to a protected directory to forbid Agent user tamper with it.
PAR doesn't have local storage, the only local file we need to protect is the example script file and we protect it on the file permission level (not dir level).

### Describe how you validated your changes
By building agent 
```
bazel build //pkg/privateactionrunner/autoconnections/conf:install
``` 
and verifying the contents: 
`C:\users\administrator\_bazel_administrator\fpl6anlv\execroot\_main\bazel-out\x64_windows-fastbuild\bin\pkg\privateactionrunner\autoconnections\conf\install.zip` --> it should contain `etc/datadog-agent/private-action-runner/powershell-script-config.yaml`

### Additional Notes
