### PR TITLE
[CWS] fix mount resolution for 25.10 kernel versions

### DIFF
--- a/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/filesystem.h
@@ -86,6 +86,18 @@ u32 __attribute__((always_inline)) get_mount_offset_of_nscommon_inum(void) {
     return offset; // offsetof(struct ns_common, inum)
 }
 
+u32 __attribute__((always_inline)) get_mount_offset_of_parent(void) {
+    u64 offset;
+    LOAD_CONSTANT("mount_parent_offset", offset);
+    return offset; // offsetof(struct mount, mnt_parent)
+}
+
+u32 __attribute__((always_inline)) get_mount_offset_of_mountpoint(void) {
+    u64 offset;
+    LOAD_CONSTANT("mount_mountpoint_offset", offset);
+    return offset; // offsetof(struct mount, mnt_mp)
+}
+
 u32 __attribute__((always_inline)) get_mnt_namespace_ns(void) {
     u64 offset;
     LOAD_CONSTANT("mnt_namespace_ns", offset);
@@ -163,6 +175,20 @@ u32 __attribute__((always_inline)) get_mount_mount_ns_inum(void *mnt) {
 
     bpf_probe_read(&inum, sizeof(inum), mnt_ns + get_mnt_namespace_ns() + get_mount_offset_of_nscommon_inum());
     return inum;
+}
+
+struct mount * __attribute__((always_inline)) get_mount_parent(void *mnt) {
+    struct mount *mnt_parent = NULL;
+
+    bpf_probe_read(&mnt_parent, sizeof(mnt_parent), mnt + get_mount_offset_of_parent());
+    return mnt_parent;
+}
+
+struct mountpoint * __attribute__((always_inline)) get_mount_mountpoint(void *mnt) {
+    struct mountpoint *mnt_mp = NULL;
+
+    bpf_probe_read(&mnt_mp, sizeof(mnt_mp), mnt + get_mount_offset_of_mountpoint());
+    return mnt_mp;
 }
 
 static struct vfsmount *__attribute__((always_inline)) get_mount_vfsmount(void *mnt) {

--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -74,7 +74,7 @@ static __attribute__((always_inline)) void set_file_layer(struct dentry *dentry,
     }
 }
 
-void __attribute__((always_inline)) fill_file(struct dentry *dentry, struct file_t *file) {
+static __attribute__((always_inline)) void fill_file(struct dentry *dentry, struct file_t *file) {
     struct inode *d_inode = get_dentry_inode(dentry);
 
     file->dev = get_dentry_dev(dentry);

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -268,6 +268,7 @@ func GetSelectorsPerEventType(hasFentry bool, hasCgroupSocket bool) map[eval.Eve
 			&manager.OneOf{Selectors: []manager.ProbesSelector{
 				hookFunc("hook_attach_mnt"),
 				hookFunc("hook___attach_mnt"),
+				hookFunc("hook_make_visible"),
 				hookFunc("hook_mnt_set_mountpoint"),
 			}},
 

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -57,6 +57,12 @@ func getMountProbes(fentry bool) []*manager.Probe {
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				UID:          SecurityAgentUID,
+				EBPFFuncName: "hook_make_visible",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
 				EBPFFuncName: "hook_cleanup_mnt",
 			},
 		},

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -33,6 +33,8 @@ const (
 	OffsetNameMountMntID                = "mount_id_offset"
 	OffsetNameMountMntIDUnique          = "mount_id_unique_offset"
 	OffsetNameMountMntNs                = "mount_ns_offset"
+	OffsetNameMountParent               = "mount_parent_offset"
+	OffsetNameMountMountpoint           = "mount_mountpoint_offset"
 	OffsetNameMntNamespaceNs            = "mnt_namespace_ns"
 	OffsetNameNsCommonInum              = "ns_common_inum_offset"
 	OffsetNameSbDev                     = "sb_dev_offset"

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3258,6 +3258,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryDSb, "struct dentry", "d_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntID, "struct mount", "mnt_id")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMntNs, "struct mount", "mnt_ns")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountParent, "struct mount", "mnt_parent")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMountMountpoint, "struct mount", "mnt_mp")
 
 	if kv.Code >= kernel.Kernel3_19 {
 		appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameMntNamespaceNs, "struct mnt_namespace", "ns")

--- a/pkg/security/tests/open_tree_test.go
+++ b/pkg/security/tests/open_tree_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func openTreeIsSupported() bool {
@@ -190,7 +189,6 @@ func TestOpenTree(t *testing.T) {
 	}()
 
 	t.Run("copy-tree-test-detached-recursive", func(t *testing.T) {
-		flake.MarkOnJobName(t, "ubuntu_25.10")
 		seen := 0
 
 		err = test.GetProbeEvent(func() error {


### PR DESCRIPTION
### What does this PR do?

On recent kernel versions, like the versions used by Ubuntu 25.10, the attach_mnt function is partially inlined. This PR uses another hookpoint to handle the mount resolution. 

### Motivation

### Describe how you validated your changes

### Additional Notes
