### PR TITLE
Use winawshost provisioner for Windows network path integration test

### DIFF
--- a/test/new-e2e/tests/netpath/network-path-integration/netpath_int_win_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/netpath_int_win_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	scenwin "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2/windows"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -32,11 +33,11 @@ func TestWindowsNetworkPathIntegrationSuite(t *testing.T) {
 	t.Parallel()
 	e2e.Run(t, &windowsNetworkPathIntegrationTestSuite{}, e2e.WithProvisioner(winawshost.Provisioner(
 		winawshost.WithRunOptions(
-			ec2.WithAgentOptions(
+			scenwin.WithAgentOptions(
 				agentparams.WithSystemProbeConfig(string(sysProbeConfig)),
 				agentparams.WithIntegration("network_path.d", string(networkPathIntegrationWindows)),
 			),
-			ec2.WithEC2InstanceOptions(ec2.WithOS(os.WindowsServerDefault)),
+			scenwin.WithEC2InstanceOptions(ec2.WithOS(os.WindowsServerDefault)),
 		),
 	)))
 }

--- a/test/new-e2e/tests/netpath/network-path-integration/netpath_int_win_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/netpath_int_win_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
-	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 )
 
 type windowsNetworkPathIntegrationTestSuite struct {
@@ -30,8 +30,8 @@ var networkPathIntegrationWindows []byte
 // TestNetworkPathIntegrationSuiteLinux runs the Network Path Integration e2e suite for linux
 func TestWindowsNetworkPathIntegrationSuite(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &windowsNetworkPathIntegrationTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithRunOptions(
+	e2e.Run(t, &windowsNetworkPathIntegrationTestSuite{}, e2e.WithProvisioner(winawshost.Provisioner(
+		winawshost.WithRunOptions(
 			ec2.WithAgentOptions(
 				agentparams.WithSystemProbeConfig(string(sysProbeConfig)),
 				agentparams.WithIntegration("network_path.d", string(networkPathIntegrationWindows)),


### PR DESCRIPTION
### What does this PR do?
Updates the Windows network path integration test to use the `winawshost` provisioner instead of the generic `awshost` provisioner. This allows things like test-signed driver and other config options of `winawshost` to be used

### Motivation

### Describe how you validated your changes
Verified that netpath test still works.

### Additional Notes
