### PR TITLE
Fix PID type mismatch in disco CLI

### DIFF
--- a/pkg/discovery/module/rust/src/bin/disco.rs
+++ b/pkg/discovery/module/rust/src/bin/disco.rs
@@ -12,7 +12,7 @@ use dd_discovery::{Params, get_services};
 struct Args {
     /// Process ID to analyze
     #[arg(short, long)]
-    pid: u32,
+    pid: i32,
 }
 
 #[allow(clippy::print_stdout, clippy::print_stderr)]


### PR DESCRIPTION
### What does this PR do?
Changes the `pid` field type from `u32` to `i32` in the disco CLI argument structure.

### Motivation
`bazel build //...` was failing with:
```rs
error[E0308]: mismatched types
  --> pkg/discovery/module/rust/src/bin/disco.rs:24:29
   |
24 |         new_pids: Some(vec![args.pid]),
   |                             ^^^^^^^^ expected `i32`, found `u32`
   |
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
   |
24 |         new_pids: Some(vec![args.pid.try_into().unwrap()]),
   |                                     ++++++++++++++++++++

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0308`.
[...]
ERROR: Build did NOT complete successfully
```

The `Params` struct expects `i32` PIDs to match the Go codebase API (`pkg/discovery/core/params.go`) which uses `int32` following POSIX conventions (for the record: allows sentinels like `-1`).

### Describe how you validated your changes
`bazel build //...` now completes successfully.