### PR TITLE
[PROF-13710] Flatten EbpfCollectorConfig and remove EnableSplitByService config

### DIFF
--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -23,9 +23,9 @@ import (
 
 // Config is the configuration for the profiles receiver.
 type Config struct {
-	EbpfCollectorConfig  *ebpfconfig.Config                  `mapstructure:",squash"`
-	SymbolUploader       symboluploader.SymbolUploaderConfig `mapstructure:"symbol_uploader"`
-	CollectContext       bool                                `mapstructure:"collect_context"`
+	EbpfCollectorConfig *ebpfconfig.Config                  `mapstructure:",squash"`
+	SymbolUploader      symboluploader.SymbolUploaderConfig `mapstructure:"symbol_uploader"`
+	CollectContext      bool                                `mapstructure:"collect_context"`
 }
 
 // ServiceNameEnvVars is the list of environment variables used to determine the service name.
@@ -93,9 +93,9 @@ func defaultConfig() component.Config {
 
 	symbolUploaderConfig := symboluploader.DefaultSymbolUploaderConfig()
 	return Config{
-		EbpfCollectorConfig:  cfg,
-		SymbolUploader:       symbolUploaderConfig,
-		CollectContext:       false,
+		EbpfCollectorConfig: cfg,
+		SymbolUploader:      symbolUploaderConfig,
+		CollectContext:      false,
 	}
 }
 

--- a/comp/host-profiler/collector/impl/receiver/config.go
+++ b/comp/host-profiler/collector/impl/receiver/config.go
@@ -23,10 +23,9 @@ import (
 
 // Config is the configuration for the profiles receiver.
 type Config struct {
-	EbpfCollectorConfig  *ebpfconfig.Config                  `mapstructure:"ebpf_collector"`
+	EbpfCollectorConfig  *ebpfconfig.Config                  `mapstructure:",squash"`
 	SymbolUploader       symboluploader.SymbolUploaderConfig `mapstructure:"symbol_uploader"`
 	CollectContext       bool                                `mapstructure:"collect_context"`
-	EnableSplitByService bool                                `mapstructure:"enable_split_by_service"`
 }
 
 // ServiceNameEnvVars is the list of environment variables used to determine the service name.
@@ -59,13 +58,12 @@ func (c *Config) Validate() error {
 		includeTracers.Enable(types.Labels)
 		c.EbpfCollectorConfig.Tracers = includeTracers.String()
 	}
-	if c.EnableSplitByService {
-		includeEnvVars := append([]string{}, serviceNameEnvVars...)
-		if c.EbpfCollectorConfig.IncludeEnvVars != "" {
-			includeEnvVars = append(includeEnvVars, c.EbpfCollectorConfig.IncludeEnvVars)
-		}
-		c.EbpfCollectorConfig.IncludeEnvVars = strings.Join(includeEnvVars, ",")
+
+	includeEnvVars := append([]string{}, serviceNameEnvVars...)
+	if c.EbpfCollectorConfig.IncludeEnvVars != "" {
+		includeEnvVars = append(includeEnvVars, c.EbpfCollectorConfig.IncludeEnvVars)
 	}
+	c.EbpfCollectorConfig.IncludeEnvVars = strings.Join(includeEnvVars, ",")
 
 	if c.SymbolUploader.Enabled {
 		if len(c.SymbolUploader.SymbolEndpoints) == 0 {
@@ -97,7 +95,6 @@ func defaultConfig() component.Config {
 	return Config{
 		EbpfCollectorConfig:  cfg,
 		SymbolUploader:       symbolUploaderConfig,
-		EnableSplitByService: true,
 		CollectContext:       false,
 	}
 }


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/PROF-13710
- Flatten the `ebpf_collector` field configuration.
- Remove unnecessary option `EnableSplitByService`.

### Motivation
- Match the upstream behavior.
- `EnableSplitByService` should always be set to true.

### Describe how you validated your changes
Addition of two test cases:
- `TestFlatConfigParsingIsAccepted`: verifies that the flattened configuration file is parsed correctly.
- `TestNestedConfigIsRejected`: verifies that the old configuration file is rejected.
- Modify the reporting interval locally with `debug: detailed` and validate the change in the time at which the profile was sent.

### Additional Notes
