### PR TITLE
Improve HA agent failover test flakiness

### DIFF
--- a/test/new-e2e/tests/ha-agent/haagent_failover_test.go
+++ b/test/new-e2e/tests/ha-agent/haagent_failover_test.go
@@ -9,6 +9,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -45,22 +46,25 @@ type multiVMEnv struct {
 func multiVMEnvProvisioner() provisioners.PulumiEnvRunFunc[multiVMEnv] {
 	return func(ctx *pulumi.Context, env *multiVMEnv) error {
 
+		// Generate a random config_id (0-9) to avoid conflicts when tests run in parallel
+		randomConfigID := fmt.Sprintf("ci-e2e-ha-failover-%d", rand.Intn(10))
+
 		// language=yaml
-		agentConfig1 := `
+		agentConfig1 := fmt.Sprintf(`
 hostname: test-e2e-agent1
 ha_agent:
     enabled: true
-config_id: ci-e2e-ha-failover
+config_id: %s
 log_level: debug
-`
+`, randomConfigID)
 
-		agentConfig2 := `
+		agentConfig2 := fmt.Sprintf(`
 hostname: test-e2e-agent2
 ha_agent:
     enabled: true
-config_id: ci-e2e-ha-failover
+config_id: %s
 log_level: debug
-`
+`, randomConfigID)
 
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Fixes flakiness in `TestHAFailover` by using randomized config_ids to prevent parallel test runs from competing for the same HA active state.

  ## Motivation

When multiple `TestHAFailover` tests run in parallel (e.g., in CI), they all used the same hardcoded `config_id: ci-e2e-ha-failover`. This caused the agents from different test runs to compete for the HA active state, leading to test failures and flakiness.

  ## Description of the changes
  
  - Added `math/rand` import
  - Generate a random config_id from 10 possible values (`ci-e2e-ha-failover-0` through `ci-e2e-ha-failover-9`)
  - Both agents in a test run still use the same config_id (required for HA pairing)
  - Different test runs now have a 90% probability of using different config_ids

  ## Possible drawbacks / trade-offs

  - With 10 possible values, there's still a ~10% chance of collision with 2 parallel runs
  - If more parallelism is needed, the range can be increased (e.g., rand.Intn(100))
