### PR TITLE
[PROF-13742] Add missing endpoint index to query failure log in uploadWorker

### DIFF
--- a/comp/host-profiler/symboluploader/symbol_uploader.go
+++ b/comp/host-profiler/symboluploader/symbol_uploader.go
@@ -292,6 +292,7 @@ func (d *DatadogSymbolUploader) uploadWorker(ctx context.Context, elfSymbols Elf
 		if backendSymbolSource.Err != nil {
 			slog.Warn("Failed to query symbols for executable",
 				slog.String("executable", elfSymbols.String()),
+				slog.Int("endpoint", i),
 				slog.String("error", backendSymbolSource.Err.Error()))
 			removeFromCache = true
 			continue


### PR DESCRIPTION
### What does this PR do?

Adds `slog.Int("endpoint", i)` to the WARN log in `uploadWorker` when a symbol query fails, matching the pattern used by all other per-endpoint logs in the upload loop and `shouldUpload`.

### Motivation

When multiple endpoints are configured, the query failure WARN log does not indicate which endpoint failed, making it hard to distinguish from the per-endpoint skip/success logs that follow. See [PROF-13742](https://datadoghq.atlassian.net/browse/PROF-13742).

### Describe how you validated your changes

Code inspection. The change adds a single structured log field consistent with the existing pattern.

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)