### PR TITLE
chore: Fix Ansible E2E test by using previous location

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -348,6 +348,7 @@ func (s *packageBaseSuite) writeAnsiblePlaybook(env map[string]string, params ..
   vars:
     datadog_api_key: "abcdef"
     datadog_site: "datadoghq.com"
+    datadog_ssi_script_dir: "/tmp/datadog-installer"
 `)
 
 	aptDefaultKeysOverrideTemplate := `


### PR DESCRIPTION
### What does this PR do?

Pins the location where the SSI install script is downloaded to `/tmp/datadog-installer` instead of the default `/var/run/datadog-ssi` which is not accessible in the runners

### Motivation

Properly fix E2E tests

### Describe how you validated your changes

### Additional Notes
