### PR TITLE
APM: Fix panic in v1 trace decoding

### DIFF
--- a/pkg/proto/pbgo/trace/idx/span.go
+++ b/pkg/proto/pbgo/trace/idx/span.go
@@ -7,6 +7,7 @@
 package idx
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tinylib/msgp/msgp"
@@ -263,7 +264,7 @@ func UnmarshalKeyValueMap(bts []byte, strings *StringTable) (kvl map[uint32]*Any
 		return
 	}
 	if numAttributes > 0 && numAttributes%3 != 0 {
-		err = msgp.WrapError(err, fmt.Sprintf("Invalid number of span attributes %d - must be a multiple of 3", numAttributes))
+		err = fmt.Errorf("Invalid number of span attributes %d - must be a multiple of 3", numAttributes)
 		return
 	}
 	kvl = make(map[uint32]*AnyValue, numAttributes/3)
@@ -296,7 +297,7 @@ func UnmarshalKeyValueList(bts []byte, strings *StringTable) (kvl []*KeyValue, o
 		return
 	}
 	if numAttributes > 0 && numAttributes%3 != 0 {
-		err = msgp.WrapError(err, fmt.Sprintf("Invalid number of span attributes %d - must be a multiple of 3", numAttributes))
+		err = fmt.Errorf("Invalid number of span attributes %d - must be a multiple of 3", numAttributes)
 		return
 	}
 	kvl = make([]*KeyValue, numAttributes/3)
@@ -378,7 +379,7 @@ func UnmarshalAnyValue(bts []byte, strings *StringTable) (value *AnyValue, o []b
 			return
 		}
 		if numElements%2 != 0 {
-			err = msgp.WrapError(err, "Invalid number of array elements, should be 2 elements per AnyValue")
+			err = fmt.Errorf("Invalid number of array elements %d - should be 2 elements per AnyValue", numElements)
 			return
 		}
 		arrayValue := make([]*AnyValue, numElements/2)
@@ -403,7 +404,7 @@ func UnmarshalAnyValue(bts []byte, strings *StringTable) (value *AnyValue, o []b
 		}
 		value.Value = &AnyValue_KeyValueList{KeyValueList: &KeyValueList{KeyValues: kvl}}
 	default:
-		err = msgp.WrapError(err, fmt.Sprintf("Unknown anyvalue type %d", valueType))
+		err = fmt.Errorf("Unknown anyvalue type %d", valueType)
 		return
 	}
 	return
@@ -413,7 +414,7 @@ func UnmarshalAnyValue(bts []byte, strings *StringTable) (value *AnyValue, o []b
 // For streaming string details see pkg/trace/api/version.go for details
 func UnmarshalStreamingString(bts []byte, strings *StringTable) (index uint32, o []byte, err error) {
 	if len(bts) < 1 {
-		err = msgp.WrapError(err, "Expected streaming string but EOF")
+		err = errors.New("Expected streaming string but EOF")
 		return
 	}
 	if isString(bts) {
@@ -431,7 +432,7 @@ func UnmarshalStreamingString(bts []byte, strings *StringTable) (index uint32, o
 			return
 		}
 		if int(index) >= strings.Len() {
-			err = msgp.WrapError(err, "Streaming string referenced an unseen string index")
+			err = fmt.Errorf("Streaming string referenced an unseen string index %d (string table length: %d)", index, strings.Len())
 			return
 		}
 	}

--- a/pkg/proto/pbgo/trace/idx/tracer_payload.go
+++ b/pkg/proto/pbgo/trace/idx/tracer_payload.go
@@ -6,6 +6,7 @@
 package idx
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/tinylib/msgp/msgp"
@@ -38,7 +39,7 @@ func (tp *InternalTracerPayload) UnmarshalMsg(bts []byte) (o []byte, err error) 
 			// If strings are sent they must be sent first.
 			// TODO: this should always be an error
 			if tp.Strings.Len() > 1 {
-				err = msgp.WrapError(err, "Unexpected strings attribute, strings must be sent first")
+				err = errors.New("Unexpected strings attribute, strings must be sent first")
 				return
 			}
 			o, err = unmarshalStringTable(o, tp.Strings)
@@ -118,7 +119,7 @@ func limitedReadArrayHeaderBytes(bts []byte) (sz uint32, o []byte, err error) {
 		return
 	}
 	if sz > maxSize {
-		err = msgp.WrapError(err, "Array too large")
+		err = fmt.Errorf("Array too large: %d > %.0f", sz, maxSize)
 		return
 	}
 	return
@@ -130,7 +131,7 @@ func limitedReadMapHeaderBytes(bts []byte) (sz uint32, o []byte, err error) {
 		return
 	}
 	if sz > maxSize {
-		err = msgp.WrapError(err, "Map too large")
+		err = fmt.Errorf("Map too large: %d > %.0f", sz, maxSize)
 		return
 	}
 	return

--- a/releasenotes/notes/apm-fix-decode-panic-c91e6100dd0ef422.yaml
+++ b/releasenotes/notes/apm-fix-decode-panic-c91e6100dd0ef422.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    APM: Fix panic that could occur when decoding malformed v1.0 trace payloads.


### PR DESCRIPTION
### What does this PR do?
Some forms of failing to decode were improperly wrapping a nil error. In those cases we should just initialize a new error, callers above us will wrap those errors to provide context.

### Motivation
Calling `Error()` on a nil wrapped error causes a panic. We found this while testing a new v1 trace payload implementation. We should never panic when decoding trace payloads.

### Describe how you validated your changes
Added new unit tests and a specialized fuzz test that validates we do not ever return an error that can trigger a panic.

### Additional Notes
