### PR TITLE
dyninst/irgen: fix ErrUnknownPC for functions at sequence boundaries and without line info

### DIFF
--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -280,6 +280,7 @@ func testDyninst(
 		makeRedactorForFunctionWithChangingState())
 	for _, log := range testServer.getLogs() {
 		redacted := redactJSON(t, "", log.body, redactors)
+		t.Logf("Snapshot [probe=%s]: %s", log.id, string(log.body))
 		if debugEnabled {
 			t.Logf("Output: %v\n", string(log.body))
 			t.Logf("Sorted and redacted: %v\n", string(redacted))

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1710,6 +1710,10 @@ type lineData struct {
 	// PC of prologue end or 0 if no prologue end statement is found.
 	prologueEnd uint64
 	lines       []line
+	// noLineInfo indicates this function has no DWARF line information
+	// (compiler-generated stub, assembly wrapper, etc.). This is not an
+	// error - the function is acceptable but won't have return probes.
+	noLineInfo bool
 }
 
 // collectLineData evaluates DWARF line programs to aggregate line data for given ranges.
@@ -4417,6 +4421,10 @@ func pickInjectionPoint(
 			Message: lines.err.Error(),
 		}, nil
 	}
+	// Functions without DWARF line information are acceptable,
+	// but they won't have return probes. The noLineInfo flag signals
+	// this condition to downstream code (e.g., for @duration validation).
+	hasLineInfo := !lines.noLineInfo && len(lines.lines) > 0
 	addr := rootRanges[0][0]
 	funcByteLen := rootRanges[0][1] - addr
 	frameless := lines.prologueEnd == 0
@@ -4459,6 +4467,10 @@ func pickInjectionPoint(
 				return nil, nil, ir.Issue{}, err
 			}
 
+			// Functions without line info shouldn't have return probes.
+			// Don't collect return locations if we lack line info.
+			collectReturnLocations := !skipReturnEvents && hasLineInfo
+
 			// Disassemble the function to find return locations and validate the
 			// injection PC.
 			returnLocations, issue := disassembleFunction(
@@ -4467,7 +4479,7 @@ func pickInjectionPoint(
 				call.pc,
 				call.frameless,
 				body,
-				!skipReturnEvents,
+				collectReturnLocations,
 			)
 			if !issue.IsNone() {
 				return buf, nil, issue, nil
@@ -4478,6 +4490,9 @@ func pickInjectionPoint(
 			if skipReturnEvents {
 				hasAssociatedReturn = false
 				noReturnReason = ir.NoReturnReasonReturnsDisabled
+			} else if !hasLineInfo {
+				hasAssociatedReturn = false
+				noReturnReason = ir.NoReturnReasonNoBody
 			} else if len(returnLocations) == 1 && returnLocations[0].PC == call.pc {
 				// Add a workaround for the fact that single-instruction
 				// functions would have the same entry and exit probes, but the
@@ -4845,35 +4860,52 @@ func collectLineDataForRange(
 	err := lineReader.SeekPC(r[0], &lineEntry)
 	// Workaround for holes: When SeekPC fails with ErrUnknownPC, the reader
 	// is experimentally observed to be left positioned at a preceding
-	// end_sequence marker. If that marker's address is at or before r[0],
-	// we can recover by:
+	// end_sequence marker. We can recover by:
 	//   1. Reading the next entry to find where the next sequence starts
-	//   2. Restoring the reader to prevPos (since seeking backward through
-	//      line tables is very inefficient - it requires restarting from
-	//      the beginning of the table)
-	//   3. Seeking to (next_address - 1) to land within the prior entry
-	//   4. If that puts us at an address >= r[0], we've found valid data
+	//   2. If the next sequence is within the function range, use it
+	//   3. For sequences starting exactly at r[0] (function entry), use directly
+	//   4. For sequences starting after r[0], seek to (next_address - 1)
+	//      to land within the prior entry, which may give us coverage
 	//
 	// The -1 works because lineEntry.Address marks an entry's start, so
 	// (address - 1) falls within the previous entry's range, and SeekPC
 	// will position us at that entry's start (a valid instruction boundary).
-	if err != nil &&
-		errors.Is(err, dwarf.ErrUnknownPC) &&
-		lineEntry.Address <= r[0] {
+	if errors.Is(err, dwarf.ErrUnknownPC) {
 		nextErr := lineReader.Next(&lineEntry)
 		if nextErr == nil {
-			lineReader.Seek(prevPos)
-			nextErr = lineReader.SeekPC(lineEntry.Address-1, &lineEntry)
-		}
-		if nextErr == nil && lineEntry.Address >= r[0] {
-			err = nil
+			nextAddr := lineEntry.Address
+			// If the next sequence starts within or at the function range,
+			// we can potentially use it
+			if nextAddr < r[1] {
+				if nextAddr == r[0] {
+					// Function starts exactly at the sequence boundary - use it directly
+					err = nil
+				} else if nextAddr > r[0] {
+					// Next sequence is inside the function - try the backward seek workaround
+					lineReader.Seek(prevPos)
+					nextErr = lineReader.SeekPC(nextAddr-1, &lineEntry)
+					if nextErr == nil && lineEntry.Address >= r[0] {
+						err = nil
+					}
+				}
+			}
+			// If nextAddr >= r[1], the function has no line info - fall through to handle below
 		}
 	}
 	if err != nil {
-		// Restore the reader to prevPos so the next call to this function
-		// can seek forward efficiently. The caller explores ranges in PC
-		// order, so prevPos is likely close to the next range we'll query.
+		// Functions without DWARF line information (compiler-generated stubs,
+		// assembly wrappers, functions at sequence boundaries with no coverage)
+		// are acceptable - they just won't have line info or return probes.
+		// Restore the reader to prevPos for efficient forward seeking.
 		lineReader.Seek(prevPos)
+		if errors.Is(err, dwarf.ErrUnknownPC) {
+			// Return lineData with noLineInfo flag to indicate this function
+			// has no line information available. This allows downstream code
+			// to distinguish "no line info" from "broken DWARF" and handle
+			// appropriately (e.g., skip return probes, mark @duration as invalid).
+			return lineData{noLineInfo: true}
+		}
+		// Other errors are genuine problems
 		return lineData{err: err}
 	}
 	prologueEnd := uint64(0)

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -4337,7 +4337,7 @@ func newProbe(
 			injectionPoints,
 			skipReturnEvents,
 		)
-		if issue != (ir.Issue{}) || err != nil {
+		if !issue.IsNone() || err != nil {
 			return nil, issue, err
 		}
 	}

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -1710,10 +1710,6 @@ type lineData struct {
 	// PC of prologue end or 0 if no prologue end statement is found.
 	prologueEnd uint64
 	lines       []line
-	// noLineInfo indicates this function has no DWARF line information
-	// (compiler-generated stub, assembly wrapper, etc.). This is not an
-	// error - the function is acceptable but won't have return probes.
-	noLineInfo bool
 }
 
 // collectLineData evaluates DWARF line programs to aggregate line data for given ranges.
@@ -4421,10 +4417,7 @@ func pickInjectionPoint(
 			Message: lines.err.Error(),
 		}, nil
 	}
-	// Functions without DWARF line information are acceptable,
-	// but they won't have return probes. The noLineInfo flag signals
-	// this condition to downstream code (e.g., for @duration validation).
-	hasLineInfo := !lines.noLineInfo && len(lines.lines) > 0
+	hasLineInfo := len(lines.lines) > 0
 	addr := rootRanges[0][0]
 	funcByteLen := rootRanges[0][1] - addr
 	frameless := lines.prologueEnd == 0
@@ -4858,38 +4851,43 @@ func collectLineDataForRange(
 	// TODO: Find a way to seek to the first entry in a range rather than just
 	// the entry that covers this PC. See https://github.com/golang/go/issues/73996.
 	err := lineReader.SeekPC(r[0], &lineEntry)
-	// Workaround for holes: When SeekPC fails with ErrUnknownPC, the reader
-	// is experimentally observed to be left positioned at a preceding
-	// end_sequence marker. We can recover by:
-	//   1. Reading the next entry to find where the next sequence starts
-	//   2. If the next sequence is within the function range, use it
-	//   3. For sequences starting exactly at r[0] (function entry), use directly
-	//   4. For sequences starting after r[0], seek to (next_address - 1)
-	//      to land within the prior entry, which may give us coverage
+	// Workaround for holes: SeekPC fails with ErrUnknownPC when the function's
+	// start PC falls in a gap between line table sequences (common for functions
+	// at sequence boundaries). After failure, SeekPC leaves the reader past the
+	// first entry of the next sequence (see Go's debug/dwarf SeekPC impl). We
+	// try two recovery strategies:
 	//
-	// The -1 works because lineEntry.Address marks an entry's start, so
-	// (address - 1) falls within the previous entry's range, and SeekPC
-	// will position us at that entry's start (a valid instruction boundary).
+	// 1. Read the next entry (which SeekPC left us near) and use
+	//    SeekPC(addr-1) to land on the first entry of that sequence.
+	// 2. If that fails, do a full scan from the beginning of the CU's line
+	//    table. Sequences may not be in PC order, so we must scan all entries
+	//    without breaking early on out-of-range addresses.
 	if errors.Is(err, dwarf.ErrUnknownPC) {
 		nextErr := lineReader.Next(&lineEntry)
-		if nextErr == nil {
-			nextAddr := lineEntry.Address
-			// If the next sequence starts within or at the function range,
-			// we can potentially use it
-			if nextAddr < r[1] {
-				if nextAddr == r[0] {
-					// Function starts exactly at the sequence boundary - use it directly
+		if nextErr == nil && lineEntry.Address > r[0] && lineEntry.Address < r[1] {
+			lineReader.Seek(prevPos)
+			nextErr = lineReader.SeekPC(lineEntry.Address-1, &lineEntry)
+			if nextErr == nil && lineEntry.Address >= r[0] {
+				err = nil
+			}
+		}
+		if err != nil {
+			// Full scan: sequences in the line table may not be in PC order,
+			// so we scan all entries to find one in [r[0], r[1]).
+			lineReader.Reset()
+			for {
+				nextErr := lineReader.Next(&lineEntry)
+				if nextErr != nil {
+					break
+				}
+				if lineEntry.EndSequence {
+					continue
+				}
+				if lineEntry.Address >= r[0] && lineEntry.Address < r[1] {
 					err = nil
-				} else if nextAddr > r[0] {
-					// Next sequence is inside the function - try the backward seek workaround
-					lineReader.Seek(prevPos)
-					nextErr = lineReader.SeekPC(nextAddr-1, &lineEntry)
-					if nextErr == nil && lineEntry.Address >= r[0] {
-						err = nil
-					}
+					break
 				}
 			}
-			// If nextAddr >= r[1], the function has no line info - fall through to handle below
 		}
 	}
 	if err != nil {
@@ -4899,11 +4897,7 @@ func collectLineDataForRange(
 		// Restore the reader to prevPos for efficient forward seeking.
 		lineReader.Seek(prevPos)
 		if errors.Is(err, dwarf.ErrUnknownPC) {
-			// Return lineData with noLineInfo flag to indicate this function
-			// has no line information available. This allows downstream code
-			// to distinguish "no line info" from "broken DWARF" and handle
-			// appropriately (e.g., skip return probes, mark @duration as invalid).
-			return lineData{noLineInfo: true}
+			return lineData{}
 		}
 		// Other errors are genuine problems
 		return lineData{err: err}

--- a/pkg/dyninst/irgen/irgen_all_symbols_test.go
+++ b/pkg/dyninst/irgen/irgen_all_symbols_test.go
@@ -114,47 +114,7 @@ func addLoclistSection(binPath, objcopy, tmpDir string) (modifiedBinPath string,
 }
 
 func testAllProbes(t *testing.T, binPath string) {
-	binary, err := os.Open(binPath)
-	require.NoError(t, err)
-	elf, err := safeelf.NewFile(binary)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, binary.Close()) }()
-	var probes []ir.ProbeDefinition
-	symbols, err := elf.Symbols()
-	require.NoError(t, err)
-
-	for i, s := range symbols {
-		if int(s.Section) >= len(elf.Sections) ||
-			elf.Sections[s.Section].Name != ".text" {
-			continue
-		}
-		// These automatically generated symbols cause problems.
-		if s.Name == "runtime.text" ||
-			s.Name == "runtime.etext" ||
-			s.Name == "" ||
-			strings.HasPrefix(s.Name, "go:") ||
-			strings.HasPrefix(s.Name, "type:.") ||
-			strings.HasPrefix(s.Name, "runtime.vdso") ||
-			strings.HasSuffix(s.Name, ".abi0") ||
-			strings.Contains(s.Name, "..typeAssert") ||
-			strings.Contains(s.Name, "..dict") ||
-			strings.Contains(s.Name, "..gobytes") ||
-			strings.Contains(s.Name, "..interfaceSwitch") ||
-			strings.Contains(s.Name, "go.shape") {
-			continue
-		}
-
-		// Speed things up by skipping some symbols.
-		probes = append(probes, &rcjson.SnapshotProbe{
-			LogProbeCommon: rcjson.LogProbeCommon{
-				ProbeCommon: rcjson.ProbeCommon{
-					ID:    fmt.Sprintf("probe_%d", i),
-					Where: &rcjson.Where{MethodName: s.Name},
-				},
-			},
-		})
-	}
-
+	probes := buildAllSymbolProbes(t, binPath)
 	obj, err := object.OpenElfFileWithDwarf(binPath)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, obj.Close()) }()
@@ -174,6 +134,30 @@ func verifyIR(t *testing.T, p *ir.Program) {
 			varNames[v.Name] = struct{}{}
 		}
 	}
+	noBodyCount := 0
+	singleInstrCount := 0
+	for _, probe := range p.Probes {
+		for _, event := range probe.Events {
+			for _, ip := range event.InjectionPoints {
+				if ip.NoReturnReason == ir.NoReturnReasonNoBody {
+					ranges := probe.Subprogram.OutOfLinePCRanges
+					if len(ranges) > 0 {
+						size := ranges[0][1] - ranges[0][0]
+						if ip.HasAssociatedReturn == false && size <= 1 {
+							singleInstrCount++
+						} else {
+							noBodyCount++
+							t.Logf("noBody function: %s (pc=0x%x, size=%d)", probe.Subprogram.Name, ranges[0][0], size)
+						}
+					} else {
+						noBodyCount++
+						t.Logf("noBody function: %s (no out-of-line ranges)", probe.Subprogram.Name)
+					}
+				}
+			}
+		}
+	}
+	t.Logf("NoReturnReasonNoBody: %d noBody + %d singleInstr", noBodyCount, singleInstrCount)
 	kindCounts := make(map[ir.IssueKind]int)
 	defer func() {
 		for kind, count := range kindCounts {
@@ -194,14 +178,11 @@ func verifyIR(t *testing.T, p *ir.Program) {
 		kindCounts[issue.Kind]++
 		switch issue.Kind {
 		case ir.IssueKindInvalidDWARF:
-			t.Logf("%s: invalid DWARF: %s", loc, issue.Message)
+			t.Errorf("%s: invalid DWARF: %s", loc, issue.Message)
 		case ir.IssueKindDisassemblyFailed:
-			// Go 1.25+ changed DWARF location list generation, introducing DW_OP_deref
-			// and other patterns that break assumptions in pkg/dyninst/dwarf/loclist/parse.go.
-			// This causes "unsupported register size" errors (e.g., 24-byte slices or
-			// 16-byte interfaces claimed to be in a single 8-byte register) and
-			// "unconsumed op" errors when DW_OP_deref (opcode 0x6) appears.
-			// Until proper go1.25+ DWARF support is implemented, log instead of fail.
+			// Some functions contain instructions the disassembler can't
+			// decode (e.g. AVX-512, LSE atomics) or have injection PCs that
+			// don't land on instruction boundaries. Log instead of fail.
 			t.Logf("%s: disassembly failed: %s", loc, issue.Message)
 		case ir.IssueKindInvalidProbeDefinition:
 			t.Logf("%s: invalid probe definition: %s", loc, issue.Message)


### PR DESCRIPTION
### What does this PR do?

The DWARF line reader was failing with ErrUnknownPC in two scenarios:

1. Functions starting at end_sequence boundaries: When a function begins
   exactly where the previous function's end_sequence marker is located,
   SeekPC would fail because the target address isn't covered by any line entry.

2. Functions with no DWARF line information: Compiler-generated stubs,
   assembly wrappers, and other synthetic functions may have no source
   line information in the DWARF data.

The previous workaround had restrictive conditions (lineEntry.Address <= 
function start address) that prevented it from triggering in most cases, 
and only checked for exact matches (lineEntry.Address == function start 
address) which was too strict.

Fix by:
- Removing the restrictive condition that blocked the recovery logic
- After SeekPC fails, reset to the previous position and iterate forward
  through the line table to find the first entry at or after the function's
  start address
- If an entry is found within the function's address range, use it
- If no entry is found (function genuinely has no line info), return empty
  lineData instead of an error, allowing the function to be processed as
  frameless

### Motivation

Many functions weren't being instrumented.

### Describe how you validated your changes

Running `TestIRGenAllProbes`. Including the commit in this PR which better highlights failing cases.

### Additional Notes
