### PR TITLE
sd-agent: fallback based on env vars value

### DIFF
--- a/pkg/discovery/module/rust/tests/fallback_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/fallback_integration_test.rs
@@ -422,3 +422,98 @@ fn test_killswitch_env_overrides_yaml_enabled() {
         "Env var should override YAML - fallback should happen"
     );
 }
+
+#[test]
+fn test_env_var_false_no_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Create empty config file
+    let mut config_file = NamedTempFile::new().unwrap();
+    config_file.write_all(b"").unwrap();
+    config_file.flush().unwrap();
+
+    // Env var set to "false" should NOT trigger fallback
+    let mut child = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .arg(format!("--config={}", config_file.path().display()))
+        .env("DD_DISCOVERY_USE_SD_AGENT", "true")
+        .env("DD_DISCOVERY_ENABLED", "true")
+        .env("DD_NETWORK_CONFIG_ENABLED", "false")
+        .spawn()
+        .expect("Failed to spawn sd-agent");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    assert!(
+        !marker_file.exists(),
+        "Env var set to 'false' should NOT trigger fallback"
+    );
+
+    child.kill().ok();
+    child.wait().expect("Failed to wait on sd-agent");
+}
+
+#[test]
+fn test_env_var_zero_no_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Create empty config file
+    let mut config_file = NamedTempFile::new().unwrap();
+    config_file.write_all(b"").unwrap();
+    config_file.flush().unwrap();
+
+    // Env var set to "0" should NOT trigger fallback
+    let mut child = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .arg(format!("--config={}", config_file.path().display()))
+        .env("DD_DISCOVERY_USE_SD_AGENT", "true")
+        .env("DD_DISCOVERY_ENABLED", "true")
+        .env("DD_NETWORK_CONFIG_ENABLED", "0")
+        .spawn()
+        .expect("Failed to spawn sd-agent");
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    assert!(
+        !marker_file.exists(),
+        "Env var set to '0' should NOT trigger fallback"
+    );
+
+    child.kill().ok();
+    child.wait().expect("Failed to wait on sd-agent");
+}
+
+#[test]
+fn test_env_var_non_boolean_triggers_fallback() {
+    let temp_dir = TempDir::new().unwrap();
+    let marker_file = temp_dir.path().join("sp-called");
+
+    let mock_sp_source = mock_system_probe_path();
+
+    // Env var set to a non-boolean value should trigger fallback (safety net)
+    let _output = Command::new(SD_AGENT_BIN)
+        .arg("--")
+        .arg(&mock_sp_source)
+        .arg(&marker_file)
+        .arg("run")
+        .env("DD_NETWORK_CONFIG_ENABLED", "maybe")
+        .output()
+        .expect("Failed to execute sd-agent");
+
+    assert!(
+        marker_file.exists(),
+        "Env var with non-boolean value should trigger fallback as safety net"
+    );
+}


### PR DESCRIPTION
### What does this PR do?

This PR makes sd-agent checks the env variables' values when determining if it needs to fallback to system-probe.

### Motivation

The Datadog Agent Helm Chart set some features' variables, even when the feature is disabled. This means sd-agent needs to check the variable's value as well.

### Describe how you validated your changes

Added unit tests.

### Additional Notes
