### PR TITLE
replace more sprintf with string concat

### DIFF
--- a/pkg/security/common/account_id.go
+++ b/pkg/security/common/account_id.go
@@ -67,7 +67,7 @@ func QueryAccountIDTag() string {
 			log.Errorf("failed to query account id: %v", err)
 			return
 		}
-		accountIDTagCache.value = fmt.Sprintf("%s:%s", tagName, tagValue)
+		accountIDTagCache.value = tagName + ":" + tagValue
 	})
 
 	return accountIDTagCache.value

--- a/pkg/security/common/address_utils.go
+++ b/pkg/security/common/address_utils.go
@@ -51,7 +51,7 @@ func GetCmdSocketPath(socketPath string, cmdSocketPath string) (string, error) {
 				return "", fmt.Errorf("invalid socket port: %s", addrPort[1])
 			}
 
-			cmdSocketPath = fmt.Sprintf("%s:%d", addrPort[0], port+1)
+			cmdSocketPath = addrPort[0] + ":" + strconv.Itoa(port+1)
 		}
 	}
 

--- a/pkg/security/ebpf/probes/rawpacket/bpffilter.go
+++ b/pkg/security/ebpf/probes/rawpacket/bpffilter.go
@@ -9,7 +9,7 @@
 package rawpacket
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -78,5 +78,5 @@ type Filter struct {
 
 // Key returns a key representing the filter
 func (f *Filter) Key() string {
-	return fmt.Sprintf("%s:%d:%d", f.RuleID, f.Pid, f.CGroupPathKey.Inode)
+	return f.RuleID + ":" + strconv.FormatUint(uint64(f.Pid), 10) + ":" + strconv.FormatUint(f.CGroupPathKey.Inode, 10)
 }

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -9,8 +9,8 @@ package module
 import (
 	"context"
 	"errors"
-	"fmt"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -310,8 +310,8 @@ func (c *CWSConsumer) reportSelfTest(success []eval.RuleID, fails []eval.RuleID)
 
 	// send metric with number of success and fails
 	tags := []string{
-		fmt.Sprintf("success:%d", len(success)),
-		fmt.Sprintf("fails:%d", len(fails)),
+		"success:" + strconv.Itoa(len(success)),
+		"fails:" + strconv.Itoa(len(fails)),
 		"os:" + runtime.GOOS,
 		"arch:" + utils.RuntimeArch(),
 		"origin:" + c.probe.Origin(),

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	json "encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"runtime"
 	"slices"
@@ -568,7 +567,7 @@ func (a *APIServer) expireDump(dump *api.ActivityDumpStreamMessage) {
 
 	selectorStr := "<unknown>"
 	if sel := dump.GetSelector(); sel != nil {
-		selectorStr = fmt.Sprintf("%s:%s", sel.GetName(), sel.GetTag())
+		selectorStr = sel.GetName() + ":" + sel.GetTag()
 	}
 	seclog.Tracef("the activity dump server channel is full, a dump of [%s] was dropped\n", selectorStr)
 }
@@ -746,7 +745,7 @@ func getEnvAsTags(cfg *config.RuntimeSecurityConfig) []string {
 	for _, env := range cfg.EnvAsTags {
 		value := os.Getenv(env)
 		if value != "" {
-			tags = append(tags, fmt.Sprintf("%s:%s", env, value))
+			tags = append(tags, env+":"+value)
 		}
 	}
 	return tags

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -1029,7 +1029,7 @@ func (fh *EBPFFieldHandlers) ResolveSessionIdentity(e *model.Event, evtCtx *mode
 	if evtCtx.K8SUsername != "" {
 		sessionIdentity = evtCtx.K8SUsername
 	} else if evtCtx.SSHClientPort != 0 {
-		sessionIdentity = fmt.Sprintf("%s:%d", evtCtx.SSHClientIP.String(), evtCtx.SSHClientPort)
+		sessionIdentity = evtCtx.SSHClientIP.String() + ":" + strconv.Itoa(evtCtx.SSHClientPort)
 	} else {
 		sessionIdentity = e.ProcessContext.User
 	}

--- a/pkg/security/probe/monitors/approver/approver_monitor.go
+++ b/pkg/security/probe/monitors/approver/approver_monitor.go
@@ -72,7 +72,7 @@ func (d *Monitor) SendStats() error {
 
 	for eventType, stats := range statsByEventType {
 		eventTypeTag := "event_type:" + model.EventType(eventType).String()
-		categoryTag := fmt.Sprintf("category:%s", model.GetEventTypeCategory(model.EventType(eventType).String()))
+		categoryTag := "category:" + model.GetEventTypeCategory(model.EventType(eventType).String()).String()
 		if stats.EventRejected != 0 {
 			tagsForRejectedEvents := []string{
 				eventTypeTag,

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
@@ -1301,7 +1302,7 @@ func (p *WindowsProbe) SendStats() error {
 
 func (p *WindowsProbe) sendMapStats(m *map[uint16]uint64, metric string) error {
 	for k, v := range *m {
-		if err := p.statsdClient.Gauge(metric, float64(v), []string{fmt.Sprintf("event_id:%d", k)}, 1); err != nil {
+		if err := p.statsdClient.Gauge(metric, float64(v), []string{"event_id:" + strconv.FormatUint(uint64(k), 10)}, 1); err != nil {
 			return err
 		}
 	}

--- a/pkg/security/resolvers/dentry/resolver.go
+++ b/pkg/security/resolvers/dentry/resolver.go
@@ -163,7 +163,7 @@ func (dr *Resolver) sendERPCStats() error {
 	}
 	for r, count := range counters {
 		if count > 0 {
-			_ = dr.statsdClient.Count(metrics.MetricDentryERPC, count, []string{fmt.Sprintf("ret:%s", r)}, 1.0)
+			_ = dr.statsdClient.Count(metrics.MetricDentryERPC, count, []string{"ret:" + r.String()}, 1.0)
 		}
 	}
 	for _, r := range allERPCRet() {

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1457,7 +1457,7 @@ func (p *EBPFResolver) ToJSON(raw bool) ([]byte, error) {
 
 func (p *EBPFResolver) toDot(writer io.Writer, entry *model.ProcessCacheEntry, already map[string]bool, withArgs bool) {
 	for entry != nil {
-		label := fmt.Sprintf("%s:%d", entry.Comm, entry.Pid)
+		label := entry.Comm + ":" + strconv.FormatUint(uint64(entry.Pid), 10)
 		if _, exists := already[label]; !exists {
 			if !entry.ExitTime.IsZero() {
 				label = "[" + label + "]"

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -113,7 +113,7 @@ func (pm *PolicyMonitor) Start(ctx context.Context) {
 					for id, status := range pm.rules {
 						tags := []string{
 							"rule_id:" + id,
-							fmt.Sprintf("status:%v", status),
+							"status:" + status,
 							constants.CardinalityTagPrefix + types.LowCardinalityString,
 						}
 

--- a/pkg/security/security_profile/activity_tree/activity_tree_graph.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_graph.go
@@ -9,7 +9,6 @@
 package activitytree
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -366,11 +365,11 @@ func (at *ActivityTree) prepareNetworkDeviceNode(n *NetworkDeviceNode, data *uti
 
 func (at *ActivityTree) prepareNetworkFlowNode(n *FlowNode, data *utils.SubGraph, deviceID utils.GraphID) {
 	label := tableHeader
-	label += "<TR><TD>Source</TD><TD>" + fmt.Sprintf("%s:%d", n.Flow.Source.IPNet.String(), n.Flow.Source.Port) + "</TD></TR>"
+	label += "<TR><TD>Source</TD><TD>" + n.Flow.Source.IPNet.String() + ":" + strconv.FormatUint(uint64(n.Flow.Source.Port), 10) + "</TD></TR>"
 	if n.Flow.Source.IsPublicResolved {
 		label += "<TR><TD>Is src public ?</TD><TD>" + strconv.FormatBool(n.Flow.Source.IsPublic) + "</TD></TR>"
 	}
-	label += "<TR><TD>Destination</TD><TD>" + fmt.Sprintf("%s:%d", n.Flow.Destination.IPNet.String(), n.Flow.Destination.Port) + "</TD></TR>"
+	label += "<TR><TD>Destination</TD><TD>" + n.Flow.Destination.IPNet.String() + ":" + strconv.FormatUint(uint64(n.Flow.Destination.Port), 10) + "</TD></TR>"
 	if n.Flow.Destination.IsPublicResolved {
 		label += "<TR><TD>Is dst public ?</TD><TD>" + strconv.FormatBool(n.Flow.Destination.IsPublic) + "</TD></TR>"
 	}
@@ -427,7 +426,7 @@ func (at *ActivityTree) prepareSocketNode(n *SocketNode, data *utils.Graph, proc
 	for i, node := range n.Bind {
 		bindNode := &utils.Node{
 			ID:    processID.Derive(utils.NewNodeIDFromPtr(n), utils.NewNodeID(uint64(i+1))),
-			Label: fmt.Sprintf("[%s]:%d", node.IP, node.Port),
+			Label: "[" + node.IP + "]:" + strconv.FormatUint(uint64(node.Port), 10),
 			Size:  smallText,
 			Color: networkColor,
 			Shape: networkShape,

--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -86,7 +86,7 @@ func (stats *Stats) SendStats(client statsd.ClientInterface, treeType string) er
 	treeTypeTag := "tree_type:" + treeType
 
 	for evtType, count := range stats.counts {
-		evtTypeTag := fmt.Sprintf("event_type:%s", evtType)
+		evtTypeTag := "event_type:" + evtType.String()
 
 		tags := []string{evtTypeTag, treeTypeTag}
 		if value := count.processedCount.Swap(0); value > 0 {
@@ -105,7 +105,7 @@ func (stats *Stats) SendStats(client statsd.ClientInterface, treeType string) er
 		}
 
 		for reason, count := range count.droppedCount {
-			tags := []string{evtTypeTag, fmt.Sprintf("reason:%s", reason), treeTypeTag}
+			tags := []string{evtTypeTag, "reason:" + reason.String(), treeTypeTag}
 			if value := count.Swap(0); value > 0 {
 				if err := client.Count(metrics.MetricActivityDumpEventDropped, int64(value), tags, 1.0); err != nil {
 					return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventDropped, err)

--- a/pkg/security/security_profile/activity_tree/file_node.go
+++ b/pkg/security/security_profile/activity_tree/file_node.go
@@ -93,12 +93,12 @@ func (fn *FileNode) buildNodeRow(prefix string) string {
 	if fn.Open != nil && fn.File != nil {
 		var pkg string
 		if len(fn.File.PkgName) != 0 {
-			pkg = fmt.Sprintf("%s:%s", fn.File.PkgName, fn.File.PkgVersion)
+			pkg = fn.File.PkgName + ":" + fn.File.PkgVersion
 		}
 		out += "<TR>"
 		out += "<TD>open</TD>"
 		out += "<TD>" + strconv.Itoa(len(fn.File.Hashes)) + " hash(es)</TD>"
-		out += "<TD ALIGN=\"LEFT\">" + fmt.Sprintf("%s/%s", prefix, fn.Name) + "</TD>"
+		out += "<TD ALIGN=\"LEFT\">" + prefix + "/" + fn.Name + "</TD>"
 		out += "<TD>" + pkg + "</TD>"
 		out += "</TR>"
 	}

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -119,7 +119,7 @@ func (pn *ProcessNode) getNodeLabel(args string) string {
 	builder.WriteString("</FONT></TD></TR>")
 
 	if len(pn.Process.FileEvent.PkgName) != 0 {
-		builder.WriteString("<TR><TD>Package</TD><TD>" + fmt.Sprintf("%s:%s", pn.Process.FileEvent.PkgName, pn.Process.FileEvent.PkgVersion) + "</TD></TR>")
+		builder.WriteString("<TR><TD>Package</TD><TD>" + pn.Process.FileEvent.PkgName + ":" + pn.Process.FileEvent.PkgVersion + "</TD></TR>")
 	}
 	// add hashes
 	if len(pn.Process.FileEvent.Hashes) > 0 {

--- a/pkg/security/security_profile/ad.go
+++ b/pkg/security/security_profile/ad.go
@@ -420,7 +420,7 @@ func (m *Manager) finalizeKernelEventCollection(ad *dump.ActivityDump, releaseTr
 	// add the container ID in a tag
 	if len(ad.Profile.Metadata.ContainerID) > 0 {
 		// make sure we are not adding the same tag twice
-		newTag := fmt.Sprintf("container_id:%s", ad.Profile.Metadata.ContainerID)
+		newTag := "container_id:" + string(ad.Profile.Metadata.ContainerID)
 		if !ad.Profile.HasTag(newTag) {
 			ad.Profile.AddTags([]string{newTag})
 		} else {

--- a/pkg/security/security_profile/load_controller.go
+++ b/pkg/security/security_profile/load_controller.go
@@ -9,7 +9,7 @@
 package securityprofile
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -84,7 +84,7 @@ func (m *Manager) getOverweightDumps() []*dump.ActivityDump {
 		dumpSize := ad.Profile.ComputeInMemorySize()
 
 		// send dump size in memory metric
-		if err := m.statsdClient.Gauge(metrics.MetricActivityDumpActiveDumpSizeInMemory, float64(dumpSize), []string{fmt.Sprintf("dump_index:%d", i)}, 1); err != nil {
+		if err := m.statsdClient.Gauge(metrics.MetricActivityDumpActiveDumpSizeInMemory, float64(dumpSize), []string{"dump_index:" + strconv.Itoa(i)}, 1); err != nil {
 			seclog.Errorf("couldn't send %s metric: %v", metrics.MetricActivityDumpActiveDumpSizeInMemory, err)
 		}
 

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -510,7 +511,7 @@ func (m *Manager) SendStats() error {
 		}
 
 		t := []string{
-			fmt.Sprintf("in_kernel:%v", profilesLoadedInKernel),
+			"in_kernel:" + strconv.FormatInt(int64(profilesLoadedInKernel), 10),
 		}
 		if err := m.statsdClient.Gauge(metrics.MetricSecurityProfileProfiles, float64(len(m.profiles)), t, 1.0); err != nil {
 			return fmt.Errorf("couldn't send MetricSecurityProfileProfiles: %w", err)
@@ -535,7 +536,7 @@ func (m *Manager) SendStats() error {
 		}
 
 		for entry, count := range m.eventFiltering {
-			t := []string{fmt.Sprintf("event_type:%s", entry.eventType), entry.state.ToTag(), entry.result.toTag()}
+			t := []string{"event_type:" + entry.eventType.String(), entry.state.ToTag(), entry.result.toTag()}
 			if value := count.Swap(0); value > 0 {
 				if err := m.statsdClient.Count(metrics.MetricSecurityProfileEventFiltering, int64(value), t, 1.0); err != nil {
 					return fmt.Errorf("couldn't send MetricSecurityProfileEventFiltering metric: %w", err)
@@ -625,7 +626,11 @@ func (m *Manager) persist(p *profile.Profile, formatsRequests map[config.Storage
 			if err := storage.Persist(request, p, data); err != nil {
 				seclog.Errorf("couldn't persist [%s] to %s storage: %v", p.GetSelectorStr(), request.Type, err)
 			} else {
-				tags := []string{"format:" + request.Format.String(), "storage_type:" + request.Type.String(), fmt.Sprintf("compression:%v", request.Compression)}
+				tags := []string{
+					"format:" + request.Format.String(),
+					"storage_type:" + request.Type.String(),
+					"compression:" + strconv.FormatBool(request.Compression),
+				}
 				if err := m.statsdClient.Count(metrics.MetricActivityDumpSizeInBytes, int64(data.Len()), tags, 1.0); err != nil {
 					seclog.Warnf("couldn't send %s metric: %v", metrics.MetricActivityDumpSizeInBytes, err)
 				}

--- a/pkg/security/security_profile/manager_v2.go
+++ b/pkg/security/security_profile/manager_v2.go
@@ -14,16 +14,17 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
-	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
-
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
@@ -38,7 +39,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/storage/backend"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 type pendingProfile struct {
@@ -355,7 +355,7 @@ func (m *ManagerV2) sendPersistenceMetrics(request config.StorageRequest, dataSi
 	tags := []string{
 		"format:" + request.Format.String(),
 		"storage_type:" + request.Type.String(),
-		fmt.Sprintf("compression:%v", request.Compression),
+		"compression:" + strconv.FormatBool(request.Compression),
 	}
 
 	if err := m.statsdClient.Count(metrics.MetricSecurityProfileV2SizeInBytes, int64(dataSize), tags, 1.0); err != nil {

--- a/pkg/security/security_profile/storage/backend/forwarder.go
+++ b/pkg/security/security_profile/storage/backend/forwarder.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/textproto"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/atomic"
 
 	logsconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -23,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	ddhttputil "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // protobufFormat is `config.Protobuf.String()`, this is temporary duplication to not have
@@ -156,7 +156,7 @@ func (backend *ActivityDumpRemoteBackend) HandleActivityDump(imageName string, i
 // SendTelemetry sends telemetry for the current storage
 func (backend *ActivityDumpRemoteBackend) SendTelemetry(sender statsd.ClientInterface) {
 	// send too large entity metric
-	tags := []string{"format:" + protobufFormat, fmt.Sprintf("compression:%v", true)}
+	tags := []string{"format:" + protobufFormat, "compression:true"}
 	_ = sender.Count(metrics.MetricActivityDumpEntityTooLarge, int64(backend.tooLargeEntities.Load()), tags, 1.0)
 }
 

--- a/pkg/security/tests/imds_test.go
+++ b/pkg/security/tests/imds_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"syscall"
 	"testing"
 
@@ -59,7 +60,7 @@ func TestAWSIMDSv1Request(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -134,7 +135,7 @@ func TestAWSIMDSv1Response(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -212,7 +213,7 @@ func TestAWSIMDSv2Request(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -287,7 +288,7 @@ func TestGCPIMDS(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -362,7 +363,7 @@ func TestAzureIMDS(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -437,7 +438,7 @@ func TestIBMIMDS(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -512,7 +513,7 @@ func TestOracleIMDS(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {
@@ -592,7 +593,7 @@ func TestIMDSProcessContext(t *testing.T) {
 	}()
 
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err = testutils.StopIMDSserver(imdsServer); err != nil {

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -141,7 +142,7 @@ func checkVersionAgainstApt(tb testing.TB, event *model.Event, pkgName string) {
 func buildDebianVersion(version, release string, epoch int) string {
 	v := version + "-" + release
 	if epoch > 0 {
-		v = fmt.Sprintf("%d:%s", epoch, v)
+		v = strconv.Itoa(epoch) + ":" + v
 	}
 	return v
 }

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 	"time"
 	"unsafe"
@@ -164,7 +165,7 @@ func SetupAndRunIMDSTest() error {
 
 func RunIMDSTest() error {
 	// create fake IMDS server
-	imdsServerAddr := fmt.Sprintf("%s:%v", testutils.IMDSTestServerIP, testutils.IMDSTestServerPort)
+	imdsServerAddr := testutils.IMDSTestServerIP + ":" + strconv.Itoa(testutils.IMDSTestServerPort)
 	imdsServer := testutils.CreateIMDSServer(imdsServerAddr)
 	defer func() {
 		if err := testutils.StopIMDSserver(imdsServer); err != nil {


### PR DESCRIPTION
### What does this PR do?

Replaces more unnecessary `fmt.Sprintf` calls with string concatenation and optimal format functions.

### Motivation

Reduced allocation pressure.

### Describe how you validated your changes

### Additional Notes
