### PR TITLE
[CONTP-1253] Avoid using subdirectories in monutpaths for UDS sockets when possible

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -555,18 +555,18 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 			expectedVolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "datadog-dogstatsd",
-					MountPath: "/var/run/datadog/dsd/dsd.socket",
+					MountPath: "/var/run/datadog/dsd.socket",
 					ReadOnly:  true,
 				},
 				{
 					Name:      "datadog-trace-agent",
-					MountPath: "/var/run/datadog/apm/apm.sock",
+					MountPath: "/var/run/datadog/apm.sock",
 					ReadOnly:  true,
 				},
 			},
 			expectedEnvs: []corev1.EnvVar{
-				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm/apm.sock"),
-				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd/dsd.socket"),
+				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.sock"),
+				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"),
 			},
 		},
 		{
@@ -601,22 +601,22 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 			expectedVolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "datadog-dogstatsd",
-					MountPath: "/var/run/datadog/dsd/dsd.socket",
+					MountPath: "/var/run/datadog/dsd.socket",
 					ReadOnly:  true,
 				},
 				{
 					Name:      "datadog-trace-agent",
-					MountPath: "/var/run/datadog/apm/apm.sock",
+					MountPath: "/var/run/datadog/apm.sock",
 					ReadOnly:  true,
 				},
 			},
 			expectedEnvs: []corev1.EnvVar{
-				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm/apm.sock"),
-				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd/dsd.socket"),
+				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.sock"),
+				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"),
 			},
 		},
 		{
-			name:                    "with csi driver",
+			name:                    "with csi driver (type socket volumes)",
 			withCSIDriver:           true,
 			globalTypeSocketVolumes: true,
 			apmSocketFilePath:       "/var/run/datadog/apm.sock",
@@ -651,18 +651,18 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 			expectedVolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "datadog-dogstatsd",
-					MountPath: "/var/run/datadog/dsd/dsd.socket",
+					MountPath: "/var/run/datadog/dsd.socket",
 					ReadOnly:  true,
 				},
 				{
 					Name:      "datadog-trace-agent",
-					MountPath: "/var/run/datadog/apm/apm.sock",
+					MountPath: "/var/run/datadog/apm.sock",
 					ReadOnly:  true,
 				},
 			},
 			expectedEnvs: []corev1.EnvVar{
-				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm/apm.sock"),
-				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd/dsd.socket"),
+				mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.sock"),
+				mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"),
 			},
 		},
 	}

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -139,7 +139,13 @@ func (i *Mutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (boo
 		apmMountBase := i.config.socketPath
 		dsdMountBase := i.config.socketPath
 
-		if (i.config.dogStatsDAgentHostSocket != i.config.traceAgentHostSocket) || isSocketVol || useCSI {
+		// If we are using a CSI driver, we always mount 2 volumes to avoid confusion.
+		// CSI volume types are: APMSocketDirectory, DSDSocketDirectory, APMSocket, DSDSocket.
+		// Although mounting only DSDSocketDirectory is sufficient in case sockets are in the same directory, we prefer mounting APMSocketDirectory and DSDSocketDirectory as well to avoid confusion.
+		//
+		// If the user requests socket volumes, we will not have a conflict because each file is mounted separately on a different mount point.
+		// In this case, we have no need for the subdirectories.
+		if !isSocketVol && (useCSI || i.config.dogStatsDAgentHostSocket != i.config.traceAgentHostSocket) {
 			apmMountBase = apmMountBase + "/" + apmSubdir
 			dsdMountBase = dsdMountBase + "/" + dsdSubdir
 		}
@@ -186,12 +192,12 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod, withCSI bool) bool {
 			hostsocketpath string
 		}{
 			DogstatsdSocketVolumeName: {
-				socketpath:     i.config.socketPath + "/" + dsdSubdir + "/" + i.config.dsdSocketFile,
+				socketpath:     i.config.socketPath + "/" + i.config.dsdSocketFile,
 				csiVolumeType:  csiDSDSocket,
 				hostsocketpath: i.config.dogStatsDAgentHostSocket + "/" + i.config.dsdSocketFile,
 			},
 			TraceAgentSocketVolumeName: {
-				socketpath:     i.config.socketPath + "/" + apmSubdir + "/" + i.config.apmSocketFile,
+				socketpath:     i.config.socketPath + "/" + i.config.apmSocketFile,
 				csiVolumeType:  csiAPMSocket,
 				hostsocketpath: i.config.traceAgentHostSocket + "/" + i.config.apmSocketFile,
 			},

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -145,6 +145,8 @@ func (i *Mutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (boo
 		//
 		// If the user requests socket volumes, we will not have a conflict because each file is mounted separately on a different mount point.
 		// In this case, we have no need for the subdirectories.
+		//
+		// See Issue #45952: https://github.com/DataDog/datadog-agent/issues/45952
 		if !isSocketVol && (useCSI || i.config.dogStatsDAgentHostSocket != i.config.traceAgentHostSocket) {
 			apmMountBase = apmMountBase + "/" + apmSubdir
 			dsdMountBase = dsdMountBase + "/" + dsdSubdir


### PR DESCRIPTION
### What does this PR do?

Resolves [Issue #45952 ](https://github.com/DataDog/datadog-agent/issues/45952)

This PR updates the cluster agent admission controller to make sure that sub directories for apm and dsd sockets are not added in case the volume type is socket.

Previously, this was introduced in 7.72.0 to make implementation and testing simpler. The change done in 7.72.0 is backwards compatible, and the change done in this PR is backward compatible as well. 

### Motivation

Although the change introduced in 7.72.0 was not a breaking change, the customer was explicitly overriding the `TRACE_AGENT_URL` environment variable injected by the admission controller. When the admission controller changed the mountpath, the environment variable was adapted by the admission controller as well to make sure things still work. But since the env var was explicitly overwritten by the customer, it broke the setup. 

The user's case can be fixed by removing the explicit overwrite for `TRACE_AGENT_URL` env var. However, this requires patching their internal helm charts and waiting all internal apps to rollout. 

The change done in this PR helps overcome this by only having to rollout the agent.

More information can be found in [Issue #45952 ](https://github.com/DataDog/datadog-agent/issues/45952)

### Describe how you validated your changes

Unit tests & E2E tests.
