### PR TITLE
[CWS] remove `/hostname` endpoint from the security-agent

### DIFF
--- a/cmd/security-agent/api/agent/agent.go
+++ b/cmd/security-agent/api/agent/agent.go
@@ -24,7 +24,6 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare/securityagent"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -50,7 +49,6 @@ func NewAgent(statusComponent status.Component, settings settings.Component, wme
 func (a *Agent) SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/version", version.Get).Methods("GET")
 	r.HandleFunc("/flare", a.makeFlare).Methods("POST")
-	r.HandleFunc("/hostname", a.getHostname).Methods("GET")
 	r.HandleFunc("/stop", a.stopAgent).Methods("POST")
 	r.HandleFunc("/status", a.getStatus).Methods("GET")
 	r.HandleFunc("/status/health", a.getHealth).Methods("GET")
@@ -89,22 +87,6 @@ func (a *Agent) stopAgent(w http.ResponseWriter, _ *http.Request) {
 	signals.Stopper <- true
 	w.Header().Set("Content-Type", "application/json")
 	j, err := json.Marshal("")
-	if err != nil {
-		log.Warnf("Failed to serialize json: %v", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.Write(j)
-}
-
-func (a *Agent) getHostname(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	hname, err := hostname.Get(r.Context())
-	if err != nil {
-		log.Warnf("Error getting hostname: %s\n", err) // or something like this
-		hname = ""
-	}
-	j, err := json.Marshal(hname)
 	if err != nil {
 		log.Warnf("Failed to serialize json: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
### What does this PR do?

The hostname reported by this endpoint is wrong, since it's the hostname computed locally and not the one computed remotely which is the one we usually use in the CWS/CSPM pipelines. This PR removes the endpoint altogether.

### Motivation

### Describe how you validated your changes

### Additional Notes
