### PR TITLE
[PROF-13750] Handle proxy/FIPS/custom URLs in host-profiler converter endpoint inference

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -318,6 +318,46 @@ func TestConverterWithAgent(t *testing.T) {
 	runSuccessTests(t, conv, tests)
 }
 
+func TestConverterWithAgentDCSite(t *testing.T) {
+	tests := []testCase{
+		{
+			name:     "infers-dc-site-from-profiling-url",
+			provided: "agent/infer-dc-from-url/in.yaml",
+			expected: "agent/infer-dc-from-url/out.yaml",
+		},
+		{
+			name:     "infers-dc-site-from-additional-endpoints",
+			provided: "agent/infer-dc-from-additional-ep/in.yaml",
+			expected: "agent/infer-dc-from-additional-ep/out.yaml",
+		},
+	}
+
+	t.Run("profiling_dd_url", func(t *testing.T) {
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"apm_config.profiling_dd_url": "https://intake.profile.us3.datadoghq.com/v1/input",
+				"api_key":                     "test_api_key_123",
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests[:1])
+	})
+
+	t.Run("additional_endpoints", func(t *testing.T) {
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"site":    "datadoghq.com",
+				"api_key": "test_api_key_123",
+				"apm_config.profiling_additional_endpoints": map[string][]string{
+					"https://intake.profile.us3.datadoghq.com/v1/input": {"us3_api_key"},
+				},
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests[1:])
+	})
+}
+
 func TestConverterWithAgentErrors(t *testing.T) {
 	tests := []errorTestCase{
 		{

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -358,6 +358,65 @@ func TestConverterWithAgentDCSite(t *testing.T) {
 	})
 }
 
+func TestConverterWithAgentProxyURL(t *testing.T) {
+	t.Run("proxy_profiling_dd_url", func(t *testing.T) {
+		tests := []testCase{
+			{
+				name:     "proxy-url-preserves-endpoint",
+				provided: "agent/proxy-url/in.yaml",
+				expected: "agent/proxy-url/out.yaml",
+			},
+		}
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"apm_config.profiling_dd_url": "https://myproxy.internal:8443/intake",
+				"api_key":                     "test_api_key_123",
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests)
+	})
+
+	t.Run("fips_localhost_url", func(t *testing.T) {
+		tests := []testCase{
+			{
+				name:     "fips-localhost-preserves-endpoint",
+				provided: "agent/fips-localhost/in.yaml",
+				expected: "agent/fips-localhost/out.yaml",
+			},
+		}
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"apm_config.profiling_dd_url": "http://localhost:9806/api/v2/profile",
+				"api_key":                     "test_api_key_123",
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests)
+	})
+
+	t.Run("proxy_additional_endpoint", func(t *testing.T) {
+		tests := []testCase{
+			{
+				name:     "proxy-additional-endpoint-preserved",
+				provided: "agent/proxy-additional-ep/in.yaml",
+				expected: "agent/proxy-additional-ep/out.yaml",
+			},
+		}
+		mockCfg := &mockConfig{
+			values: map[string]interface{}{
+				"site":    "datadoghq.com",
+				"api_key": "test_api_key_123",
+				"apm_config.profiling_additional_endpoints": map[string][]string{
+					"https://myproxy.internal:8443/intake": {"proxy_api_key"},
+				},
+			},
+		}
+		conv := newConverterWithAgent(confmap.ConverterSettings{}, mockCfg)
+		runSuccessTests(t, conv, tests)
+	})
+}
+
 func TestConverterWithAgentErrors(t *testing.T) {
 	tests := []errorTestCase{
 		{

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -11,6 +11,7 @@ package converters
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"slices"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -48,8 +49,7 @@ func newConfigManager(config config.Component) configManager {
 	for endpointURL, keys := range profilingAdditionalEndpoints {
 		site := configutils.ExtractSiteFromURL(endpointURL)
 		if site == "" {
-			log.Warnf("Could not extract site from URL %s, skipping endpoint", endpointURL)
-			continue
+			log.Infof("Additional endpoint URL %s is not a recognized Datadog domain; treating as proxy endpoint", endpointURL)
 		}
 		endpoints = append(endpoints, endpoint{
 			site:    site,
@@ -57,12 +57,16 @@ func newConfigManager(config config.Component) configManager {
 			apiKeys: keys,
 		})
 	}
-	log.Infof("Main site inferred from core configuration is %s", usedSite)
 
-	// Add main endpoint if we have a valid site
-	if usedSite == "" {
+	// Add main endpoint if we have a valid site or URL
+	if usedSite == "" && usedURL == "" {
 		log.Warn("Could not determine site from core configuration, no default endpoint will be configured")
 	} else {
+		if usedSite == "" {
+			log.Infof("Main endpoint URL %s is not a recognized Datadog domain; treating as proxy endpoint", usedURL)
+		} else {
+			log.Infof("Main site inferred from core configuration is %s", usedSite)
+		}
 		endpoints = append(endpoints, endpoint{site: usedSite, url: usedURL, apiKeys: []string{apiKey}})
 	}
 
@@ -249,6 +253,10 @@ func (c *converterWithAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporter
 func (c *converterWithAgent) inferHostProfilerEndpointConfig(hostProfiler confMap) error {
 	var symbolEndpoints []any
 	for _, endpoint := range c.configManager.endpoints {
+		if endpoint.site == "" {
+			log.Warnf("Endpoint %s is not a recognized Datadog domain; skipping symbol endpoint inference. Configure symbol_endpoints explicitly if needed.", endpoint.url)
+			continue
+		}
 		for _, key := range endpoint.apiKeys {
 			symbolEndpoints = append(symbolEndpoints, confMap{
 				"site":      endpoint.site,
@@ -261,6 +269,20 @@ func (c *converterWithAgent) inferHostProfilerEndpointConfig(hostProfiler confMa
 		return err
 	}
 	return nil
+}
+
+// extractBaseURL parses a URL and returns scheme://host (including port if present),
+// stripping any path. Returns the original URL on parse error.
+func extractBaseURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
 }
 
 func (c *converterWithAgent) inferOtlpHTTPConfig(conf confMap) error {
@@ -282,10 +304,29 @@ func (c *converterWithAgent) inferOtlpHTTPConfig(conf confMap) error {
 
 	const profilesExportersPath = "service::pipelines::profiles::exporters"
 	profilesExporters, _ := Get[[]any](conf, profilesExportersPath)
+	var proxyIdx int
 	for _, endpoint := range c.configManager.endpoints {
 		for i, key := range endpoint.apiKeys {
-			exporterName := fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, i)
-			if err := Set(conf, pathPrefixExporters+exporterName, createOtlpHTTPFromEndpoint(endpoint.site, key)); err != nil {
+			var exporterName string
+			var exporterConf confMap
+
+			if endpoint.site != "" {
+				// Standard Datadog URL: reconstruct from site
+				exporterName = fmt.Sprintf(otlpHTTPNameFormat, endpoint.site, i)
+				exporterConf = createOtlpHTTPFromEndpoint(endpoint.site, key)
+			} else {
+				// Proxy/FIPS URL: parse base URL (scheme://host:port) and append OTLP profiles path
+				exporterName = fmt.Sprintf("otlphttp/proxy_%d", proxyIdx)
+				proxyIdx++
+				baseURL := extractBaseURL(endpoint.url)
+				exporterConf = confMap{
+					"profiles_endpoint": baseURL + "/v1development/profiles",
+					"headers":           confMap{fieldDDAPIKey: key},
+				}
+				log.Warnf("Endpoint %s is not a recognized Datadog domain; only profiles intake is configured. Metrics endpoint requires explicit otlphttp exporter configuration.", endpoint.url)
+			}
+
+			if err := Set(conf, pathPrefixExporters+exporterName, exporterConf); err != nil {
 				return err
 			}
 			profilesExporters = append(profilesExporters, exporterName)

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -11,14 +11,12 @@ package converters
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"slices"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.opentelemetry.io/collector/confmap"
-	"golang.org/x/net/publicsuffix"
 )
 
 type endpoint struct {
@@ -32,26 +30,6 @@ type configManager struct {
 	config    config.Component
 }
 
-func extractSite(s string) string {
-	u, err := url.Parse(s)
-	if err != nil {
-		log.Debugf("Failed to parse URL %s: %v", s, err)
-		return ""
-	}
-
-	hostname := strings.Trim(u.Hostname(), ".")
-	if hostname == "" {
-		return ""
-	}
-	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(hostname)
-	if err != nil {
-		log.Debugf("Failed to extract apex domain from %s: %v", hostname, err)
-		return hostname
-	}
-
-	return apexDomain
-}
-
 func newConfigManager(config config.Component) configManager {
 	profilingDDURL := config.GetString("apm_config.profiling_dd_url")
 	ddSite := config.GetString("site")
@@ -59,7 +37,7 @@ func newConfigManager(config config.Component) configManager {
 
 	var usedURL, usedSite string
 	if profilingDDURL != "" {
-		usedSite = extractSite(profilingDDURL)
+		usedSite = configutils.ExtractSiteFromURL(profilingDDURL)
 		usedURL = profilingDDURL
 	} else if ddSite != "" {
 		usedSite = ddSite
@@ -68,7 +46,7 @@ func newConfigManager(config config.Component) configManager {
 	profilingAdditionalEndpoints := config.GetStringMapStringSlice("apm_config.profiling_additional_endpoints")
 	var endpoints []endpoint
 	for endpointURL, keys := range profilingAdditionalEndpoints {
-		site := extractSite(endpointURL)
+		site := configutils.ExtractSiteFromURL(endpointURL)
 		if site == "" {
 			log.Warnf("Could not extract site from URL %s, skipping endpoint", endpointURL)
 			continue

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -251,7 +251,7 @@ func (c *converterWithAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporter
 }
 
 func (c *converterWithAgent) inferHostProfilerEndpointConfig(hostProfiler confMap) error {
-	var symbolEndpoints []any
+	symbolEndpoints := make([]any, 0)
 	for _, endpoint := range c.configManager.endpoints {
 		if endpoint.site == "" {
 			log.Warnf("Endpoint %s is not a recognized Datadog domain; skipping symbol endpoint inference. Configure symbol_endpoints explicitly if needed.", endpoint.url)

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -265,6 +265,16 @@ func (c *converterWithAgent) inferHostProfilerEndpointConfig(hostProfiler confMa
 		}
 	}
 
+	if len(symbolEndpoints) == 0 {
+		// No Datadog endpoints available for symbol upload (all proxy/FIPS).
+		// Disable the symbol uploader to avoid failing receiver validation
+		// which requires non-empty symbol_endpoints when enabled.
+		if err := Set(hostProfiler, pathSymbolUploaderEnabled, false); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if err := Set(hostProfiler, "symbol_uploader::symbol_endpoints", symbolEndpoints); err != nil {
 		return err
 	}

--- a/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/out.yaml
@@ -1,0 +1,31 @@
+exporters:
+    otlphttp/proxy_0:
+        headers:
+            dd-api-key: test_api_key_123
+        profiles_endpoint: http://localhost:9806/v1development/profiles
+processors:
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints: []
+service:
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/proxy_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/fips-localhost/out.yaml
@@ -17,8 +17,7 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: true
-            symbol_endpoints: []
+            enabled: false
 service:
     pipelines:
         profiles:

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
@@ -1,0 +1,33 @@
+exporters:
+  otlphttp/datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+  otlphttp/us3.datadoghq.com_0:
+    headers:
+      dd-api-key: us3_api_key
+    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: us3_api_key
+        site: us3.datadoghq.com
+      - api_key: test_api_key_123
+        site: datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp/us3.datadoghq.com_0
+      - otlphttp/datadoghq.com_0
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-additional-ep/out.yaml
@@ -1,33 +1,42 @@
 exporters:
-  otlphttp/datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
-  otlphttp/us3.datadoghq.com_0:
-    headers:
-      dd-api-key: us3_api_key
-    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    otlphttp/us3.datadoghq.com_0:
+        headers:
+            dd-api-key: us3_api_key
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: us3_api_key
-        site: us3.datadoghq.com
-      - api_key: test_api_key_123
-        site: datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: us3_api_key
+                  site: us3.datadoghq.com
+                - api_key: test_api_key_123
+                  site: datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp/us3.datadoghq.com_0
-      - otlphttp/datadoghq.com_0
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/us3.datadoghq.com_0
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
@@ -1,0 +1,25 @@
+exporters:
+  otlphttp/us3.datadoghq.com_0:
+    headers:
+      dd-api-key: test_api_key_123
+    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+processors:
+  infraattributes/default:
+    allow_hostname_override: true
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: true
+      symbol_endpoints:
+      - api_key: test_api_key_123
+        site: us3.datadoghq.com
+service:
+  pipelines:
+    profiles:
+      exporters:
+      - otlphttp/us3.datadoghq.com_0
+      processors:
+      - infraattributes/default
+      receivers:
+      - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/infer-dc-from-url/out.yaml
@@ -1,25 +1,34 @@
 exporters:
-  otlphttp/us3.datadoghq.com_0:
-    headers:
-      dd-api-key: test_api_key_123
-    metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
-    profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
+    otlphttp/us3.datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 processors:
-  infraattributes/default:
-    allow_hostname_override: true
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
 receivers:
-  hostprofiler:
-    symbol_uploader:
-      enabled: true
-      symbol_endpoints:
-      - api_key: test_api_key_123
-        site: us3.datadoghq.com
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: us3.datadoghq.com
 service:
-  pipelines:
-    profiles:
-      exporters:
-      - otlphttp/us3.datadoghq.com_0
-      processors:
-      - infraattributes/default
-      receivers:
-      - hostprofiler
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/us3.datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proxy-additional-ep/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proxy-additional-ep/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/proxy-additional-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proxy-additional-ep/out.yaml
@@ -1,0 +1,39 @@
+exporters:
+    otlphttp/datadoghq.com_0:
+        headers:
+            dd-api-key: test_api_key_123
+        metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
+        profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
+    otlphttp/proxy_0:
+        headers:
+            dd-api-key: proxy_api_key
+        profiles_endpoint: https://myproxy.internal:8443/v1development/profiles
+processors:
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints:
+                - api_key: test_api_key_123
+                  site: datadoghq.com
+service:
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/proxy_0
+                - otlphttp/datadoghq.com_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/in.yaml
@@ -1,0 +1,6 @@
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: []

--- a/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/out.yaml
@@ -1,0 +1,31 @@
+exporters:
+    otlphttp/proxy_0:
+        headers:
+            dd-api-key: test_api_key_123
+        profiles_endpoint: https://myproxy.internal:8443/v1development/profiles
+processors:
+    infraattributes/default:
+        allow_hostname_override: true
+    resource/dd-profiler-internal-metadata:
+        attributes:
+            - action: upsert
+              key: profiler_name
+              value: full-host-profiler
+            - action: upsert
+              key: profiler_version
+              value: 7.0.0-test
+receivers:
+    hostprofiler:
+        symbol_uploader:
+            enabled: true
+            symbol_endpoints: []
+service:
+    pipelines:
+        profiles:
+            exporters:
+                - otlphttp/proxy_0
+            processors:
+                - infraattributes/default
+                - resource/dd-profiler-internal-metadata
+            receivers:
+                - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/agent/proxy-url/out.yaml
@@ -17,8 +17,7 @@ processors:
 receivers:
     hostprofiler:
         symbol_uploader:
-            enabled: true
-            symbol_endpoints: []
+            enabled: false
 service:
     pipelines:
         profiles:

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -197,7 +197,49 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (EndpointDescriptorSet, error
 	return eds, nil
 }
 
-var wellKnownSitesRe = regexp.MustCompile(`(?:datadoghq|datad0g)\.(?:com|eu)$|ddog-gov\.com$`)
+// ddDomainPattern matches known Datadog domains (e.g., datadoghq.com,
+// datad0g.eu, ddog-gov.com). This is the shared building block for
+// wellKnownSitesRe, ddSitePattern, ddSiteFromHostnameRe, and ddURLRegexp.
+const ddDomainPattern = `datad(?:oghq|0g)\.(?:com|eu)|ddog-gov\.com`
+
+var wellKnownSitesRe = regexp.MustCompile(`(?:` + ddDomainPattern + `)$`)
+
+// ddSitePattern matches a Datadog site: an optional datacenter subdomain
+// (e.g., us3, ap1) followed by a known Datadog domain.
+const ddSitePattern = `([a-z]{2,}\d{1,2}\.)?(` + ddDomainPattern + `)`
+
+// ddSiteFromHostnameRe extracts the Datadog site from the end of a hostname.
+// The (?:^|\.) prefix ensures the match starts at a label boundary so that,
+// e.g., "notdatadoghq.com" is not mistaken for "datadoghq.com".
+var ddSiteFromHostnameRe = regexp.MustCompile(`(?:^|\.)` + ddSitePattern + `\.?$`)
+
+// ExtractSiteFromURL extracts the Datadog site from a URL.
+// For example:
+//
+//	"https://intake.profile.us3.datadoghq.com/v1/input" returns "us3.datadoghq.com"
+//	"https://intake.profile.datadoghq.com/v1/input" returns "datadoghq.com"
+//	"https://intake.profile.datadoghq.eu/v1/input" returns "datadoghq.eu"
+//
+// Returns an empty string if the URL cannot be parsed or does not contain a
+// recognized Datadog domain.
+func ExtractSiteFromURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	hostname := strings.ToLower(strings.TrimRight(u.Hostname(), "."))
+	if hostname == "" {
+		return ""
+	}
+
+	matches := ddSiteFromHostnameRe.FindStringSubmatch(hostname)
+	if matches == nil {
+		return ""
+	}
+	// matches[1] is the DC label with trailing dot (e.g., "us3.") or empty
+	// matches[2] is the known domain (e.g., "datadoghq.com")
+	return matches[1] + matches[2]
+}
 
 // BuildURLWithPrefix will return an HTTP(s) URL for a site given a certain prefix.
 // If the site is a datadog well-known one, it is suffixed with a dot to make it a FQDN.
@@ -281,7 +323,7 @@ func GetMRFInfraEndpoint(c pkgconfigmodel.Reader) (string, error) {
 
 // ddURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed with the Agent
 // version (see AddAgentVersionToDomain).
-var ddURLRegexp = regexp.MustCompile(`^app(\.mrf)?(\.[a-z]{2,}\d{1,2})?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)(\.)?$`)
+var ddURLRegexp = regexp.MustCompile(`^app(\.mrf)?\.` + ddSitePattern + `\.?$`)
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z
 func getDomainPrefix(app string) string {

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -427,6 +427,60 @@ external_config:
 	assert.Equal(t, "https://custom.external-agent.datadoghq.eu", externalAgentURL)
 }
 
+func TestExtractSiteFromURL(t *testing.T) {
+	tests := []struct {
+		url      string
+		expected string
+	}{
+		// Standard sites
+		{"https://intake.profile.datadoghq.com/v1/input", "datadoghq.com"},
+		{"https://intake.profile.datadoghq.eu/v1/input", "datadoghq.eu"},
+		{"https://intake.profile.ddog-gov.com/v1/input", "ddog-gov.com"},
+
+		// Datacenter subdomains
+		{"https://intake.profile.us3.datadoghq.com/v1/input", "us3.datadoghq.com"},
+		{"https://intake.profile.us5.datadoghq.com/v1/input", "us5.datadoghq.com"},
+		{"https://intake.profile.ap1.datadoghq.com/v1/input", "ap1.datadoghq.com"},
+		{"https://intake.profile.eu1.datadoghq.eu/v1/input", "eu1.datadoghq.eu"},
+
+		// Staging/alternative domains
+		{"https://intake.profile.datad0g.com/v1/input", "datad0g.com"},
+		{"https://intake.profile.us3.datad0g.com/v1/input", "us3.datad0g.com"},
+
+		// Trailing dots (FQDN)
+		{"https://intake.profile.datadoghq.com./v1/input", "datadoghq.com"},
+		{"https://intake.profile.us3.datadoghq.com./v1/input", "us3.datadoghq.com"},
+
+		// Custom service prefixes
+		{"https://ophzngaa-intake.profile.datadoghq.com/api/v2/profile", "datadoghq.com"},
+		{"https://sourcemap-intake.us3.datadoghq.com/v1/input", "us3.datadoghq.com"},
+
+		// Bare site as URL
+		{"https://datadoghq.com", "datadoghq.com"},
+		{"https://us3.datadoghq.com", "us3.datadoghq.com"},
+
+		// Non-Datadog domains
+		{"https://example.com/foo", ""},
+		{"https://myproxy.internal/intake", ""},
+		{"https://notdatadoghq.com/v1/input", ""},
+		{"https://notdatad0g.eu/v1/input", ""},
+
+		// Case-insensitive hostnames
+		{"https://INTAKE.PROFILE.US3.DATADOGHQ.COM/v1/input", "us3.datadoghq.com"},
+		{"https://intake.profile.Datadoghq.COM/v1/input", "datadoghq.com"},
+
+		// Invalid/empty
+		{"", ""},
+		{"not-a-url", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.url, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ExtractSiteFromURL(tc.url))
+		})
+	}
+}
+
 func TestAddAgentVersionToDomain(t *testing.T) {
 	appVersionPrefix := getDomainPrefix("app")
 	flareVersionPrefix := getDomainPrefix("flare")


### PR DESCRIPTION
### What does this PR do?

Fixes endpoint inference in the host-profiler converter when `apm_config.profiling_dd_url` or `profiling_additional_endpoints` points to a proxy, FIPS localhost, or other non-Datadog URL.

After #46356, `ExtractSiteFromURL` returns empty for any hostname not in the known Datadog domain list. In `newConfigManager` this caused those endpoints to be skipped entirely, leaving inferred OTLP exporters and symbol endpoints empty and stopping profile/symbol delivery.

**Changes in `converter_with_agent.go`:**
1. `newConfigManager`: preserve endpoints with empty site when a valid URL is present (previously skipped)
2. `inferOtlpHTTPConfig`: when site is empty, build profiles endpoint as URL + path using `extractBaseURL`; skip metrics with warning
3. `inferHostProfilerEndpointConfig`: when site is empty, skip symbol endpoint inference with warning; disable symbol uploader when no Datadog endpoints available
4. FIPS localhost URLs follow the same proxy path (Info log, not Warn)

### Motivation

Users with proxy or FIPS configurations get broken profile/symbol delivery because `ExtractSiteFromURL` returns empty for non-Datadog hostnames, and the converter skips those endpoints entirely.

### Describe how you validated your changes

- 3 new golden-file test cases in `TestConverterWithAgentProxyURL`: `proxy_profiling_dd_url`, `fips_localhost_url`, `proxy_additional_endpoint`
- Full converter test suite passes with no regressions
- Existing Datadog URL tests (`TestConverterWithAgent`, `TestConverterWithAgentDCSite`) still pass

### Additional Notes

- **Draft**: Deferring actual implementation until the host-profiler moves from a converter to a confmap provider with a dedicated `datadog.yaml` key for profiler config. This PR serves as a reference implementation.
- Jira: PROF-13750
- Depends on: #46356