### PR TITLE
fix nghttp2 libname

### DIFF
--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -110,7 +110,7 @@ cc_library(
 
 cc_shared_library(
     name = "nghttp2_shared",
-    shared_lib_name = "nghttp2.so.%s" % SO_VERSION,
+    shared_lib_name = "libnghttp2.so.%s" % SO_VERSION,
     deps = ["nghttp2"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### What does this PR do?

Fix the nghttp2 shared library name

### Motivation

Fixing healthcheck by shipping the expected name for shared objects
See the failures in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1417602327

The symlink is already named `libnghttp2.so[...]`, and the omnibus build also outputs the lib as `libnghttp2.so` as is the standard name

### Describe how you validated your changes

### Additional Notes
