### PR TITLE
fix(jmxfetch): check if DSD UDS listener is available before selecting a transport

### DIFF
--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -33,7 +33,7 @@ import (
 	jmxStatus "github.com/DataDog/datadog-agent/pkg/status/jmx"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	utilnet "github.com/DataDog/datadog-agent/pkg/util/net"
+	netutil "github.com/DataDog/datadog-agent/pkg/util/net"
 )
 
 const (
@@ -511,7 +511,7 @@ func (j *JMXFetch) getPreferredDSDEndpoint() string {
 	// Check UDS datagram first (preferred transport).
 	socketPath := cfg.GetString("dogstatsd_socket")
 	if dsdConfig.Enabled() && socketPath != "" {
-		if utilnet.IsUDSAvailable(socketPath) {
+		if netutil.IsUDSAvailable(socketPath) {
 			return "statsd:unix://" + socketPath
 		}
 		log.Warnf("DogStatsD configured to listen on UDS (%q) but not available, falling back to UDP.", socketPath)

--- a/pkg/jmxfetch/jmxfetch.go
+++ b/pkg/jmxfetch/jmxfetch.go
@@ -33,6 +33,7 @@ import (
 	jmxStatus "github.com/DataDog/datadog-agent/pkg/status/jmx"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	utilnet "github.com/DataDog/datadog-agent/pkg/util/net"
 )
 
 const (
@@ -46,14 +47,6 @@ const (
 	defaultJavaBinPath                = "java"
 	defaultLogLevel                   = "info"
 	jmxAllowAttachSelf                = " -Djdk.attach.allowAttachSelf=true"
-)
-
-type DSDStatus int
-
-const (
-	DSDStatusRunningUDSDatagram DSDStatus = iota + 1
-	DSDStatusRunningUDP
-	DSDStatusUnknown
 )
 
 var (
@@ -222,22 +215,7 @@ func (j *JMXFetch) Start(manage bool) error {
 	case ReporterJSON:
 		reporter = "json"
 	default:
-		dsdStatus := j.getDSDStatus()
-		if dsdStatus == DSDStatusRunningUDSDatagram {
-			reporter = "statsd:unix://" + pkgconfigsetup.Datadog().GetString("dogstatsd_socket")
-		} else {
-			// We always use UDP if we don't definitively detect UDS running, but we want to let the user know if we
-			// actually detected that UDP should be running, or if we're just in fallback mode.
-			if dsdStatus == DSDStatusUnknown {
-				log.Warnf("DogStatsD status is unknown, falling back to UDP. JMXFetch may not be able to report metrics.")
-			}
-
-			bindHost := configutils.GetBindHost(pkgconfigsetup.Datadog())
-			if bindHost == "" || bindHost == "0.0.0.0" {
-				bindHost = "localhost"
-			}
-			reporter = fmt.Sprintf("statsd:%s:%s", bindHost, pkgconfigsetup.Datadog().GetString("dogstatsd_port"))
-		}
+		reporter = j.getPreferredDSDEndpoint()
 	}
 
 	//TODO : support auto discovery
@@ -524,18 +502,25 @@ func (j *JMXFetch) ConfigureFromInstance(instance integration.Data) error {
 	return nil
 }
 
-func (j *JMXFetch) getDSDStatus() DSDStatus {
-	dsdConfig := dogstatsdConfig.NewConfig(pkgconfigsetup.Datadog())
+// getPreferredDSDEndpoint determines the DogStatsD endpoint for JMXFetch to report to.
+// It prefers UDS datagram if the configured socket is available, otherwise falls back to UDP.
+func (j *JMXFetch) getPreferredDSDEndpoint() string {
+	cfg := pkgconfigsetup.Datadog()
+	dsdConfig := dogstatsdConfig.NewConfig(cfg)
 
-	dsdEnabled := dsdConfig.Enabled()
-	udsEnabled := pkgconfigsetup.Datadog().GetString("dogstatsd_socket") != ""
-	udpEnabled := pkgconfigsetup.Datadog().GetInt("dogstatsd_port") != 0
-
-	if dsdEnabled && udsEnabled {
-		return DSDStatusRunningUDSDatagram
-	} else if dsdEnabled && udpEnabled {
-		return DSDStatusRunningUDP
-	} else {
-		return DSDStatusUnknown
+	// Check UDS datagram first (preferred transport).
+	socketPath := cfg.GetString("dogstatsd_socket")
+	if dsdConfig.Enabled() && socketPath != "" {
+		if utilnet.IsUDSAvailable(socketPath) {
+			return "statsd:unix://" + socketPath
+		}
+		log.Warnf("DogStatsD configured to listen on UDS (%q) but not available, falling back to UDP.", socketPath)
 	}
+
+	// Fall back to UDP.
+	bindHost := configutils.GetBindHost(cfg)
+	if bindHost == "" || bindHost == "0.0.0.0" {
+		bindHost = "localhost"
+	}
+	return fmt.Sprintf("statsd:%s:%s", bindHost, cfg.GetString("dogstatsd_port"))
 }

--- a/pkg/jmxfetch/jmxfetch_nix_test.go
+++ b/pkg/jmxfetch/jmxfetch_nix_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 

--- a/pkg/jmxfetch/jmxfetch_nix_test.go
+++ b/pkg/jmxfetch/jmxfetch_nix_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build jmx && !windows
+
+package jmxfetch
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestGetPreferredDSDEndpointNix(t *testing.T) {
+	cfg := configmock.New(t)
+
+	// Helper to create a unixgram socket at a short path under /tmp
+	// (macOS has a 108-char limit on Unix socket paths).
+	createSocket := func(t *testing.T) string {
+		t.Helper()
+		dir, err := os.MkdirTemp("/tmp", "dsd-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		sockPath := filepath.Join(dir, "s")
+		conn, err := net.ListenPacket("unixgram", sockPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+		return sockPath
+	}
+
+	t.Run("UDS available", func(t *testing.T) {
+		sockPath := createSocket(t)
+		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
+		cfg.SetWithoutSource("use_dogstatsd", true)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:unix://"+sockPath, j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("DSD disabled falls back to UDP", func(t *testing.T) {
+		sockPath := createSocket(t)
+		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
+		cfg.SetWithoutSource("dogstatsd_port", "8125")
+		cfg.SetWithoutSource("use_dogstatsd", false)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
+	})
+}

--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -8,9 +8,6 @@
 package jmxfetch
 
 import (
-	"net"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -75,29 +75,6 @@ func TestConflictingInstanceInitJavaOptions(t *testing.T) {
 func TestGetPreferredDSDEndpoint(t *testing.T) {
 	cfg := configmock.New(t)
 
-	// Helper to create a unixgram socket at a short path under /tmp
-	// (macOS has a 108-char limit on Unix socket paths).
-	createSocket := func(t *testing.T) string {
-		t.Helper()
-		dir, err := os.MkdirTemp("/tmp", "dsd-test-*")
-		require.NoError(t, err)
-		t.Cleanup(func() { os.RemoveAll(dir) })
-		sockPath := filepath.Join(dir, "s")
-		conn, err := net.ListenPacket("unixgram", sockPath)
-		require.NoError(t, err)
-		t.Cleanup(func() { conn.Close() })
-		return sockPath
-	}
-
-	t.Run("UDS available", func(t *testing.T) {
-		sockPath := createSocket(t)
-		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
-		cfg.SetWithoutSource("use_dogstatsd", true)
-
-		j := NewJMXFetch(nil, nil)
-		assert.Equal(t, "statsd:unix://"+sockPath, j.getPreferredDSDEndpoint())
-	})
-
 	t.Run("UDS configured but not available", func(t *testing.T) {
 		cfg.SetWithoutSource("dogstatsd_socket", "/tmp/nonexistent-dsd-test.sock")
 		cfg.SetWithoutSource("dogstatsd_port", "8125")
@@ -111,16 +88,6 @@ func TestGetPreferredDSDEndpoint(t *testing.T) {
 		cfg.SetWithoutSource("dogstatsd_socket", "")
 		cfg.SetWithoutSource("dogstatsd_port", "8125")
 		cfg.SetWithoutSource("use_dogstatsd", true)
-
-		j := NewJMXFetch(nil, nil)
-		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
-	})
-
-	t.Run("DSD disabled falls back to UDP", func(t *testing.T) {
-		sockPath := createSocket(t)
-		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
-		cfg.SetWithoutSource("dogstatsd_port", "8125")
-		cfg.SetWithoutSource("use_dogstatsd", false)
 
 		j := NewJMXFetch(nil, nil)
 		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())

--- a/pkg/jmxfetch/jmxfetch_test.go
+++ b/pkg/jmxfetch/jmxfetch_test.go
@@ -8,11 +8,16 @@
 package jmxfetch
 
 import (
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
 func TestInitConfigJavaOptions(t *testing.T) {
@@ -65,4 +70,79 @@ func TestConflictingInstanceInitJavaOptions(t *testing.T) {
 	// First config wins
 	require.Contains(t, j.JavaOptions, "Xmx200m")
 	require.NotContains(t, j.JavaOptions, "Xmx444m")
+}
+
+func TestGetPreferredDSDEndpoint(t *testing.T) {
+	cfg := configmock.New(t)
+
+	// Helper to create a unixgram socket at a short path under /tmp
+	// (macOS has a 108-char limit on Unix socket paths).
+	createSocket := func(t *testing.T) string {
+		t.Helper()
+		dir, err := os.MkdirTemp("/tmp", "dsd-test-*")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		sockPath := filepath.Join(dir, "s")
+		conn, err := net.ListenPacket("unixgram", sockPath)
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+		return sockPath
+	}
+
+	t.Run("UDS available", func(t *testing.T) {
+		sockPath := createSocket(t)
+		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
+		cfg.SetWithoutSource("use_dogstatsd", true)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:unix://"+sockPath, j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("UDS configured but not available", func(t *testing.T) {
+		cfg.SetWithoutSource("dogstatsd_socket", "/tmp/nonexistent-dsd-test.sock")
+		cfg.SetWithoutSource("dogstatsd_port", "8125")
+		cfg.SetWithoutSource("use_dogstatsd", true)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("UDS not configured", func(t *testing.T) {
+		cfg.SetWithoutSource("dogstatsd_socket", "")
+		cfg.SetWithoutSource("dogstatsd_port", "8125")
+		cfg.SetWithoutSource("use_dogstatsd", true)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("DSD disabled falls back to UDP", func(t *testing.T) {
+		sockPath := createSocket(t)
+		cfg.SetWithoutSource("dogstatsd_socket", sockPath)
+		cfg.SetWithoutSource("dogstatsd_port", "8125")
+		cfg.SetWithoutSource("use_dogstatsd", false)
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("bind host 0.0.0.0 normalized to localhost", func(t *testing.T) {
+		cfg.SetWithoutSource("dogstatsd_socket", "")
+		cfg.SetWithoutSource("dogstatsd_port", "8125")
+		cfg.SetWithoutSource("use_dogstatsd", true)
+		cfg.SetWithoutSource("bind_host", "0.0.0.0")
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:localhost:8125", j.getPreferredDSDEndpoint())
+	})
+
+	t.Run("custom bind host and port", func(t *testing.T) {
+		cfg.SetWithoutSource("dogstatsd_socket", "")
+		cfg.SetWithoutSource("dogstatsd_port", "9125")
+		cfg.SetWithoutSource("use_dogstatsd", true)
+		cfg.SetWithoutSource("bind_host", "127.0.0.2")
+
+		j := NewJMXFetch(nil, nil)
+		assert.Equal(t, "statsd:127.0.0.2:9125", j.getPreferredDSDEndpoint())
+	})
 }

--- a/pkg/util/net/endpoint_check_nix.go
+++ b/pkg/util/net/endpoint_check_nix.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package net
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// IsUDSAvailable checks if the given path refers to an existing Unix domain socket
+// that the current process can write to. This is intended for verifying that a
+// DogStatsD UDS datagram socket is ready to receive data.
+//
+// It checks three things:
+//  1. The path exists on disk.
+//  2. The file is a socket.
+//  3. The current process has write permission.
+func IsUDSAvailable(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return false
+	}
+	if err := syscall.Access(path, unix.W_OK); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/util/net/endpoint_check_test.go
+++ b/pkg/util/net/endpoint_check_test.go
@@ -18,7 +18,8 @@ import (
 )
 
 func TestIsUDSAvailable_NonExistentPath(t *testing.T) {
-	assert.False(t, IsUDSAvailable("/tmp/does-not-exist-dsd-test.sock"))
+	path := filepath.Join(t.TempDir(), "socket-we-wont-ever-create")
+	assert.False(t, IsUDSAvailable(path))
 }
 
 func TestIsUDSAvailable_RegularFile(t *testing.T) {

--- a/pkg/util/net/endpoint_check_test.go
+++ b/pkg/util/net/endpoint_check_test.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package net
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsUDSAvailable_NonExistentPath(t *testing.T) {
+	assert.False(t, IsUDSAvailable("/tmp/does-not-exist-dsd-test.sock"))
+}
+
+func TestIsUDSAvailable_RegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-socket")
+	require.NoError(t, writeFile(path))
+	assert.False(t, IsUDSAvailable(path))
+}
+
+func TestIsUDSAvailable_ValidSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "test.sock")
+	conn, err := net.ListenPacket("unixgram", sockPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.True(t, IsUDSAvailable(sockPath))
+}
+
+// writeFile creates a regular file at path for testing.
+func writeFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/pkg/util/net/endpoint_check_windows.go
+++ b/pkg/util/net/endpoint_check_windows.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package net
+
+// IsUDSAvailable always returns false on Windows. DogStatsD does not use
+// Unix domain datagram sockets on Windows.
+func IsUDSAvailable(_ string) bool {
+	return false
+}


### PR DESCRIPTION
### What does this PR do?

Updates the logic used by the JMXFetch runner to determine the best DogStatsD transport to assert that, when attempting to use UDS, that the UDS socket is actually present.

### Motivation

In #32919, we changed the behavior of the aforementioned logic to support DSD being run by either the Core Agent _or_ Agent Data Plane. This involved removing a check that actively introspected the DSD component to see if the UDS listener was active. The thinking was that it was both irrelevant for ADP and that the logic of the DSD component in the Core Agent would always spawn the UDS listener if `dogstatsd_socket` was non-empty, so checking if it was listening was extraneous.

However, the original logic was added at a time when `dogstatsd_socket` had no default value, and in 7.57, we updated the default value. However, in some cases, the underlying directory that the default socket path uses would not get created automatically, leading the UDS listener to fail to properly create the socket and listen. With the old logic checking if the UDS listener was running, the JMXFetch could gracefully handle this scenario... but with our change to _remove_ that logic, it no longer handled it gracefully, and tried to forcefully use UDS regardless of whether or not there was an actual UDS listener present. No bueno.

This PR adds back a direct check -- is the UDS listener present? -- but adapted to handle both Core Agent _or_ ADP being the ones running the listener: we check for the presence of the socket, and that it's a socket file. If neither of those things are true, we simply default to UDP. This brings back the previous behavior but in a way that is acceptable for both use cases.

### Describe how you validated your changes

New unit tests were added for the helper functions we added to check for the presence of the UDS listener, as well as for the new `getPreferredDSDEndpoint` function which picks the optimal DSD transport to use subject to whether or not the hypothetical best transport is actually available.

### Additional Notes
