### PR TITLE
set integration_id field for notable events

### DIFF
--- a/comp/notableevents/impl/submitter.go
+++ b/comp/notableevents/impl/submitter.go
@@ -77,20 +77,16 @@ func (s *submitter) submitEvent(payload eventPayload) error {
 	hostnameValue := s.hostname.GetSafe(context.TODO())
 	timestamp := payload.Timestamp.In(time.UTC).Format("2006-01-02T15:04:05.000000Z")
 
-	tags := []string{
-		"source:notable_events",
-	}
-
 	// Create Event Management v2 API payload
 	eventData := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "event",
 			"attributes": map[string]interface{}{
-				"host":     hostnameValue,
-				"title":    payload.Title,
-				"category": "alert",
-				// TODO(WINA-1969): add integration_id and schema fields
-				// "integration_id": "",
+				"host":           hostnameValue,
+				"title":          payload.Title,
+				"category":       "alert",
+				"integration_id": "system-notable-events",
+				// TODO(WINA-1969): add integration_id schema fields
 				// "notable_events": map[string]interface{}{
 				// 	"event_type": payload.EventType,
 				// },
@@ -100,7 +96,6 @@ func (s *submitter) submitEvent(payload eventPayload) error {
 					"custom":   payload.Custom,
 				},
 				"message":   payload.Message,
-				"tags":      tags,
 				"timestamp": timestamp,
 			},
 		},

--- a/comp/notableevents/impl/submitter.go
+++ b/comp/notableevents/impl/submitter.go
@@ -86,10 +86,9 @@ func (s *submitter) submitEvent(payload eventPayload) error {
 				"title":          payload.Title,
 				"category":       "alert",
 				"integration_id": "system-notable-events",
-				// TODO(WINA-1969): add integration_id schema fields
-				// "notable_events": map[string]interface{}{
-				// 	"event_type": payload.EventType,
-				// },
+				"system-notable-events": map[string]interface{}{
+					"event_type": payload.EventType,
+				},
 				"attributes": map[string]interface{}{
 					"status":   "error",
 					"priority": "5",


### PR DESCRIPTION
### What does this PR do?

Sets the `integration_id` field to `system-notable-events` in the Event Management v2 API payload for notable events. 
Adds the `system-notable-events.event_type` field.
Removes the unused `tags` variable that was previously hardcoded.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-1969
The `integration_id` field is required for proper event categorization in the Event Management v2 API. 
The `system-notable-events.event_type` field will be used to group and bubble up alerts.

### Describe how you validated your changes

Manual testing of event submission with the updated payload structure [[event-management]](https://dd.datad0g.com/event/explorer?query=host%3ALAPTOP-J4KNN9ON%20source%3Asystem_notable_events&cols=&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&view=all&from_ts=1770928046546&to_ts=1770928090326&live=false)