### PR TITLE
chore: Temporarily pin Ansible collection version

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -229,7 +229,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 		var ansiblePrefix string
 		for i := 0; i < 3; i++ {
 			ansiblePrefix = s.installAnsible(s.os)
-			if _, err := s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd:6.4.0"); err == nil {
+			if _, err := s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd:==6.4.0"); err == nil {
 				break
 			}
 			if i == 2 {

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -229,7 +229,7 @@ func (s *packageBaseSuite) RunInstallScript(params ...string) {
 		var ansiblePrefix string
 		for i := 0; i < 3; i++ {
 			ansiblePrefix = s.installAnsible(s.os)
-			if _, err := s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd"); err == nil {
+			if _, err := s.Env().RemoteHost.Execute(ansiblePrefix + "ansible-galaxy collection install -vvv datadog.dd:6.4.0"); err == nil {
 				break
 			}
 			if i == 2 {


### PR DESCRIPTION
### What does this PR do?

Pin Ansible collection for tests

### Motivation

Same as https://github.com/DataDog/datadog-agent/pull/40452, last released Ansible version breaks E2E, let's pin while working on proper fix

### Describe how you validated your changes

### Additional Notes
