### PR TITLE
[pkg/dyninst] Minor circuit breaker tweaks

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -166,7 +166,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interval", 1*time.Second)
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.per_probe_cpu_limit", 0.1)
 	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.all_probes_cpu_limit", 0.5)
-	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interrupt_overhead", 5*time.Microsecond)
+	cfg.BindEnvAndSetDefault("dynamic_instrumentation.circuit_breaker.interrupt_overhead", 2*time.Microsecond)
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.

--- a/pkg/config/setup/system_probe_test.go
+++ b/pkg/config/setup/system_probe_test.go
@@ -38,7 +38,7 @@ func TestSystemProbeDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "dynamic_instrumentation.circuit_breaker.interrupt_overhead",
-			defaultValue: 5 * time.Microsecond,
+			defaultValue: 2 * time.Microsecond,
 		},
 	} {
 		t.Run(tc.key, func(t *testing.T) {

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -943,17 +943,19 @@ func handleHeartbeatCheck(sm *state, effects effectHandler) {
 				prog.state = programStateDraining
 				proc.state = processStateFailed
 				err := fmt.Errorf(
-					"probe exceeded CPU limit of %fcpus/s using %fcpus = %fcpus (exec) + %fcpus (%d interrupts) over %fs on core %d",
+					"probe exceeded CPU limit of %fcpus/s using %fcpus/s = %fcpus/s (exec) + %fcpus/s (%d interrupts) over %fs on core %d",
 					sm.breakerCfg.PerProbeCPULimit,
-					(execCost + interruptCost).Seconds(),
-					execCost.Seconds(),
-					interruptCost.Seconds(),
+					costSPS,
+					execCost.Seconds()/interval.Seconds(),
+					interruptCost.Seconds()/interval.Seconds(),
 					hits,
 					interval.Seconds(),
 					core,
 				)
 				effects.detachFromProcess(proc.attachedProgram, err)
+				proc.attachedProgram = nil
 				detachedAny = true
+				break
 			}
 		}
 	}

--- a/pkg/dyninst/circuit_breaker_test.go
+++ b/pkg/dyninst/circuit_breaker_test.go
@@ -58,7 +58,7 @@ func testCircuitBreaker(
 		Interval:          10 * time.Millisecond,
 		PerProbeCPULimit:  0.1,
 		AllProbesCPULimit: 0.5,
-		InterruptOverhead: 5 * time.Microsecond,
+		InterruptOverhead: 2 * time.Microsecond,
 	}
 	cfg.ProbeTombstoneFilePath = filepath.Join(tempDir, "tombstone.json")
 	var sendUpdate fakeProcessSubscriber

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -624,7 +624,7 @@ func TestNoSuccessfulProbes(t *testing.T) {
 		Interval:          1 * time.Second,
 		PerProbeCPULimit:  0.1,
 		AllProbesCPULimit: 0.5,
-		InterruptOverhead: 5 * time.Microsecond,
+		InterruptOverhead: 2 * time.Microsecond,
 	})
 	t.Cleanup(func() { require.NoError(t, a.Shutdown()) })
 	deps := fakeDeps.toDeps()


### PR DESCRIPTION
Adjust interrupt estimate, based on observing staging, we are overly sensitive.
Polish error message (use cpu/s consistently).
Break after first violation for clarity (same effective behavior).
