### PR TITLE
[PROF-13667] Converter: Verify and enforce 'don't override, only add' behavior

### DIFF
--- a/comp/host-profiler/README.md
+++ b/comp/host-profiler/README.md
@@ -85,7 +85,7 @@ Configuration converters normalize user-provided OTEL collector configs for the 
 
 Files:
 
-- **[`converters.go`](collector/impl/converters/converters.go)** - Shared helpers (`Get`, `Set`, `SetIfAbsent`, `Ensure`) for path-based config manipulation, and configuration converter factories.
+- **[`converters.go`](collector/impl/converters/converters.go)** - Shared helpers (`Get`, `Set`, `EnsureDefault`, `Ensure`) for path-based config manipulation, and configuration converter factories.
 - **[`converter_with_agent.go`](collector/impl/converters/converter_with_agent.go)** - Converter applied when running alongside the Datadog Agent. Can infer missing config (exporters, endpoints) from the Agent's own configuration.
 - **[`converter_without_agent.go`](collector/impl/converters/converter_without_agent.go)** - Converter applied when running standalone (without the Agent). Cannot infer external settings, so it errors out if required config (API keys, exporters) is missing.
 

--- a/comp/host-profiler/README.md
+++ b/comp/host-profiler/README.md
@@ -76,7 +76,18 @@ Datadog Platform
 
 #### `collector/impl/converters/`
 
-- **[`converters.go`](collector/impl/converters/converters.go)** - Implements configuration converters that remove Agent-dependent components from the pipeline when running without Agent Core.
+Configuration converters normalize user-provided OTEL collector configs for the host profiler. They follow the **"explicit config wins"** principle:
+
+- **User-set leaf configs are never overwritten.** If a user explicitly sets a value, even if incompatible with what Datadog needs, the converter preserves it.
+- **Missing configs are added.** If a required leaf config is not defined, the converter adds it along with all required parent keys using sensible defaults.
+- **Incompatible values generate warnings.** If a user-set value conflicts with Datadog requirements (e.g. host.arch disabled), a warning is logged but the user's value is preserved.
+- **External settings error out.** Configs that require external information (API keys, endpoints) that cannot be inferred will cause an error in standalone mode.
+
+Files:
+
+- **[`converters.go`](collector/impl/converters/converters.go)** - Shared helpers (`Get`, `Set`, `SetIfAbsent`, `Ensure`) for path-based config manipulation, and configuration converter factories.
+- **[`converter_with_agent.go`](collector/impl/converters/converter_with_agent.go)** - Converter applied when running alongside the Datadog Agent. Can infer missing config (exporters, endpoints) from the Agent's own configuration.
+- **[`converter_without_agent.go`](collector/impl/converters/converter_without_agent.go)** - Converter applied when running standalone (without the Agent). Cannot infer external settings, so it errors out if required config (API keys, exporters) is missing.
 
 #### `collector/impl/receiver/`
 

--- a/comp/host-profiler/README.md
+++ b/comp/host-profiler/README.md
@@ -85,7 +85,7 @@ Configuration converters normalize user-provided OTEL collector configs for the 
 
 Files:
 
-- **[`converters.go`](collector/impl/converters/converters.go)** - Shared helpers (`Get`, `Set`, `EnsureDefault`, `Ensure`) for path-based config manipulation, and configuration converter factories.
+- **[`converters.go`](collector/impl/converters/converters.go)** - Shared helpers (`Get`, `Set`, `SetDefault`, `Ensure`) for path-based config manipulation, and configuration converter factories.
 - **[`converter_with_agent.go`](collector/impl/converters/converter_with_agent.go)** - Converter applied when running alongside the Datadog Agent. Can infer missing config (exporters, endpoints) from the Agent's own configuration.
 - **[`converter_without_agent.go`](collector/impl/converters/converter_without_agent.go)** - Converter applied when running standalone (without the Agent). Cannot infer external settings, so it errors out if required config (API keys, exporters) is missing.
 

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -514,6 +514,31 @@ func TestConverterWithoutAgent(t *testing.T) {
 			provided: "no_agent/headers-wrong-type/in.yaml",
 			expected: "no_agent/headers-wrong-type/out.yaml",
 		},
+		{
+			name:     "preserve-host-arch",
+			provided: "no_agent/preserve-host-arch/in.yaml",
+			expected: "no_agent/preserve-host-arch/out.yaml",
+		},
+		{
+			name:     "preserve-host-name",
+			provided: "no_agent/preserve-host-name/in.yaml",
+			expected: "no_agent/preserve-host-name/out.yaml",
+		},
+		{
+			name:     "preserve-os-type",
+			provided: "no_agent/preserve-os-type/in.yaml",
+			expected: "no_agent/preserve-os-type/out.yaml",
+		},
+		{
+			name:     "preserve-all-res-attrs",
+			provided: "no_agent/preserve-all-res-attrs/in.yaml",
+			expected: "no_agent/preserve-all-res-attrs/out.yaml",
+		},
+		{
+			name:     "preserve-res-attrs-no-system",
+			provided: "no_agent/preserve-res-attrs-no-system/in.yaml",
+			expected: "no_agent/preserve-res-attrs-no-system/out.yaml",
+		},
 	}
 
 	runSuccessTests(t, &converterWithoutAgent{}, tests)

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -341,10 +341,12 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 
 		// Track if we have infraattributes
 		if isComponentType(name, componentTypeInfraAttributes) {
-			if ddDefaultValue, err := SetDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
+			ddDefaultValue, err := SetDefault(processors, name+"::"+fieldAllowHostnameOverride, true)
+			if err != nil {
 				return nil, err
-			} else if !ddDefaultValue {
-				log.Warn("allow_hostname_override is required but is disabled by user config; preserving user value")
+			}
+			if !ddDefaultValue {
+				log.Warn("allow_hostname_override is required but is disabled by user configuration; preserving user value.")
 			}
 			foundInfraattributes = true
 		}

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -341,9 +341,10 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 
 		// Track if we have infraattributes
 		if isComponentType(name, componentTypeInfraAttributes) {
-			// Make sure allow_hostname_override is true
-			if err := Set(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
+			if set, err := SetIfAbsent(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
 				return nil, err
+			} else if !set {
+				log.Warn("allow_hostname_override is required but is disabled by user config; preserving user value")
 			}
 			foundInfraattributes = true
 		}

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -341,9 +341,9 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 
 		// Track if we have infraattributes
 		if isComponentType(name, componentTypeInfraAttributes) {
-			if isDefaultValue, err := EnsureDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
+			if ddDefaultValue, err := EnsureDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
 				return nil, err
-			} else if !isDefaultValue {
+			} else if !ddDefaultValue {
 				log.Warn("allow_hostname_override is required but is disabled by user config; preserving user value")
 			}
 			foundInfraattributes = true

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -341,9 +341,9 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 
 		// Track if we have infraattributes
 		if isComponentType(name, componentTypeInfraAttributes) {
-			if set, err := SetIfAbsent(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
+			if isDefaultValue, err := EnsureDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
 				return nil, err
-			} else if !set {
+			} else if !isDefaultValue {
 				log.Warn("allow_hostname_override is required but is disabled by user config; preserving user value")
 			}
 			foundInfraattributes = true

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -341,7 +341,7 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 
 		// Track if we have infraattributes
 		if isComponentType(name, componentTypeInfraAttributes) {
-			if ddDefaultValue, err := EnsureDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
+			if ddDefaultValue, err := SetDefault(processors, name+"::"+fieldAllowHostnameOverride, true); err != nil {
 				return nil, err
 			} else if !ddDefaultValue {
 				log.Warn("allow_hostname_override is required but is disabled by user config; preserving user value")

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -238,18 +238,18 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	if set, err := SetIfAbsent(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
+	if isDefaultValue, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
 		return err
-	} else if !set {
+	} else if !isDefaultValue {
 		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value")
 	}
 
 	// Only set these defaults if we added the system detector
 	if !hasSystemDetector {
-		if _, err := SetIfAbsent(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
+		if _, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
 			return err
 		}
-		if _, err := SetIfAbsent(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
+		if _, err := EnsureDefault(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
 			return err
 		}
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -238,18 +238,18 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	if ddDefaultValue, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
+	if ddDefaultValue, err := SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
 		return err
 	} else if !ddDefaultValue {
-		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value")
+		standaloneLogger.Warn("host.arch is required but is disabled by user configuration and will break symbol uploading; preserving user value")
 	}
 
 	// Only set these defaults if we added the system detector
 	if !hasSystemDetector {
-		if _, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
+		if _, err := SetDefault(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
 			return err
 		}
-		if _, err := EnsureDefault(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
+		if _, err := SetDefault(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
 			return err
 		}
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -238,16 +238,18 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	if err := Set(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
+	if set, err := SetIfAbsent(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
 		return err
+	} else if !set {
+		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value")
 	}
 
 	// Only set these defaults if we added the system detector
 	if !hasSystemDetector {
-		if err := Set(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
+		if _, err := SetIfAbsent(resourceDetection, "system::resource_attributes::host.name::enabled", false); err != nil {
 			return err
 		}
-		if err := Set(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
+		if _, err := SetIfAbsent(resourceDetection, "system::resource_attributes::os.type::enabled", false); err != nil {
 			return err
 		}
 	}

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -241,7 +241,7 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	if ddDefaultValue, err := SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
 		return err
 	} else if !ddDefaultValue {
-		standaloneLogger.Warn("host.arch is required but is disabled by user configuration and will break symbol uploading; preserving user value")
+		standaloneLogger.Warn("host.arch is required but is disabled by user configuration and will break symbolication; preserving user value")
 	}
 
 	// Only set these defaults if we added the system detector

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -238,10 +238,12 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	if ddDefaultValue, err := SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
+	ddDefaultValue, err := SetDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true)
+	if err != nil {
 		return err
-	} else if !ddDefaultValue {
-		standaloneLogger.Warn("host.arch is required but is disabled by user configuration and will break symbolication; preserving user value")
+	}
+	if !ddDefaultValue {
+		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value. Profiles for compiled languages will be missing symbols.")
 	}
 
 	// Only set these defaults if we added the system detector

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -238,9 +238,9 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 	}
 
 	// Always ensure host.arch is enabled
-	if isDefaultValue, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
+	if ddDefaultValue, err := EnsureDefault(resourceDetection, "system::resource_attributes::host.arch::enabled", true); err != nil {
 		return err
-	} else if !isDefaultValue {
+	} else if !ddDefaultValue {
 		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value")
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -196,13 +196,13 @@ func Set[T any](c confMap, path string, value T) error {
 	return nil
 }
 
-// SetIfAbsent sets a value only if the key does not already exist at the given path.
-// If the key already exists, the existing value is preserved and the function returns false.
+// EnsureDefault sets a default value if the key does not exist or already holds the same value.
+// If the key exists with a different value, the existing value is preserved (user override wins).
 // Path segments are separated by "::".
 // Creates intermediate maps as needed.
-// Returns true if the value was set, false if a value already existed (preserved).
-// Returns an error if an intermediate path element exists but is not a map.
-func SetIfAbsent[T any](c confMap, path string, value T) (bool, error) {
+// Returns true if the default is active (set or already matching), false if a user override was preserved.
+// Returns an error only if path traversal fails (intermediate element is not a map).
+func EnsureDefault[T any](c confMap, path string, value T) (bool, error) {
 	currentMap, target, err := ensurePath(c, path)
 	if err != nil {
 		return false, err

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -196,8 +196,8 @@ func SetDefault[T any](c confMap, path string, value T) (bool, error) {
 		return false, err
 	}
 
-	if existingValue, exists := currentMap[target]; exists && !reflect.DeepEqual(existingValue, value) {
-		return false, nil
+	if existingValue, exists := currentMap[target]; exists {
+		return reflect.DeepEqual(existingValue, value), nil
 	}
 	currentMap[target] = value
 	return true, nil

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -5,22 +5,10 @@
 
 //go:build linux
 
-// Package converters implements the converters for the host profiler collector.
+// Package converters implements OTEL collector configuration converters for the host profiler.
 //
-// # Configuration Converter Behavior
-//
-// Converters normalize user-provided OTEL collector configs for the host profiler.
-// They follow the "explicit config wins" principle:
-//
-//   - User-set leaf configs are never overwritten. If a user explicitly sets a value,
-//     even if incompatible with what Datadog needs, the converter preserves it.
-//   - Missing configs are added. If a required leaf config is not defined, the converter
-//     adds it along with all required parent keys using sensible defaults.
-//   - Incompatible values generate warnings. If a user-set value conflicts with
-//     Datadog requirements (e.g. host.arch disabled), a warning is logged but the
-//     user's value is preserved.
-//   - External settings error out. Configs that require external information (API keys,
-//     endpoints) that cannot be inferred will cause an error in standalone mode.
+// Converters normalize user-provided OTEL collector configs by adding required Datadog-specific
+// components while preserving explicit user configuration values wherever possible.
 package converters
 
 import (
@@ -196,13 +184,13 @@ func Set[T any](c confMap, path string, value T) error {
 	return nil
 }
 
-// EnsureDefault sets a default value if the key does not exist or already holds the same value.
+// SetDefault sets a default value if the key does not exist or already holds the same value.
 // If the key exists with a different value, the existing value is preserved (user override wins).
 // Path segments are separated by "::".
 // Creates intermediate maps as needed.
 // Returns true if the default is active (set or already matching), false if a user override was preserved.
 // Returns an error only if path traversal fails (intermediate element is not a map).
-func EnsureDefault[T any](c confMap, path string, value T) (bool, error) {
+func SetDefault[T any](c confMap, path string, value T) (bool, error) {
 	currentMap, target, err := ensurePath(c, path)
 	if err != nil {
 		return false, err

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
@@ -1,42 +1,42 @@
 exporters:
-  otlphttp/datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
-  otlphttp/us3.datadoghq.com_0:
-    headers:
-      dd-api-key: us3_api_key
-    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    otlphttp/us3.datadoghq.com_0:
+        headers:
+            dd-api-key: us3_api_key
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
-  resource/dd-profiler-internal-metadata:
-    attributes:
-    - action: upsert
-      key: profiler_name
-      value: full-host-profiler
-    - action: upsert
-      key: profiler_version
-      value: 7.0.0-test
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: us3_api_key
-        site: us3.datadoghq.com
-      - api_key: test_api_key_123
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: us3_api_key
+                  site: us3.datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp/us3.datadoghq.com_0
-      - otlphttp/datadoghq.com_0
-      processors:
-      - infraattributes/default
-      - resource/dd-profiler-internal-metadata
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/us3.datadoghq.com_0
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
@@ -1,34 +1,34 @@
 exporters:
-  otlphttp/us3.datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+    otlphttp/us3.datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
-  resource/dd-profiler-internal-metadata:
-    attributes:
-    - action: upsert
-      key: profiler_name
-      value: full-host-profiler
-    - action: upsert
-      key: profiler_version
-      value: 7.0.0-test
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: test_api_key_123
-        site: us3.datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: us3.datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp/us3.datadoghq.com_0
-      processors:
-      - infraattributes/default
-      - resource/dd-profiler-internal-metadata
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/us3.datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/override-hostname/out.yaml
@@ -4,7 +4,7 @@ exporters:
             dd-api-key: test-api-key
 processors:
     infraattributes:
-        allow_hostname_override: true
+        allow_hostname_override: false
         some_config: value
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/in.yaml
@@ -1,0 +1,25 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+        host.name:
+          enabled: true
+        os.type:
+          enabled: true
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resourcedetection]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection:
         detectors:
             - system
@@ -27,5 +35,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -1,0 +1,31 @@
+exporters:
+    otlphttp:
+        headers:
+            dd-api-key: test-key
+processors:
+    resourcedetection:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: true
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        metrics:
+            processors: []
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - resourcedetection
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/in.yaml
@@ -1,0 +1,21 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resourcedetection]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -1,0 +1,27 @@
+exporters:
+    otlphttp:
+        headers:
+            dd-api-key: test-key
+processors:
+    resourcedetection:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        metrics:
+            processors: []
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - resourcedetection
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection:
         detectors:
             - system
@@ -23,5 +31,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/in.yaml
@@ -1,0 +1,21 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        host.name:
+          enabled: true
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resourcedetection]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection:
         detectors:
             - system
@@ -25,5 +33,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -1,0 +1,29 @@
+exporters:
+    otlphttp:
+        headers:
+            dd-api-key: test-key
+processors:
+    resourcedetection:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                host.name:
+                    enabled: true
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        metrics:
+            processors: []
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - resourcedetection
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/in.yaml
@@ -1,0 +1,21 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resourcedetection:
+    detectors: [system]
+    system:
+      resource_attributes:
+        os.type:
+          enabled: true
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resourcedetection]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection:
         detectors:
             - system
@@ -25,5 +33,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -1,0 +1,29 @@
+exporters:
+    otlphttp:
+        headers:
+            dd-api-key: test-key
+processors:
+    resourcedetection:
+        detectors:
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: true
+                os.type:
+                    enabled: true
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        metrics:
+            processors: []
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - resourcedetection
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/in.yaml
@@ -1,0 +1,23 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  resourcedetection:
+    detectors: [env]
+    system:
+      resource_attributes:
+        host.arch:
+          enabled: false
+        host.name:
+          enabled: true
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [resourcedetection]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -1,0 +1,32 @@
+exporters:
+    otlphttp:
+        headers:
+            dd-api-key: test-key
+processors:
+    resourcedetection:
+        detectors:
+            - env
+            - system
+        system:
+            resource_attributes:
+                host.arch:
+                    enabled: false
+                host.name:
+                    enabled: true
+                os.type:
+                    enabled: false
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: false
+service:
+    pipelines:
+        metrics:
+            processors: []
+        profiles:
+            exporters:
+                - otlphttp
+            processors:
+                - resourcedetection
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -3,6 +3,14 @@ exporters:
         headers:
             dd-api-key: test-key
 processors:
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
     resourcedetection:
         detectors:
             - env
@@ -28,5 +36,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler


### PR DESCRIPTION
### What does this PR do?
[PROF-13667](https://datadoghq.atlassian.net/browse/PROF-13667)

Enforce that the host profiler config converters respect user-provided configuration: only add missing keys through inference, never overwrite explicitly set values.

- Add `EnsureDefault` helper that sets a default config value only if the key does not exist or already holds the same value; preserves user overrides
- Update `converter_without_agent.go`: use `EnsureDefault` for `host.arch`, `host.name`, and `os.type` resource attributes in the `resourcedetection` processor. Warn when `host.arch` is disabled
- Update `converter_with_agent.go`: use `EnsureDefault` for `allow_hostname_override` in the `infraattributes` processor. Warn when disabled
- Document the "explicit config wins" behavior in the package doc comment and `comp/host-profiler/README.md`

### Motivation

The converters were unconditionally overwriting user-set leaf configs (e.g., `host.arch: enabled: false` was forced to `true`). Users should be able to explicitly set config values and have them respected, even if they conflict with Datadog's defaults. Incompatible values now generate a warning instead of being silently overwritten.

### Describe how you validated your changes

- Added 6 golden file tests (`preserve-*`) covering edge cases where user config should be preserved:
  - `preserve-host-arch`: user disables `host.arch` with system detector present
  - `preserve-host-name`: user enables `host.name` with system detector present
  - `preserve-os-type`: user enables `os.type` with system detector present
  - `preserve-all-res-attrs`: user sets all three resource attributes to non-default values
  - `preserve-res-attrs-no-system`: user pre-configures resource attributes without system detector in the list
  - `preserve-hostname-override`: user disables `allow_hostname_override` on infraattributes (agent mode)

### Additional Notes

It seems that the `standaloneLogger` (`zap.L().Sugar()`) used in `converter_without_agent.go` isn't setup (`TODO: currently converter helpers use datadog-agent's logger which isn't setup when in Standalone mode`). I'm not sure if I should see some logs or not.


[PROF-13667]: https://datadoghq.atlassian.net/browse/PROF-13667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ