### PR TITLE
chore: Temporarily pin Ansible collection version

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -236,7 +236,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 				(s.os.Flavor == e2eos.CentOS && s.os.Version == e2eos.CentOS7.Version) {
 				s.T().Skip("Ansible doesn't install support Python2 anymore")
 			} else {
-				_, err = s.Env().RemoteHost.Execute(fmt.Sprintf("%sansible-galaxy collection install -vvv datadog.dd", ansiblePrefix))
+				_, err = s.Env().RemoteHost.Execute(fmt.Sprintf("%sansible-galaxy collection install -vvv datadog.dd:6.4.0", ansiblePrefix))
 			}
 			if err == nil {
 				break


### PR DESCRIPTION
### What does this PR do?

Pin Ansible collection for tests

### Motivation

Same as https://github.com/DataDog/datadog-agent/pull/40452, last released Ansible version breaks E2E, let's pin while working on proper fix

### Describe how you validated your changes

### Additional Notes
