### PR TITLE
reduce allocations from activity tree stats

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree_stats.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_stats.go
@@ -85,18 +85,19 @@ func (stats *Stats) ApproximateSize() int64 {
 func (stats *Stats) SendStats(client statsd.ClientInterface, treeType string) error {
 	treeTypeTag := "tree_type:" + treeType
 
+	tags := []string{treeTypeTag, "", ""}
 	for evtType, count := range stats.counts {
 		evtTypeTag := "event_type:" + evtType.String()
 
-		tags := []string{evtTypeTag, treeTypeTag}
+		tags[1] = evtTypeTag
 		if value := count.processedCount.Swap(0); value > 0 {
-			if err := client.Count(metrics.MetricActivityDumpEventProcessed, int64(value), tags, 1.0); err != nil {
+			if err := client.Count(metrics.MetricActivityDumpEventProcessed, int64(value), tags[:1], 1.0); err != nil {
 				return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventProcessed, err)
 			}
 		}
 
 		for generationType, count := range count.addedCount {
-			tags := []string{evtTypeTag, generationType.Tag(), treeTypeTag}
+			tags[2] = generationType.Tag()
 			if value := count.Swap(0); value > 0 {
 				if err := client.Count(metrics.MetricActivityDumpEventAdded, int64(value), tags, 1.0); err != nil {
 					return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventAdded, err)
@@ -105,7 +106,7 @@ func (stats *Stats) SendStats(client statsd.ClientInterface, treeType string) er
 		}
 
 		for reason, count := range count.droppedCount {
-			tags := []string{evtTypeTag, "reason:" + reason.String(), treeTypeTag}
+			tags[2] = reason.Tag()
 			if value := count.Swap(0); value > 0 {
 				if err := client.Count(metrics.MetricActivityDumpEventDropped, int64(value), tags, 1.0); err != nil {
 					return fmt.Errorf("couldn't send %s metric: %w", metrics.MetricActivityDumpEventDropped, err)


### PR DESCRIPTION
### What does this PR do?

Reduces string slice allocations when sending activity tree stats

### Motivation

Reduce allocation load

### Describe how you validated your changes

### Additional Notes

[profile](https://ddstaging.datadoghq.com/profiling/profile/AZxT1wRcAADKg7gL6_ulggAA?query=service%3Asystem-probe%20kube_cluster_name%3Aoddish-c%20host%3Ai-09f0301e67d1712b3&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZxT1wQLkj8h3QAAABhBWnhUMXdSY0FBREtnN2dMNl91bGdnQUEAAAAkZjE5YzUzZDctNzRhNi00YWEzLWIxODktZmQ2MGQ3NzZmMDBiAASH9Q&group_by=line&my_code=disabled&profile_type=alloc-samples&refresh_mode=paused&selection=%7B%22incl%22%3A%5B%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fsecurity%2Fsecurity_profile%2Factivity_tree.%28%2AStats%29.SendStats%22%5D%7D&viz=stream&from_ts=1770929743364&to_ts=1770933343364&live=false) showing ~4% of allocations