### PR TITLE
[CAP-3099] Fix watch resource version on retry watcher reconnect

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_deletion_watcher.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_deletion_watcher.go
@@ -92,7 +92,6 @@ func (w *PodDeletionWatcher) getInitialResourceVersion(ctx context.Context) (str
 // RetryWatcher occurs. In the later case the [errors.StatusError] object is returned.
 func (w *PodDeletionWatcher) runWatch(ctx context.Context, resourceVersion string) error {
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-		options.ResourceVersion = resourceVersion
 		return w.client.CoreV1().Pods(metav1.NamespaceAll).Watch(ctx, options)
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_deletion_watcher_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_deletion_watcher_test.go
@@ -9,12 +9,13 @@ package k8s
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,29 +31,33 @@ type PodDeletionWatcherTestSuite struct {
 	fakeWatch  *watch.FakeWatcher
 	mu         sync.Mutex
 	podChan    chan *corev1.Pod
+	recorder   *actionRecorder
 	stopCh     chan struct{}
+	fakeStore  *fakeStore
 	watcher    *PodDeletionWatcher
 }
 
 // SetupTest runs before each test to create a fresh fake client and watcher.
 func (s *PodDeletionWatcherTestSuite) SetupTest() {
 	s.fakeClient = fake.NewSimpleClientset()
+	s.recorder = newActionRecorder()
 	s.setFakeWatcher(watch.NewFake())
+	s.fakeStore = NewFakeStore()
 
-	// Intercept list calls to return a resource version
-	// nolint:revive
+	// Intercept list calls to return the resource version
 	s.fakeClient.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		s.recorder.RecordAction(action)
 		podList := &corev1.PodList{
 			ListMeta: metav1.ListMeta{
-				ResourceVersion: "1000",
+				ResourceVersion: s.fakeStore.ResourceVersion(),
 			},
 		}
 		return true, podList, nil
 	})
 
 	// Intercept watch calls and return our fake watcher
-	// nolint:revive
 	s.fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		s.recorder.RecordAction(action)
 		return true, s.getFakeWatcher(), nil
 	})
 
@@ -79,7 +84,7 @@ func (s *PodDeletionWatcherTestSuite) TearDownTest() {
 // TestFiltersNonDeleteEvents verifies that the watcher only processes
 // delete events and ignores add, modify, and bookmark events.
 func (s *PodDeletionWatcherTestSuite) TestFiltersNonDeleteEvents() {
-	pod := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod := s.createPod("pod-name-1", "pod-namespace-1")
 
 	// Send non-delete events which should be filtered
 	s.getFakeWatcher().Add(pod)
@@ -91,7 +96,7 @@ func (s *PodDeletionWatcherTestSuite) TestFiltersNonDeleteEvents() {
 // TestHandles401Unauthorized verifies that the watcher handles 401 Unauthorized errors
 // by reconnecting with backoff.
 func (s *PodDeletionWatcherTestSuite) TestHandles401Unauthorized() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -106,7 +111,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles401Unauthorized() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -114,7 +119,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles401Unauthorized() {
 // TestHandles403Forbidden verifies that the watcher handles 403 Forbidden errors
 // by reconnecting with backoff.
 func (s *PodDeletionWatcherTestSuite) TestHandles403Forbidden() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -129,7 +134,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles403Forbidden() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -137,7 +142,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles403Forbidden() {
 // TestHandles410Gone verifies that the watcher detects 410 Gone errors
 // and reconnects successfully.
 func (s *PodDeletionWatcherTestSuite) TestHandles410Gone() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -152,7 +157,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles410Gone() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -160,7 +165,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles410Gone() {
 // TestHandles429TooManyRequests verifies that the watcher handles 429 errors
 // by reconnecting with backoff.
 func (s *PodDeletionWatcherTestSuite) TestHandles429TooManyRequests() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -175,7 +180,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles429TooManyRequests() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -183,7 +188,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles429TooManyRequests() {
 // TestHandles500InternalError verifies that the watcher handles 500 errors
 // by reconnecting with backoff.
 func (s *PodDeletionWatcherTestSuite) TestHandles500InternalError() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -198,7 +203,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles500InternalError() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -206,7 +211,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles500InternalError() {
 // TestHandles504GatewayTimeout verifies that the watcher handles 504 errors
 // by reconnecting with backoff.
 func (s *PodDeletionWatcherTestSuite) TestHandles504GatewayTimeout() {
-	pod1 := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod1 := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod1)
 	s.Equal(pod1, s.receivePod())
 
@@ -221,7 +226,7 @@ func (s *PodDeletionWatcherTestSuite) TestHandles504GatewayTimeout() {
 	s.setFakeWatcher(watch.NewFake())
 
 	// Verify watcher reconnected by sending event on new fake watcher
-	pod2 := s.createPod("pod-name-2", "pod-namespace-2", "2")
+	pod2 := s.createPod("pod-name-2", "pod-namespace-2")
 	s.getFakeWatcher().Delete(pod2)
 	s.Equal(pod2, s.receivePod())
 }
@@ -230,9 +235,9 @@ func (s *PodDeletionWatcherTestSuite) TestHandles504GatewayTimeout() {
 // multiple pod deletion events in sequence.
 func (s *PodDeletionWatcherTestSuite) TestHandlesMultipleDeletions() {
 	pods := []*corev1.Pod{
-		s.createPod("pod-name-1", "pod-namespace-1", "1"),
-		s.createPod("pod-name-2", "pod-namespace-2", "2"),
-		s.createPod("pod-name-3", "pod-namespace-3", "3"),
+		s.createPod("pod-name-1", "pod-namespace-1"),
+		s.createPod("pod-name-2", "pod-namespace-2"),
+		s.createPod("pod-name-3", "pod-namespace-3"),
 	}
 
 	for _, pod := range pods {
@@ -258,9 +263,24 @@ func (s *PodDeletionWatcherTestSuite) TestHandlesNonPodDeleteEvent() {
 // TestReceivesDeleteEvents verifies that the watcher receives and processes
 // pod deletion events.
 func (s *PodDeletionWatcherTestSuite) TestReceivesDeleteEvents() {
-	pod := s.createPod("pod-name-1", "pod-namespace-1", "1")
+	pod := s.createPod("pod-name-1", "pod-namespace-1")
 	s.getFakeWatcher().Delete(pod)
 	s.Equal(pod, s.receivePod())
+}
+
+func (s *PodDeletionWatcherTestSuite) TestResourceVersionAdvances() {
+	pod := s.createPod("pod-name-1", "pod-namespace-1")
+	s.getFakeWatcher().Delete(pod)
+	s.Equal(pod, s.receivePod())
+
+	s.recorder.Enable()
+
+	// Close fake watcher result channel forces reconnect
+	s.getFakeWatcher().Stop()
+
+	action, received := s.recorder.ConsumeWatchAction()
+	s.Require().True(received)
+	s.Require().Equal(s.fakeStore.ResourceVersion(), action.GetWatchRestrictions().ResourceVersion)
 }
 
 func (s *PodDeletionWatcherTestSuite) assertNoPod() {
@@ -272,12 +292,12 @@ func (s *PodDeletionWatcherTestSuite) assertNoPod() {
 	}
 }
 
-func (s *PodDeletionWatcherTestSuite) createPod(name, namespace, resourceVersion string) *corev1.Pod {
+func (s *PodDeletionWatcherTestSuite) createPod(name, namespace string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
-			ResourceVersion: resourceVersion,
+			ResourceVersion: s.fakeStore.Update(),
 		},
 	}
 }
@@ -296,6 +316,100 @@ func (s *PodDeletionWatcherTestSuite) setFakeWatcher(watcher *watch.FakeWatcher)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.fakeWatch = watcher
+}
+
+const (
+	actionRecorderBufferSize     = 100
+	actionRecorderReceiveTimeout = 5 * time.Second
+)
+
+// actionRecorder is a component for recording actions from fake client reactors.
+// By default it drops all actions. Call Record to start buffering them
+// into internal channels that can be later consumed.
+type actionRecorder struct {
+	isRecording  atomic.Bool
+	listActions  chan k8stesting.ListAction
+	watchActions chan k8stesting.WatchAction
+}
+
+// NewActionRecorder creates a new action recorder that drops all actions until Record is called.
+func newActionRecorder() *actionRecorder {
+	return &actionRecorder{
+		listActions:  make(chan k8stesting.ListAction, actionRecorderBufferSize),
+		watchActions: make(chan k8stesting.WatchAction, actionRecorderBufferSize),
+	}
+}
+
+// ConsumeListAction returns the next recorded list action, blocking until one is available or the internal timeout is
+// reached. Returns the action and true if one was received, or a zero value and false on timeout.
+func (r *actionRecorder) ConsumeListAction() (k8stesting.ListAction, bool) {
+	select {
+	case action := <-r.listActions:
+		return action, true
+	case <-time.After(actionRecorderReceiveTimeout):
+		return nil, false
+	}
+}
+
+// ConsumeWatchAction returns the next recorded watch action, blocking until one is available or the internal timeout is
+// reached. Returns the action and true if one was received, or a zero value and false on timeout.
+func (r *actionRecorder) ConsumeWatchAction() (k8stesting.WatchAction, bool) {
+	select {
+	case action := <-r.watchActions:
+		return action, true
+	case <-time.After(actionRecorderReceiveTimeout):
+		return nil, false
+	}
+}
+
+// Enable starts recording actions. Actions received before this call are dropped.
+func (r *actionRecorder) Enable() {
+	r.isRecording.Store(true)
+}
+
+// RecordAction should be called to record a List or Watch action.
+func (r *actionRecorder) RecordAction(action k8stesting.Action) {
+	if !r.isRecording.Load() {
+		return
+	}
+
+	switch typedAction := action.(type) {
+	case k8stesting.ListAction:
+		r.listActions <- typedAction
+	case k8stesting.WatchAction:
+		r.watchActions <- typedAction
+	}
+}
+
+const (
+	storeInitialResourceVersion = 1000
+)
+
+type fakeStore struct {
+	mu              sync.Mutex
+	resourceVersion int
+}
+
+// NewFakeStore creates a new fake store.
+func NewFakeStore() *fakeStore {
+	return &fakeStore{
+		resourceVersion: storeInitialResourceVersion,
+	}
+}
+
+// ResourceVersion returns the store current resource version.
+func (s *fakeStore) ResourceVersion() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strconv.Itoa(s.resourceVersion)
+}
+
+// Update advances the store resource version and returns the new value.
+func (s *fakeStore) Update() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resourceVersion++
+	return strconv.Itoa(s.resourceVersion)
 }
 
 // TestPodDeletionWatcher runs the test suite.


### PR DESCRIPTION
### What does this PR do?

Fix a bug in `PodDeletionWatcher` where the requested initial resource version was not advancing on certain errors not followed by a new List operation prior to running a new Watch.

Related: https://github.com/DataDog/datadog-agent/pull/45803