### PR TITLE
[Backport 7.75.x] bump SGC to v1.5.2 to address [VULN-16238] CVE-2025-61728 & [VULN-17056] CVE-2025-68121

### DIFF
--- a/deps/secret_connector/secret_connector.MODULE.bazel
+++ b/deps/secret_connector/secret_connector.MODULE.bazel
@@ -2,7 +2,7 @@
 
 http_archive = use_repo_rule("//third_party/bazel/tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "1.5.1"
+VERSION = "1.5.2"
 
 # Define URLs for each platform
 secret_generic_urls = {
@@ -24,16 +24,16 @@ secret_generic_urls = {
 # Note: These should be updated for each version
 secret_generic_sha256 = {
     "linux": {
-        "x86_64": "eb17a21c4aa543737c34597a67815f273de9240629a03d91643e3e8d40019e48",
-        "arm64": "1987a766917a119c15cdcce7ef9e1d1a19289b26c1bf304427ea329c9a2c16f1",
+        "x86_64": "3f7a999d12a07ceb5d02151e44c3943ec898ae2a8789b8949b43c8d384e6217c",
+        "arm64": "b656210a0b1e8e2ec10457837d85faa3e8847ccd613c671a95a038543747b846",
     },
     "windows": {
-        "x86_64": "e370fb7953de604d39a7ecb05ba03be3477d923445f2d8ceddf172a3474325d8",
-        "arm64": "2a93ebe2d7468afb7f657cb90702f1e66d8006405b31db254d0c5194f2019fe2",
+        "x86_64": "ea46bd9f1efd0ae4ac1c9fc0591f5860e994771e6717d08a4f1502a888a2f372",
+        "arm64": "2c1b70474b52fee0ea805026d4cfdd8f96d1b38b9384382a76ec0cf0f23e3971",
     },
     "macos": {
-        "x86_64": "5e3318786f168f15ac02db144132a044ea981edded45def8aa1c763c568ce388",
-        "arm64": "f75de28244a2282858a3e9ae7222ad668ddab92e7a13009c26b3f7c84c642229",
+        "x86_64": "e957504a8c86221482d1b850574509c7a381084fae5ab73661345a4e46212737",
+        "arm64": "3ef1e4e533707a55dec5e2f141070f79b67f3a6e1bfd440b2d27bad64d62ad7a",
     },
 }
 


### PR DESCRIPTION
### What does this PR do?
bumps SGC to `1.5.2` which addresses [[VULN-16238](https://datadoghq.atlassian.net/browse/VULN-16238)] CVE-2025-61728 & [[VULN-17056](https://datadoghq.atlassian.net/browse/VULN-17056)] CVE-2025-68121 due to `go version` < `1.25.7`

### Motivation
CVE

### Describe how you validated your changes
CI

### Additional Notes
This should be handled in Agent 7.76+ as we have migrated SGC from an external repo to within the datadog-agent, so we have inherited its security benefits, including it's CVE fixes. 