### PR TITLE
[ACTP] [par] Use k8s secret for enrollment only in DCA

### DIFF
--- a/pkg/privateactionrunner/bundles/gitlab/users/test_connection.go
+++ b/pkg/privateactionrunner/bundles/gitlab/users/test_connection.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_gitlab_users
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type TestConnectionHandler struct {
+	currentUserHandler *CurrentUserHandler
+}
+
+func NewTestConnectionHandler() *TestConnectionHandler {
+	return &TestConnectionHandler{
+		currentUserHandler: NewCurrentUserHandler(),
+	}
+}
+
+type TestConnectionInputs struct{}
+
+type TestConnectionOutputs = CurrentUserOutputs
+
+func (h *TestConnectionHandler) Run(
+	ctx context.Context,
+	task *types.Task,
+	credential *privateconnection.PrivateCredentials,
+) (any, error) {
+	return h.currentUserHandler.Run(ctx, task, credential)
+}

--- a/pkg/privateactionrunner/enrollment/storage.go
+++ b/pkg/privateactionrunner/enrollment/storage.go
@@ -18,11 +18,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	log "github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/logging"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 // GetIdentityFromPreviousEnrollment retrieves PAR identity from either K8s secret or file based on configuration
 func GetIdentityFromPreviousEnrollment(ctx context.Context, cfg configModel.Reader) (*PersistedIdentity, error) {
-	if cfg.GetBool("cluster_agent.enabled") {
+	if cfg.GetBool("cluster_agent.enabled") && flavor.GetFlavor() == flavor.ClusterAgent {
 		return getIdentityFromK8sSecret(ctx, cfg)
 	}
 	return getIdentityFromFile(cfg)
@@ -30,7 +31,7 @@ func GetIdentityFromPreviousEnrollment(ctx context.Context, cfg configModel.Read
 
 // PersistIdentity persists identity to either K8s secret or file based on configuration
 func PersistIdentity(ctx context.Context, cfg configModel.Reader, result *Result) error {
-	if cfg.GetBool("cluster_agent.enabled") {
+	if cfg.GetBool("cluster_agent.enabled") && flavor.GetFlavor() == flavor.ClusterAgent {
 		return persistIdentityToK8sSecret(ctx, cfg, result)
 	}
 	return persistIdentityToFile(cfg, result)


### PR DESCRIPTION
### What does this PR do?
Ensure PAR enrollment uses k8s secret only for the DCA. It was wrongly assumed that the dca and the node agent has different configs.

### Motivation
See https://github.com/DataDog/datadog-agent/pull/46225#discussion_r2805154484

### Describe how you validated your changes


### Additional Notes
