### PR TITLE
[ACTP] Setup flavor in PAR opms requests

### DIFF
--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -5,12 +5,20 @@
 
 package constants
 
-const JwtHeaderName = "X-Datadog-OnPrem-JWT"
-const ModeHeaderName = "X-Datadog-OnPrem-Modes"
-const VersionHeaderName = "X-Datadog-OnPrem-Version"
-const PlatformHeaderName = "X-Datadog-OnPrem-Platform"
-const ArchitectureHeaderName = "X-Datadog-OnPrem-Architecture"
-const DeploymentHeaderName = "X-Datadog-OnPrem-Deployment"
+const (
+	JwtHeaderName          = "X-Datadog-OnPrem-JWT"
+	ModeHeaderName         = "X-Datadog-OnPrem-Modes"
+	VersionHeaderName      = "X-Datadog-OnPrem-Version"
+	PlatformHeaderName     = "X-Datadog-OnPrem-Platform"
+	ArchitectureHeaderName = "X-Datadog-OnPrem-Architecture"
+	DeploymentHeaderName   = "X-Datadog-OnPrem-Deployment"
+
+	RunnerVersionQueryParam = "runnerVersion"
+	ModesQueryParam         = "modes"
+	PlatformQueryParam      = "platform"
+	ArchitectureQueryParam  = "architecture"
+	DeploymentQueryParam    = "deployment"
+)
 
 // HTTP Connection Constants
 var (

--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -8,6 +8,9 @@ package constants
 const JwtHeaderName = "X-Datadog-OnPrem-JWT"
 const ModeHeaderName = "X-Datadog-OnPrem-Modes"
 const VersionHeaderName = "X-Datadog-OnPrem-Version"
+const PlatformHeaderName = "X-Datadog-OnPrem-Platform"
+const ArchitectureHeaderName = "X-Datadog-OnPrem-Architecture"
+const DeploymentHeaderName = "X-Datadog-OnPrem-Deployment"
 
 // HTTP Connection Constants
 var (

--- a/pkg/privateactionrunner/adapters/constants/constants_adapter.go
+++ b/pkg/privateactionrunner/adapters/constants/constants_adapter.go
@@ -6,18 +6,20 @@
 package constants
 
 const (
-	JwtHeaderName          = "X-Datadog-OnPrem-JWT"
-	ModeHeaderName         = "X-Datadog-OnPrem-Modes"
-	VersionHeaderName      = "X-Datadog-OnPrem-Version"
-	PlatformHeaderName     = "X-Datadog-OnPrem-Platform"
-	ArchitectureHeaderName = "X-Datadog-OnPrem-Architecture"
-	DeploymentHeaderName   = "X-Datadog-OnPrem-Deployment"
+	JwtHeaderName           = "X-Datadog-OnPrem-JWT"
+	ModeHeaderName          = "X-Datadog-OnPrem-Modes"
+	VersionHeaderName       = "X-Datadog-OnPrem-Version"
+	PlatformHeaderName      = "X-Datadog-OnPrem-Platform"
+	ArchitectureHeaderName  = "X-Datadog-OnPrem-Architecture"
+	FlavorHeaderName        = "X-Datadog-OnPrem-Flavor"
+	ContainerizedHeaderName = "X-Datadog-OnPrem-Containerized"
 
 	RunnerVersionQueryParam = "runnerVersion"
 	ModesQueryParam         = "modes"
 	PlatformQueryParam      = "platform"
 	ArchitectureQueryParam  = "architecture"
-	DeploymentQueryParam    = "deployment"
+	FlavorQueryParam        = "flavor"
+	ContainerizedQueryParam = "containerized"
 )
 
 // HTTP Connection Constants

--- a/pkg/privateactionrunner/bundles/gitlab/users/entrypoint.gen.go
+++ b/pkg/privateactionrunner/bundles/gitlab/users/entrypoint.gen.go
@@ -18,6 +18,7 @@ func NewGitlabUsers() types.Bundle {
 		actions: map[string]types.Action{
 			// Manual actions
 			"createServiceAccountUser": NewCreateServiceAccountUserHandler(),
+			"testConnection":           NewTestConnectionHandler(),
 			// Auto-generated actions
 			"activateUser":              NewActivateUserHandler(),
 			"addEmail":                  NewAddEmailHandler(),

--- a/pkg/privateactionrunner/bundles/gitlab/users/entrypoint.gen.go
+++ b/pkg/privateactionrunner/bundles/gitlab/users/entrypoint.gen.go
@@ -18,7 +18,6 @@ func NewGitlabUsers() types.Bundle {
 		actions: map[string]types.Action{
 			// Manual actions
 			"createServiceAccountUser": NewCreateServiceAccountUserHandler(),
-			"testConnection":           NewTestConnectionHandler(),
 			// Auto-generated actions
 			"activateUser":              NewActivateUserHandler(),
 			"addEmail":                  NewAddEmailHandler(),

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -291,12 +291,12 @@ func (c *client) HealthCheck(ctx context.Context) (*HealthCheckData, error) {
 	}
 
 	query := u.Query()
-	query.Add("runnerVersion", c.config.Version)
+	query.Add(app.RunnerVersionQueryParam, c.config.Version)
 	modesStr := modes.ToStrings(c.config.Modes)
-	query.Add("modes", strings.Join(modesStr, ","))
-	query.Add("platform", runtime.GOOS)
-	query.Add("architecture", runtime.GOARCH)
-	query.Add("deployment", getDeploymentType())
+	query.Add(app.ModesQueryParam, strings.Join(modesStr, ","))
+	query.Add(app.PlatformQueryParam, runtime.GOOS)
+	query.Add(app.ArchitectureQueryParam, runtime.GOARCH)
+	query.Add(app.DeploymentQueryParam, getDeploymentType())
 	u.RawQuery = query.Encode()
 
 	_, resHeaders, err := c.makeRequest(ctx, http.MethodGet, u.String(), nil, nil, http.StatusOK)

--- a/pkg/privateactionrunner/opms/opms.go
+++ b/pkg/privateactionrunner/opms/opms.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -297,7 +298,7 @@ func (c *client) HealthCheck(ctx context.Context) (*HealthCheckData, error) {
 	query.Add(app.PlatformQueryParam, runtime.GOOS)
 	query.Add(app.ArchitectureQueryParam, runtime.GOARCH)
 	query.Add(app.FlavorQueryParam, flavor.GetFlavor())
-	query.Add(app.ContainerizedQueryParam, fmt.Sprintf("%t", env.IsContainerized()))
+	query.Add(app.ContainerizedQueryParam, strconv.FormatBool(env.IsContainerized()))
 	u.RawQuery = query.Encode()
 
 	_, resHeaders, err := c.makeRequest(ctx, http.MethodGet, u.String(), nil, nil, http.StatusOK)
@@ -387,7 +388,7 @@ func (c *client) makeRequest(
 	req.Header.Set(app.PlatformHeaderName, runtime.GOOS)
 	req.Header.Set(app.ArchitectureHeaderName, runtime.GOARCH)
 	req.Header.Set(app.FlavorHeaderName, flavor.GetFlavor())
-	req.Header.Set(app.ContainerizedHeaderName, fmt.Sprintf("%t", env.IsContainerized()))
+	req.Header.Set(app.ContainerizedHeaderName, strconv.FormatBool(env.IsContainerized()))
 	res, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error making HTTP request: %w", err)


### PR DESCRIPTION
## What does this PR do?
Adds platform, architecture, and deployment type metadata to PAR OPMS requests.

## Motivation
OPMS needs to track how Private Action Runners are deployed and on which platforms/architectures to:
- Provide better observability into PAR deployment patterns
- Enable platform-specific features and troubleshooting
- Differentiate between standalone PAR installations vs embedded deployments (cluster agent, node agent)

## Describe how you validated your changes
Deployed the PAR locally. For now OPMS doesn't read the params and headers sent in request

## Additional Notes
This change is backward compatible - the new headers/query params are additive and don't affect existing OPMS behavior. The deployment type distinction helps differentiate standalone PAR installations from PARs embedded within agents. 