### PR TITLE
Revert "[APMLP-876] Enable tag-based gradual rollout and clean up remote config code"

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -570,6 +570,7 @@ func start(log log.Component,
 			StopCh:                       stopCh,
 			ValidatingStopCh:             validatingStopCh,
 			Demultiplexer:                demultiplexer,
+			RcClient:                     rcClient,
 		}
 
 		webhooks, err := admissionpkg.StartControllers(admissionCtx, wmeta, pa, datadogConfig)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -36,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/validate/kubernetesadmissionevents"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -58,11 +59,12 @@ func NewController(
 	pa workload.PodPatcher,
 	datadogConfig config.Component,
 	demultiplexer demultiplexer.Component,
+	rcClient *rcclient.Client,
 ) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pa, datadogConfig, demultiplexer)
+		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pa, datadogConfig, demultiplexer, rcClient)
 	}
-	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pa, datadogConfig, demultiplexer)
+	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, leadershipStateNotif, config, wmeta, pa, datadogConfig, demultiplexer, rcClient)
 }
 
 // Webhook represents an admission webhook
@@ -100,7 +102,7 @@ type Webhook interface {
 // The reason is that the volume mount for the APM socket added by the configWebhook webhook
 // doesn't always work on Fargate (one of the envs where we use an agent sidecar), and
 // the agent sidecar webhook needs to remove it.
-func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, datadogConfig config.Component, demultiplexer demultiplexer.Component) []Webhook {
+func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, datadogConfig config.Component, demultiplexer demultiplexer.Component, rcClient *rcclient.Client) []Webhook {
 	var webhooks []Webhook
 	var validatingWebhooks []Webhook
 
@@ -147,7 +149,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	webhooks = append(webhooks, appsecWebhook)
 
 	// Setup APM Instrumentation webhook. APM Instrumentation webhook needs to be registered after the config webhook.
-	apmWebhook, err := autoinstrumentation.NewAutoInstrumentation(datadogConfig, wmeta)
+	apmWebhook, err := autoinstrumentation.NewAutoInstrumentation(datadogConfig, wmeta, rcClient)
 	if err != nil {
 		log.Errorf("failed to register APM Instrumentation webhook: %v", err)
 	} else {

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -51,6 +51,7 @@ func TestNewController(t *testing.T) {
 		nil,
 		datadogConfig,
 		nil,
+		nil,
 	)
 
 	assert.IsType(t, &ControllerV1{}, controller)
@@ -67,6 +68,7 @@ func TestNewController(t *testing.T) {
 		wmeta,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 	)
 
@@ -139,7 +141,7 @@ func TestAutoInstrumentation(t *testing.T) {
 			))
 
 			// Create APM webhook.
-			apm, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, wmeta)
+			apm, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, wmeta, nil)
 			assert.NoError(t, err)
 
 			// Create request.

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -29,6 +29,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -59,6 +60,7 @@ func NewControllerV1(
 	pa workload.PodPatcher,
 	datadogConfig config.Component,
 	demultiplexer demultiplexer.Component,
+	rcClient *rcclient.Client,
 ) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
@@ -76,7 +78,7 @@ func NewControllerV1(
 	)
 	controller.isLeaderFunc = isLeaderFunc
 	controller.leadershipStateNotif = leadershipStateNotif
-	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig, demultiplexer)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig, demultiplexer, rcClient)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -1019,7 +1019,7 @@ func TestGenerateTemplatesV1(t *testing.T) {
 
 			c := &ControllerV1{}
 			c.config = tt.configFunc(mockConfig)
-			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig, nil)
+			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig, nil, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1263,6 +1263,7 @@ func (f *fixtureV1) createController() (*ControllerV1, informers.SharedInformerF
 		wmeta,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 	), factory
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -30,6 +30,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/certificate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -60,6 +61,7 @@ func NewControllerV1beta1(
 	pa workload.PodPatcher,
 	datadogConfig config.Component,
 	demultiplexer demultiplexer.Component,
+	rcClient *rcclient.Client,
 ) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
@@ -77,7 +79,7 @@ func NewControllerV1beta1(
 	)
 	controller.isLeaderFunc = isLeaderFunc
 	controller.leadershipStateNotif = leadershipStateNotif
-	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig, demultiplexer)
+	controller.webhooks = controller.generateWebhooks(wmeta, pa, datadogConfig, demultiplexer, rcClient)
 	controller.generateTemplates()
 
 	if _, err := secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -1013,7 +1013,7 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 
 			c := &ControllerV1beta1{}
 			c.config = tt.configFunc(mockConfig)
-			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig, nil)
+			c.webhooks = c.generateWebhooks(wmeta, nil, mockConfig, nil, nil)
 			c.generateTemplates()
 
 			assert.EqualValues(t, tt.want(), c.mutatingWebhookTemplates)
@@ -1257,6 +1257,7 @@ func (f *fixtureV1beta1) createController() (*ControllerV1beta1, informers.Share
 		wmeta,
 		nil,
 		datadogConfig,
+		nil,
 		nil,
 	), factory
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -18,17 +18,18 @@ import (
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configWebhook "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/tagsfromlabels"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 )
 
 // NewAutoInstrumentation is a helper function to create a fully initialized webhook for SSI. Our webhook is made up of
 // several components, but consumers of this webhook should not need to care about how the webhook is wired together.
-func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.Component) (*Webhook, error) {
+func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.Component, rcClient *rcclient.Client) (*Webhook, error) {
 	config, err := NewConfig(datadogConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auto instrumentation config: %v", err)
 	}
 
-	imageResolver := imageresolver.New(imageresolver.NewConfig(datadogConfig))
+	imageResolver := imageresolver.New(imageresolver.NewConfig(datadogConfig, rcClient))
 	apm, err := NewTargetMutator(config, wmeta, imageResolver)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auto instrumentation namespace mutator: %v", err)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2699,8 +2699,6 @@ func TestAutoinstrumentation(t *testing.T) {
 			mockConfig := common.FakeConfigWithValues(t, test.config)
 			mockMeta := common.FakeStoreWithDeployment(t, test.deployments)
 			mockDynamic := fake.NewSimpleDynamicClient(runtime.NewScheme())
-			// Disable gradual rollout for this test to use the NoOpResolver.
-			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.gradual_rollout.enabled", false)
 
 			// Add the namespaces.
 			for _, ns := range test.namespaces {
@@ -2708,7 +2706,7 @@ func TestAutoinstrumentation(t *testing.T) {
 			}
 
 			// Setup webhook.
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.
@@ -2853,7 +2851,6 @@ func TestEnvVarsAlreadySet(t *testing.T) {
 			mockConfig := common.FakeConfigWithValues(t, test.config)
 			mockMeta := common.FakeStoreWithDeployment(t, test.deployments)
 			mockDynamic := fake.NewSimpleDynamicClient(runtime.NewScheme())
-			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.gradual_rollout.enabled", false)
 
 			// Add the namespaces.
 			for _, ns := range test.namespaces {
@@ -2861,7 +2858,7 @@ func TestEnvVarsAlreadySet(t *testing.T) {
 			}
 
 			// Setup webhook.
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.
@@ -3046,7 +3043,6 @@ func TestSkippedDueToResources(t *testing.T) {
 			mockConfig := common.FakeConfigWithValues(t, test.config)
 			mockMeta := common.FakeStoreWithDeployment(t, test.deployments)
 			mockDynamic := fake.NewSimpleDynamicClient(runtime.NewScheme())
-			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.gradual_rollout.enabled", false)
 
 			// Add the namespaces.
 			for _, ns := range test.namespaces {
@@ -3054,7 +3050,7 @@ func TestSkippedDueToResources(t *testing.T) {
 			}
 
 			// Setup webhook.
-			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta)
+			webhook, err := autoinstrumentation.NewAutoInstrumentation(mockConfig, mockMeta, nil)
 			require.NoError(t, err)
 
 			// Mutate pod.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/config.go
@@ -16,16 +16,26 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
 const (
 	rolloutBucketCount = 10 // Max number of buckets for gradual rollout
 )
 
+// RemoteConfigClient defines the interface we need for remote config operations
+type RemoteConfigClient interface {
+	GetConfigs(product string) map[string]state.RawConfig
+	Subscribe(product string, callback func(map[string]state.RawConfig, func(string, state.ApplyStatus)))
+}
+
 // Config contains information needed to create a Resolver
 type Config struct {
 	Site           string
 	DDRegistries   map[string]struct{}
+	RCClient       RemoteConfigClient
+	MaxInitRetries int
+	InitRetryDelay time.Duration
 	BucketID       string
 	DigestCacheTTL time.Duration
 	Enabled        bool
@@ -38,10 +48,13 @@ func calculateRolloutBucket(apiKey string) string {
 	return strconv.Itoa(int(hashInt % rolloutBucketCount))
 }
 
-func NewConfig(cfg config.Component) Config {
+func NewConfig(cfg config.Component, rcClient RemoteConfigClient) Config {
 	return Config{
 		Site:           cfg.GetString("site"),
 		DDRegistries:   newDatadoghqRegistries(cfg.GetStringSlice("admission_controller.auto_instrumentation.default_dd_registries")),
+		RCClient:       rcClient,
+		MaxInitRetries: 5,
+		InitRetryDelay: 1 * time.Second,
 		BucketID:       calculateRolloutBucket(cfg.GetString("api_key")),
 		DigestCacheTTL: cfg.GetDuration("admission_controller.auto_instrumentation.gradual_rollout.cache_ttl"),
 		Enabled:        cfg.GetBool("admission_controller.auto_instrumentation.gradual_rollout.enabled"),

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/config_test.go
@@ -34,6 +34,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datadoghq.com",
 				DDRegistries:   map[string]struct{}{"gcr.io/datadoghq": {}, "docker.io/datadog": {}, "public.ecr.aws/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "2",
 				DigestCacheTTL: 1 * time.Hour,
 				Enabled:        true,
@@ -50,6 +53,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datadoghq.com",
 				DDRegistries:   map[string]struct{}{"helloworld.io/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "2",
 				DigestCacheTTL: 1 * time.Hour,
 				Enabled:        true,
@@ -65,6 +71,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datad0g.com",
 				DDRegistries:   map[string]struct{}{"gcr.io/datadoghq": {}, "docker.io/datadog": {}, "public.ecr.aws/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "2",
 				DigestCacheTTL: 1 * time.Hour,
 				Enabled:        true,
@@ -81,6 +90,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datadoghq.com",
 				DDRegistries:   map[string]struct{}{"gcr.io/datadoghq": {}, "docker.io/datadog": {}, "public.ecr.aws/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "0",
 				DigestCacheTTL: 1 * time.Hour,
 				Enabled:        true,
@@ -98,6 +110,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datadoghq.com",
 				DDRegistries:   map[string]struct{}{"gcr.io/datadoghq": {}, "docker.io/datadog": {}, "public.ecr.aws/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "0",
 				DigestCacheTTL: 1 * time.Hour,
 				Enabled:        false,
@@ -115,6 +130,9 @@ func TestNewConfig(t *testing.T) {
 			expectedState: Config{
 				Site:           "datadoghq.com",
 				DDRegistries:   map[string]struct{}{"gcr.io/datadoghq": {}, "docker.io/datadog": {}, "public.ecr.aws/datadog": {}},
+				RCClient:       nil,
+				MaxInitRetries: 5,
+				InitRetryDelay: 1 * time.Second,
 				BucketID:       "0",
 				DigestCacheTTL: 2 * time.Hour,
 				Enabled:        true,
@@ -125,7 +143,7 @@ func TestNewConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := tt.configFactory(t)
-			result := NewConfig(mockConfig)
+			result := NewConfig(mockConfig, nil)
 
 			require.Equal(t, tt.expectedState, result)
 		})

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/image.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/image.go
@@ -7,8 +7,28 @@
 
 package imageresolver
 
+// ImageInfo represents information about an image from remote configuration.
+type ImageInfo struct {
+	Tag              string `json:"tag"`
+	Digest           string `json:"digest"`
+	CanonicalVersion string `json:"canonical_version"`
+}
+
+// RepositoryConfig represents a repository configuration from remote config.
+type RepositoryConfig struct {
+	RepositoryName string      `json:"repository_name"`
+	Images         []ImageInfo `json:"images"`
+}
+
 // ResolvedImage represents a fully resolved image with digest and metadata.
 type ResolvedImage struct {
 	FullImageRef     string // e.g., "gcr.io/datadoghq/dd-lib-python-init@sha256:abc123..."
 	CanonicalVersion string // e.g., "3.1.0"
+}
+
+func newResolvedImage(registry string, repositoryName string, imageInfo ImageInfo) *ResolvedImage {
+	return &ResolvedImage{
+		FullImageRef:     registry + "/" + repositoryName + "@" + imageInfo.Digest,
+		CanonicalVersion: imageInfo.CanonicalVersion,
+	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
@@ -10,9 +10,13 @@ package imageresolver
 import (
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -41,6 +45,174 @@ func (r *noOpResolver) Resolve(registry string, repository string, tag string) (
 	log.Debugf("Cannot resolve %s/%s:%s without remote config", registry, repository, tag)
 	metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
 	return nil, false
+}
+
+// remoteConfigImageResolver resolves image references using remote configuration data.
+// It maintains a cache of image mappings received from the remote config service.
+type rcResolver struct {
+	rcClient RemoteConfigClient
+
+	mu                  sync.RWMutex
+	imageMappings       map[string]map[string]ImageInfo // repository name -> tag -> resolved image
+	datadoghqRegistries map[string]struct{}
+
+	// Retry configuration for initial cache loading
+	maxRetries int
+	retryDelay time.Duration
+}
+
+var _ Resolver = (*rcResolver)(nil)
+
+func newRcResolver(cfg Config) Resolver {
+	resolver := &rcResolver{
+		rcClient:            cfg.RCClient,
+		imageMappings:       make(map[string]map[string]ImageInfo),
+		maxRetries:          cfg.MaxInitRetries,
+		retryDelay:          cfg.InitRetryDelay,
+		datadoghqRegistries: cfg.DDRegistries,
+	}
+
+	resolver.rcClient.Subscribe(state.ProductGradualRollout, resolver.processUpdate)
+	log.Debugf("Subscribed to %s", state.ProductGradualRollout)
+
+	go func() {
+		if err := resolver.waitForInitialConfig(); err != nil {
+			log.Warnf("Failed to load initial image resolution config: %v. Image resolution will remain disabled.", err)
+		} else {
+			log.Infof("Image resolution cache initialized successfully")
+		}
+	}()
+
+	return resolver
+}
+
+func (r *rcResolver) waitForInitialConfig() error {
+	if currentConfigs := r.rcClient.GetConfigs(state.ProductGradualRollout); len(currentConfigs) > 0 {
+		log.Debugf("Initial configs available immediately: %d configurations", len(currentConfigs))
+		r.updateCache(currentConfigs)
+		return nil
+	}
+
+	for attempt := 1; attempt <= r.maxRetries; attempt++ {
+		time.Sleep(r.retryDelay)
+
+		currentConfigs := r.rcClient.GetConfigs(state.ProductGradualRollout)
+		if len(currentConfigs) > 0 {
+			log.Infof("Loaded initial image resolution config after %d attempts: %d configurations", attempt, len(currentConfigs))
+			r.updateCache(currentConfigs)
+			return nil
+		}
+
+		log.Debugf("Attempt %d/%d: Still waiting for initial remote config, retrying in %v", attempt, r.maxRetries, r.retryDelay)
+	}
+
+	return fmt.Errorf("failed to load initial remote config after %d attempts (%v total wait)", r.maxRetries, time.Duration(r.maxRetries)*r.retryDelay)
+}
+
+// Resolve resolves a registry, repository, and tag to a digest-based reference.
+// Input: "gcr.io/datadoghq", "dd-lib-python-init", "v3"
+// Output: "dd-lib-python-init@sha256:abc123...", true
+// If resolution fails or is not available, it returns nil.
+// Output: nil, false
+func (r *rcResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
+	if !isDatadoghqRegistry(registry, r.datadoghqRegistries) {
+		log.Debugf("Not a Datadoghq registry, not resolving")
+		return nil, false
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.imageMappings) == 0 {
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
+		return nil, false
+	}
+
+	repoCache, exists := r.imageMappings[repository]
+	if !exists {
+		log.Debugf("No mapping found for repository %s", repository)
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
+		return nil, false
+	}
+
+	normalizedTag := strings.TrimPrefix(tag, "v")
+
+	resolved, exists := repoCache[normalizedTag]
+	if !exists {
+		log.Debugf("No mapping found for %s:%s", repository, normalizedTag)
+		metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
+		return nil, false
+	}
+	resolvedImage := newResolvedImage(registry, repository, resolved)
+	log.Debugf("Resolved %s/%s:%s -> %s", registry, repository, tag, resolvedImage.FullImageRef)
+	metrics.ImageResolutionAttempts.Inc(repository, tag, resolved.Digest)
+	return resolvedImage, true
+}
+
+// updateCache processes configuration data and updates the image mappings cache.
+// This is the core logic shared by both initialization and remote config updates.
+func (r *rcResolver) updateCache(configs map[string]state.RawConfig) {
+	validConfigs, errors := parseAndValidateConfigs(configs)
+
+	for configKey, err := range errors {
+		log.Errorf("Failed to process config %s during initialization: %v", configKey, err)
+	}
+
+	r.updateCacheFromParsedConfigs(validConfigs)
+}
+
+func (r *rcResolver) updateCacheFromParsedConfigs(validConfigs map[string]RepositoryConfig) {
+	newCache := make(map[string]map[string]ImageInfo)
+
+	for _, repo := range validConfigs {
+		tagMap := make(map[string]ImageInfo)
+		for _, imageInfo := range repo.Images {
+			if imageInfo.Tag == "" || imageInfo.Digest == "" {
+				log.Warnf("Skipping invalid image entry (missing tag or digest) in %s", repo.RepositoryName)
+				continue
+			}
+
+			if !isValidDigest(imageInfo.Digest) {
+				log.Warnf("Skipping invalid image entry (invalid digest format: %s) in %s", imageInfo.Digest, repo.RepositoryName)
+				continue
+			}
+
+			tagMap[imageInfo.Tag] = imageInfo
+		}
+
+		newCache[repo.RepositoryName] = tagMap
+		log.Debugf("Processed config for repository %s with %d images", repo.RepositoryName, len(tagMap))
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.imageMappings = newCache
+}
+
+// processUpdate handles remote configuration updates for image resolution.
+//
+// NOTE:
+// - Remote config maintains a complete state of all active configurations
+// - When processUpdate is called, it receives the complete current state via GetConfigs()
+// - If a repository is not in the update, it means it's no longer active
+// - Therefore, replacing the entire cache ensures we stay in sync with remote config
+func (r *rcResolver) processUpdate(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	validConfigs, errors := parseAndValidateConfigs(update)
+
+	r.updateCacheFromParsedConfigs(validConfigs)
+
+	for configKey := range update {
+		if err, hasError := errors[configKey]; hasError {
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: err.Error(),
+			})
+		} else {
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+			})
+		}
+	}
 }
 
 // bucketTagResolver resolves image references using bucket tags.
@@ -100,10 +272,14 @@ func newBucketTagResolver(cfg Config) *bucketTagResolver {
 }
 
 // New creates the appropriate Resolver based on whether
-// gradual rollout is enabled.
+// a remote config client is available.
 func New(cfg Config) Resolver {
 	if !cfg.Enabled {
 		return NewNoOpResolver()
 	}
-	return newBucketTagResolver(cfg)
+	if cfg.RCClient == nil || reflect.ValueOf(cfg.RCClient).IsNil() {
+		log.Debugf("No remote config client available")
+		return NewNoOpResolver()
+	}
+	return newRcResolver(cfg)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver_test.go
@@ -8,35 +8,127 @@
 package imageresolver
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"sync"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// mockRCClient is a lightweight mock that implements RemoteConfigClient
+type mockRCClient struct {
+	configs     map[string]state.RawConfig
+	subscribers map[string]func(map[string]state.RawConfig, func(string, state.ApplyStatus))
+
+	// For async testing
+	blockGetConfigs bool
+	configsReady    chan struct{}
+	mu              sync.Mutex
+}
+
+// loadTestConfigFile loads a test data file and converts it to the format returned by rcClient.GetConfigs()
+func loadTestConfigFile(filename string) (map[string]state.RawConfig, error) {
+	data, err := os.ReadFile(filepath.Join("testdata", filename))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read test data file %s: %v", filename, err)
+	}
+
+	var repoConfigs map[string]RepositoryConfig
+	if err := json.Unmarshal(data, &repoConfigs); err != nil {
+		return nil, fmt.Errorf("failed to parse test data: %v", err)
+	}
+
+	// Convert each repository config to RawConfig format (as rcClient.GetConfigs() would return)
+	rawConfigs := make(map[string]state.RawConfig)
+	for configName, repoConfig := range repoConfigs {
+		configJSON, err := json.Marshal(repoConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal config %s: %v", configName, err)
+		}
+		rawConfigs[configName] = state.RawConfig{Config: configJSON}
+	}
+
+	return rawConfigs, nil
+}
+
+func newMockRCClient(filename string) *mockRCClient {
+	rawConfigs, err := loadTestConfigFile(filename)
+	if err != nil {
+		panic(err)
+	}
+
+	return &mockRCClient{
+		configs:         rawConfigs,
+		subscribers:     make(map[string]func(map[string]state.RawConfig, func(string, state.ApplyStatus))),
+		blockGetConfigs: false,
+		configsReady:    make(chan struct{}),
+	}
+}
+
+func (m *mockRCClient) Subscribe(product string, _ func(map[string]state.RawConfig, func(string, state.ApplyStatus))) {
+	log.Debugf("Would subscribe called with product on RCClient: %s", product)
+}
+
+func (m *mockRCClient) GetConfigs(_ string) map[string]state.RawConfig {
+	m.mu.Lock()
+	shouldBlock := m.blockGetConfigs
+	channel := m.configsReady
+	m.mu.Unlock()
+
+	if shouldBlock {
+		<-channel
+	}
+
+	return m.configs
+}
+
+func (m *mockRCClient) setBlocking(block bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Only close when switching from blocking to non-blocking
+	if !block && m.blockGetConfigs {
+		close(m.configsReady)
+	}
+
+	m.blockGetConfigs = block
+}
+
 func TestNew(t *testing.T) {
-	t.Run("gradual_rollout_enabled", func(t *testing.T) {
-		mockConfig := NewConfig(config.NewMock(t))
+	t.Run("with_remote_config_client", func(t *testing.T) {
+		mockClient := newMockRCClient("multi_repo.json")
+		mockConfig := NewConfig(config.NewMock(t), mockClient)
 		resolver := New(mockConfig)
 
-		_, ok := resolver.(*bucketTagResolver)
-		assert.True(t, ok, "Should return bucketTagResolver when gradual rollout is enabled")
+		_, ok := resolver.(*rcResolver)
+		assert.True(t, ok, "Should return remoteConfigImageResolver when rcClient is not nil")
 	})
 
-	t.Run("gradual_rollout_disabled", func(t *testing.T) {
-		mockConfig := Config{
-			Enabled: false,
-		}
-		mockConfig.Enabled = false
+	t.Run("without_remote_config_client__typed_nil", func(t *testing.T) {
+		mockConfig := NewConfig(config.NewMock(t), (*mockRCClient)(nil))
 		resolver := New(mockConfig)
 
 		_, ok := resolver.(*noOpResolver)
-		assert.True(t, ok, "Should return noOpImageResolver when gradual rollout is disabled")
+		assert.True(t, ok, "Should return noOpImageResolver when rcClient is nil")
+	})
+
+	t.Run("without_remote_config_client__untyped_nil", func(t *testing.T) {
+		mockConfig := NewConfig(config.NewMock(t), nil)
+		resolver := New(mockConfig)
+
+		_, ok := resolver.(*noOpResolver)
+		assert.True(t, ok, "Should return noOpImageResolver when rcClient is nil")
 	})
 }
 
@@ -76,6 +168,281 @@ func TestNoOpResolver_Resolve(t *testing.T) {
 			assert.False(t, ok, "NoOpImageResolver should always return false")
 		})
 	}
+}
+
+func TestRcResolver_processUpdate(t *testing.T) {
+	resolver := &rcResolver{
+		imageMappings: make(map[string]map[string]ImageInfo),
+	}
+
+	testConfigs, err := loadTestConfigFile("multi_repo.json")
+	require.NoError(t, err)
+
+	t.Run("multiple_repositories", func(t *testing.T) {
+		appliedStatuses := make(map[string]state.ApplyStatus)
+		applyStateCallback := func(cfgPath string, status state.ApplyStatus) {
+			appliedStatuses[cfgPath] = status
+		}
+
+		resolver.processUpdate(testConfigs, applyStateCallback)
+
+		assert.Len(t, resolver.imageMappings, 4) // python, java, js, apm-inject
+		assert.Contains(t, resolver.imageMappings, "dd-lib-python-init")
+		assert.Contains(t, resolver.imageMappings, "dd-lib-java-init")
+		assert.Contains(t, resolver.imageMappings, "dd-lib-js-init")
+		assert.Contains(t, resolver.imageMappings, "apm-inject")
+
+		// Verify apply statuses were called
+		assert.Len(t, appliedStatuses, 4)
+		for _, status := range appliedStatuses {
+			assert.Equal(t, state.ApplyStateAcknowledged, status.State)
+		}
+	})
+
+	t.Run("empty_update_clears_cache", func(t *testing.T) {
+		update := map[string]state.RawConfig{}
+
+		appliedStatuses := make(map[string]state.ApplyStatus)
+		applyStateCallback := func(cfgPath string, status state.ApplyStatus) {
+			appliedStatuses[cfgPath] = status
+		}
+
+		resolver.processUpdate(update, applyStateCallback)
+
+		assert.Len(t, resolver.imageMappings, 0)
+		assert.Len(t, appliedStatuses, 0)
+	})
+}
+
+func TestRcResolver_EmptyConfig(t *testing.T) {
+	resolver := &rcResolver{
+		imageMappings: make(map[string]map[string]ImageInfo),
+	}
+
+	resolver.processUpdate(map[string]state.RawConfig{}, func(string, state.ApplyStatus) {})
+
+	resolved, ok := resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+	assert.False(t, ok, "Resolution should fail with empty config")
+	assert.Nil(t, resolved, "Should not return resolved image with empty cache")
+}
+
+func TestRcResolver_Resolve(t *testing.T) {
+	mockRCClient := newMockRCClient("multi_repo.json")
+	resolver := newRcResolver(NewConfig(config.NewMock(t), mockRCClient))
+
+	testCases := []struct {
+		name           string
+		registry       string
+		repository     string
+		tag            string
+		expectedResult string
+		expectedOK     bool
+	}{
+		{
+			name:           "successful_resolution_latest",
+			registry:       "gcr.io/datadoghq",
+			repository:     "dd-lib-python-init",
+			tag:            "latest",
+			expectedResult: "gcr.io/datadoghq/dd-lib-python-init@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedOK:     true,
+		},
+		{
+			name:           "successful_resolution_versioned",
+			registry:       "gcr.io/datadoghq",
+			repository:     "dd-lib-python-init",
+			tag:            "3",
+			expectedResult: "gcr.io/datadoghq/dd-lib-python-init@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			expectedOK:     true,
+		},
+		{
+			name:       "non_existent_repository",
+			registry:   "gcr.io/datadoghq",
+			repository: "dd-lib-hello-init",
+			tag:        "latest",
+			expectedOK: false,
+		},
+		{
+			name:       "non_existent_tag",
+			registry:   "gcr.io/datadoghq",
+			repository: "dd-lib-python-init",
+			tag:        "2",
+			expectedOK: false,
+		},
+		{
+			name:           "versioned_tag_with_v",
+			registry:       "gcr.io/datadoghq",
+			repository:     "dd-lib-python-init",
+			tag:            "v3",
+			expectedResult: "gcr.io/datadoghq/dd-lib-python-init@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+			expectedOK:     true,
+		},
+		{
+			name:       "non_datadog_registry_rejected",
+			registry:   "docker.io",
+			repository: "dd-lib-python-init",
+			tag:        "latest",
+			expectedOK: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolved, ok := resolver.Resolve(tc.registry, tc.repository, tc.tag)
+
+			if tc.expectedOK {
+				assert.Eventually(t, func() bool {
+					resolved, ok = resolver.Resolve(tc.registry, tc.repository, tc.tag)
+					return ok
+				}, 100*time.Millisecond, 5*time.Millisecond, "Should resolve after async init")
+
+				require.NotNil(t, resolved, "Should have resolved image when expectedOK is true")
+				assert.Equal(t, tc.expectedResult, resolved.FullImageRef, "Resolved image should match expected")
+			} else {
+				assert.Nil(t, resolved, "Should not have resolved image when expectedOK is false")
+			}
+		})
+	}
+
+	// Test empty cache
+	t.Run("empty_cache", func(t *testing.T) {
+		emptyResolver := &rcResolver{
+			imageMappings: make(map[string]map[string]ImageInfo),
+		}
+		resolved, ok := emptyResolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+		assert.False(t, ok, "Resolution should fail with empty cache")
+		assert.Nil(t, resolved, "Should not return resolved image with empty cache")
+	})
+}
+
+func TestRcResolver_ErrorHandling(t *testing.T) {
+	resolver := &rcResolver{
+		imageMappings: make(map[string]map[string]ImageInfo),
+	}
+
+	testCases := []struct {
+		name           string
+		rawConfig      map[string]state.RawConfig
+		expectedErrors int
+		description    string
+	}{
+		{
+			name: "invalid_json",
+			rawConfig: map[string]state.RawConfig{
+				"bad-config": {Config: []byte(`{invalid json}`)},
+			},
+			expectedErrors: 1,
+			description:    "Should handle malformed JSON gracefully",
+		},
+		{
+			name: "missing_repository_name",
+			rawConfig: map[string]state.RawConfig{
+				"incomplete-config": {Config: []byte(`{"repository_url": "gcr.io/test", "images": []}`)},
+			},
+			expectedErrors: 1,
+			description:    "Should reject configs missing required fields",
+		},
+		{
+			name: "images_with_missing_fields",
+			rawConfig: map[string]state.RawConfig{
+				"partial-images": {Config: []byte(`{
+                    "repository_name": "test-repo",
+                    "repository_url": "gcr.io/test",
+                    "images": [
+                        {"tag": "v1", "digest": ""},
+                        {"tag": "", "digest": "sha256:abc"},
+                        {"tag": "v2", "digest": "sha256:def"}
+                    ]
+                }`)},
+			},
+			expectedErrors: 0, // Should process valid images, skip invalid ones
+			description:    "Should skip images with missing tag/digest",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var appliedStatuses []state.ApplyStatus
+			resolver.processUpdate(tc.rawConfig, func(_ string, status state.ApplyStatus) {
+				appliedStatuses = append(appliedStatuses, status)
+			})
+
+			errorCount := 0
+			for _, status := range appliedStatuses {
+				if status.State == state.ApplyStateError {
+					errorCount++
+				}
+			}
+			assert.Equal(t, tc.expectedErrors, errorCount, tc.description)
+		})
+	}
+}
+
+func TestRcResolver_InvalidDigestValidation(t *testing.T) {
+	testConfigs, err := loadTestConfigFile("invalid_digest.json")
+	require.NoError(t, err)
+
+	resolver := &rcResolver{
+		imageMappings: make(map[string]map[string]ImageInfo),
+	}
+
+	resolver.updateCache(testConfigs)
+
+	t.Run("cache_contains_only_valid_digests", func(t *testing.T) {
+		resolver.mu.RLock()
+		defer resolver.mu.RUnlock()
+
+		repoCache, exists := resolver.imageMappings["dd-lib-test-digest-validation"]
+		require.True(t, exists, "Repository should exist in cache after processing")
+
+		assert.Len(t, repoCache, 1, "Cache should contain exactly 1 image with valid digest")
+
+		for tag, imageInfo := range repoCache {
+			assert.True(t, isValidDigest(imageInfo.Digest),
+				"Image %s should have valid digest format, got: %s", tag, imageInfo.Digest)
+		}
+
+		assert.Contains(t, repoCache, "latest", "Should contain image with valid digest")
+
+		// Verify specific invalid digest formats are NOT in cache
+		assert.NotContains(t, repoCache, "invalid-short", "Should not contain image with short digest")
+		assert.NotContains(t, repoCache, "missing-prefix", "Should not contain image missing sha256: prefix")
+		assert.NotContains(t, repoCache, "invalid-algorithm", "Should not contain image with unsupported algorithm")
+		assert.NotContains(t, repoCache, "malformed", "Should not contain image with malformed digest")
+		assert.NotContains(t, repoCache, "empty", "Should not contain image with empty digest")
+	})
+}
+
+func TestRcResolver_ConcurrentAccess(t *testing.T) {
+	resolver := newRcResolver(NewConfig(config.NewMock(t), newMockRCClient("multi_repo.json")))
+
+	t.Run("concurrent_read_write", func(_ *testing.T) {
+		var wg sync.WaitGroup
+		numReaders := 10
+		numWriters := 3
+
+		for i := 0; i < numReaders; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					_, _ = resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+				}
+			}()
+		}
+
+		for i := 0; i < numWriters; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 10; j++ {
+					resolver.(*rcResolver).processUpdate(map[string]state.RawConfig{}, func(string, state.ApplyStatus) {})
+					time.Sleep(10 * time.Millisecond)
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
 }
 
 func TestIsDatadoghqRegistry(t *testing.T) {
@@ -120,6 +487,55 @@ func TestIsDatadoghqRegistry(t *testing.T) {
 			assert.Equal(t, tc.expected, result, "isDatadoghqRegistry(%s) should return %v", tc.registry, tc.expected)
 		})
 	}
+}
+
+func TestRcResolver_AsyncInitialization(t *testing.T) {
+	t.Run("noop_during_initialization", func(t *testing.T) {
+		mockClient := newMockRCClient("multi_repo.json")
+		mockClient.setBlocking(true) // Block initialization
+
+		resolver := newRcResolver(NewConfig(config.NewMock(t), mockClient))
+
+		resolved, ok := resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+		assert.False(t, ok, "Should not complete image resolution during initialization")
+		assert.Nil(t, resolved, "Should return nil during initialization")
+	})
+
+	t.Run("successful_async_initialization", func(t *testing.T) {
+		mockClient := newMockRCClient("multi_repo.json")
+		mockClient.setBlocking(true)
+
+		resolver := newRcResolver(NewConfig(config.NewMock(t), mockClient))
+
+		resolved, ok := resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+		assert.False(t, ok, "Should not complete image resolution during initialization")
+		assert.Nil(t, resolved, "Should return nil during initialization")
+
+		mockClient.setBlocking(false)
+
+		assert.Eventually(t, func() bool {
+			_, ok := resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+			return ok
+		}, 100*time.Millisecond, 5*time.Millisecond, "Should resolve after async init")
+	})
+
+	t.Run("failed_initialization_stays_noop", func(t *testing.T) {
+		// Empty configs cause initialization to fail
+		mockClient := &mockRCClient{
+			configs:         map[string]state.RawConfig{},
+			subscribers:     make(map[string]func(map[string]state.RawConfig, func(string, state.ApplyStatus))),
+			blockGetConfigs: false,
+			configsReady:    make(chan struct{}),
+		}
+		close(mockClient.configsReady)
+
+		resolver := newRcResolver(NewConfig(config.NewMock(t), mockClient))
+		time.Sleep(50 * time.Millisecond)
+
+		resolved, ok := resolver.Resolve("gcr.io/datadoghq", "dd-lib-python-init", "latest")
+		assert.False(t, ok, "Should not complete image resolution after failed init")
+		assert.Nil(t, resolved, "Should return nil after failed init")
+	})
 }
 
 func newMockBucketTagResolver(ttl time.Duration, bucketID string) bucketTagResolver {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/testdata/invalid_digest.json
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/testdata/invalid_digest.json
@@ -1,0 +1,38 @@
+{
+  "employee/K8S_INJECTION_DD/1.dd-lib-test-digest-validation.json/config":
+    {
+      "repository_name": "dd-lib-test-digest-validation",
+      "images": [
+        {
+          "tag": "latest",
+          "digest": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "canonical_version": "1.0.0"
+        },
+        {
+          "tag": "invalid-short",
+          "digest": "sha256:abcdef",
+          "canonical_version": "1.0.1"
+        },
+        {
+          "tag": "missing-prefix",
+          "digest": "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "canonical_version": "1.0.2"
+        },
+        {
+          "tag": "invalid-algorithm",
+          "digest": "md5:5d41402abc4b2a76b9719d911017c592",
+          "canonical_version": "1.0.3"
+        },
+        {
+          "tag": "malformed",
+          "digest": "not-a-valid-digest-at-all",
+          "canonical_version": "1.0.4"
+        },
+        {
+          "tag": "empty",
+          "digest": "",
+          "canonical_version": "1.0.5"
+        }
+      ]
+    }
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/testdata/multi_repo.json
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/testdata/multi_repo.json
@@ -1,0 +1,66 @@
+{
+  "employee/K8S_INJECTION_DD/1.dd-lib-python-init.json/config":
+    {
+      "repository_name": "dd-lib-python-init",
+      "images": [
+        {
+          "tag": "latest",
+          "digest": "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+          "canonical_version": "3.1.0"
+        },
+        {
+          "tag": "3",
+          "digest": "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+          "canonical_version": "3.0.0"
+        }
+      ]
+    },
+  "employee/K8S_INJECTION_DD/2.dd-lib-java-init.json/config":
+    {
+      "repository_name": "dd-lib-java-init",
+      "images": [
+        {
+          "tag": "latest",
+          "digest": "sha256:fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+          "canonical_version": "1.5.2"
+        },
+        {
+          "tag": "1",
+          "digest": "sha256:0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba",
+          "canonical_version": "1.0.0"
+        }
+      ]
+    },
+  "employee/K8S_INJECTION_DD/3.dd-lib-js-init.json/config":
+    {
+      "repository_name": "dd-lib-js-init",
+      "images": [
+        {
+          "tag": "latest",
+          "digest": "sha256:123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          "canonical_version": "5.2.1"
+        },
+        {
+          "tag": "5",
+          "digest": "sha256:456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01",
+          "canonical_version": "5.0.0"
+        }
+      ]
+    },
+  "employee/K8S_INJECTION_DD/1.apm-inject.json/config":
+    {
+      "repository_name": "apm-inject",
+      "images": [
+        {
+          "tag": "latest",
+          "digest": "sha256:1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890",
+          "canonical_version": "0.2.1"
+        },
+        {
+          "tag": "0",
+          "digest": "sha256:9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba",
+          "canonical_version": "0.2.1"
+        }
+      ]
+    }
+  }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/util.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/util.go
@@ -10,8 +10,11 @@
 package imageresolver
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/opencontainers/go-digest"
 )
 
@@ -35,4 +38,23 @@ func isValidDigest(digestStr string) bool {
 		return false
 	}
 	return strings.HasPrefix(digestStr, "sha256:")
+}
+
+func parseAndValidateConfigs(configs map[string]state.RawConfig) (map[string]RepositoryConfig, map[string]error) {
+	validConfigs := make(map[string]RepositoryConfig)
+	errors := make(map[string]error)
+	for configKey, rawConfig := range configs {
+		var repo RepositoryConfig
+		if err := json.Unmarshal(rawConfig.Config, &repo); err != nil {
+			errors[configKey] = fmt.Errorf("failed to unmarshal: %w", err)
+			continue
+		}
+
+		if repo.RepositoryName == "" {
+			errors[configKey] = fmt.Errorf("missing repository_name in config %s", configKey)
+			continue
+		}
+		validConfigs[configKey] = repo
+	}
+	return validConfigs, errors
 }

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/secret"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
+	rcclient "github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -36,6 +37,7 @@ type ControllerContext struct {
 	StopCh                       chan struct{}
 	ValidatingStopCh             chan struct{}
 	Demultiplexer                demultiplexer.Component
+	RcClient                     *rcclient.Client
 }
 
 // StartControllers starts the secret and webhook controllers
@@ -96,6 +98,7 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa wo
 		pa,
 		datadogConfig,
 		ctx.Demultiplexer,
+		ctx.RcClient,
 	)
 
 	go secretController.Run(ctx.StopCh)


### PR DESCRIPTION
Reverts DataDog/datadog-agent#46224

#incident-49510