### PR TITLE
Fix empty cel_selector appearing in inventory payloads

### DIFF
--- a/comp/core/autodiscovery/providers/config_reader.go
+++ b/comp/core/autodiscovery/providers/config_reader.go
@@ -34,7 +34,7 @@ import (
 type configFormat struct {
 	ADIdentifiers           []string                           `yaml:"ad_identifiers,omitempty"`
 	AdvancedADIdentifiers   []integration.AdvancedADIdentifier `yaml:"advanced_ad_identifiers,omitempty"`
-	CELSelector             workloadfilter.Rules               `yaml:"cel_selector"`
+	CELSelector             workloadfilter.Rules               `yaml:"cel_selector,omitempty"`
 	ClusterCheck            bool                               `yaml:"cluster_check,omitempty"`
 	InitConfig              interface{}                        `yaml:"init_config,omitempty"`
 	MetricConfig            interface{}                        `yaml:"jmx_metrics,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where empty `cel_selector` fields appear in Fleet Automation inventory payloads for integration configs that don't define CEL selectors.

### Motivation

Following #41031 which added CEL selector support to autodiscovery, the `cel_selector` field appears in all inventory payloads with empty values even when not defined in the config file:

```yaml
cel_selector:
  containers: []
  processes: []
  pods: []
  kube_services: []
  kube_endpoints: []
```

This confuses customers viewing their configs in Fleet Automation, as they see fields that aren't in their actual `.conf` files.

### How

Added `omitempty` YAML tag to the `CELSelector` field in `configFormat` struct, consistent with all other optional fields. This ensures empty CEL selectors are omitted during YAML marshaling for inventory payloads while preserving configs that explicitly define CEL selectors.

### Describe how to test/QA your changes

- Unit tests pass for autodiscovery providers
- Configs without `cel_selector` → field omitted from inventory payload
- Configs with `cel_selector` → field present with values