### PR TITLE
Add `bazelisk` to `install-tools` list

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aarzilli/whydeadcode v0.0.0-20241226171816-ed86f8ea0a6f
+	github.com/bazelbuild/bazelisk v1.28.1
 	github.com/frapposelli/wwhrd v0.4.0
 	github.com/go-enry/go-license-detector/v4 v4.3.1
 	github.com/golangci/golangci-lint/v2 v2.7.0
@@ -49,6 +50,7 @@ require (
 	github.com/ashanbrown/makezero/v2 v2.1.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bitfield/gotestdox v0.2.2 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -74,8 +74,12 @@ github.com/ashanbrown/makezero/v2 v2.1.0 h1:snuKYMbqosNokUKm+R6/+vOPs8yVAi46La7C
 github.com/ashanbrown/makezero/v2 v2.1.0/go.mod h1:aEGT/9q3S8DHeE57C88z2a6xydvgx8J5hgXIGWgo0MY=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/bazelbuild/bazelisk v1.28.1 h1:p+U4By+b8cnPabjFCubA7qi/GURU24J/Tn3NXOwGLog=
+github.com/bazelbuild/bazelisk v1.28.1/go.mod h1:hpvsc/YkfAFoNwTKk8LaprQHUd/l+MClrEs4e+EzdnM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
+github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bitfield/gotestdox v0.2.2 h1:x6RcPAbBbErKLnapz1QeAlf3ospg8efBsedU93CDsnE=
 github.com/bitfield/gotestdox v0.2.2/go.mod h1:D+gwtS0urjBrzguAkTM2wodsTQYFHdpx8eqRJ3N+9pY=
 github.com/bkielbasa/cyclop v1.2.3 h1:faIVMIGDIANuGPWH031CZJTi2ymOQBULs9H21HSMa5w=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,6 +12,7 @@ package tools
 
 import (
 	_ "github.com/aarzilli/whydeadcode"
+	_ "github.com/bazelbuild/bazelisk"
 	_ "github.com/frapposelli/wwhrd"
 	_ "github.com/go-enry/go-license-detector/v4/cmd/license-detector"
 	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -10,9 +10,10 @@ from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.go import download_go_dependencies
 from tasks.libs.common.retry import run_command_with_retry
-from tasks.libs.common.utils import environ, gitlab_section
+from tasks.libs.common.utils import environ, get_gobin, gitlab_section, link_or_copy
 
 TOOL_LIST = [
+    'github.com/bazelbuild/bazelisk',
     'github.com/frapposelli/wwhrd',
     'github.com/go-enry/go-license-detector/v4/cmd/license-detector',
     'github.com/golangci/golangci-lint/v2/cmd/golangci-lint',
@@ -62,6 +63,8 @@ def install_tools(ctx: Context, max_retry: int = 3):
                 with ctx.cd(path):
                     for tool in tools:
                         run_command_with_retry(ctx, f"go install {tool}", max_retry=max_retry)
+        for bazelisk in Path(get_gobin(ctx)).glob('bazelisk*'):
+            link_or_copy(bazelisk, bazelisk.with_stem(bazelisk.stem.replace('isk', '')))
 
 
 @task

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -139,6 +139,21 @@ def get_gobin(ctx):
     return gobin
 
 
+def link_or_copy(src: Path, dst: Path) -> None:
+    """Create dst from src using the first available strategy: relative symlink, hardlink, absolute symlink, or copy."""
+    dst.unlink(missing_ok=True)
+    for strategy in (
+        lambda: dst.symlink_to(src.relative_to(dst.parent, walk_up=True)),
+        lambda: dst.hardlink_to(src),
+        lambda: dst.symlink_to(src),
+    ):
+        try:
+            return strategy()
+        except (NotImplementedError, OSError, ValueError):
+            pass
+    return shutil.copy2(src, dst)
+
+
 def get_rtloader_paths(embedded_path=None, rtloader_root=None):
     rtloader_lib = []
     rtloader_headers = ""

--- a/tasks/unit_tests/libs/common/utils_tests.py
+++ b/tasks/unit_tests/libs/common/utils_tests.py
@@ -1,8 +1,12 @@
 import os
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 from tasks.libs.common.utils import (
+    link_or_copy,
     running_in_ci,
     running_in_github_actions,
     running_in_gitlab_ci,
@@ -32,3 +36,50 @@ class TestRunningIn(unittest.TestCase):
             with self.subTest(env_var=env_var, value=value, expected_value=expected):
                 with mock.patch.dict(os.environ, {env_var: value}, clear=True):
                     self.assertEqual(expected, func())
+
+
+class TestLinkOrCopy(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="test-link-or-copy"))
+        self.src = self._tmpdir / "src.txt"
+        self.dst = self._tmpdir / "dst.txt"
+        self.src.write_text("new")
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpdir)
+
+    def test_links_or_copies(self):
+        link_or_copy(self.src, self.dst)
+        self.assertEqual(self.dst.read_text(), "new")
+
+    def test_removes_old_dst(self):
+        self.dst.write_text("old")
+        link_or_copy(self.src, self.dst)
+        self.assertEqual(self.dst.read_text(), "new")
+
+    @mock.patch("tasks.libs.common.utils.shutil.copy2")
+    @mock.patch.object(Path, "hardlink_to", side_effect=OSError)
+    @mock.patch.object(Path, "symlink_to", side_effect=OSError)
+    def test_tries_methods_in_order(self, symlink_to, hardlink_to, copy2):
+        in_order = mock.Mock()
+        in_order.attach_mock(symlink_to, "symlink_to")
+        in_order.attach_mock(hardlink_to, "hardlink_to")
+        in_order.attach_mock(copy2, "copy2")
+
+        link_or_copy(self.src, self.dst)
+
+        in_order.assert_has_calls(
+            (
+                mock.call.symlink_to(Path("src.txt")),
+                mock.call.hardlink_to(self.src),
+                mock.call.symlink_to(self.src),
+                mock.call.copy2(self.src, self.dst),
+            )
+        )
+
+    @mock.patch("tasks.libs.common.utils.shutil.copy2", side_effect=OSError)
+    @mock.patch.object(Path, "hardlink_to", side_effect=NotImplementedError)
+    @mock.patch.object(Path, "symlink_to", side_effect=NotImplementedError)
+    def test_propagates_last_error(self, symlink_to, hardlink_to, copy2):
+        with self.assertRaises(OSError):
+            link_or_copy(self.src, self.dst)


### PR DESCRIPTION
### What does this PR do?
Install `bazelisk` via the automated tool installation mechanism for local developerment, esp. for those working on bare metal.

### Motivation
Minimize developer-facing disruptions since the `bazel` symlink to `bazelisk` is expected to be present in the shell's `PATH`.

This provides the same experience for bare metal developers as those using containers: `bazel build`/`bazel test`/`bazel run`/etc.

### Describe how you validated your changes
Additional unit tests.

### Additional Notes
1. as of **today**, containers do have `bazelisk` and its `bazel` alias in the image, which means we might think about offloading them in favor of repo/branch specific version requirements,
2. the new `link_or_copy` utility is meant to favor _relative_ symlinks (no tree traversal, move-friendly), then hardlinks (don't require any special privilege), then _absolute_ symlinks (might require permissions on Windows), and finally falls back to copies should always work (well, unless there's no space left on device).