### PR TITLE
[CWS/CSPM] stop depending on the local hostname resolution service

### DIFF
--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -47,7 +46,7 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 		endpoints,
 		dstcontext,
 		&common.NoopStatusProvider{},
-		hostnameimpl.NewHostnameService(),
+		common.NewStaticHostnameService(hostname),
 		cfg,
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),

--- a/pkg/security/common/hostname_service.go
+++ b/pkg/security/common/hostname_service.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package common
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+)
+
+// StaticHostnameService is a hostname service that returns a fixed hostname
+type StaticHostnameService struct {
+	hostname string
+}
+
+// NewStaticHostnameService creates a new hostname service that returns the provided hostname
+func NewStaticHostnameService(hostname string) *StaticHostnameService {
+	return &StaticHostnameService{
+		hostname: hostname,
+	}
+}
+
+// Get returns the fixed hostname
+func (s *StaticHostnameService) Get(_ context.Context) (string, error) {
+	return s.hostname, nil
+}
+
+// GetWithProvider returns the fixed hostname with "static" as the provider
+func (s *StaticHostnameService) GetWithProvider(_ context.Context) (hostnameinterface.Data, error) {
+	return hostnameinterface.Data{
+		Hostname: s.hostname,
+		Provider: "static",
+	}, nil
+}
+
+// GetSafe returns the fixed hostname
+func (s *StaticHostnameService) GetSafe(_ context.Context) string {
+	return s.hostname
+}

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -9,7 +9,6 @@ package reporter
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -56,7 +55,7 @@ func newReporter(hostname string, stopper startstop.Stopper, sourceName, sourceT
 		endpoints,
 		context,
 		&seccommon.NoopStatusProvider{},
-		hostnameimpl.NewHostnameService(),
+		seccommon.NewStaticHostnameService(hostname),
 		cfg,
 		compression,
 		cfg.GetBool("logs_config.disable_distributed_senders"),


### PR DESCRIPTION
### What does this PR do?

In the CWS and CSPM pipeline creation we currently provide a regular hostname service, that is backed by the local hostname component (the one that resolves the hostname locally).

This is not correct since in the security-agent and system-probe we usually resolve the hostname remotely, i.e. we ask the core agent for the correct hostname. Happily we already do that, and we already have access to the actual hostname when creating the pipeline.

This PR fixes this by creating a static hostname service, that always returns the provided hostname.

N.B: by chance we always provide the hostname in the logs messages we send to the pipeline and this hostname is used instead of using the service, but it's kind of by chance and error-prone, and fixing this also allows to stop depending on the local hostname resolution packages.

### Motivation

### Describe how you validated your changes

### Additional Notes
