### PR TITLE
[WINA-2114] stop PAR across msi, windows service and fleet

### DIFF
--- a/pkg/fleet/installer/packages/service/windows/impl.go
+++ b/pkg/fleet/installer/packages/service/windows/impl.go
@@ -148,6 +148,7 @@ func (w *WinServiceManager) StopAllAgentServices(ctx context.Context) (err error
 		"datadog-process-agent",
 		"datadog-security-agent",
 		"datadog-system-probe",
+		"datadog-private-action-runner",
 		"Datadog Installer",
 		"datadogagent",
 	}

--- a/pkg/fleet/installer/packages/service/windows/impl_test.go
+++ b/pkg/fleet/installer/packages/service/windows/impl_test.go
@@ -191,6 +191,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -211,6 +212,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -246,6 +248,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 				otherServices := []string{
 					"datadog-process-agent",
 					"datadog-security-agent",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -281,6 +284,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 				otherServices := []string{
 					"datadog-process-agent",
 					"datadog-security-agent",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -306,6 +310,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -334,6 +339,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
+					"datadog-private-action-runner",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -379,6 +385,7 @@ func TestWinServiceManager_RestartAgentServices(t *testing.T) {
 			"datadog-process-agent",
 			"datadog-security-agent",
 			"datadog-system-probe",
+			"datadog-private-action-runner",
 			"Datadog Installer",
 			"datadogagent",
 		}
@@ -414,6 +421,7 @@ func TestWinServiceManager_RestartAgentServices(t *testing.T) {
 			"datadog-process-agent",
 			"datadog-security-agent",
 			"datadog-system-probe",
+			"datadog-private-action-runner",
 			"Datadog Installer",
 			"datadogagent",
 		}

--- a/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
+++ b/releasenotes/notes/windows-par-stop-services-9b7d0a6e3d2c4a1b.yaml
@@ -1,5 +1,6 @@
 features:
   - |
-    On Windows, stop the private action runner service during MSI upgrades and
-    fleet-driven stop-all operations so it is shut down alongside the Agent.
+    On Windows, the Agent stops the private action runner service during MSI
+    upgrades and fleet-driven stop-all operations so it is shut down alongside
+    the Agent.
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
@@ -8,6 +8,7 @@ namespace Datadog.CustomActions
         public const string ProcessAgentServiceName = "datadog-process-agent";
         public const string SystemProbeServiceName = "datadog-system-probe";
         public const string SecurityAgentServiceName = "datadog-security-agent";
+        public const string PrivateActionRunnerServiceName = "datadog-private-action-runner";
         public const string InstallerServiceName = "Datadog Installer";
         public const string NpmServiceName = "ddnpm";
         public const string ProcmonServiceName = "ddprocmon";

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -363,6 +363,7 @@ namespace Datadog.CustomActions
                     Constants.NpmServiceName,
                     Constants.ProcmonServiceName,       // might not exist depending on compile time options**
                     Constants.SecurityAgentServiceName, // might not exist depending on compile time options**
+                    Constants.PrivateActionRunnerServiceName,
                     Constants.ProcessAgentServiceName,
                     Constants.TraceAgentServiceName,
                     Constants.InstallerServiceName,


### PR DESCRIPTION
### What does this PR do?
This PR updates Windows stop lists to stop PAR explicitly stopped during MSI upgrades and at fleet stop-all.
PAR is already stopped in windows services.

### Motivation
This change is part of the Private Action Runner integration with Agent on Windows.

### Describe how you validated your changes
MSI: manually install old version (7.48.0-1), start upgrading and check the the runner stops:
```
# 0) Set MSI paths
$OldMsi = "C:\Temp\dd-agent-old.msi"   # stable old MSI (e.g., 7.48.0-1)
$NewMsi = "C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\datadog-agent-7.77.0-devel.git.453.db2f08c-1-x86_64.msi"

# 1) Install old MSI
Start-Process msiexec.exe -ArgumentList "/i `"$OldMsi`" /qn /l*v C:\Temp\dd-install-old.log" -Wait

# 2) Enable PAR in config
private_action_runner:
  enabled: true

# 3) Start Agent + PAR
Restart-Service datadogagent -Force
Start-Service "datadog-private-action-runner"

# 4) Confirm PAR is running
sc.exe query "datadog-private-action-runner"

# 5) Upgrade to new MSI (should stop PAR)
Start-Process msiexec.exe -ArgumentList "/i `"$NewMsi`" /qn /l*v C:\Temp\dd-upgrade.log" -Wait

# 6) Verify stop occurred (log + service status)
Select-String -Path C:\Temp\dd-upgrade.log -Pattern "StopDDServices","datadog-private-action-runner","Stopping service"
sc.exe query "datadog-private-action-runner"

```

Fleet:
```
#unit tests
go test ./pkg/fleet/installer/packages/service/windows -run TestWinServiceManager_StopAllAgentServices -v

# manual test - used the script below and checked that PAr service was stopped along with others:
import (
	"context"
	"fmt"
	"os"

	windowssvc "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/windows"
)

func main() {
	manager := windowssvc.NewWinServiceManager()
	if err := manager.StopAllAgentServices(context.Background()); err != nil {
		fmt.Fprintf(os.Stderr, "StopAllAgentServices failed: %v\n", err)
		os.Exit(1)
	}
	fmt.Println("StopAllAgentServices OK")
}
```

### Additional Notes
