### PR TITLE
Update helm chart version used by new-e2e tests

### DIFF
--- a/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
+++ b/test/e2e-framework/components/datadog/agent/kubernetes_helm.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	HelmVersion = "3.155.1"
+	HelmVersion = "3.170.1"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component

--- a/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
+++ b/test/new-e2e/tests/ssi/testdata/injection_mode.yaml
@@ -2,13 +2,6 @@
 clusterAgent:
   admissionController:
     configMode: "hostip"
-
-# Temporary until the Datadog CSI driver is released
-datadog-csi-driver:
-  image:
-    repository: "gcr.io/datadoghq/csi-driver"
-    tag: "main"
-
 datadog:
   csi:
     enabled: true


### PR DESCRIPTION
### What does this PR do?

Update helm chart version

### Motivation

Use the last version of the chart to get rid of a manual override in new-e2e-ssi tests

### Describe how you validated your changes

### Additional Notes
