### PR TITLE
new-e2e-ssi: remove unnecessary dep causing the job to be skipped

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -1077,7 +1077,6 @@ new-e2e-ssi:
     - !reference [.needs_new_e2e_template]
     - qa_dca
     - qa_agent_linux
-    - qa_agent_full
   variables:
     TARGETS: ./tests/ssi
     TEAM: injection-platform

--- a/test/new-e2e/tests/ssi/provisioner.go
+++ b/test/new-e2e/tests/ssi/provisioner.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
 )
 
-// ProvisionerOptions contains the common options for Kubernetes provisioners
+// ProvisionerOptions contains the common options for Kubernetes provisioners.
 type ProvisionerOptions struct {
 	AgentOptions                  []kubernetesagentparams.Option
 	WorkloadAppFunc               kubeComp.WorkloadAppFunc


### PR DESCRIPTION
### What does this PR do?

Removes an unnecessary job dependency that was causing the SSI e2e job to be skipped.

### Motivation

The SSI e2e job did not always run when files in its path triggers were modified.

### Describe how you validated your changes

### Additional Notes
