### PR TITLE
[CNM-5156] Make go4.org/intern string accesses safe.

### DIFF
--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -192,7 +192,9 @@ func (cs *ContainerStore) addProcess(entry *events.Process) {
 func logEvictingID(containerID network.ContainerID) {
 	containerStr := "host"
 	if containerID != nil {
-		containerStr = containerID.Get().(string)
+		if s, ok := containerID.Get().(string); ok {
+			containerStr = s
+		}
 	}
 	log.Tracef("CNM ContainerStore evicting ID %s", containerStr)
 }

--- a/pkg/network/encoding/marshal/format.go
+++ b/pkg/network/encoding/marshal/format.go
@@ -55,7 +55,7 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 
 	var containerID string
 	if conn.ContainerID.Source != nil {
-		containerID = conn.ContainerID.Source.Get().(string)
+		containerID, _ = conn.ContainerID.Source.Get().(string)
 	}
 	builder.SetLaddr(func(w *model.AddrBuilder) {
 		w.SetIp(ipc.Get(conn.Source))
@@ -65,7 +65,7 @@ func FormatConnection(builder *model.ConnectionBuilder, conn network.ConnectionS
 
 	containerID = ""
 	if conn.ContainerID.Dest != nil {
-		containerID = conn.ContainerID.Dest.Get().(string)
+		containerID, _ = conn.ContainerID.Dest.Get().(string)
 	}
 	builder.SetRaddr(func(w *model.AddrBuilder) {
 		w.SetIp(ipc.Get(conn.Dest))
@@ -292,7 +292,13 @@ func formatTags(c network.ConnectionStats, tagsSet *network.TagsSet, connDynamic
 
 	// other tags, e.g., from process env vars like DD_ENV, etc.
 	for _, tag := range c.Tags {
-		t := tag.Get().(string)
+		if tag == nil {
+			continue
+		}
+		t, ok := tag.Get().(string)
+		if !ok {
+			continue
+		}
 		checksum ^= murmur3.StringSum32(t)
 		tagsIdx = append(tagsIdx, tagsSet.Add(t))
 	}

--- a/pkg/network/resolver.go
+++ b/pkg/network/resolver.go
@@ -59,7 +59,11 @@ func (r LocalResolver) Resolve(conns slice.Chain[ConnectionStats]) {
 
 	ctrsByConn := make(map[connKey]*intern.Value, conns.Len()/2)
 	conns.Iterate(func(_ int, conn *ConnectionStats) {
-		if conn.ContainerID.Source == nil || len(conn.ContainerID.Source.Get().(string)) == 0 {
+		if conn.ContainerID.Source == nil {
+			return
+		}
+		srcCID, _ := conn.ContainerID.Source.Get().(string)
+		if len(srcCID) == 0 {
 			return
 		}
 

--- a/pkg/network/sender/sender_linux.go
+++ b/pkg/network/sender/sender_linux.go
@@ -307,7 +307,7 @@ func (d *directSender) networkPathConnections(conns *network.Connections) iter.S
 
 			srcContainerID := ""
 			if conn.ContainerID.Source != nil {
-				srcContainerID = conn.ContainerID.Source.Get().(string)
+				srcContainerID, _ = conn.ContainerID.Source.Get().(string)
 			}
 
 			npc := npmodel.NetworkPathConnection{
@@ -553,7 +553,8 @@ func getInternedString(v *intern.Value) string {
 	if v == nil {
 		return ""
 	}
-	return v.Get().(string)
+	s, _ := v.Get().(string)
+	return s
 }
 
 const (

--- a/pkg/network/sender/tags.go
+++ b/pkg/network/sender/tags.go
@@ -43,7 +43,13 @@ func formatTags(c network.ConnectionStats, tagsSet *indexedSet[string], connDyna
 
 	// other tags, e.g., from process env vars like DD_ENV, etc.
 	for _, tag := range c.Tags {
-		t := tag.Get().(string)
+		if tag == nil {
+			continue
+		}
+		t, ok := tag.Get().(string)
+		if !ok {
+			continue
+		}
 		checksum ^= murmur3.StringSum32(t)
 		tagsIdx = append(tagsIdx, tagsSet.Add(t))
 	}
@@ -59,7 +65,9 @@ func (d *directSender) getContainersForExplicitTagging(currentConnections *netwo
 	ids := make(map[string]struct{})
 	for _, conn := range currentConnections.Conns {
 		if conn.ContainerID.Source != nil {
-			ids[conn.ContainerID.Source.Get().(string)] = struct{}{}
+			if cid, ok := conn.ContainerID.Source.Get().(string); ok {
+				ids[cid] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -209,7 +209,7 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 		cid := conn.Laddr.ContainerId
 		if cid == "" {
 			if v, ok := l.ctrForPid[int(conn.Pid)]; ok {
-				cid = v.cid.Get().(string)
+				cid, _ = v.cid.Get().(string)
 			}
 		}
 
@@ -291,7 +291,7 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 			Port:     int32(raddr.Port()),
 			Protocol: conn.Type,
 		}]; ok {
-			conn.Raddr.ContainerId = v.cid.Get().(string)
+			conn.Raddr.ContainerId, _ = v.cid.Get().(string)
 		} else {
 			log.Tracef("could not resolve raddr %v", conn.Raddr)
 		}


### PR DESCRIPTION
### What does this PR do?

In this code, go4.org/intern.Value instances store strings, but the Get() method returns interface{}, requiring a type assertion to extract the string. A bare assertion like v.Get().(string) panics if the underlying value is corrupted — and the go4.org/intern package uses unsafe pointer tricks that can lead to corruption under GC pressure.  Instead, these changes use a comma-ok assertion: s, ok := v.Get().(string). This returns ok=false instead of panicing when the value is corrupted, allowing the code to safely skip the bad value and continue.

### Motivation

A system-probe panic occurred on a staging cluster.

### Describe how you validated your changes

Existing test coverage.

### Additional Notes
