### PR TITLE
[workloadmeta] Remove pointer to interface in Filter.MatchEntity

### DIFF
--- a/comp/core/workloadmeta/def/filter.go
+++ b/comp/core/workloadmeta/def/filter.go
@@ -100,7 +100,7 @@ func (fb *FilterBuilder) SetEventType(eventType EventType) *FilterBuilder {
 
 // MatchEntity returns true if the filter matches the passed entity.
 // If the filter is nil, or has no kinds, it always matches.
-func (f *Filter) MatchEntity(entity *Entity) bool {
+func (f *Filter) MatchEntity(entity Entity) bool {
 	if len(f.Kinds()) == 0 {
 		return true
 	}
@@ -109,11 +109,11 @@ func (f *Filter) MatchEntity(entity *Entity) bool {
 		return false
 	}
 
-	entityKind := (*entity).GetID().Kind
+	entityKind := entity.GetID().Kind
 
 	if entityFilterFunc, found := f.kinds[entityKind]; found {
 		// A nil filter should match
-		return entityFilterFunc == nil || entityFilterFunc(*entity)
+		return entityFilterFunc == nil || entityFilterFunc(entity)
 	}
 
 	return false

--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -357,9 +357,9 @@ func TestFilter_MatchEntity(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			if test.expectMatch {
-				assert.True(tt, test.filter.MatchEntity(&test.entity))
+				assert.True(tt, test.filter.MatchEntity(test.entity))
 			} else {
-				assert.False(tt, test.filter.MatchEntity(&test.entity))
+				assert.False(tt, test.filter.MatchEntity(test.entity))
 			}
 		})
 	}

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -136,7 +136,7 @@ func (w *workloadmeta) Subscribe(name string, priority wmdef.SubscriberPriority,
 
 			for _, cachedEntity := range entitiesOfKind {
 				entity := cachedEntity.get(sub.filter.Source())
-				if entity != nil && sub.filter.MatchEntity(&entity) {
+				if entity != nil && sub.filter.MatchEntity(entity) {
 					events = append(events, wmdef.Event{
 						Type:   wmdef.EventTypeSet,
 						Entity: entity,
@@ -851,7 +851,7 @@ func (w *workloadmeta) handleEvents(evs []wmdef.CollectorEvent) {
 			}
 
 			entity := cachedEntity.get(filter.Source())
-			if !filter.MatchEntity(&entity) {
+			if !filter.MatchEntity(entity) {
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?

Minor cleanup in workloadmeta. `Filter.MatchEntity` took a pointer to an interface parameter, which is unnecessary because interfaces in Go already reference types ([reference](https://go.dev/doc/faq#pointer_to_interface)).

### Describe how you validated your changes

CI.