### PR TITLE
fix(ci): Fix skip-ci check in merge queue to prevent CI bypass on main

### DIFF
--- a/.gitlab/.pre/common/skip_ci_check.yml
+++ b/.gitlab/.pre/common/skip_ci_check.yml
@@ -1,18 +1,17 @@
-# Disallow [skip ci] in commit messages
+# Disallow [skip ci] in commit messages and PR descriptions
 
 skip-ci-check:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   needs: []
   stage: setup
   tags: ["arch:amd64", "specific:true"]
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   rules:
     - !reference [.on_mergequeue]
   script:
-    - commit_message="$(git log --format=%B -n 1 $CI_COMMIT_SHA)"
-    # https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-    - |
-      if [[ "$commit_message" =~ *"[ci skip]"*|*"[skip ci]"*|*"[actions skip]"*|*"[skip actions]"*|*"[no ci]"*|*"skip-checks: true"*|*"skip-checks:true"* ]]; then
-            echo "error: The commit message of this PR contains ci skip tags. Do not skip checks when merging PRs, please change the description of the merge commit" >& 2
-            exit 1
-      fi
-    - "echo 'success: No check skip found'"
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/datadog-agent --policy self.gitlab.pull-request-read)
+    - bash tools/ci/check_skip_ci.sh "$CI_COMMIT_SHA"
+  after_script:
+    - if [ -n "${GITHUB_TOKEN:-}" ]; then dd-octo-sts revoke -t "$GITHUB_TOKEN" || true; fi

--- a/tools/ci/check_skip_ci.sh
+++ b/tools/ci/check_skip_ci.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check that a commit message (and optionally its associated PR) do not contain
+# CI-skip directives.  When run in CI the script expects GITHUB_TOKEN to be set
+# so it can query the GitHub API for PR metadata.
+#
+# Usage:
+#   check_skip_ci.sh <commit_sha>          # in CI (uses GITHUB_TOKEN)
+#   GITHUB_TOKEN=ghp_... check_skip_ci.sh <commit_sha>  # locally
+
+COMMIT_SHA="${1:-HEAD}"
+REPO="DataDog/datadog-agent"
+SKIP_CI_PATTERN='\[(ci skip|skip ci|actions skip|skip actions|no ci)\]|skip-checks:\s*true'
+
+# --- 1. Check the commit message -------------------------------------------
+
+commit_message="$(git log --format=%B -n 1 "$COMMIT_SHA")"
+
+if echo "$commit_message" | grep -qEi "$SKIP_CI_PATTERN"; then
+    echo "error: The commit message contains ci skip tags." >&2
+    echo "Do not skip checks when merging PRs, please change the description of the merge commit." >&2
+    exit 1
+fi
+
+# --- 2. Check the PR title and body ----------------------------------------
+
+# Extract PR number from the commit subject line (format: "title (#1234)")
+PR_NUMBER=$(echo "$commit_message" | head -1 | grep -oE '\(#[0-9]+\)' | grep -oE '[0-9]+' | tail -n 1)
+
+if [ -z "$PR_NUMBER" ]; then
+    echo "info: No PR number found in commit message, skipping PR metadata check."
+    echo "success: No ci skip tags found."
+    exit 0
+fi
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "warning: GITHUB_TOKEN is not set, skipping PR metadata check." >&2
+    echo "success: No ci skip tags found in commit message (PR metadata not checked)."
+    exit 0
+fi
+
+echo "info: Checking PR #${PR_NUMBER} title and body for ci skip tags..."
+
+pr_json=$(curl -sf -H "Authorization: token ${GITHUB_TOKEN}" \
+    "https://api.github.com/repos/${REPO}/pulls/${PR_NUMBER}" || true)
+
+if [ -z "$pr_json" ]; then
+    echo "warning: Could not fetch PR #${PR_NUMBER} from GitHub API, skipping PR metadata check." >&2
+    echo "success: No ci skip tags found in commit message (PR metadata not checked)."
+    exit 0
+fi
+
+pr_title=$(printf '%s' "$pr_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('title',''))" 2>/dev/null || true)
+pr_body=$(printf '%s' "$pr_json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('body','') or '')" 2>/dev/null || true)
+
+if echo "$pr_title" | grep -qEi "$SKIP_CI_PATTERN"; then
+    echo "error: The PR title (#${PR_NUMBER}) contains ci skip tags. Please update the PR title before merging." >&2
+    exit 1
+fi
+
+if echo "$pr_body" | grep -qEi "$SKIP_CI_PATTERN"; then
+    echo "error: The PR description (#${PR_NUMBER}) contains ci skip tags. Please update the PR description before merging." >&2
+    exit 1
+fi
+
+echo "success: No ci skip tags found."


### PR DESCRIPTION
### What does this PR do?

Fixes the `skip-ci-check` merge queue job so it actually detects `[skip ci]` tags in commit messages and PR descriptions before they reach `main`.

- **Fixes broken regex**: The previous bash `[[ =~ ]]` pattern used glob-style `*` wildcards instead of proper ERE syntax, meaning it never matched anything — commits with `[skip ci]` passed through undetected.
- **Adds PR metadata check**: Extracts the PR number from the commit subject and fetches the PR title and body via the GitHub API, catching `[skip ci]` tags even when they're only in the PR description (not in the commit message).
- **Moves logic to a standalone script** (`tools/ci/check_skip_ci.sh`) that can be run locally for testing and debugging.
- **Uses `dd-octo-sts`** with the `self.gitlab.pull-request-read` policy for authenticated GitHub API access, with proper token revocation in `after_script`.

### Motivation

[ACIX-1272](https://datadoghq.atlassian.net/browse/ACIX-1272) — #Incident-48102: a commit with `[skip ci]` in its message was merged to `main` through the merge queue. GitLab skipped the pipeline for that commit, and a known GitLab 17 bug caused all subsequent CI linting to return 500 errors, blocking the merge queue for ~1 hour.

### Describe how you validated your changes

- Tested the grep regex locally against all CI-skip variants (`[skip ci]`, `[ci skip]`, `[actions skip]`, `[skip actions]`, `[no ci]`, `skip-checks: true`) — all match correctly.
- Tested negative cases (normal commit messages) — none produce false positives.
- Tested the script locally with `bash tools/ci/check_skip_ci.sh HEAD` — gracefully handles missing `GITHUB_TOKEN`.
- Tested PR metadata fetching against real PRs via the GitHub API.

### Additional Notes

This is **part 2 of 2**. Depends on #46312 which adds the `self.gitlab.pull-request-read` octo-sts chainguard policy.

[ACIX-1272]: https://datadoghq.atlassian.net/browse/ACIX-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ