### PR TITLE
feat(dev): Add run-jira Claude Code skill for Jira-driven implementation

### DIFF
--- a/.claude/skills/run-jira/SKILL.md
+++ b/.claude/skills/run-jira/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: run-jira
+description: Fetch a Jira issue and propose an implementation plan based on codebase analysis
+argument-hint: "<JIRA-KEY e.g. ACTP-1234>"
+---
+
+Fetch the Jira issue **$ARGUMENTS** from the Datadog Atlassian instance and use it as the basis for a codebase analysis and implementation proposal.
+
+## Step 1: Gather Jira issue data
+
+Use the Atlassian MCP tools to fetch the issue. **Only request the fields you need** to avoid huge responses:
+
+1. Call `mcp__atlassian__getJiraIssue` with:
+   - `cloudId`: `datadoghq.atlassian.net`
+   - `issueIdOrKey`: `$ARGUMENTS`
+   - `fields`: `["summary", "description", "status", "assignee", "issuetype", "comment", "priority"]`
+2. Extract the **title** (summary), **description**, **status**, **assignee**, and **comments** from the response.
+
+If the issue cannot be found, stop and inform the user.
+
+## Step 2: Summarize the issue
+
+Present a clear summary of the Jira issue:
+- **Key**: $ARGUMENTS
+- **Title**: the issue summary
+- **Status**: current status
+- **Assignee**: who is assigned
+- **Description**: the full description
+- **Comments**: any relevant context or discussion from comments
+- **Link**: https://datadoghq.atlassian.net/browse/$ARGUMENTS
+
+## Step 3: Fetch linked resources
+
+Scan the issue description and comments for links to external resources and fetch them for additional context:
+
+- **Datadog notebooks / postmortems** (`app.datadoghq.com/notebook/<id>`): use `mcp__datadog-mcp__get_datadog_notebook` with the notebook ID
+- **GitHub PRs** (`github.com/.../pull/<number>`): use `gh pr view <number>` via Bash
+- **GitLab commits/pipelines** or other URLs: use `WebFetch` if accessible
+
+This step is critical — linked resources often contain the root cause analysis, timelines, and technical details that the Jira description alone does not capture.
+
+## Step 4: Analyze the codebase
+
+Based on the issue requirements and linked resources, explore the codebase to understand:
+- Which files and packages are relevant
+- Existing patterns and conventions that should be followed
+- Dependencies and potential impacts
+
+Use Glob, Grep, and Read tools extensively. For broad exploration, use the Task tool with `subagent_type=Explore`.
+
+## Step 5: Propose an implementation
+
+Enter plan mode with `EnterPlanMode` and write a detailed implementation plan that includes:
+- A breakdown of the changes needed, organized by file
+- Any new files that need to be created
+- Test strategy
+- Potential risks or open questions
+
+Wait for user approval before implementing.


### PR DESCRIPTION
### What does this PR do?

Adds a new Claude Code skill `/run-jira <JIRA-KEY>` that fetches a Jira issue and proposes an implementation plan based on codebase analysis.

The skill:
1. Fetches the Jira issue via the Atlassian MCP tools, requesting only the needed fields (`summary`, `description`, `status`, `assignee`, `issuetype`, `comment`, `priority`) to keep responses small
2. Summarizes the issue with key metadata
3. Proactively fetches linked resources found in the description — Datadog notebooks/postmortems, GitHub PRs, and other URLs — which often contain critical context not in the Jira issue itself
4. Explores the codebase to identify relevant files and patterns
5. Enters plan mode to propose an implementation for user approval

### Motivation

Streamlines the workflow of picking up a Jira ticket and starting implementation. Instead of manually reading the ticket, finding linked resources, and exploring the codebase, `/run-jira ACIX-1234` does it all in one step.

### Additional Notes

This skill requires the Atlassian MCP server to be configured. It also leverages the Datadog MCP server for fetching linked notebooks/postmortems.