### PR TITLE
Fix flaky `TestIntakeRefreshAPIKey` by adding retry, delay, and ordering logic for FakeIntake API key check 

### DIFF
--- a/test/new-e2e/tests/agent-configuration/config-refresh/api_key_refresh_test.go
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/api_key_refresh_test.go
@@ -66,15 +66,17 @@ api_key: ENC[api_key]
 	require.Contains(v.T(), secretRefreshOutput, "api_key")
 
 	// Assert that the status command shows the new API Key
-	status = v.Env().Agent.Client.Status()
 	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		status = v.Env().Agent.Client.Status()
 		assert.Contains(t, status.Content, "API key ending with vwxyz")
 	}, 1*time.Minute, 10*time.Second)
 
-	// Assert that the fakeIntake has received the API Key
-	lastAPIKey, err := v.Env().FakeIntake.Client().GetLastAPIKey()
-	assert.NoError(v.T(), err)
-	assert.Equal(v.T(), lastAPIKey, secondAPIKey)
+	// Assert that the fakeIntake has received the new API Key
+	assert.EventuallyWithT(v.T(), func(t *assert.CollectT) {
+		lastAPIKey, err := v.Env().FakeIntake.Client().GetLastAPIKey()
+		assert.NoError(t, err)
+		assert.Equal(t, secondAPIKey, lastAPIKey)
+	}, 1*time.Minute, 10*time.Second)
 }
 
 func (v *linuxAPIKeyRefreshSuite) TestIntakeRefreshAPIKeysAdditionalEndpoints() {


### PR DESCRIPTION
### What does this PR do?
Fixes flaky `TestIntakeRefreshAPIKey` e2e CI test by adding retry, delay, and ordering logic for FakeIntake API key check 

### Motivation
This will hopefully resolve this flaky CI failure:
https://datadoghq.atlassian.net/jira/software/c/projects/AGENTCFG/boards/8668?selectedIssue=AGENTCFG-597

### Describe how you validated your changes
CI

### Additional Notes
