### PR TITLE
CONTINT-5040 - expose cluster api-resources to new metric

### DIFF
--- a/pkg/util/kubernetes/apiserver/resourcetypes.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -28,29 +29,37 @@ var (
 	cacheErr      error
 )
 
+type ClusterResource struct {
+	Group      string
+	APIVersion string
+	Kind       string
+}
+
 // ResourceTypeCache is a global cache to store Kubernetes resource types.
 type ResourceTypeCache struct {
 	// kindGroupToType maps a resource kind (singular name) and api group to resource type (plural name)
 	// this mapping is assumed bijective.
 	kindGroupToType map[string]string
 	// typeGroupToKind is a reverse map of kindGroupToType
-	typeGroupToKind map[string]string
-	lock            sync.RWMutex
-	discoveryClient discovery.DiscoveryInterface
-	refreshing      bool
-	refreshWaitCh   chan struct{}
-	refreshErr      error
-	refreshTTL      time.Duration
+	typeGroupToKind  map[string]string
+	clusterResources map[string]ClusterResource
+	lock             sync.RWMutex
+	discoveryClient  discovery.DiscoveryInterface
+	refreshing       bool
+	refreshWaitCh    chan struct{}
+	refreshErr       error
+	refreshTTL       time.Duration
 }
 
 // InitializeGlobalResourceTypeCache initializes the global cache if it hasn't been already.
 func InitializeGlobalResourceTypeCache(discoveryClient discovery.DiscoveryInterface) error {
 	cacheOnce.Do(func() {
 		resourceCache = &ResourceTypeCache{
-			kindGroupToType: make(map[string]string),
-			typeGroupToKind: make(map[string]string),
-			discoveryClient: discoveryClient,
-			refreshTTL:      5 * time.Second,
+			kindGroupToType:  make(map[string]string),
+			typeGroupToKind:  make(map[string]string),
+			clusterResources: make(map[string]ClusterResource),
+			discoveryClient:  discoveryClient,
+			refreshTTL:       5 * time.Second,
 		}
 
 		err := initRetry.SetupRetrier(&retry.Config{
@@ -108,6 +117,22 @@ func GetAPIGroup(apiVersion string) string {
 		apiGroup = ""
 	}
 	return apiGroup
+}
+
+// GetAPIVersion extracts the version from an API version string (e.g., "apps/v1" → "v1").
+func GetAPIVersion(apiVersion string) string {
+	if index := strings.Index(apiVersion, "/"); index > 0 {
+		return apiVersion[index+1:]
+	}
+	return apiVersion
+}
+
+// GetClusterResources return all known resources from the cache
+func GetClusterResources() (map[string]ClusterResource, error) {
+	if resourceCache == nil {
+		return nil, errors.New("resource type cache is not initialized")
+	}
+	return resourceCache.getClusterResources(), nil
 }
 
 // getResourceType is the instance method to retrieve a resource type.
@@ -173,6 +198,16 @@ func (r *ResourceTypeCache) getResourceKind(resource, apiGroup string) (string, 
 		return kind, nil
 	}
 	return "", fmt.Errorf("resource kind not found for resource %q and group %q", resource, apiGroup)
+}
+
+func (r *ResourceTypeCache) getClusterResources() map[string]ClusterResource {
+	var resources map[string]ClusterResource
+
+	r.lock.RLock()
+	resources = maps.Clone(r.clusterResources)
+	r.lock.RUnlock()
+
+	return resources
 }
 
 func (r *ResourceTypeCache) refreshCache(ctx context.Context) error {
@@ -288,6 +323,14 @@ func (r *ResourceTypeCache) prepopulateCache() error {
 
 			r.kindGroupToType[getCacheKey(kind, group)] = trimmedResourceType
 			r.typeGroupToKind[getCacheKey(trimmedResourceType, group)] = resource.Kind
+
+			if !resource.Namespaced {
+				r.clusterResources[trimmedResourceType] = ClusterResource{
+					Group:      group,
+					APIVersion: GetAPIVersion(list.GroupVersion),
+					Kind:       kind,
+				}
+			}
 		}
 	}
 

--- a/pkg/util/kubernetes/apiserver/resourcetypes_test.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes_test.go
@@ -192,12 +192,22 @@ func TestPrepopulateCache(t *testing.T) {
 				{Kind: "Deployment", Name: "deployments"},
 			},
 		},
+		{
+			GroupVersion: "v1",
+			APIResources: []v1.APIResource{
+				{Kind: "Node", Name: "nodes", Namespaced: false},
+				{Kind: "Namespace", Name: "namespaces", Namespaced: false},
+				{Kind: "CustomResource", Name: "customresources/status", Namespaced: false},
+				{Kind: "InvalidClusterSubresource", Name: "invalidclusterresource/notvalid", Namespaced: false},
+			},
+		},
 	}
 
 	resourceCache = &ResourceTypeCache{
-		kindGroupToType: make(map[string]string),
-		typeGroupToKind: make(map[string]string),
-		discoveryClient: fakeDiscoveryClient,
+		kindGroupToType:  make(map[string]string),
+		typeGroupToKind:  make(map[string]string),
+		clusterResources: make(map[string]ClusterResource),
+		discoveryClient:  fakeDiscoveryClient,
 	}
 
 	err := resourceCache.prepopulateCache()
@@ -212,6 +222,10 @@ func TestPrepopulateCache(t *testing.T) {
 	assert.Equal(t, "Secret", resourceCache.typeGroupToKind["secrets"])
 	assert.Equal(t, "ConfigMap", resourceCache.typeGroupToKind["configmaps"])
 	assert.Equal(t, "Deployment", resourceCache.typeGroupToKind["deployments/apps"])
+
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "Node"}, resourceCache.clusterResources["nodes"])
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "Namespace"}, resourceCache.clusterResources["namespaces"])
+	assert.Equal(t, ClusterResource{Group: "", APIVersion: "v1", Kind: "CustomResource"}, resourceCache.clusterResources["customresources"])
 }
 
 type blockingDiscovery struct {

--- a/releasenotes/notes/expose-cluster-wide-api-resources-0be3022888aa9051.yaml
+++ b/releasenotes/notes/expose-cluster-wide-api-resources-0be3022888aa9051.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    expose a new metric ``kube_apiserver.api_resource`` that holds the ``name``, ``kind``, ``group`` and ``version``
+    of all known cluster wide (non namespaced) resources on the cluster.


### PR DESCRIPTION
Expose a new metric under the `kubernetes_apiserver` check.

The metric exposes a dummy value of 1, and a tag with the existing, clusre wide resource name, kind, group and version.

- metric name: `kube_apiserver.api_resource`
- tags:
  - `kind`: the resource kind
  - `group`: the resource group
  - `version`: the current version for that group
  - `name`: the name of the that resource.
- value: always 1, we are interested in the existence of the tags, not the value.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
