### PR TITLE
[PROF-13747] Fix extractSite dropping datacenter subdomains from profiling URLs

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -343,6 +343,26 @@ func TestConverterWithAgentDCSite(t *testing.T) {
 		runSuccessTests(t, conv, tests[:1])
 	})
 
+	t.Run("duplicate_site_exporters", func(t *testing.T) {
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"site":    "datadoghq.com",
+				"api_key": "main_api_key",
+				"apm_config.profiling_additional_endpoints": map[string][]string{
+					"https://intake.profile.datadoghq.com/v1/input": {"additional_api_key"},
+				},
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, []testCase{
+			{
+				name:     "unique-exporter-names-for-same-site",
+				provided: "agent/duplicate-site-exporters/in.yaml",
+				expected: "agent/duplicate-site-exporters/out.yaml",
+			},
+		})
+	})
+
 	t.Run("additional_endpoints", func(t *testing.T) {
 		mockCfg := &mockConfig{
 			values: map[string]interface{}{

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -318,6 +318,46 @@ func TestConverterWithAgent(t *testing.T) {
 	runSuccessTests(t, conv, tests)
 }
 
+func TestConverterWithAgentDCSite(t *testing.T) {
+	tests := []testCase{
+		{
+			name:     "infers-dc-site-from-profiling-url",
+			provided: "agent/infer-dc-from-url/in.yaml",
+			expected: "agent/infer-dc-from-url/out.yaml",
+		},
+		{
+			name:     "infers-dc-site-from-additional-endpoints",
+			provided: "agent/infer-dc-from-additional-ep/in.yaml",
+			expected: "agent/infer-dc-from-additional-ep/out.yaml",
+		},
+	}
+
+	t.Run("profiling_dd_url", func(t *testing.T) {
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"apm_config.profiling_dd_url": "https://intake.profile.us3.datadoghq.com/v1/input",
+				"api_key":                     "test_api_key_123",
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests[:1])
+	})
+
+	t.Run("additional_endpoints", func(t *testing.T) {
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"site":    "datadoghq.com",
+				"api_key": "test_api_key_123",
+				"apm_config.profiling_additional_endpoints": map[string][]string{
+					"https://intake.profile.us3.datadoghq.com/v1/input": {"us3_api_key"},
+				},
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests[1:])
+	})
+}
+
 func TestConverterWithAgentErrors(t *testing.T) {
 	tests := []errorTestCase{
 		{

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -11,14 +11,12 @@ package converters
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.opentelemetry.io/collector/confmap"
-	"golang.org/x/net/publicsuffix"
 )
 
 type endpoint struct {
@@ -32,26 +30,6 @@ type configManager struct {
 	config    config.Component
 }
 
-func extractSite(s string) string {
-	u, err := url.Parse(s)
-	if err != nil {
-		log.Debugf("Failed to parse URL %s: %v", s, err)
-		return ""
-	}
-
-	hostname := strings.Trim(u.Hostname(), ".")
-	if hostname == "" {
-		return ""
-	}
-	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(hostname)
-	if err != nil {
-		log.Debugf("Failed to extract apex domain from %s: %v", hostname, err)
-		return hostname
-	}
-
-	return apexDomain
-}
-
 func newConfigManager(config config.Component) configManager {
 	profilingDDURL := config.GetString("apm_config.profiling_dd_url")
 	ddSite := config.GetString("site")
@@ -59,7 +37,10 @@ func newConfigManager(config config.Component) configManager {
 
 	var usedURL, usedSite string
 	if profilingDDURL != "" {
-		usedSite = extractSite(profilingDDURL)
+		usedSite = configutils.ExtractSiteFromURL(profilingDDURL)
+		if usedSite == "" {
+			log.Warnf("Could not extract site from apm_config.profiling_dd_url %s, skipping endpoint", profilingDDURL)
+		}
 		usedURL = profilingDDURL
 	} else if ddSite != "" {
 		usedSite = ddSite
@@ -68,7 +49,7 @@ func newConfigManager(config config.Component) configManager {
 	profilingAdditionalEndpoints := config.GetStringMapStringSlice("apm_config.profiling_additional_endpoints")
 	var endpoints []endpoint
 	for endpointURL, keys := range profilingAdditionalEndpoints {
-		site := extractSite(endpointURL)
+		site := configutils.ExtractSiteFromURL(endpointURL)
 		if site == "" {
 			log.Warnf("Could not extract site from URL %s, skipping endpoint", endpointURL)
 			continue

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -285,9 +285,11 @@ func (c *converterWithAgent) inferOtlpHTTPConfig(conf confMap) error {
 
 	const profilesExportersPath = "service::pipelines::profiles::exporters"
 	profilesExporters, _ := Get[[]any](conf, profilesExportersPath)
+	siteCounter := make(map[string]int)
 	for _, endpoint := range c.configManager.endpoints {
-		for i, key := range endpoint.apiKeys {
-			exporterName := fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, i)
+		for _, key := range endpoint.apiKeys {
+			exporterName := fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, siteCounter[endpoint.site])
+			siteCounter[endpoint.site]++
 			if err := Set(conf, pathPrefixExporters+exporterName, createOtlpHTTPFromEndpoint(endpoint.site, key)); err != nil {
 				return err
 			}

--- a/comp/host-profiler/collector/impl/converters/td/agent/duplicate-site-exporters/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/duplicate-site-exporters/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/duplicate-site-exporters/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/duplicate-site-exporters/out.yaml
@@ -1,0 +1,42 @@
+exporters:
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: additional_api_key
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    otlphttp/datadoghq.com_1:
+        headers:
+            dd-api-key: main_api_key
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+processors:
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: additional_api_key
+                  site: datadoghq.com
+                - api_key: main_api_key
+                  site: datadoghq.com
+service:
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/datadoghq.com_0
+                - otlphttp/datadoghq.com_1
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
@@ -1,0 +1,42 @@
+exporters:
+  otlphttp/datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+  otlphttp/us3.datadoghq.com_0:
+    headers:
+      dd-api-key: us3_api_key
+    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+  resource/dd-profiler-internal-metadata:
+    attributes:
+    - action: upsert
+      key: profiler_name
+      value: full-host-profiler
+    - action: upsert
+      key: profiler_version
+      value: 7.0.0-test
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: us3_api_key
+        site: us3.datadoghq.com
+      - api_key: test_api_key_123
+        site: datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp/us3.datadoghq.com_0
+      - otlphttp/datadoghq.com_0
+      processors:
+      - infraattributes/default
+      - resource/dd-profiler-internal-metadata
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
@@ -1,0 +1,34 @@
+exporters:
+  otlphttp/us3.datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+  resource/dd-profiler-internal-metadata:
+    attributes:
+    - action: upsert
+      key: profiler_name
+      value: full-host-profiler
+    - action: upsert
+      key: profiler_version
+      value: 7.0.0-test
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: test_api_key_123
+        site: us3.datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp/us3.datadoghq.com_0
+      processors:
+      - infraattributes/default
+      - resource/dd-profiler-internal-metadata
+      receivers:
+      - hostprofiler

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -197,7 +197,49 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 	return eds, nil
 }
 
-var wellKnownSitesRe = regexp.MustCompile(`(?:datadoghq|datad0g)\.(?:com|eu)$|ddog-gov\.com$`)
+// ddDomainPattern matches known Datadog domains (e.g., datadoghq.com,
+// datad0g.eu, ddog-gov.com). This is the shared building block for
+// wellKnownSitesRe, ddSitePattern, ddSiteFromHostnameRe, and ddURLRegexp.
+const ddDomainPattern = `datad(?:oghq|0g)\.(?:com|eu)|ddog-gov\.com`
+
+var wellKnownSitesRe = regexp.MustCompile(`(?:` + ddDomainPattern + `)$`)
+
+// ddSitePattern matches a Datadog site: an optional datacenter subdomain
+// (e.g., us3, ap1) followed by a known Datadog domain.
+const ddSitePattern = `([a-z]{2,}\d{1,2}\.)?(` + ddDomainPattern + `)`
+
+// ddSiteFromHostnameRe extracts the Datadog site from the end of a hostname.
+// The (?:^|\.) prefix ensures the match starts at a label boundary so that,
+// e.g., "notdatadoghq.com" is not mistaken for "datadoghq.com".
+var ddSiteFromHostnameRe = regexp.MustCompile(`(?:^|\.)` + ddSitePattern + `\.?$`)
+
+// ExtractSiteFromURL extracts the Datadog site from a URL.
+// For example:
+//
+//	"https://intake.profile.us3.datadoghq.com/v1/input" returns "us3.datadoghq.com"
+//	"https://intake.profile.datadoghq.com/v1/input" returns "datadoghq.com"
+//	"https://intake.profile.datadoghq.eu/v1/input" returns "datadoghq.eu"
+//
+// Returns an empty string if the URL cannot be parsed or does not contain a
+// recognized Datadog domain.
+func ExtractSiteFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	hostname := strings.ToLower(strings.TrimRight(u.Hostname(), "."))
+	if hostname == "" {
+		return ""
+	}
+
+	matches := ddSiteFromHostnameRe.FindStringSubmatch(hostname)
+	if matches == nil {
+		return ""
+	}
+	// matches[1] is the DC label with trailing dot (e.g., "us3.") or empty
+	// matches[2] is the known domain (e.g., "datadoghq.com")
+	return matches[1] + matches[2]
+}
 
 // BuildURLWithPrefix will return an HTTP(s) URL for a site given a certain prefix.
 // If the site is a datadog well-known one, it is suffixed with a dot to make it a FQDN.
@@ -281,7 +323,7 @@ func GetMRFInfraEndpoint(c pkgconfigmodel.Reader) (string, error) {
 
 // ddURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed with the Agent
 // version (see AddAgentVersionToDomain).
-var ddURLRegexp = regexp.MustCompile(`^app(\.mrf)?(\.[a-z]{2,}\d{1,2})?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)(\.)?$`)
+var ddURLRegexp = regexp.MustCompile(`^app(\.mrf)?\.` + ddSitePattern + `\.?$`)
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z
 func getDomainPrefix(app string) string {

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -427,6 +427,60 @@ external_config:
 	assert.Equal(t, "https://custom.external-agent.datadoghq.eu", externalAgentURL)
 }
 
+func TestExtractSiteFromURL(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		// Standard sites
+		{"https://intake.profile.datadoghq.com/v1/input", "datadoghq.com"},
+		{"https://intake.profile.datadoghq.eu/v1/input", "datadoghq.eu"},
+		{"https://intake.profile.ddog-gov.com/v1/input", "ddog-gov.com"},
+
+		// Datacenter subdomains
+		{"https://intake.profile.us3.datadoghq.com/v1/input", "us3.datadoghq.com"},
+		{"https://intake.profile.us5.datadoghq.com/v1/input", "us5.datadoghq.com"},
+		{"https://intake.profile.ap1.datadoghq.com/v1/input", "ap1.datadoghq.com"},
+		{"https://intake.profile.eu1.datadoghq.eu/v1/input", "eu1.datadoghq.eu"},
+
+		// Staging/alternative domains
+		{"https://intake.profile.datad0g.com/v1/input", "datad0g.com"},
+		{"https://intake.profile.us3.datad0g.com/v1/input", "us3.datad0g.com"},
+
+		// Trailing dots (FQDN)
+		{"https://intake.profile.datadoghq.com./v1/input", "datadoghq.com"},
+		{"https://intake.profile.us3.datadoghq.com./v1/input", "us3.datadoghq.com"},
+
+		// Custom service prefixes
+		{"https://ophzngaa-intake.profile.datadoghq.com/api/v2/profile", "datadoghq.com"},
+		{"https://sourcemap-intake.us3.datadoghq.com/v1/input", "us3.datadoghq.com"},
+
+		// Bare site as URL
+		{"https://datadoghq.com", "datadoghq.com"},
+		{"https://us3.datadoghq.com", "us3.datadoghq.com"},
+
+		// Non-Datadog domains
+		{"https://example.com/foo", ""},
+		{"https://myproxy.internal/intake", ""},
+		{"https://notdatadoghq.com/v1/input", ""},
+		{"https://notdatad0g.eu/v1/input", ""},
+
+		// Case-insensitive hostnames
+		{"https://INTAKE.PROFILE.US3.DATADOGHQ.COM/v1/input", "us3.datadoghq.com"},
+		{"https://intake.profile.Datadoghq.COM/v1/input", "datadoghq.com"},
+
+		// Invalid/empty
+		{"", ""},
+		{"not-a-url", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.url, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ExtractSiteFromURL(tc.url))
+		})
+	}
+}
+
 func TestAddAgentVersionToDomain(t *testing.T) {
 	appVersionPrefix := getDomainPrefix("app")
 	flareVersionPrefix := getDomainPrefix("flare")


### PR DESCRIPTION
### What does this PR do?

The converter used `publicsuffix.EffectiveTLDPlusOne` to extract the site from profiling URLs, which only returns the apex domain (`datadoghq.com`) and drops DC subdomains like `us3`. This caused 403s with DC-specific API keys (due to sending requests to the wrong DC).

- Add shared `ExtractSiteFromURL` in `pkg/config/utils/endpoints.go` using regex, reusing `ddDomainPattern` as single source of truth for known DD domains
- Replace the converter's local `extractSite`, drop `publicsuffix` dep
- Fix duplicate otlphttp exporter names when multiple endpoints share the same site (per-site counter instead of per-endpoint key index)

### Motivation

`profiling_additional_endpoints` with `https://intake.profile.us3.datadoghq.com/v1/input` resolved to `datadoghq.com` instead of `us3.datadoghq.com`.

Separately, when the main endpoint and an additional endpoint shared the same site, `inferOtlpHTTPConfig` generated the same exporter name for both (`otlphttp/datadoghq.com_0`), overwriting the first config.

### Describe how you validated your changes

- Unit tests for `ExtractSiteFromURL`
- Golden tests for DC-subdomain inference and same-site exporter name collision
- Existing `TestAddAgentVersionToDomain` tests still pass