### PR TITLE
Collect emr logs from steps folder

### DIFF
--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -23,7 +23,6 @@ const (
 	emrInjectorVersion   = "0.53.0-1"
 	emrJavaTracerVersion = "1.58.0-1"
 	emrAgentVersion      = "7.74.0-1"
-	hadoopLogFolder      = "/var/log/hadoop-yarn/containers/"
 	hadoopDriverFolder   = "/mnt/var/log/hadoop/steps/"
 )
 
@@ -93,17 +92,18 @@ func SetupEmr(s *common.Setup) error {
 	if isMaster {
 		s.Out.WriteString("Setting up Spark integration config on the Resource Manager\n")
 		setupResourceManager(s, clusterName)
-		if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
-			s.Out.WriteString("Enabling EMR logs collection from driver based on env variable DD_EMR_DRIVER_LOGS_ENABLED=true\n")
-			enableEmrLogs(s, true)
+		// Add logs config to the Resource Manager only
+		if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
+			s.Out.WriteString("Enabling EMR logs collection\n")
+			s.Span.SetTag("host_tag_set.logs_enabled", "true")
+			enableEmrLogs(s)
+		} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") == "true" {
+			// Tag install spans to track usage of DD_EMR_DRIVER_LOGS_ENABLED versus DD_EMR_LOGS_ENABLED
+			s.Span.SetTag("host_tag_set.driver_logs_enabled", "true")
+			enableEmrLogs(s)
+		} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
+			s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")
 		}
-	}
-	// Add logs config to both Resource Manager and Workers
-	if os.Getenv("DD_EMR_LOGS_ENABLED") == "true" {
-		s.Out.WriteString("Enabling EMR logs collection based on env variable DD_EMR_LOGS_ENABLED=true\n")
-		enableEmrLogs(s, false)
-	} else if os.Getenv("DD_EMR_DRIVER_LOGS_ENABLED") != "true" {
-		s.Out.WriteString("EMR logs collection not enabled. To enable it, set DD_EMR_LOGS_ENABLED=true\n")
 	}
 	return nil
 }
@@ -192,52 +192,28 @@ func resolveEmrClusterName(s *common.Setup, jobFlowID string) string {
 	return clusterName
 }
 
-func enableEmrLogs(s *common.Setup, collectFromDriver bool) {
+func enableEmrLogs(s *common.Setup) {
 	s.Config.DatadogYAML.LogsEnabled = config.BoolToPtr(true)
 	loadLogProcessingRules(s)
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]
 	var emrLogs []config.IntegrationConfigLogs
-	if collectFromDriver {
-		s.Span.SetTag("host_tag_set.driver_logs_enabled", "true")
-		emrLogs = []config.IntegrationConfigLogs{
-			{
-				Type:    "file",
-				Path:    hadoopDriverFolder + "*/stdout",
-				Source:  "hadoop-yarn",
-				Service: "emr-logs",
-				LogProcessingRules: []config.LogProcessingRule{
-					{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
-				},
+	emrLogs = []config.IntegrationConfigLogs{
+		{
+			Type:    "file",
+			Path:    hadoopDriverFolder + "*/stdout",
+			Source:  "hadoop-yarn",
+			Service: "emr-logs",
+			LogProcessingRules: []config.LogProcessingRule{
+				{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
 			},
-			{
-				Type:    "file",
-				Path:    hadoopDriverFolder + "*/stderr",
-				Source:  "hadoop-yarn",
-				Service: "emr-logs",
-			},
-		}
-	} else {
-		s.Span.SetTag("host_tag_set.logs_enabled", "true")
-		// Add dd-agent user to yarn group so that it gets read permission to the hadoop-yarn logs folder
-		s.DdAgentAdditionalGroups = append(s.DdAgentAdditionalGroups, "yarn")
-		emrLogs = []config.IntegrationConfigLogs{
-			{
-				Type:    "file",
-				Path:    hadoopLogFolder + "*/*/stdout",
-				Source:  "hadoop-yarn",
-				Service: "emr-logs",
-				LogProcessingRules: []config.LogProcessingRule{
-					{Type: "multi_line", Name: "logger_dataframe_show", Pattern: "(^\\+[-+]+\\n(\\|.*\\n)+\\+[-+]+$)|^(ERROR|INFO|DEBUG|WARN|CRITICAL|NOTSET|Traceback)"},
-				},
-			},
-			{
-				Type:    "file",
-				Path:    hadoopLogFolder + "*/*/stderr",
-				Source:  "hadoop-yarn",
-				Service: "emr-logs",
-			},
-		}
+		},
+		{
+			Type:    "file",
+			Path:    hadoopDriverFolder + "*/stderr",
+			Source:  "hadoop-yarn",
+			Service: "emr-logs",
+		},
 	}
 	sparkIntegration.Logs = emrLogs
 	s.Config.IntegrationConfigs["spark.d/conf.yaml"] = sparkIntegration

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -197,8 +197,7 @@ func enableEmrLogs(s *common.Setup) {
 	loadLogProcessingRules(s)
 	// Load the existing integration config and add logs section to it
 	sparkIntegration := s.Config.IntegrationConfigs["spark.d/conf.yaml"]
-	var emrLogs []config.IntegrationConfigLogs
-	emrLogs = []config.IntegrationConfigLogs{
+	emrLogs := []config.IntegrationConfigLogs{
 		{
 			Type:    "file",
 			Path:    hadoopDriverFolder + "*/stdout",


### PR DESCRIPTION
### What does this PR do?

Previously:
 - DD_EMR_LOGS_ENABLED was turning on collection from `.../containers/<container_id>` folder
 - DD_EMR_DRIVER_LOGS_ENABLED, only used by 1 customer, collects from `.../steps/<emr_step_id>` folder

But job stdout logs are no longer present in the `containers/` folder

So we make the steps collection default logs collection method, turned on by both DD_EMR_LOGS_ENABLED and DD_EMR_DRIVER LOGS_ENABLED, for keeping compatibility with current configuration of everyone.

Install tags for DD_EMR_LOGS_ENABLED and DD_EMR_DRIVER LOGS_ENABLED remain different so we can know who uses what


