### PR TITLE
[tagger] Expose TagWithCompleteness()

### DIFF
--- a/comp/core/tagger/collectors/pod_tag_extractor.go
+++ b/comp/core/tagger/collectors/pod_tag_extractor.go
@@ -22,7 +22,10 @@ type PodTagExtractor struct {
 
 // Extract extracts and returns tags from a workloadmeta pod entity
 func (p *PodTagExtractor) Extract(podEntity *workloadmeta.KubernetesPod, cardinality types.TagCardinality) []string {
-	tagInfos := p.c.extractTagsFromPodEntity(podEntity, taglist.NewTagList())
+	// The value sent for isComplete in this call does not matter, because we're
+	// not processing an event from workloadmeta which is the component that
+	// reports completeness.
+	tagInfos := p.c.extractTagsFromPodEntity(podEntity, taglist.NewTagList(), false)
 
 	switch cardinality {
 	case types.HighCardinality:

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
@@ -208,10 +209,12 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.TagInfo {
 	container := ev.Entity.(*workloadmeta.Container)
 
+	c.entityCompleteness[container.EntityID] = ev.IsComplete
+
 	// Garden containers tagging is specific as we don't have any information locally
 	// Metadata are not available and tags are retrieved as-is from Cluster Agent
 	if container.Runtime == workloadmeta.ContainerRuntimeGarden {
-		return c.handleGardenContainer(container)
+		return c.handleGardenContainer(container, ev.IsComplete)
 	}
 
 	tagList := taglist.NewTagList()
@@ -279,6 +282,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*types.
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           c.containerCompleteness(container.ID, ev.IsComplete),
 		},
 	}
 }
@@ -336,6 +340,7 @@ func (c *WorkloadMetaCollector) handleProcess(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 }
@@ -386,6 +391,7 @@ func (c *WorkloadMetaCollector) handleContainerImage(ev workloadmeta.Event) []*t
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 }
@@ -412,7 +418,7 @@ func (c *WorkloadMetaCollector) labelsToTags(labels map[string]string, tags *tag
 	}
 }
 
-func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.KubernetesPod, tagList *taglist.TagList) *types.TagInfo {
+func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.KubernetesPod, tagList *taglist.TagList, isComplete bool) *types.TagInfo {
 	tagList.AddOrchestrator(tags.KubePod, pod.Name)
 	tagList.AddLow(tags.KubeNamespace, pod.Namespace)
 	tagList.AddLow(tags.PodPhase, strings.ToLower(pod.Phase))
@@ -503,6 +509,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 		OrchestratorCardTags: orch,
 		LowCardTags:          low,
 		StandardTags:         standard,
+		IsComplete:           isComplete,
 	}
 
 	return tagInfo
@@ -510,13 +517,16 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 
 func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*types.TagInfo {
 	pod := ev.Entity.(*workloadmeta.KubernetesPod)
+
+	c.entityCompleteness[pod.EntityID] = ev.IsComplete
+
 	tagList := taglist.NewTagList()
-	tagInfos := []*types.TagInfo{c.extractTagsFromPodEntity(pod, tagList)}
+	tagInfos := []*types.TagInfo{c.extractTagsFromPodEntity(pod, tagList, ev.IsComplete)}
 
 	c.extractTagsFromPodLabels(pod, tagList)
 
 	for _, podContainer := range pod.GetAllContainers() {
-		cTagInfo, err := c.extractTagsFromPodContainer(pod, podContainer, tagList.Copy())
+		cTagInfo, err := c.extractTagsFromPodContainer(pod, podContainer, tagList.Copy(), ev.IsComplete)
 		if err != nil {
 			log.Debugf("cannot extract tags from pod container: %s", err)
 			continue
@@ -593,6 +603,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          append(low, clusterLow...),
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		})
 	}
 
@@ -609,6 +620,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 			OrchestratorCardTags: orch,
 			LowCardTags:          append(low, clusterLow...),
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		})
 	}
 
@@ -626,18 +638,20 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 				OrchestratorCardTags: clusterOrch,
 				LowCardTags:          clusterLow,
 				StandardTags:         clusterStandard,
+				IsComplete:           ev.IsComplete,
 			})
 		}
 	}
 	return tagInfos
 }
 
-func (c *WorkloadMetaCollector) handleGardenContainer(container *workloadmeta.Container) []*types.TagInfo {
+func (c *WorkloadMetaCollector) handleGardenContainer(container *workloadmeta.Container, isComplete bool) []*types.TagInfo {
 	return []*types.TagInfo{
 		{
 			Source:       containerSource,
 			EntityID:     common.BuildTaggerEntityID(container.EntityID),
 			HighCardTags: container.CollectorTags,
+			IsComplete:   isComplete,
 		},
 	}
 }
@@ -681,6 +695,7 @@ func (c *WorkloadMetaCollector) handleKubeDeployment(ev workloadmeta.Event) []*t
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 
@@ -723,6 +738,7 @@ func (c *WorkloadMetaCollector) handleKubeMetadata(ev workloadmeta.Event) []*typ
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 
@@ -749,6 +765,7 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 
@@ -797,6 +814,7 @@ func (c *WorkloadMetaCollector) handleCRD(ev workloadmeta.Event) []*types.TagInf
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 
@@ -819,6 +837,7 @@ func (c *WorkloadMetaCollector) handleKubeCapabilities(ev workloadmeta.Event) []
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,
 			StandardTags:         standard,
+			IsComplete:           ev.IsComplete,
 		},
 	}
 
@@ -895,7 +914,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodOwner(pod *workloadmeta.Kubern
 	}
 }
 
-func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.KubernetesPod, podContainer workloadmeta.OrchestratorContainer, tagList *taglist.TagList) (*types.TagInfo, error) {
+func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.KubernetesPod, podContainer workloadmeta.OrchestratorContainer, tagList *taglist.TagList, podComplete bool) (*types.TagInfo, error) {
 	container, err := c.store.GetContainer(podContainer.ID)
 	if err != nil {
 		return nil, fmt.Errorf("pod %q has reference to non-existing container %q", pod.Name, podContainer.ID)
@@ -938,6 +957,8 @@ func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.Ku
 	containerAdapter := newResolvableAdapter(pod, container)
 	c.extractTagsFromJSONWithResolution(annotation, pod.Annotations, tagList, containerAdapter)
 
+	containerComplete := c.entityCompleteness[container.EntityID]
+
 	low, orch, high, standard := tagList.Compute()
 	return &types.TagInfo{
 		// podSource here is not a mistake. the source is
@@ -948,6 +969,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.Ku
 		OrchestratorCardTags: orch,
 		LowCardTags:          low,
 		StandardTags:         standard,
+		IsComplete:           containerComplete && podComplete,
 	}, nil
 }
 
@@ -980,8 +1002,34 @@ func (c *WorkloadMetaCollector) handleDelete(ev workloadmeta.Event) []*types.Tag
 	tagInfos = append(tagInfos, c.handleDeleteChildren(source, children)...)
 
 	delete(c.children, taggerEntityID)
+	delete(c.entityCompleteness, entityID)
 
 	return tagInfos
+}
+
+// containerCompleteness computes the effective completeness for a container. In
+// Kubernetes, a container's tags also depend on its pod's data, so completeness
+// requires both the container and its pod to be complete.
+func (c *WorkloadMetaCollector) containerCompleteness(containerID string, containerComplete bool) bool {
+	if !env.IsFeaturePresent(env.Kubernetes) {
+		return containerComplete
+	}
+
+	if !containerComplete {
+		return false
+	}
+
+	pod, err := c.store.GetKubernetesPodForContainer(containerID)
+	if err != nil {
+		return false
+	}
+
+	podComplete, ok := c.entityCompleteness[pod.EntityID]
+	if !ok {
+		return false
+	}
+
+	return podComplete
 }
 
 func (c *WorkloadMetaCollector) handleDeleteChildren(source string, children map[types.EntityID]struct{}) []*types.TagInfo {

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -68,6 +68,11 @@ type WorkloadMetaCollector struct {
 
 	collectEC2ResourceTags            bool
 	collectPersistentVolumeClaimsTags bool
+
+	// entityCompleteness tracks raw per-entity completeness from workloadmeta
+	// events. This is the completeness of the entity itself, without
+	// considering cross-entity dependencies (for example, a container's pod).
+	entityCompleteness map[workloadmeta.EntityID]bool
 }
 
 func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags map[string]string) {
@@ -180,6 +185,7 @@ func NewWorkloadMetaCollector(ctx context.Context, cfg config.Component, store w
 		staticTags:                        make(map[string][]string),
 		collectEC2ResourceTags:            cfg.GetBool("ecs_collect_resource_tags_ec2"),
 		collectPersistentVolumeClaimsTags: cfg.GetBool("kubernetes_persistent_volume_claims_as_tags"),
+		entityCompleteness:                make(map[workloadmeta.EntityID]bool),
 	}
 
 	containerLabelsAsTags := mergeMaps(

--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -18,6 +18,19 @@ import (
 // Component is the component type.
 type Component interface {
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
+	// TagWithCompleteness returns tags for an entity together with a boolean
+	// indicating whether the entity's data is complete. An entity is complete
+	// when all expected collectors have reported data for it. For containers in
+	// Kubernetes, completeness also considers the associated pod's
+	// completeness.
+	//
+	// Important: completeness tracking is currently only supported for
+	// containers and pods when the agent runs on Kubernetes. For all other
+	// entity kinds the returned boolean is always true. Also note that tags may
+	// not be complete immediately after an entity is first seen, because the
+	// different workloadmeta collectors discover entity data at different
+	// speeds.
+	TagWithCompleteness(entityID types.EntityID, cardinality types.TagCardinality) ([]string, bool, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
 	Standard(entityID types.EntityID) ([]string, error)
 	List() types.TaggerListResponse

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -27,6 +27,10 @@ func (n *noopTagger) Tag(types.EntityID, types.TagCardinality) ([]string, error)
 	return nil, nil
 }
 
+func (n *noopTagger) TagWithCompleteness(types.EntityID, types.TagCardinality) ([]string, bool, error) {
+	return nil, true, nil
+}
+
 // GenerateContainerIDFromOriginInfo generates a container ID from Origin Info.
 // This is a no-op for the noop tagger
 func (n *noopTagger) GenerateContainerIDFromOriginInfo(origindetection.OriginInfo) (string, error) {

--- a/comp/core/tagger/impl/tagger_mock.go
+++ b/comp/core/tagger/impl/tagger_mock.go
@@ -109,6 +109,11 @@ func (f *fakeTagger) Tag(entityID types.EntityID, cardinality types.TagCardinali
 	return f.tagger.Tag(entityID, cardinality)
 }
 
+// TagWithCompleteness calls tagger.TagWithCompleteness().
+func (f *fakeTagger) TagWithCompleteness(entityID types.EntityID, cardinality types.TagCardinality) ([]string, bool, error) {
+	return f.tagger.TagWithCompleteness(entityID, cardinality)
+}
+
 // GenerateContainerIDFromOriginInfo calls tagger.GenerateContainerIDFromOriginInfo().
 func (f *fakeTagger) GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error) {
 	return f.tagger.GenerateContainerIDFromOriginInfo(originInfo)

--- a/comp/core/tagger/proto/proto.go
+++ b/comp/core/tagger/proto/proto.go
@@ -54,6 +54,7 @@ func Tagger2PbEntityEvent(event types.EntityEvent) (*pb.StreamTagsEvent, error) 
 			OrchestratorCardinalityTags: entity.OrchestratorCardinalityTags,
 			LowCardinalityTags:          entity.LowCardinalityTags,
 			StandardTags:                entity.StandardTags,
+			IsComplete:                  entity.IsComplete,
 		},
 	}, nil
 }

--- a/comp/core/tagger/tagstore/entity_tags.go
+++ b/comp/core/tagger/tagstore/entity_tags.go
@@ -51,6 +51,8 @@ type EntityTags interface {
 	setSourceExpiration(source string, expiryDate time.Time)
 	deleteExpired(time time.Time) bool
 	shouldRemove() bool
+	getIsComplete() bool
+	setIsComplete(isComplete bool)
 }
 
 // EntityTagsWithMultipleSources holds the tag information for a given entity
@@ -64,6 +66,7 @@ type EntityTagsWithMultipleSources struct {
 	cachedAll          tagset.HashedTags // Low + orchestrator + high
 	cachedOrchestrator tagset.HashedTags // Low + orchestrator (subslice of cachedAll)
 	cachedLow          tagset.HashedTags // Sub-slice of cachedAll
+	isComplete         bool
 }
 
 func newEntityTags(entityID types.EntityID, source string) EntityTags {
@@ -96,7 +99,16 @@ func (e *EntityTagsWithMultipleSources) toEntity() types.Entity {
 		HighCardinalityTags:         cachedAll[len(cachedOrchestrator):],
 		OrchestratorCardinalityTags: cachedOrchestrator[len(cachedLow):],
 		LowCardinalityTags:          cachedLow,
+		IsComplete:                  e.isComplete,
 	}
+}
+
+func (e *EntityTagsWithMultipleSources) getIsComplete() bool {
+	return e.isComplete
+}
+
+func (e *EntityTagsWithMultipleSources) setIsComplete(isComplete bool) {
+	e.isComplete = isComplete
 }
 
 func (e *EntityTagsWithMultipleSources) getStandard() []string {
@@ -268,6 +280,7 @@ type EntityTagsWithSingleSource struct {
 	cachedOrchestrator tagset.HashedTags // Low + orchestrator (subslice of cachedAll)
 	cachedLow          tagset.HashedTags // Sub-slice of cachedAll
 	isExpired          bool
+	isComplete         bool // Whether all expected collectors have reported
 }
 
 func newEntityTagsWithSingleSource(entityID types.EntityID, source string) *EntityTagsWithSingleSource {
@@ -294,7 +307,16 @@ func (e *EntityTagsWithSingleSource) toEntity() types.Entity {
 		HighCardinalityTags:         cachedAll[len(cachedOrchestrator):],
 		OrchestratorCardinalityTags: cachedOrchestrator[len(cachedLow):],
 		LowCardinalityTags:          cachedLow,
+		IsComplete:                  e.isComplete,
 	}
+}
+
+func (e *EntityTagsWithSingleSource) getIsComplete() bool {
+	return e.isComplete
+}
+
+func (e *EntityTagsWithSingleSource) setIsComplete(isComplete bool) {
+	e.isComplete = isComplete
 }
 
 func (e *EntityTagsWithSingleSource) getStandard() []string {

--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -128,10 +128,11 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 		}
 
 		eventType := types.EventTypeModified
+		tagsChanged := true
 		if exist {
 			tags := storedTags.tagsForSource(info.Source)
 			if tags != nil && reflect.DeepEqual(tags, newSt) {
-				continue
+				tagsChanged = false
 			}
 		} else {
 			eventType = types.EventTypeAdded
@@ -139,10 +140,21 @@ func (s *TagStore) ProcessTagInfo(tagInfos []*types.TagInfo) {
 			s.store.Set(info.EntityID, storedTags)
 		}
 
+		completenessChanged := storedTags.getIsComplete() != info.IsComplete
+
+		// Skip if nothing changed
+		if !tagsChanged && !completenessChanged {
+			continue
+		}
+
 		if s.telemetryStore != nil {
 			s.telemetryStore.UpdatedEntities.Inc()
 		}
-		storedTags.setTagsForSource(info.Source, newSt)
+
+		if tagsChanged {
+			storedTags.setTagsForSource(info.Source, newSt)
+		}
+		storedTags.setIsComplete(info.IsComplete)
 
 		events = append(events, types.EntityEvent{
 			EventType: eventType,
@@ -259,6 +271,20 @@ func (s *TagStore) LookupHashed(entityID types.EntityID, cardinality types.TagCa
 	}
 
 	return storedTags.getHashedTags(cardinality), nil
+}
+
+// LookupHashedWithCompleteness similar to LookupHashed but returns the
+// completeness of the entity
+func (s *TagStore) LookupHashedWithCompleteness(entityID types.EntityID, cardinality types.TagCardinality) (tagset.HashedTags, bool, error) {
+	s.RLock()
+	defer s.RUnlock()
+
+	storedTags, present := s.store.Get(entityID)
+	if !present {
+		return tagset.HashedTags{}, false, ErrNotFound
+	}
+
+	return storedTags.getHashedTags(cardinality), storedTags.getIsComplete(), nil
 }
 
 // Lookup gets tags from the store and returns them concatenated in a string slice.

--- a/comp/core/tagger/types/types.go
+++ b/comp/core/tagger/types/types.go
@@ -39,6 +39,7 @@ type TagInfo struct {
 	StandardTags         []string  // the discovered standard tags (env, version, service) for the entity
 	DeleteEntity         bool      // true if the entity is to be deleted from the store
 	ExpiryDate           time.Time // keep in cache until expiryDate
+	IsComplete           bool      // whether all expected collectors have reported data for this entity in wmeta
 }
 
 // CollectorPriority helps resolving dupe tags from collectors
@@ -74,6 +75,10 @@ type Entity struct {
 	OrchestratorCardinalityTags []string
 	LowCardinalityTags          []string
 	StandardTags                []string
+	// IsComplete indicates whether all expected collectors have reported data
+	// for this entity. For containers in Kubernetes, this also considers the
+	// completeness of the associated pod.
+	IsComplete bool
 }
 
 // GetTags flattens all tags from all cardinalities into a single slice of tag

--- a/pkg/proto/datadog/model/v1/model.proto
+++ b/pkg/proto/datadog/model/v1/model.proto
@@ -80,6 +80,7 @@ message Entity {
     repeated string orchestratorCardinalityTags = 4;
     repeated string lowCardinalityTags = 5;
     repeated string standardTags = 6;
+    bool isComplete = 7;
 }
 
 message GenerateContainerIDFromOriginInfoRequest {

--- a/pkg/proto/pbgo/core/model.pb.go
+++ b/pkg/proto/pbgo/core/model.pb.go
@@ -634,6 +634,7 @@ type Entity struct {
 	OrchestratorCardinalityTags []string               `protobuf:"bytes,4,rep,name=orchestratorCardinalityTags,proto3" json:"orchestratorCardinalityTags,omitempty"`
 	LowCardinalityTags          []string               `protobuf:"bytes,5,rep,name=lowCardinalityTags,proto3" json:"lowCardinalityTags,omitempty"`
 	StandardTags                []string               `protobuf:"bytes,6,rep,name=standardTags,proto3" json:"standardTags,omitempty"`
+	IsComplete                  bool                   `protobuf:"varint,7,opt,name=isComplete,proto3" json:"isComplete,omitempty"`
 	unknownFields               protoimpl.UnknownFields
 	sizeCache                   protoimpl.SizeCache
 }
@@ -708,6 +709,13 @@ func (x *Entity) GetStandardTags() []string {
 		return x.StandardTags
 	}
 	return nil
+}
+
+func (x *Entity) GetIsComplete() bool {
+	if x != nil {
+		return x.IsComplete
+	}
+	return false
 }
 
 type GenerateContainerIDFromOriginInfoRequest struct {
@@ -1631,14 +1639,17 @@ const file_datadog_model_v1_model_proto_rawDesc = "" +
 	"\x10DeprecatedFilter\x12$\n" +
 	"\rkubeNamespace\x18\x01 \x01(\tR\rkubeNamespace\x12\x14\n" +
 	"\x05image\x18\x02 \x01(\tR\x05image\x12$\n" +
-	"\rcontainerName\x18\x03 \x01(\tR\rcontainerName\"\x90\x02\n" +
+	"\rcontainerName\x18\x03 \x01(\tR\rcontainerName\"\xb0\x02\n" +
 	"\x06Entity\x12*\n" +
 	"\x02id\x18\x01 \x01(\v2\x1a.datadog.model.v1.EntityIdR\x02id\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x120\n" +
 	"\x13highCardinalityTags\x18\x03 \x03(\tR\x13highCardinalityTags\x12@\n" +
 	"\x1borchestratorCardinalityTags\x18\x04 \x03(\tR\x1borchestratorCardinalityTags\x12.\n" +
 	"\x12lowCardinalityTags\x18\x05 \x03(\tR\x12lowCardinalityTags\x12\"\n" +
-	"\fstandardTags\x18\x06 \x03(\tR\fstandardTags\"\xff\x04\n" +
+	"\fstandardTags\x18\x06 \x03(\tR\fstandardTags\x12\x1e\n" +
+	"\n" +
+	"isComplete\x18\a \x01(\bR\n" +
+	"isComplete\"\xff\x04\n" +
 	"(GenerateContainerIDFromOriginInfoRequest\x12g\n" +
 	"\tlocalData\x18\x01 \x01(\v2D.datadog.model.v1.GenerateContainerIDFromOriginInfoRequest.LocalDataH\x00R\tlocalData\x88\x01\x01\x12p\n" +
 	"\fexternalData\x18\x02 \x01(\v2G.datadog.model.v1.GenerateContainerIDFromOriginInfoRequest.ExternalDataH\x01R\fexternalData\x88\x01\x01\x1a\xc0\x01\n" +


### PR DESCRIPTION
### What does this PR do?

This is the second PR in the series to address the missing tags issue. The first PR was https://github.com/DataDog/datadog-agent/pull/46233

This PR adds completeness tracking to the tagger. The tagger now exposes a new function that returns tags and a boolean that indicates whether the entity's data is complete or not. The completeness info is based on what's returned from workloadmeta (added in the first PR mentioned above).

Following PRs will use the new function in tag callers (dogstatsd, metrics, logs, APM) to decide what to do when tags are incomplete.


### Describe how you validated your changes

Unit tests for now. More tests will be added for the full functionality once after following PRs are merged.