### PR TITLE
Increase the time a PR is allowed to be in the merge queue from 4 to 6 hours

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -5,7 +5,7 @@ enable: true
 merge_method: squash
 workflow_type: speculative_parallel_impact
 speculative_max_depth: 5
-wait_for_check_timeout_in_minutes: 240
+wait_for_check_timeout_in_minutes: 360
 gitlab_jobs_retry_enable: true
 gitlab_check_enable: true
 skip_labels: true


### PR DESCRIPTION
Increase the time a PR is allowed to be waiting in the merge queue from 4 to 6 hours.

Since it can very often take 90 minutes to run tests, if you have one flake, then notice it an hour later, then rerun, or even merge to head and re-push, you can easily run out the 4 hour time. I see that at least once every 2 weeks.
