### PR TITLE
fix `GetSafe` of the remote hostname provider to follow the component contract

### DIFF
--- a/comp/core/hostname/remotehostnameimpl/hostname.go
+++ b/comp/core/hostname/remotehostnameimpl/hostname.go
@@ -80,7 +80,10 @@ func (r *remotehostimpl) Get(ctx context.Context) (string, error) {
 }
 
 func (r *remotehostimpl) GetSafe(ctx context.Context) string {
-	h, _ := r.Get(ctx)
+	h, err := r.Get(ctx)
+	if err != nil {
+		return "unknown host"
+	}
 	return h
 }
 


### PR DESCRIPTION
### What does this PR do?

The hostname component interface [is defined as:](https://github.com/DataDog/datadog-agent/blob/ee4c0bd87f6313c7ee7ad6b0b88d4cd40add57fd/comp/core/hostname/hostnameinterface/component.go#L22)
```
// Component is the type for hostname methods.
type Component interface {
	...
	// GetSafe is Get(), but it returns 'unknown host' if anything goes wrong.
	GetSafe(context.Context) string
}
```

but the `GetSafe` implementation in the remote hostname provider doesn't respect this requirement, and return the empty string in the case of an error.

This PR fixes this.

### Motivation

### Describe how you validated your changes

### Additional Notes
