### PR TITLE
[CWS] avoid variable hash conflict for process

### DIFF
--- a/pkg/security/generators/accessors/field_handlers.tmpl
+++ b/pkg/security/generators/accessors/field_handlers.tmpl
@@ -130,7 +130,9 @@ type FieldHandlers interface {
     ExtraFieldHandlers
 }
 
-type FakeFieldHandlers struct {}
+type FakeFieldHandlers struct {
+    PCEs map[uint32]*ProcessCacheEntry
+}
 
 {{$Handlers := .Fields | GetHandlers}}
 {{range $Proto, $Impl := $Handlers}}

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -962,8 +962,8 @@ func NewIPArrayVariable(value []net.IPNet, opts VariableOpts) *IPArrayVariable {
 // it currently contains an integer and a string to cover most common use cases
 // the goal of this is to prevent the need to allocate a string for each `Hash()` call
 type ScopeHashKey struct {
-	Integer uint32
 	String  string
+	Uintptr uintptr
 }
 
 // VariableScope is the interface to be implemented by scoped variable in order to be released

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -1155,7 +1155,9 @@ type FieldHandlers interface {
 	// custom handlers not tied to any fields
 	ExtraFieldHandlers
 }
-type FakeFieldHandlers struct{}
+type FakeFieldHandlers struct {
+	PCEs map[uint32]*ProcessCacheEntry
+}
 
 func (dfh *FakeFieldHandlers) ResolveAcceptHostnames(ev *Event, e *AcceptEvent) []string {
 	return []string(e.Hostnames)

--- a/pkg/security/secl/model/field_handlers_windows.go
+++ b/pkg/security/secl/model/field_handlers_windows.go
@@ -140,7 +140,9 @@ type FieldHandlers interface {
 	// custom handlers not tied to any fields
 	ExtraFieldHandlers
 }
-type FakeFieldHandlers struct{}
+type FakeFieldHandlers struct {
+	PCEs map[uint32]*ProcessCacheEntry
+}
 
 func (dfh *FakeFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
 	return []string(e.Tags)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -16,6 +16,7 @@ import (
 	"net/netip"
 	"runtime"
 	"time"
+	"unsafe"
 
 	"github.com/google/gopacket"
 
@@ -438,8 +439,7 @@ func SetAncestorFields(pce *ProcessCacheEntry, subField string, _ interface{}) (
 // Hash returns a unique key for the entity
 func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
 	return eval.ScopeHashKey{
-		Integer: pc.Pid,
-		String:  pc.Comm,
+		Uintptr: uintptr(unsafe.Pointer(pc)),
 	}
 }
 

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -43,7 +43,9 @@ func (m *Model) NewEvent() eval.Event {
 func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers:  &FakeFieldHandlers{},
+			FieldHandlers: &FakeFieldHandlers{
+				PCEs: make(map[uint32]*ProcessCacheEntry),
+			},
 			ProcessContext: &ProcessContext{},
 			Os:             runtime.GOOS,
 		},
@@ -52,6 +54,9 @@ func NewFakeEvent() *Event {
 
 // ResolveProcessCacheEntryFromPID stub implementation
 func (fh *FakeFieldHandlers) ResolveProcessCacheEntryFromPID(pid uint32) *ProcessCacheEntry {
+	if fh.PCEs[pid] != nil {
+		return fh.PCEs[pid]
+	}
 	return GetPlaceholderProcessCacheEntry(pid, pid, false)
 }
 

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -12,6 +12,7 @@ package model
 import (
 	"runtime"
 	"time"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -250,7 +251,7 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 // Hash returns a unique key for the entity
 func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
 	return eval.ScopeHashKey{
-		Integer: pc.Pid,
+		Uintptr: uintptr(unsafe.Pointer(pc)),
 	}
 }
 

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -30,14 +30,19 @@ func (m *Model) NewEvent() eval.Event {
 func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers: &FakeFieldHandlers{},
-			Os:            runtime.GOOS,
+			FieldHandlers: &FakeFieldHandlers{
+				PCEs: make(map[uint32]*ProcessCacheEntry),
+			},
+			Os: runtime.GOOS,
 		},
 	}
 }
 
 // ResolveProcessCacheEntryFromPID stub implementation
 func (fh *FakeFieldHandlers) ResolveProcessCacheEntryFromPID(pid uint32) *ProcessCacheEntry {
+	if fh.PCEs[pid] != nil {
+		return fh.PCEs[pid]
+	}
 	return GetPlaceholderProcessCacheEntry(pid)
 }
 

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -259,11 +259,11 @@ func (s *SetDefinition) PreCheck(_ PolicyLoaderOpts) error {
 		return fmt.Errorf("failed to infer type for variable '%s', please set 'default_value'", s.Name)
 	}
 
-	if s.Inherited && s.Scope != "process" {
+	if s.Inherited && s.Scope != ScopeProcess {
 		return errors.New("only variables scoped to process can be marked as inherited")
 	}
 
-	if len(s.ScopeField) > 0 && s.Scope != "process" {
+	if len(s.ScopeField) > 0 && s.Scope != ScopeProcess {
 		return errors.New("only variables scoped to process can have a custom scope_field")
 	}
 

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1097,21 +1097,10 @@ func stringPtr(input string) *string {
 	return &input
 }
 
-func fakeOpenEvent(path string, pid uint32, ancestor *model.ProcessCacheEntry) *model.Event {
+func fakeOpenEvent(path string, pce *model.ProcessCacheEntry) *model.Event {
 	event := model.NewFakeEvent()
 	event.Type = uint32(model.FileOpenEventType)
-	event.ProcessCacheEntry = &model.ProcessCacheEntry{
-		ProcessContext: model.ProcessContext{
-			Process: model.Process{
-				PIDContext: model.PIDContext{
-					Pid: pid,
-				},
-			},
-		},
-	}
-	if ancestor != nil {
-		event.ProcessCacheEntry.ProcessContext.Ancestor = ancestor
-	}
+	event.ProcessCacheEntry = pce
 	event.SetFieldValue("open.file.path", path)
 	return event
 }
@@ -1222,7 +1211,9 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	assert.NotNil(t, parentCorrelationKeysScopedVariable)
 	assert.True(t, ok)
 
-	event := fakeOpenEvent("/tmp/first", 1, nil)
+	pce1 := newFakeProcessCacheEntry(1, nil)
+
+	event := fakeOpenEvent("/tmp/first", pce1)
 	ctx := eval.NewContext(event)
 
 	// test correlation key initial value
@@ -1245,8 +1236,10 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 
 	correlationKeyFromFirstRule := correlationKeyValue.(string)
 
+	pce2 := newFakeProcessCacheEntry(2, pce1)
+
 	// trigger the first rule again, and make sure nothing changes
-	event2 := fakeOpenEvent("/tmp/first", 2, event.ProcessCacheEntry)
+	event2 := fakeOpenEvent("/tmp/first", pce2)
 	ctx = eval.NewContext(event2)
 
 	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
@@ -1269,7 +1262,8 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	// jump to the third rule, check:
 	//  - that the correlation key is updated with the pattern from the third rule
 	//  - that the first correlation key is now in the "parent correlation keys" variable
-	event3 := fakeOpenEvent("/tmp/third", 3, event2.ProcessCacheEntry)
+	pce3 := newFakeProcessCacheEntry(3, pce2)
+	event3 := fakeOpenEvent("/tmp/third", pce3)
 	ctx = eval.NewContext(event3)
 
 	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
@@ -1292,7 +1286,8 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	correlationKeyFromThirdRule := correlationKeyValue.(string)
 
 	// trigger the second rule, make sure nothing changes
-	event4 := fakeOpenEvent("/tmp/second", 4, event3.ProcessCacheEntry)
+	pce4 := newFakeProcessCacheEntry(4, pce3)
+	event4 := fakeOpenEvent("/tmp/second", pce4)
 	ctx = eval.NewContext(event4)
 
 	correlationKeyValue, set = correlationKeyScopedVariable.GetValue(ctx, false)
@@ -1313,21 +1308,23 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	assert.True(t, len(parentCorrelationKeysValue.([]string)) == 1 && slices.Contains(parentCorrelationKeysValue.([]string), correlationKeyFromFirstRule))
 }
 
-func newFakeCGroupWrite(cgroupWritePID int, path string, pid uint32, ancestor *model.ProcessCacheEntry) *model.Event {
-	event := model.NewFakeEvent()
-	event.Type = uint32(model.CgroupWriteEventType)
-	event.ProcessCacheEntry = &model.ProcessCacheEntry{
+func newFakeProcessCacheEntry(pid uint32, ancestor *model.ProcessCacheEntry) *model.ProcessCacheEntry {
+	return &model.ProcessCacheEntry{
 		ProcessContext: model.ProcessContext{
 			Process: model.Process{
 				PIDContext: model.PIDContext{
 					Pid: pid,
 				},
 			},
+			Ancestor: ancestor,
 		},
 	}
-	if ancestor != nil {
-		event.ProcessCacheEntry.ProcessContext.Ancestor = ancestor
-	}
+}
+
+func newFakeCGroupWrite(cgroupWritePID int, path string, pce *model.ProcessCacheEntry) *model.Event {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.CgroupWriteEventType)
+	event.ProcessCacheEntry = pce
 	event.SetFieldValue("cgroup_write.pid", cgroupWritePID)
 	event.SetFieldValue("cgroup_write.file.path", path)
 	return event
@@ -1482,11 +1479,19 @@ func TestActionSetVariableScopeField(t *testing.T) {
 	assert.NotNil(t, parentCorrelationKeysScopedVariable)
 	assert.True(t, ok)
 
+	pce1 := newFakeProcessCacheEntry(1, nil)
+	pce2 := newFakeProcessCacheEntry(2, nil)
+	pce3 := newFakeProcessCacheEntry(3, pce2)
+
 	// create cgroup_write event
-	event1 := newFakeCGroupWrite(2, "/tmp/one", 1, nil)
-	event2 := newFakeCGroupWrite(2, "/tmp/two", 1, nil)
-	eventPID2 := newFakeCGroupWrite(0, "", 2, nil)
-	event3 := fakeOpenEvent("/tmp/third", 3, eventPID2.ProcessCacheEntry)
+	event1 := newFakeCGroupWrite(2, "/tmp/one", pce1)
+	event1.FieldHandlers.(*model.FakeFieldHandlers).PCEs[2] = pce2
+
+	event2 := newFakeCGroupWrite(2, "/tmp/two", pce1)
+	event2.FieldHandlers.(*model.FakeFieldHandlers).PCEs[2] = pce2
+
+	event3 := fakeOpenEvent("/tmp/third", pce3)
+
 	ctx1 := eval.NewContext(event1)
 	ctx3 := eval.NewContext(event3)
 

--- a/pkg/security/seclwin/model/field_handlers_win.go
+++ b/pkg/security/seclwin/model/field_handlers_win.go
@@ -138,7 +138,9 @@ type FieldHandlers interface {
 	// custom handlers not tied to any fields
 	ExtraFieldHandlers
 }
-type FakeFieldHandlers struct{}
+type FakeFieldHandlers struct {
+	PCEs map[uint32]*ProcessCacheEntry
+}
 
 func (dfh *FakeFieldHandlers) ResolveContainerTags(ev *Event, e *ContainerContext) []string {
 	return []string(e.Tags)

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -12,6 +12,7 @@ package model
 import (
 	"runtime"
 	"time"
+	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -250,7 +251,7 @@ func SetAncestorFields(_ *ProcessCacheEntry, _ string, _ interface{}) (bool, err
 // Hash returns a unique key for the entity
 func (pc *ProcessCacheEntry) Hash() eval.ScopeHashKey {
 	return eval.ScopeHashKey{
-		Integer: pc.Pid,
+		Uintptr: uintptr(unsafe.Pointer(pc)),
 	}
 }
 

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -30,14 +30,19 @@ func (m *Model) NewEvent() eval.Event {
 func NewFakeEvent() *Event {
 	return &Event{
 		BaseEvent: BaseEvent{
-			FieldHandlers: &FakeFieldHandlers{},
-			Os:            runtime.GOOS,
+			FieldHandlers: &FakeFieldHandlers{
+				PCEs: make(map[uint32]*ProcessCacheEntry),
+			},
+			Os: runtime.GOOS,
 		},
 	}
 }
 
 // ResolveProcessCacheEntryFromPID stub implementation
 func (fh *FakeFieldHandlers) ResolveProcessCacheEntryFromPID(pid uint32) *ProcessCacheEntry {
+	if fh.PCEs[pid] != nil {
+		return fh.PCEs[pid]
+	}
 	return GetPlaceholderProcessCacheEntry(pid)
 }
 


### PR DESCRIPTION
### What does this PR do?

Use the process cache entry pointer as a key for the variable hash to avoid conflict when a process exec to itself.

### Motivation

### Describe how you validated your changes

### Additional Notes
