### PR TITLE
Simplify OpenSSL hardcoded string replacements

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -63,10 +63,9 @@ MACOS_LIBCRYPTO = "libcrypto.dylib"
 FIX_OPENSSL_PATHS = """
     # Fix OpenSSL hardcoded paths in binaries
     TARGET="##########################################################################################PLACEHOLDERDIRECTORY##########################################################################################"
+    SANDBOX="$$BUILD_TMPDIR/$$INSTALL_PREFIX"
 
-    # === OPENSSLDIR paths (no extra slash between BUILD_TMPDIR and INSTALL_PREFIX) ===
-    SANDBOX="$$BUILD_TMPDIR$$INSTALL_PREFIX"
-
+    # === OPENSSLDIR paths ===
     # OPENSSLDIR display string: /ssl"
     OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
@@ -82,9 +81,7 @@ FIX_OPENSSL_PATHS = """
     # SSL cert.pem: /ssl/cert.pem
     OLD_PATH="$${SANDBOX}/ssl/cert.pem" NEW_PATH="$${TARGET}/ssl/cert.pem" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
-    # === ENGINESDIR and MODULESDIR paths (extra slash between BUILD_TMPDIR and INSTALL_PREFIX) ===
-    SANDBOX="$$BUILD_TMPDIR/$$INSTALL_PREFIX"
-
+    # === ENGINESDIR and MODULESDIR paths ===
     # ENGINESDIR display string: /lib/engines-3"
     OLD_PATH="$${SANDBOX}/lib/engines-3\\"" NEW_PATH="$${TARGET}/lib/engines-3\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
@@ -138,11 +135,6 @@ configure_make(
             "--openssldir='C:/Program Files/Datadog/Datadog Agent/embedded3/ssl'",
         ],
         "//conditions:default": [],
-    }),
-    # We should set this to make placeholder placement easier and more predictable.
-    install_prefix = select({
-        "@platforms//os:windows": "",
-        "//conditions:default": "/opt/datadog-agent/embedded",
     }),
     env = select({
         "@platforms//os:macos": {


### PR DESCRIPTION
### What does this PR do?

Simplifies some of the details around how we determine the patterns to replace when doing the replacements of OpenSSL hardcoded paths.

### Motivation

Some discussion around a comment explaining why we were setting `install_prefix` https://github.com/DataDog/datadog-agent/pull/46323#discussion_r2798999454

It turns out that using a path `/opt/datadog-agent/embedded` in the `install_prefix` would cause some of the paths to have a double `/` (MODULESDIR, ENGINESDIR) and some a single `/` (OPENSSLDIR). So something in the middle is collapsing multiple consecutive slashes. That's why we were treating these two differently sets in the replacement script.

### Describe how you validated your changes

I ran the following command before and after the change
```
strings bazel-bin/external/+_repo_rules+openssl/openssl/lib/libcrypto.so | grep 'PLACEHOLDERDIRECTORY'
```

and I got the exact same output.

CI.

### Additional Notes
