### PR TITLE
[APMLP-747]: Set `exclude.zero_metric: true` for `image_resolution_attempts` metric

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -451,6 +451,8 @@ var defaultProfiles = `
       period: 900
   - name: cluster-agent
     metric:
+      exclude:
+        zero_metric: true
       metrics:
         - name: admission_webhooks.image_resolution_attempts
           aggregate_tags:


### PR DESCRIPTION
### What does this PR do?
Flips the `exclude.zero_metric` value from `false` to `true` for the `image_resolution_attempts` metric.

### Motivation
When `exclude.zero_metric` is set to `true`, only time series that changed during the reporting interval (15 minutes) are emitted and counted as contexts.

> For example, if your metric has thousands of time series but only three changed in the last 15 minutes, only those three will be reported — and the “context count” applies only to those three.

If `exclude.zero_metric: false` is used, then all time series (including zero-value ones) will always be emitted, regardless of whether they changed since the Agent started.

([Source doc](https://datadoghq.atlassian.net/wiki/x/rwLBVQE))

### Describe how you validated your changes

### Additional Notes
