### PR TITLE
APM: Obfuscate HELLO and MIGRATE redis commands

### DIFF
--- a/pkg/obfuscate/redis.go
+++ b/pkg/obfuscate/redis.go
@@ -123,9 +123,11 @@ func obfuscateRedisCmd(out *strings.Builder, cmd string, args ...string) {
 	out.WriteByte(' ')
 
 	switch strings.ToUpper(cmd) {
-	case "AUTH":
+	case "AUTH", "MIGRATE", "HELLO":
 		// Obfuscate everything after command
 		// • AUTH password
+		// • MIGRATE host port key|"" destination-db timeout [COPY] [REPLACE] [AUTH password] [AUTH2 username password] [KEYS key [key ...]]
+		// • HELLO [protover [AUTH username password] [SETNAME clientname]]
 		if len(args) > 0 {
 			args[0] = "?"
 			args = args[:1]

--- a/pkg/obfuscate/redis_test.go
+++ b/pkg/obfuscate/redis_test.go
@@ -110,6 +110,38 @@ func TestRedisObfuscator(t *testing.T) {
 			"AUTH",
 		},
 		{
+			"MIGRATE host port key destination-db timeout",
+			"MIGRATE ?",
+		},
+		{
+			"MIGRATE host port key destination-db timeout COPY REPLACE",
+			"MIGRATE ?",
+		},
+		{
+			"MIGRATE host port \"\" destination-db timeout KEYS key1 key2 key3",
+			"MIGRATE ?",
+		},
+		{
+			"MIGRATE",
+			"MIGRATE",
+		},
+		{
+			"HELLO 3",
+			"HELLO ?",
+		},
+		{
+			"HELLO 3 AUTH username password",
+			"HELLO ?",
+		},
+		{
+			"HELLO 3 AUTH username password SETNAME clientname",
+			"HELLO ?",
+		},
+		{
+			"HELLO",
+			"HELLO",
+		},
+		{
 			"APPEND key value",
 			"APPEND key ?",
 		},

--- a/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
+++ b/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
@@ -8,6 +8,6 @@
 ---
 security:
   - |
-    APM: On span tags, add obfuscation on `HELLO` and `MIGRATE` redis commands.
-    Similar to AUTH, all arguments passed to these commands will be obfuscated
-    and replaced with `?`.
+    APM: On span tags, add obfuscation on ``HELLO`` and ``MIGRATE`` redis commands.
+    Similar to ``AUTH``, all arguments passed to these commands will be obfuscated
+    and replaced with ``?``.

--- a/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
+++ b/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
@@ -8,6 +8,6 @@
 ---
 security:
   - |
-    APM: On span tags, add obfuscation on ``HELLO`` and ``MIGRATE`` redis commands.
+    APM: On span tags, add obfuscation for ``HELLO`` and ``MIGRATE`` Redis commands.
     Similar to ``AUTH``, all arguments passed to these commands will be obfuscated
     and replaced with ``?``.

--- a/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
+++ b/releasenotes/notes/apm-redis-obfuscate-hello-migrate-f3c59071e4903805.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    APM: On span tags, add obfuscation on `HELLO` and `MIGRATE` redis commands.
+    Similar to AUTH, all arguments passed to these commands will be obfuscated
+    and replaced with `?`.


### PR DESCRIPTION
### What does this PR do?
APM: On span tags, add obfuscation on `HELLO` and `MIGRATE` redis commands. Similar to AUTH, all arguments passed to these commands will be obfuscated and replaced with `?`.

### Motivation

These commands can contain sensitive information, and should be obfuscated.

### Describe how you validated your changes
Unit tests

### Additional Notes
