### PR TITLE
Onboard datadog-agent onto Depot Rust

### DIFF
--- a/.adms/rust/gitlab.yaml
+++ b/.adms/rust/gitlab.yaml
@@ -1,0 +1,19 @@
+# DO NOT EDIT
+
+# Base configuration for Rust builds to use internal Datadog registry
+.rust_internal_registry:
+  before_script:
+    # Configure Cargo to use internal Datadog registry for Rust crates
+    - mkdir -p .cargo
+    - |
+      cat > .cargo/config.toml << 'EOF'
+      [registries]
+      datadog = { index = "sparse+https://depot-read-api-rust.us1.ddbuild.io/datadog/rust/" }
+
+      [registry]
+      default = "datadog"
+
+      [source]
+      [source.crates-io]
+      replace-with = "datadog"
+      EOF

--- a/.gitlab/build/binary_build/sd_agent.yml
+++ b/.gitlab/build/binary_build/sd_agent.yml
@@ -1,6 +1,8 @@
 ---
 .sd-agent_build_common:
-  extends: .bazel:defs:cache:ephemeral
+  extends:
+    - .bazel:defs:cache:ephemeral
+    - .rust_internal_registry
   rules:
     - !reference [.except_mergequeue]
     - when: on_success


### PR DESCRIPTION
### What does this PR do?

- Allows this repo's CI to pull Rust crates from Depot directly, rather than having to go through rewrites

### Motivation

### Describe how you validated your changes

### Additional Notes
