### PR TITLE
dyninst: recompile eBPF programs based on discovered types

### DIFF
--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -19,11 +19,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// DefaultDiscoveredTypesLimit is the default value for the discovered types
+// limit.
+const defaultDiscoveredTypesLimit = 512
+
 // Config configures the actuator.
 type Config struct {
 	// CircuitBreakerConfig configures the circuit breaker for enforcing probe
 	// CPU limits.
 	CircuitBreakerConfig CircuitBreakerConfig
+	// DiscoveredTypesLimit is the maximum number of discovered type names
+	// tracked across all services before orphaned entries are evicted. If
+	// zero, the default value is used. If negative, all discovered types are
+	// evicted when the processes for that service are removed.
+	DiscoveredTypesLimit int
 	// RecompilationDisabled disables recompilation of programs when new types
 	// are discovered. This is generally useful for testing.
 	RecompilationDisabled bool
@@ -80,6 +89,9 @@ func (a *Actuator) Stats() map[string]any {
 
 // NewActuator creates a new Actuator instance.
 func NewActuator(cfg Config) *Actuator {
+	if cfg.DiscoveredTypesLimit == 0 {
+		cfg.DiscoveredTypesLimit = defaultDiscoveredTypesLimit
+	}
 	shuttingDownCh := make(chan struct{})
 	eventCh := make(chan event)
 	a := &Actuator{

--- a/pkg/dyninst/actuator/actuator.go
+++ b/pkg/dyninst/actuator/actuator.go
@@ -19,6 +19,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// Config configures the actuator.
+type Config struct {
+	// CircuitBreakerConfig configures the circuit breaker for enforcing probe
+	// CPU limits.
+	CircuitBreakerConfig CircuitBreakerConfig
+	// RecompilationDisabled disables recompilation of programs when new types
+	// are discovered. This is generally useful for testing.
+	RecompilationDisabled bool
+}
+
 // CircuitBreakerConfig configures the circuit breaker for enforcing probe CPU limits.
 type CircuitBreakerConfig struct {
 	// Interval is the interval at which probe CPU usage is checked.
@@ -69,7 +79,7 @@ func (a *Actuator) Stats() map[string]any {
 }
 
 // NewActuator creates a new Actuator instance.
-func NewActuator(breakerCfg CircuitBreakerConfig) *Actuator {
+func NewActuator(cfg Config) *Actuator {
 	shuttingDownCh := make(chan struct{})
 	eventCh := make(chan event)
 	a := &Actuator{
@@ -79,12 +89,12 @@ func NewActuator(breakerCfg CircuitBreakerConfig) *Actuator {
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
-		a.runEventProcessor(breakerCfg, eventCh, shuttingDownCh)
+		a.runEventProcessor(cfg, eventCh, shuttingDownCh)
 	}()
 	a.wg.Add(1)
 	go func() {
 		defer a.wg.Done()
-		a.heartbeatLoop(breakerCfg.Interval)
+		a.heartbeatLoop(cfg.CircuitBreakerConfig.Interval)
 	}()
 	return a
 }
@@ -92,6 +102,27 @@ func NewActuator(breakerCfg CircuitBreakerConfig) *Actuator {
 // SetRuntime initializes the actuator with a runtime and makes it ready to use.
 func (a *Actuator) SetRuntime(runtime Runtime) {
 	a.runtime.Store(&runtime)
+}
+
+// ReportMissingTypes reports type names that were encountered at runtime in
+// interface values but were not present in the IR program's type registry.
+// The actuator accumulates these per service and triggers recompilation when
+// new types are discovered and the loading pipeline is idle.
+func (a *Actuator) ReportMissingTypes(processID ProcessID, typeNames []string) {
+	if len(typeNames) == 0 {
+		return
+	}
+	select {
+	case <-a.shuttingDown:
+	default:
+		select {
+		case <-a.shuttingDown:
+		case a.events <- eventMissingTypesReported{
+			processID: processID,
+			typeNames: typeNames,
+		}:
+		}
+	}
 }
 
 // HandleUpdate processes an update to process instrumentation configuration.
@@ -118,11 +149,11 @@ func (a *Actuator) HandleUpdate(update ProcessesUpdate) {
 // runEventProcessor runs in a separate goroutine and processes events sequentially
 // to maintain state machine consistency. Only this goroutine accesses state.
 func (a *Actuator) runEventProcessor(
-	breakerCfg CircuitBreakerConfig,
+	cfg Config,
 	eventCh <-chan event,
 	shuttingDownCh chan<- struct{},
 ) {
-	state := newState(breakerCfg)
+	state := newState(cfg)
 	for !state.isShutdown() {
 		event := <-eventCh
 		if _, isShutdown := event.(eventShutdown); isShutdown {
@@ -176,6 +207,7 @@ func (a *effects) loadProgram(
 	executable Executable,
 	processID ProcessID,
 	probes []ir.ProbeDefinition,
+	opts LoadOptions,
 ) {
 	a.wg.Add(1)
 	go func() {
@@ -189,7 +221,7 @@ func (a *effects) loadProgram(
 		}
 		runtime := *runtimePtr
 		loaded, err := runtime.Load(
-			programID, executable, processID, probes,
+			programID, executable, processID, probes, opts,
 		)
 		if err != nil {
 			log.Infof(

--- a/pkg/dyninst/actuator/dependencies.go
+++ b/pkg/dyninst/actuator/dependencies.go
@@ -12,6 +12,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 )
 
+// LoadOptions carries optional parameters for Runtime.Load.
+type LoadOptions struct {
+	// AdditionalTypes is a sorted, deduplicated list of Go type names
+	// discovered at runtime (e.g. from interface decoding) that should be
+	// included in the IR program's type registry.
+	AdditionalTypes []string
+}
+
 // Runtime abstracts the creation, attachment, and cleanup of a program.
 type Runtime interface {
 	// Load loads a program into the runtime.
@@ -19,7 +27,7 @@ type Runtime interface {
 	// If loading fails, the process will enter a failed state until new
 	// probes are added for it or the process is removed.
 	Load(
-		ir.ProgramID, Executable, ProcessID, []ir.ProbeDefinition,
+		ir.ProgramID, Executable, ProcessID, []ir.ProbeDefinition, LoadOptions,
 	) (LoadedProgram, error)
 }
 

--- a/pkg/dyninst/actuator/state.go
+++ b/pkg/dyninst/actuator/state.go
@@ -656,6 +656,7 @@ func clearProcessProgram(
 }
 
 // mergeIntoSorted merges src into dst, maintaining a sorted, deduplicated slice.
+// src must be sorted; duplicates in src are tolerated.
 func mergeIntoSorted(dst, src []string) (_ []string, changed bool) {
 	var i int
 	for _, name := range src {
@@ -688,6 +689,7 @@ func handleMissingTypesReported(
 
 	// Merge reported type names into the per-service discovered set,
 	// maintaining a sorted, deduplicated slice.
+	slices.Sort(ev.typeNames)
 	types, changed := mergeIntoSorted(sm.discoveredTypes[service], ev.typeNames)
 	if !changed {
 		return nil

--- a/pkg/dyninst/actuator/state_effects_test.go
+++ b/pkg/dyninst/actuator/state_effects_test.go
@@ -25,10 +25,11 @@ type effect interface {
 // Effect implementations
 
 type effectSpawnBpfLoading struct {
-	processID  ProcessID
-	programID  ir.ProgramID
-	executable Executable
-	probes     []ir.ProbeDefinition
+	processID       ProcessID
+	programID       ir.ProgramID
+	executable      Executable
+	probes          []ir.ProbeDefinition
+	additionalTypes []string
 }
 
 func (e effectSpawnBpfLoading) yamlTag() string {
@@ -41,12 +42,16 @@ func (e effectSpawnBpfLoading) yamlData() map[string]any {
 		probeKeys = append(probeKeys, probe.GetID())
 	}
 	slices.Sort(probeKeys)
-	return map[string]any{
+	data := map[string]any{
 		"process_id": int(e.processID.PID),
 		"program_id": int(e.programID),
 		"executable": e.executable.String(),
 		"probes":     probeKeys,
 	}
+	if len(e.additionalTypes) > 0 {
+		data["additional_types"] = e.additionalTypes
+	}
+	return data
 }
 
 type effectAttachToProcess struct {
@@ -135,12 +140,14 @@ func (er *effectRecorder) loadProgram(
 	executable Executable,
 	processID ProcessID,
 	probes []ir.ProbeDefinition,
+	opts LoadOptions,
 ) {
 	er.recordEffect(effectSpawnBpfLoading{
-		processID:  processID,
-		programID:  programID,
-		executable: executable,
-		probes:     probes,
+		processID:       processID,
+		programID:       programID,
+		executable:      executable,
+		probes:          probes,
+		additionalTypes: opts.AdditionalTypes,
 	})
 }
 

--- a/pkg/dyninst/actuator/state_events.go
+++ b/pkg/dyninst/actuator/state_events.go
@@ -106,6 +106,19 @@ func (e eventProgramUnloaded) String() string {
 	return fmt.Sprintf("eventProgramUnloaded{programID: %v}", e.programID)
 }
 
+type eventMissingTypesReported struct {
+	baseEvent
+	processID ProcessID
+	typeNames []string
+}
+
+func (e eventMissingTypesReported) String() string {
+	return fmt.Sprintf(
+		"eventMissingTypesReported{processID: %v, typeNames: %d}",
+		e.processID, len(e.typeNames),
+	)
+}
+
 type eventShutdown struct {
 	baseEvent
 }

--- a/pkg/dyninst/actuator/state_events_test.go
+++ b/pkg/dyninst/actuator/state_events_test.go
@@ -76,6 +76,13 @@ func TestEventStringer(t *testing.T) {
 			wantStr: "eventShutdown{}",
 		},
 		{
+			ev: eventMissingTypesReported{
+				processID: ProcessID{PID: 100},
+				typeNames: []string{"Foo", "Bar"},
+			},
+			wantStr: "eventMissingTypesReported{processID: {PID:100}, typeNames: 2}",
+		},
+		{
 			ev: eventRuntimeStatsUpdated{
 				programID: 1,
 			},

--- a/pkg/dyninst/actuator/state_helpers_test.go
+++ b/pkg/dyninst/actuator/state_helpers_test.go
@@ -8,6 +8,8 @@
 package actuator
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,7 +28,7 @@ func deepCopyState(original *state) *state {
 	}
 
 	// Create new state with basic fields copied.
-	copied := newState(CircuitBreakerConfig{})
+	copied := newState(Config{})
 
 	copied.counters = original.counters
 	copied.programIDAlloc = original.programIDAlloc
@@ -52,6 +54,16 @@ func deepCopyState(original *state) *state {
 		copied.queuedLoading.pushBack(copied.programs[prog.id])
 	}
 
+	// Deep copy discoveredTypes map.
+	for svc, types := range original.discoveredTypes {
+		copied.discoveredTypes[svc] = slices.Clone(types)
+	}
+
+	// Deep copy processesByService map.
+	for svc, pids := range original.processesByService {
+		copied.processesByService[svc] = maps.Clone(pids)
+	}
+
 	return copied
 }
 
@@ -66,11 +78,12 @@ func deepCopyProgram(original *program) *program {
 	copy(copiedConfig, original.config)
 
 	copied := &program{
-		state:      original.state,
-		id:         original.id,
-		config:     copiedConfig,
-		executable: original.executable,
-		processID:  original.processID,
+		state:              original.state,
+		id:                 original.id,
+		config:             copiedConfig,
+		executable:         original.executable,
+		processID:          original.processID,
+		needsRecompilation: original.needsRecompilation,
 	}
 	if len(original.lastRuntimeStats) > 0 {
 		copied.lastRuntimeStats = append(
@@ -106,6 +119,7 @@ func deepCopyProcess(original *process) *process {
 		state:           original.state,
 		processID:       original.processID,
 		executable:      original.executable,
+		service:         original.service,
 		probes:          copiedProbes,
 		currentProgram:  original.currentProgram,
 		attachedProgram: original.attachedProgram,
@@ -116,7 +130,7 @@ func deepCopyProcess(original *process) *process {
 
 // TestDeepCopyState verifies that deepCopyState works correctly.
 func TestDeepCopyState(t *testing.T) {
-	s := newState(CircuitBreakerConfig{})
+	s := newState(Config{})
 	processID := ProcessID{PID: 123}
 	executable := Executable{Path: "/test/path"}
 	probe := &rcjson.SnapshotProbe{

--- a/pkg/dyninst/actuator/state_helpers_test.go
+++ b/pkg/dyninst/actuator/state_helpers_test.go
@@ -55,6 +55,9 @@ func deepCopyState(original *state) *state {
 	}
 
 	copied.totalDiscoveredTypes = original.totalDiscoveredTypes
+	copied.recompilationRateLimit = original.recompilationRateLimit
+	copied.recompilationRateBurst = original.recompilationRateBurst
+	copied.recompilationAllowance = original.recompilationAllowance
 
 	// Deep copy discoveredTypes map.
 	for svc, types := range original.discoveredTypes {

--- a/pkg/dyninst/actuator/state_helpers_test.go
+++ b/pkg/dyninst/actuator/state_helpers_test.go
@@ -28,7 +28,7 @@ func deepCopyState(original *state) *state {
 	}
 
 	// Create new state with basic fields copied.
-	copied := newState(Config{})
+	copied := newState(Config{DiscoveredTypesLimit: original.discoveredTypesLimit})
 
 	copied.counters = original.counters
 	copied.programIDAlloc = original.programIDAlloc
@@ -53,6 +53,8 @@ func deepCopyState(original *state) *state {
 	for prog := range original.queuedLoading.items() {
 		copied.queuedLoading.pushBack(copied.programs[prog.id])
 	}
+
+	copied.totalDiscoveredTypes = original.totalDiscoveredTypes
 
 	// Deep copy discoveredTypes map.
 	for svc, types := range original.discoveredTypes {

--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -94,7 +94,7 @@ func runStateMachinePropertyTest(t *testing.T, seed int64) []byte {
 	rng := rand.New(rand.NewSource(seed))
 
 	pts := &propertyTestState{
-		sm:               newState(CircuitBreakerConfig{}),
+		sm:               newState(Config{}),
 		processIDCounter: 1000,
 		rng:              rng,
 	}
@@ -197,11 +197,16 @@ func (pts *propertyTestState) generateRandomEvent() (event, bool) {
 		pts.shuttingDown = true
 		return eventShutdown{}, true
 	case choice < 0.5 || len(pts.unresolvedEffects) == 0:
+		if ev := pts.maybeGenerateMissingTypes(); ev != nil {
+			return ev, true
+		}
 		return pts.generateProcessUpdate(), true
 	default:
 		return pts.completeRandomEffect(), true
 	}
 }
+
+var serviceNames = []string{"svc-a", "svc-b", "svc-c"}
 
 func (pts *propertyTestState) generateProcessUpdate() event {
 	numUpdates := pts.rng.Intn(3) + 1 // 1-3 process updates
@@ -238,9 +243,11 @@ func (pts *propertyTestState) generateProcessUpdate() event {
 				probes = append(probes, probe)
 			}
 
+			service := serviceNames[pts.rng.Intn(len(serviceNames))]
 			updates = append(updates, ProcessUpdate{
 				Info: procinfo.Info{
 					ProcessID: processID,
+					Service:   service,
 					Executable: Executable{
 						Path: fmt.Sprintf("/usr/bin/app_%d", pts.processIDCounter),
 					},
@@ -311,6 +318,35 @@ func (pts *propertyTestState) existingProcesses() []ProcessID {
 		return cmp.Compare(a.PID, b.PID)
 	})
 	return existing
+}
+
+var missingTypeNames = []string{"TypeA", "TypeB", "TypeC", "TypeD", "TypeE"}
+
+// maybeGenerateMissingTypes generates an eventMissingTypesReported for a
+// random existing process with ~10% probability. Returns nil if no event
+// should be generated.
+func (pts *propertyTestState) maybeGenerateMissingTypes() event {
+	if pts.rng.Float64() > 0.1 {
+		return nil
+	}
+	existing := pts.existingProcesses()
+	if len(existing) == 0 {
+		return nil
+	}
+	pid := existing[pts.rng.Intn(len(existing))]
+	proc := pts.sm.processes[pid]
+	if proc.service == "" {
+		return nil
+	}
+	numTypes := pts.rng.Intn(3) + 1
+	var types []string
+	for i := 0; i < numTypes; i++ {
+		types = append(types, missingTypeNames[pts.rng.Intn(len(missingTypeNames))])
+	}
+	return eventMissingTypesReported{
+		processID: pid,
+		typeNames: types,
+	}
 }
 
 func (pts *propertyTestState) completeRandomEffect() event {

--- a/pkg/dyninst/actuator/state_property_test.go
+++ b/pkg/dyninst/actuator/state_property_test.go
@@ -94,7 +94,9 @@ func runStateMachinePropertyTest(t *testing.T, seed int64) []byte {
 	rng := rand.New(rand.NewSource(seed))
 
 	pts := &propertyTestState{
-		sm:               newState(Config{}),
+		sm: newState(Config{
+			DiscoveredTypesLimit: 10,
+		}),
 		processIDCounter: 1000,
 		rng:              rng,
 	}

--- a/pkg/dyninst/actuator/state_snapshot_test.go
+++ b/pkg/dyninst/actuator/state_snapshot_test.go
@@ -99,16 +99,24 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 	// Check if the first event is a config event; if so, extract settings
 	// and remove it from the events list.
 	discoveredTypesLimit := defaultDiscoveredTypesLimit
+	var recompilationRateLimit float64
+	var recompilationRateBurst int
 	if len(events) > 0 {
 		if cfg, ok := events[0].event.(eventConfig); ok {
 			discoveredTypesLimit = cfg.discoveredTypesLimit
+			recompilationRateLimit = cfg.recompilationRateLimit
+			recompilationRateBurst = cfg.recompilationRateBurst
 			events = events[1:]
 			eventNodes = eventNodes[1:]
 		}
 	}
 
 	// Process each event
-	s := newState(Config{DiscoveredTypesLimit: discoveredTypesLimit})
+	s := newState(Config{
+		DiscoveredTypesLimit:   discoveredTypesLimit,
+		RecompilationRateLimit: recompilationRateLimit,
+		RecompilationRateBurst: recompilationRateBurst,
+	})
 	effects := effectRecorder{}
 	for i, ev := range events {
 

--- a/pkg/dyninst/actuator/state_snapshot_test.go
+++ b/pkg/dyninst/actuator/state_snapshot_test.go
@@ -96,8 +96,19 @@ func runSnapshotTest(t *testing.T, file string, rewrite bool) {
 		}
 	}()
 
+	// Check if the first event is a config event; if so, extract settings
+	// and remove it from the events list.
+	discoveredTypesLimit := defaultDiscoveredTypesLimit
+	if len(events) > 0 {
+		if cfg, ok := events[0].event.(eventConfig); ok {
+			discoveredTypesLimit = cfg.discoveredTypesLimit
+			events = events[1:]
+			eventNodes = eventNodes[1:]
+		}
+	}
+
 	// Process each event
-	s := newState(Config{})
+	s := newState(Config{DiscoveredTypesLimit: discoveredTypesLimit})
 	effects := effectRecorder{}
 	for i, ev := range events {
 

--- a/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_evict_on_process_removal.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_evict_on_process_removal.yaml
@@ -1,0 +1,357 @@
+# Tests that removing the last process of a service triggers eviction of that
+# service's discovered types when the total exceeds the limit.
+#
+# Flow:
+# 1. Configure low limit (4)
+# 2. Two services get types, total exceeds limit
+# 3. Removing svc-a's last process triggers eviction of svc-a's types
+- !config {discovered_types_limit: 4}
+# Add svc-a process
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+- !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Add svc-b process
+- !processes-updated
+  updated:
+    - process_id: {pid: 2001}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 2001}
+# svc-b gets types, total = 2 + 3 = 5 > limit (4)
+- !missing-types-reported {process_id: 2001, type_names: [TypeC, TypeD, TypeE]}
+- !detached {program_id: 3, process_id: 2001}
+- !unloaded {program_id: 3}
+- !loaded {program_id: 4}
+- !attached {program_id: 4, process_id: 2001}
+# Now remove svc-a process; svc-a's 2 types are evicted because total > limit
+- !processes-updated
+  removed: [1001]
+- !detached {program_id: 2, process_id: 1001}
+- !unloaded {program_id: 2}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    svc-a: '[] -> [TypeA TypeB]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [TypeA, TypeB], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 2001}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-b@0.0m0.0, probes: [probe2], process_id: 2001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: <nil> -> WaitingForProgram (prog 3)
+  programs:
+    2: Loaded (proc 1001)
+    3: <nil> -> Loading (proc 2001)
+  stats:
+    numProcesses: 1 -> 2
+    numPrograms: 1 -> 2
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-b@0.0m0.0, process_id: 2001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+  programs:
+    2: Loaded (proc 1001)
+    3: Loading (proc 2001) -> Loaded (proc 2001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 2001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: Attaching (prog 3) -> Attached (prog 3)
+  programs:
+    2: Loaded (proc 1001)
+    3: Loaded (proc 2001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 2001, type_names: [TypeC, TypeD, TypeE]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 2001, program_id: 3}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: Attached (prog 3) -> Detaching (prog 3)
+  programs:
+    2: Loaded (proc 1001)
+    3: Loaded (proc 2001) -> Draining (proc 2001)
+  discovered_types:
+    svc-b: '[] -> [TypeC TypeD TypeE]'
+  stats:
+    numAttached: 2 -> 1
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 1 -> 2
+---
+event: !detached {program_id: 3, process_id: 2001}
+effects:
+  - !unload-program {program_id: 3}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: Detaching (prog 3)
+  programs:
+    2: Loaded (proc 1001)
+    3: Draining (proc 2001) -> Unloading (proc 2001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 3}
+effects:
+  - !spawn-bpf-loading {additional_types: [TypeC, TypeD, TypeE], executable: /usr/bin/app-b@0.0m0.0, probes: [probe2], process_id: 2001, program_id: 4}
+state:
+  currently_loading: <nil> -> 4
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: Detaching (prog 3) -> WaitingForProgram (prog 4)
+  programs:
+    2: Loaded (proc 1001)
+    3: Unloading (proc 2001) -> <nil>
+    4: <nil> -> Loading (proc 2001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 1 -> 2
+---
+event: !loaded {program_id: 4}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-b@0.0m0.0, process_id: 2001, program_id: 4}
+state:
+  currently_loading: 4 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: WaitingForProgram (prog 4) -> Attaching (prog 4)
+  programs:
+    2: Loaded (proc 1001)
+    4: Loading (proc 2001) -> Loaded (proc 2001)
+  stats:
+    loaded: 3 -> 4
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 4, process_id: 2001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+    2001: Attaching (prog 4) -> Attached (prog 4)
+  programs:
+    2: Loaded (proc 1001)
+    4: Loaded (proc 2001)
+  stats:
+    attached: 3 -> 4
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  removed: [1001]
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) -> Detaching (prog 2)
+    2001: Attached (prog 4)
+  programs:
+    2: Loaded (proc 1001) -> Draining (proc 1001)
+    4: Loaded (proc 2001)
+  stats:
+    numAttached: 2 -> 1
+    numDetaching: 0 -> 1
+---
+event: !detached {program_id: 2, process_id: 1001}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2)
+    2001: Attached (prog 4)
+  programs:
+    2: Draining (proc 1001) -> Unloading (proc 1001)
+    4: Loaded (proc 2001)
+  stats:
+    detached: 2 -> 3
+---
+event: !unloaded {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2) -> <nil>
+    2001: Attached (prog 4)
+  programs:
+    2: Unloading (proc 1001) -> <nil>
+    4: Loaded (proc 2001)
+  discovered_types:
+    svc-a: '[TypeA TypeB] -> []'
+  stats:
+    numDetaching: 1 -> 0
+    numProcesses: 2 -> 1
+    numPrograms: 2 -> 1
+    unloaded: 2 -> 3
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_evict_orphan_on_add.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_evict_orphan_on_add.yaml
@@ -1,0 +1,273 @@
+# Tests that when discovered types exceed the limit, orphaned entries (services
+# with no live processes) are evicted when new types are added.
+#
+# Flow:
+# 1. Configure low limit (5)
+# 2. Process for svc-a added -> loads, attaches, gets types
+# 3. Process for svc-a removed -> types become orphaned
+# 4. Process for svc-b added -> loads, attaches, gets types pushing over limit
+# 5. svc-a's orphaned types are evicted
+- !config {discovered_types_limit: 5}
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+- !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB, TypeC]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Remove svc-a process; types become orphaned but total (3) is under limit (5)
+- !processes-updated
+  removed: [1001]
+- !detached {program_id: 2, process_id: 1001}
+- !unloaded {program_id: 2}
+# Now add svc-b process with types that push total over limit
+- !processes-updated
+  updated:
+    - process_id: {pid: 2001}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 2001}
+- !missing-types-reported {process_id: 2001, type_names: [TypeD, TypeE, TypeF]}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB, TypeC]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    svc-a: '[] -> [TypeA TypeB TypeC]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [TypeA, TypeB, TypeC], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  removed: [1001]
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) -> Detaching (prog 2)
+  programs:
+    2: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+---
+event: !detached {program_id: 2, process_id: 1001}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2) -> <nil>
+  programs:
+    2: Unloading (proc 1001) -> <nil>
+  stats:
+    numDetaching: 1 -> 0
+    numProcesses: 1 -> 0
+    numPrograms: 1 -> 0
+    unloaded: 1 -> 2
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 2001}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-b@0.0m0.0, probes: [probe2], process_id: 2001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    2001: <nil> -> WaitingForProgram (prog 3)
+  programs:
+    3: <nil> -> Loading (proc 2001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-b@0.0m0.0, process_id: 2001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    2001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+  programs:
+    3: Loading (proc 2001) -> Loaded (proc 2001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 2001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    2001: Attaching (prog 3) -> Attached (prog 3)
+  programs:
+    3: Loaded (proc 2001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 2001, type_names: [TypeD, TypeE, TypeF]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 2001, program_id: 3}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    2001: Attached (prog 3) -> Detaching (prog 3)
+  programs:
+    3: Loaded (proc 2001) -> Draining (proc 2001)
+  discovered_types:
+    svc-a: '[TypeA TypeB TypeC] -> []'
+    svc-b: '[] -> [TypeD TypeE TypeF]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 1 -> 2
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_no_evict_under_limit.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/discovered_types_limit_no_evict_under_limit.yaml
@@ -1,0 +1,193 @@
+# Tests that orphaned discovered types are preserved when the total stays
+# under the configured limit.
+#
+# Flow:
+# 1. Configure limit of 10
+# 2. Process for svc-a gets 3 types, then is removed
+# 3. Types remain orphaned because total (3) is under limit (10)
+- !config {discovered_types_limit: 10}
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+- !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB, TypeC]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Remove process; types stay because total (3) < limit (10)
+- !processes-updated
+  removed: [1001]
+- !detached {program_id: 2, process_id: 1001}
+- !unloaded {program_id: 2}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [TypeA, TypeB, TypeC]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    svc-a: '[] -> [TypeA TypeB TypeC]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [TypeA, TypeB, TypeC], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  removed: [1001]
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) -> Detaching (prog 2)
+  programs:
+    2: Loaded (proc 1001) -> Draining (proc 1001)
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+---
+event: !detached {program_id: 2, process_id: 1001}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2) -> <nil>
+  programs:
+    2: Unloading (proc 1001) -> <nil>
+  stats:
+    numDetaching: 1 -> 0
+    numProcesses: 1 -> 0
+    numPrograms: 1 -> 0
+    unloaded: 1 -> 2
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_dedup.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_dedup.yaml
@@ -1,0 +1,151 @@
+# Tests that reporting the same missing types twice does not trigger
+# redundant recompilation.
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# First report triggers recompilation
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Same type reported again -- no recompilation
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    my-service: '[] -> [MyStruct]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_during_loading_same_service.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_during_loading_same_service.yaml
@@ -1,0 +1,285 @@
+# Tests that missing types reported while one process of a service is loading
+# marks both programs for recompilation.
+#
+# Flow:
+# 1. Process 1001 (svc-a) attached, process 1002 (svc-a) loading.
+# 2. Missing types reported for process 1001.
+# 3. Both programs get needsRecompilation=true.
+# 4. When prog 2 finishes loading, pipeline becomes idle.
+#    maybeTriggerTypeRecompilation clears prog 1 (min ID).
+# 5. Prog 2's process attaches. Pipeline idle again.
+#    maybeTriggerTypeRecompilation clears prog 2.
+# 6. Both processes recompile with updated types.
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app-a2}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Process 1002 is still loading (program 2). Report missing types.
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+# Program 2 finishes loading. maybeTriggerTypeRecompilation fires for prog 1.
+- !loaded {program_id: 2}
+# Prog 2 attached. maybeTriggerTypeRecompilation fires for prog 2.
+- !attached {program_id: 2, process_id: 1002}
+# Complete recompilation of process 1001 (prog 1).
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+# Complete recompilation of process 1002 (prog 2).
+- !detached {program_id: 2, process_id: 1002}
+- !unloaded {program_id: 2}
+# Both processes recompile with types. Prog 3 for process 1001, prog 4 for process 1002.
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 1001}
+- !loaded {program_id: 4}
+- !attached {program_id: 4, process_id: 1002}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app-a2}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[] -> [2]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+    1002: <nil> -> WaitingForProgram (prog 2)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+    2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/app-a2@0.0m0.0, probes: [probe1], process_id: 1002, program_id: 2}
+state:
+  currently_loading: 1 -> 2
+  queued_programs: '[2] -> []'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+    2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  discovered_types:
+    svc-a: '[] -> [MyStruct]'
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a2@0.0m0.0, process_id: 1002, program_id: 2}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+    1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+    2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttached: 1 -> 0
+    numAttaching: 0 -> 1
+    numDetaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !attached {program_id: 2, process_id: 1002}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1002, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attaching (prog 2) -> Detaching (prog 2)
+  programs:
+    1: Draining (proc 1001)
+    2: Loaded (proc 1002) -> Draining (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttaching: 1 -> 0
+    numDetaching: 1 -> 2
+    typeRecompilationsTriggered: 1 -> 2
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Detaching (prog 2)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+    2: Draining (proc 1002)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: Draining (proc 1002)
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 2 -> 1
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !detached {program_id: 2, process_id: 1002}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: "3"
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1002) -> Unloading (proc 1002)
+    3: Loading (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+state:
+  currently_loading: "3"
+  queued_programs: '[] -> [4]'
+  processes:
+    1001: WaitingForProgram (prog 3)
+    1002: Detaching (prog 2) -> WaitingForProgram (prog 4)
+  programs:
+    2: Unloading (proc 1002) -> <nil>
+    3: Loading (proc 1001)
+    4: <nil> -> Queued (proc 1002)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 1 -> 2
+    unloaded: 1 -> 2
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 3}
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app-a2@0.0m0.0, probes: [probe1], process_id: 1002, program_id: 4}
+state:
+  currently_loading: 3 -> 4
+  queued_programs: '[4] -> []'
+  processes:
+    1001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+    1002: WaitingForProgram (prog 4)
+  programs:
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+    4: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: "4"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) -> Attached (prog 3)
+    1002: WaitingForProgram (prog 4)
+  programs:
+    3: Loaded (proc 1001)
+    4: Loading (proc 1002)
+  stats:
+    attached: 2 -> 3
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !loaded {program_id: 4}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a2@0.0m0.0, process_id: 1002, program_id: 4}
+state:
+  currently_loading: 4 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: WaitingForProgram (prog 4) -> Attaching (prog 4)
+  programs:
+    3: Loaded (proc 1001)
+    4: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 3 -> 4
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 4, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: Attaching (prog 4) -> Attached (prog 4)
+  programs:
+    3: Loaded (proc 1001)
+    4: Loaded (proc 1002)
+  stats:
+    attached: 3 -> 4
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_multi_process_same_service.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_multi_process_same_service.yaml
@@ -1,0 +1,283 @@
+# Tests that missing types reported for one process triggers recompilation
+# for ALL processes of the same service.
+#
+# Flow:
+# 1. Two processes (1001, 1002) of service-a are created and both attached.
+# 2. Missing types reported for process 1001.
+# 3. Both programs should get needsRecompilation=true.
+# 4. Pipeline triggers recompilation for the minimum-ID program first (prog 1),
+#    then the second (prog 2).
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1002}
+# Both processes attached, pipeline idle. Report missing types.
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+# Complete recompilation of process 1001 (prog 1, minimum ID).
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 1001}
+# Now pipeline is idle again; process 1002 (prog 2) should be recompiled.
+- !detached {program_id: 2, process_id: 1002}
+- !unloaded {program_id: 2}
+- !loaded {program_id: 4}
+- !attached {program_id: 4, process_id: 1002}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[] -> [2]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+    1002: <nil> -> WaitingForProgram (prog 2)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+    2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app@0.0m0.0, process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/app@0.0m0.0, probes: [probe1], process_id: 1002, program_id: 2}
+state:
+  currently_loading: 1 -> 2
+  queued_programs: '[2] -> []'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+    2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app@0.0m0.0, process_id: 1002, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+    1002: Attached (prog 2)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+    2: Loaded (proc 1002)
+  discovered_types:
+    svc-a: '[] -> [MyStruct]'
+  stats:
+    numAttached: 2 -> 1
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+  - !detach-from-process {failure: "no", process_id: 1002, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attached (prog 2) -> Detaching (prog 2)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+    2: Loaded (proc 1002) -> Draining (proc 1002)
+  stats:
+    detached: 0 -> 1
+    numAttached: 1 -> 0
+    numDetaching: 1 -> 2
+    typeRecompilationsTriggered: 1 -> 2
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: Draining (proc 1002)
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 2 -> 1
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/app@0.0m0.0, process_id: 1001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1002)
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) -> Attached (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1002)
+    3: Loaded (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !detached {program_id: 2, process_id: 1002}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1002) -> Unloading (proc 1002)
+    3: Loaded (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app@0.0m0.0, probes: [probe1], process_id: 1002, program_id: 4}
+state:
+  currently_loading: <nil> -> 4
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: Detaching (prog 2) -> WaitingForProgram (prog 4)
+  programs:
+    2: Unloading (proc 1002) -> <nil>
+    3: Loaded (proc 1001)
+    4: <nil> -> Loading (proc 1002)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 1 -> 2
+---
+event: !loaded {program_id: 4}
+effects:
+  - !attach-to-process {executable: /usr/bin/app@0.0m0.0, process_id: 1002, program_id: 4}
+state:
+  currently_loading: 4 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: WaitingForProgram (prog 4) -> Attaching (prog 4)
+  programs:
+    3: Loaded (proc 1001)
+    4: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 3 -> 4
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 4, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+    1002: Attaching (prog 4) -> Attached (prog 4)
+  programs:
+    3: Loaded (proc 1001)
+    4: Loaded (proc 1002)
+  stats:
+    attached: 3 -> 4
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_new_process_inherits.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_new_process_inherits.yaml
@@ -1,0 +1,292 @@
+# Tests the interaction between deferred recompilation and new processes
+# inheriting discovered types. Exercises:
+# 1. Processes 1001 (svc-a) and 1002 (svc-b) start; pipeline loads them.
+# 2. While loading process 1002, missing types are reported for process 1001.
+# 3. Types are recorded but recompilation is deferred (pipeline busy).
+# 4. Process 1002 finishes loading. Pipeline becomes idle.
+# 5. Deferred recompilation triggers for process 1001.
+# 6. While process 1001 is being recompiled, a new process 1003 for svc-a
+#    arrives. Its program inherits the discovered types immediately.
+# 7. Everything completes. Both 1001 and 1003 are attached with types.
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: foo}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Pipeline is busy loading program 2 for process 1002.
+# Report missing types for process 1001 -- deferred since pipeline is busy.
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+# Program 2 loads. Pipeline becomes idle → deferred recompilation for 1001.
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1002}
+# While 1001 is being recompiled, a new process 1003 joins svc-a.
+# Its program should inherit the discovered types [MyStruct].
+- !processes-updated
+  updated:
+    - process_id: {pid: 1003}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+# Complete the recompilation cycle for process 1001.
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+# Process 1003's program loads (program 3). Process 1001's recompiled
+# program (program 4) is dequeued and starts loading.
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 1003}
+# Process 1001's recompiled program loads with inherited types.
+- !loaded {program_id: 4}
+- !attached {program_id: 4, process_id: 1001}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/app-b}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: foo}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[] -> [2]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+    1002: <nil> -> WaitingForProgram (prog 2)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+    2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/app-b@0.0m0.0, probes: [probe2], process_id: 1002, program_id: 2}
+state:
+  currently_loading: 1 -> 2
+  queued_programs: '[2] -> []'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+    2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  discovered_types:
+    svc-a: '[] -> [MyStruct]'
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-b@0.0m0.0, process_id: 1002, program_id: 2}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+    1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+    2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttached: 1 -> 0
+    numAttaching: 0 -> 1
+    numDetaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !attached {program_id: 2, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    1: Draining (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1003}
+      executable: {path: /usr/bin/app-a}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1003, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attached (prog 2)
+    1003: <nil> -> WaitingForProgram (prog 3)
+  programs:
+    1: Draining (proc 1001)
+    2: Loaded (proc 1002)
+    3: <nil> -> Loading (proc 1003)
+  stats:
+    numProcesses: 2 -> 3
+    numPrograms: 2 -> 3
+    numWaitingForProgram: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: "3"
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attached (prog 2)
+    1003: WaitingForProgram (prog 3)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+    2: Loaded (proc 1002)
+    3: Loading (proc 1003)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+state:
+  currently_loading: "3"
+  queued_programs: '[] -> [4]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 4)
+    1002: Attached (prog 2)
+    1003: WaitingForProgram (prog 3)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: Loaded (proc 1002)
+    3: Loading (proc 1003)
+    4: <nil> -> Queued (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 1 -> 2
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1003, program_id: 3}
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/app-a@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 4}
+state:
+  currently_loading: 3 -> 4
+  queued_programs: '[4] -> []'
+  processes:
+    1001: WaitingForProgram (prog 4)
+    1002: Attached (prog 2)
+    1003: WaitingForProgram (prog 3) -> Attaching (prog 3)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loading (proc 1003) -> Loaded (proc 1003)
+    4: Queued (proc 1001) -> Loading (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 3, process_id: 1003}
+state:
+  currently_loading: "4"
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 4)
+    1002: Attached (prog 2)
+    1003: Attaching (prog 3) -> Attached (prog 3)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1003)
+    4: Loading (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0
+---
+event: !loaded {program_id: 4}
+effects:
+  - !attach-to-process {executable: /usr/bin/app-a@0.0m0.0, process_id: 1001, program_id: 4}
+state:
+  currently_loading: 4 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 4) -> Attaching (prog 4)
+    1002: Attached (prog 2)
+    1003: Attached (prog 3)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1003)
+    4: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 3 -> 4
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 4, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 4) -> Attached (prog 4)
+    1002: Attached (prog 2)
+    1003: Attached (prog 3)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1003)
+    4: Loaded (proc 1001)
+  stats:
+    attached: 3 -> 4
+    numAttached: 2 -> 3
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_trigger_recompilation.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_trigger_recompilation.yaml
@@ -1,0 +1,145 @@
+# Tests that missing types reported by the decoder trigger recompilation
+# when the process is attached and the loading pipeline is idle.
+#
+# Flow:
+# 1. Process added with service name -> program loads and attaches
+# 2. Missing types reported -> triggers detach + recompilation
+# 3. New program loads with additional types
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Report missing types while attached and idle
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct, OtherType]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct, OtherType]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    my-service: '[] -> [MyStruct OtherType]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct, OtherType], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/missing_types_while_loading.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/missing_types_while_loading.yaml
@@ -1,0 +1,204 @@
+# Tests that missing types reported while the loading pipeline is busy
+# do not trigger recompilation immediately, but are deferred until the
+# pipeline becomes idle.
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/other}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: foo}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Pipeline is busy loading program 2 for process 1002.
+# Missing types for process 1001 should be recorded but not trigger recompilation.
+- !missing-types-reported {process_id: 1001, type_names: [SomeType]}
+# When program 2 finishes loading, the pipeline becomes idle and the deferred
+# recompilation for process 1001 is triggered.
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1002}
+# Complete the recompilation cycle for process 1001.
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 1001}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: svc-a
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+    - process_id: {pid: 1002}
+      executable: {path: /usr/bin/other}
+      service: svc-b
+      probes:
+        - {type: LOG_PROBE, id: probe2, where: {methodName: foo}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[] -> [2]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+    1002: <nil> -> WaitingForProgram (prog 2)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+    2: <nil> -> Queued (proc 1002)
+  stats:
+    numProcesses: 0 -> 2
+    numPrograms: 0 -> 2
+    numWaitingForProgram: 0 -> 2
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+  - !spawn-bpf-loading {executable: /usr/bin/other@0.0m0.0, probes: [probe2], process_id: 1002, program_id: 2}
+state:
+  currently_loading: 1 -> 2
+  queued_programs: '[2] -> []'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+    2: Queued (proc 1002) -> Loading (proc 1002)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 2 -> 1
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [SomeType]}
+state:
+  currently_loading: "2"
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+    1002: WaitingForProgram (prog 2)
+  programs:
+    1: Loaded (proc 1001)
+    2: Loading (proc 1002)
+  discovered_types:
+    svc-a: '[] -> [SomeType]'
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/other@0.0m0.0, process_id: 1002, program_id: 2}
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+    1002: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+    2: Loading (proc 1002) -> Loaded (proc 1002)
+  stats:
+    loaded: 1 -> 2
+    numAttached: 1 -> 0
+    numAttaching: 0 -> 1
+    numDetaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !attached {program_id: 2, process_id: 1002}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    1: Draining (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+    1002: Attached (prog 2)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+    2: Loaded (proc 1002)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [SomeType], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 3)
+    1002: Attached (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: Loaded (proc 1002)
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+    1002: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) -> Attached (prog 3)
+    1002: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1002)
+    3: Loaded (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 1 -> 2
+    numAttaching: 1 -> 0

--- a/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_limited.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_limited.yaml
@@ -1,0 +1,161 @@
+# Tests that recompilation is rate-limited when burst=1.
+# After the first recompilation exhausts the single token, subsequent
+# recompilations are throttled until the allowance is replenished.
+#
+# Flow:
+# 1. Process attaches, missing types reported -> recompilation triggers (allowance 1->0)
+# 2. Recompilation completes, process re-attaches
+# 3. New missing types reported -> throttled (allowance 0 < 1)
+- !config {recompilation_rate_limit: 0.001, recompilation_rate_burst: 1}
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Report missing types while attached and idle -> triggers recompilation
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Report new missing types -> should be throttled (no token left)
+- !missing-types-reported {process_id: 1001, type_names: [OtherType]}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    my-service: '[] -> [MyStruct]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [OtherType]}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  discovered_types:
+    my-service: '[MyStruct] -> [MyStruct OtherType]'
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_limited_burst.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_limited_burst.yaml
@@ -1,0 +1,242 @@
+# Tests that burst allows multiple recompilations before throttling.
+# With burst=2, two recompilations are allowed before exhausting tokens.
+#
+# Flow:
+# 1. Process attaches, missing types reported -> recompilation triggers (allowance 2->1)
+# 2. Recompilation completes, process re-attaches
+# 3. New missing types -> recompilation triggers again (allowance 1->0)
+# 4. Recompilation completes, process re-attaches
+# 5. More missing types -> throttled (allowance 0 < 1)
+- !config {recompilation_rate_limit: 0.001, recompilation_rate_burst: 2}
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# First recompilation (allowance 2 -> 1)
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+- !detached {program_id: 1, process_id: 1001}
+- !unloaded {program_id: 1}
+- !loaded {program_id: 2}
+- !attached {program_id: 2, process_id: 1001}
+# Second recompilation (allowance 1 -> 0)
+- !missing-types-reported {process_id: 1001, type_names: [OtherType]}
+- !detached {program_id: 2, process_id: 1001}
+- !unloaded {program_id: 2}
+- !loaded {program_id: 3}
+- !attached {program_id: 3, process_id: 1001}
+# Third attempt -> throttled (allowance 0 < 1)
+- !missing-types-reported {process_id: 1001, type_names: [ThirdType]}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1) -> Detaching (prog 1)
+  programs:
+    1: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    my-service: '[] -> [MyStruct]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 0 -> 1
+---
+event: !detached {program_id: 1, process_id: 1001}
+effects:
+  - !unload-program {program_id: 1}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1)
+  programs:
+    1: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 0 -> 1
+---
+event: !unloaded {program_id: 1}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil> -> 2
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 1) -> WaitingForProgram (prog 2)
+  programs:
+    1: Unloading (proc 1001) -> <nil>
+    2: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 0 -> 1
+---
+event: !loaded {program_id: 2}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 2}
+state:
+  currently_loading: 2 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 2) -> Attaching (prog 2)
+  programs:
+    2: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 1 -> 2
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 2, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 2) -> Attached (prog 2)
+  programs:
+    2: Loaded (proc 1001)
+  stats:
+    attached: 1 -> 2
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [OtherType]}
+effects:
+  - !detach-from-process {failure: "no", process_id: 1001, program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 2) -> Detaching (prog 2)
+  programs:
+    2: Loaded (proc 1001) -> Draining (proc 1001)
+  discovered_types:
+    my-service: '[MyStruct] -> [MyStruct OtherType]'
+  stats:
+    numAttached: 1 -> 0
+    numDetaching: 0 -> 1
+    typeRecompilationsTriggered: 1 -> 2
+---
+event: !detached {program_id: 2, process_id: 1001}
+effects:
+  - !unload-program {program_id: 2}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2)
+  programs:
+    2: Draining (proc 1001) -> Unloading (proc 1001)
+  stats:
+    detached: 1 -> 2
+---
+event: !unloaded {program_id: 2}
+effects:
+  - !spawn-bpf-loading {additional_types: [MyStruct, OtherType], executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 3}
+state:
+  currently_loading: <nil> -> 3
+  queued_programs: '[]'
+  processes:
+    1001: Detaching (prog 2) -> WaitingForProgram (prog 3)
+  programs:
+    2: Unloading (proc 1001) -> <nil>
+    3: <nil> -> Loading (proc 1001)
+  stats:
+    numDetaching: 1 -> 0
+    numWaitingForProgram: 0 -> 1
+    unloaded: 1 -> 2
+---
+event: !loaded {program_id: 3}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 3}
+state:
+  currently_loading: 3 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 3) -> Attaching (prog 3)
+  programs:
+    3: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 2 -> 3
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 3, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 3) -> Attached (prog 3)
+  programs:
+    3: Loaded (proc 1001)
+  stats:
+    attached: 2 -> 3
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [ThirdType]}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 3)
+  programs:
+    3: Loaded (proc 1001)
+  discovered_types:
+    my-service: '[MyStruct OtherType] -> [MyStruct OtherType ThirdType]'
+---

--- a/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_negative_disables.yaml
+++ b/pkg/dyninst/actuator/testdata/snapshot/recompilation_rate_negative_disables.yaml
@@ -1,0 +1,75 @@
+# Tests that a negative rate limit disables recompilation entirely.
+# Missing types are recorded but no recompilation is triggered.
+- !config {recompilation_rate_limit: -1}
+- !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+- !loaded {program_id: 1}
+- !attached {program_id: 1, process_id: 1001}
+# Report missing types -> no recompilation (disabled)
+- !missing-types-reported {process_id: 1001, type_names: [MyStruct, OtherType]}
+---
+event: !processes-updated
+  updated:
+    - process_id: {pid: 1001}
+      executable: {path: /usr/bin/test}
+      service: my-service
+      probes:
+        - {type: LOG_PROBE, id: probe1, where: {methodName: main}, captureSnapshot: true}
+effects:
+  - !spawn-bpf-loading {executable: /usr/bin/test@0.0m0.0, probes: [probe1], process_id: 1001, program_id: 1}
+state:
+  currently_loading: <nil> -> 1
+  queued_programs: '[]'
+  processes:
+    1001: <nil> -> WaitingForProgram (prog 1)
+  programs:
+    1: <nil> -> Loading (proc 1001)
+  stats:
+    numProcesses: 0 -> 1
+    numPrograms: 0 -> 1
+    numWaitingForProgram: 0 -> 1
+---
+event: !loaded {program_id: 1}
+effects:
+  - !attach-to-process {executable: /usr/bin/test@0.0m0.0, process_id: 1001, program_id: 1}
+state:
+  currently_loading: 1 -> <nil>
+  queued_programs: '[]'
+  processes:
+    1001: WaitingForProgram (prog 1) -> Attaching (prog 1)
+  programs:
+    1: Loading (proc 1001) -> Loaded (proc 1001)
+  stats:
+    loaded: 0 -> 1
+    numAttaching: 0 -> 1
+    numWaitingForProgram: 1 -> 0
+---
+event: !attached {program_id: 1, process_id: 1001}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attaching (prog 1) -> Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  stats:
+    attached: 0 -> 1
+    numAttached: 0 -> 1
+    numAttaching: 1 -> 0
+---
+event: !missing-types-reported {process_id: 1001, type_names: [MyStruct, OtherType]}
+state:
+  currently_loading: <nil>
+  queued_programs: '[]'
+  processes:
+    1001: Attached (prog 1)
+  programs:
+    1: Loaded (proc 1001)
+  discovered_types:
+    my-service: '[] -> [MyStruct OtherType]'
+---

--- a/pkg/dyninst/circuit_breaker_test.go
+++ b/pkg/dyninst/circuit_breaker_test.go
@@ -54,7 +54,7 @@ func testCircuitBreaker(
 	cfg.DiskCacheConfig.DirPath = filepath.Join(tempDir, "disk-cache")
 	cfg.LogUploaderURL = testServer.getLogsURL()
 	cfg.DiagsUploaderURL = testServer.getDiagsURL()
-	cfg.CircuitBreakerConfig = actuator.CircuitBreakerConfig{
+	cfg.ActuatorConfig.CircuitBreakerConfig = actuator.CircuitBreakerConfig{
 		Interval:          10 * time.Millisecond,
 		PerProbeCPULimit:  0.1,
 		AllProbesCPULimit: 0.5,

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -63,7 +63,7 @@ func FuzzDecoder(f *testing.F) {
 		_, _, _ = decoder.Decode(Event{
 			EntryOrLine: output.Event(item),
 			ServiceName: "foo",
-		}, &noopSymbolicator{}, []byte{})
+		}, &noopSymbolicator{}, nil, []byte{})
 		require.Empty(t, decoder.entryOrLine.dataItems)
 		require.Empty(t, decoder.entryOrLine.currentlyEncoding)
 		require.Empty(t, decoder._return.dataItems)
@@ -99,7 +99,7 @@ func TestDecoderManually(t *testing.T) {
 			buf, probe, err := decoder.Decode(Event{
 				EntryOrLine: output.Event(item),
 				ServiceName: "foo",
-			}, &noopSymbolicator{}, []byte{})
+			}, &noopSymbolicator{}, nil, []byte{})
 			require.NoError(t, err)
 			require.Equal(t, c.probeName, probe.GetID())
 			var e eventCaptures
@@ -131,7 +131,7 @@ func BenchmarkDecoder(b *testing.B) {
 			}
 			b.ResetTimer()
 			for b.Loop() {
-				_, _, err := decoder.Decode(event, symbolicator, []byte{})
+				_, _, err := decoder.Decode(event, symbolicator, nil, []byte{})
 				require.NoError(b, err)
 			}
 		})
@@ -1319,6 +1319,7 @@ func TestDecoderPanics(t *testing.T) {
 		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
+		nil,
 		[]byte{},
 	)
 	require.Error(t, err)
@@ -1348,6 +1349,7 @@ func TestDecoderFailsOnEvaluationError(t *testing.T) {
 		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
+		nil,
 		[]byte{},
 	)
 	require.NoError(t, err)
@@ -1386,7 +1388,7 @@ func TestDecoderIsRobustToDataItemDecodingErrors(t *testing.T) {
 	buf, probe, err := decoder.Decode(Event{
 		EntryOrLine: event,
 		ServiceName: "foo",
-	}, &noopSymbolicator{}, []byte{})
+	}, &noopSymbolicator{}, nil, []byte{})
 	require.NoError(t, err)
 	require.Equal(t, c.probeName, probe.GetID())
 	var e eventCaptures
@@ -1428,6 +1430,7 @@ func TestDecoderFailsOnEvaluationErrorAndRetainsPassedBuffer(t *testing.T) {
 		EntryOrLine: output.Event(input),
 		ServiceName: "foo"},
 		&noopSymbolicator{},
+		nil,
 		buf,
 	)
 	require.NoError(t, err)
@@ -1515,7 +1518,7 @@ func TestDecoderMissingReturnEventEvaluationError(t *testing.T) {
 				EntryOrLine: newEvent,
 				Return:      nil, // Explicitly no return event
 				ServiceName: "foo",
-			}, &noopSymbolicator{}, []byte{})
+			}, &noopSymbolicator{}, nil, []byte{})
 			require.NoError(t, err)
 			require.Equal(t, "stringArg", probe.GetID())
 

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -150,6 +150,7 @@ type encodingContext struct {
 	currentlyEncoding    map[typeAndAddr]struct{}
 	dataItems            map[typeAndAddr]output.DataItem
 	typeResolver         TypeNameResolver
+	missingTypeCollector MissingTypeCollector
 }
 
 // ResolveTypeName implements encodingContext.
@@ -1965,6 +1966,8 @@ func encodeInterface(
 			name = fmt.Sprintf(
 				"UnknownType(0x%x): %v", runtimeType, err,
 			)
+		} else if c.missingTypeCollector != nil {
+			c.missingTypeCollector.RecordMissingType(name)
 		}
 		if err := writeTokens(enc,
 			jsontext.String("type"),
@@ -2032,6 +2035,8 @@ func formatInterface(
 			name = fmt.Sprintf(
 				"UnknownType(0x%x): %v", runtimeType, err,
 			)
+		} else if c.missingTypeCollector != nil {
+			c.missingTypeCollector.RecordMissingType(name)
 		}
 		msg := "unknown type " + name
 		writeBoundedError(buf, limits, "interface", msg)

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -236,7 +236,7 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 
 	modCfg, err := module.NewConfig(nil)
 	require.NoError(t, err)
-	modCfg.ActuatorConfig.RecompilationDisabled = true
+	modCfg.ActuatorConfig.RecompilationRateLimit = -1
 
 	modCfg.SymDBUploadEnabled = true
 	modCfg.LogUploaderURL = ts.backendServer.URL + "/logs"

--- a/pkg/dyninst/end_to_end_test.go
+++ b/pkg/dyninst/end_to_end_test.go
@@ -236,6 +236,7 @@ func runE2ETest(t *testing.T, cfg e2eTestConfig) {
 
 	modCfg, err := module.NewConfig(nil)
 	require.NoError(t, err)
+	modCfg.ActuatorConfig.RecompilationDisabled = true
 
 	modCfg.SymDBUploadEnabled = true
 	modCfg.LogUploaderURL = ts.backendServer.URL + "/logs"

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -151,6 +151,7 @@ func testDyninst(
 			MaxBackoffTime: time.Millisecond.Seconds(),
 		},
 	}
+	cfg.ActuatorConfig.RecompilationRateLimit = -1 // disable recompilation
 	m, err := module.NewModule(cfg, nil)
 	require.NoError(t, err)
 	t.Cleanup(m.Close)

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irprinter"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
@@ -575,9 +576,9 @@ type outputSavingIRGenerator struct {
 
 // GenerateIR implements module.IRGenerator.
 func (o *outputSavingIRGenerator) GenerateIR(
-	programID ir.ProgramID, binaryPath string, probes []ir.ProbeDefinition,
+	programID ir.ProgramID, binaryPath string, probes []ir.ProbeDefinition, options ...irgen.Option,
 ) (*ir.Program, error) {
-	ir, err := o.irGenerator.GenerateIR(programID, binaryPath, probes)
+	ir, err := o.irGenerator.GenerateIR(programID, binaryPath, probes, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/dyninst/irgen/config.go
+++ b/pkg/dyninst/irgen/config.go
@@ -13,6 +13,7 @@ type config struct {
 	objectLoader     object.Loader
 	typeIndexFactory goTypeIndexFactory
 	skipReturnEvents bool
+	additionalTypes  []string
 }
 
 var defaultConfig = config{
@@ -40,6 +41,14 @@ func WithOnDiskGoTypeIndexFactory(diskCache *object.DiskCache) Option {
 // WithSkipReturnEvents skips the generation of return events.
 func WithSkipReturnEvents(skip bool) Option {
 	return optionFunc(func(c *config) { c.skipReturnEvents = skip })
+}
+
+// WithAdditionalTypes provides a list of Go type names (as reported by
+// gotype) that should be resolved against the binary's Go runtime type
+// table and added to the IR type registry. This is used to include types
+// discovered at runtime through interface decoding.
+func WithAdditionalTypes(typeNames []string) Option {
+	return optionFunc(func(c *config) { c.additionalTypes = typeNames })
 }
 
 type optionFunc func(c *config)

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -85,13 +85,18 @@ func (g *Generator) GenerateIR(
 	programID ir.ProgramID,
 	binaryPath string,
 	probeDefs []ir.ProbeDefinition,
+	options ...Option,
 ) (*ir.Program, error) {
-	elfFile, err := g.config.objectLoader.Load(binaryPath)
+	cfg := g.config
+	for _, option := range options {
+		option.apply(&cfg)
+	}
+	elfFile, err := cfg.objectLoader.Load(binaryPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load elf file: %w", err)
 	}
 	defer elfFile.Close()
-	return generateIR(g.config, programID, elfFile, probeDefs)
+	return generateIR(cfg, programID, elfFile, probeDefs)
 }
 
 // GenerateIR generates an IR program from a binary and a list of probes.
@@ -240,6 +245,14 @@ func generateIR(
 	}
 	defer cleanupCloser(ib, "method index builder")()
 
+	// Build a set of additional type names requested via
+	// WithAdditionalTypes for efficient lookup during the gotype iteration.
+	additionalTypeSet := make(map[string]struct{}, len(cfg.additionalTypes))
+	for _, name := range cfg.additionalTypes {
+		additionalTypeSet[name] = struct{}{}
+	}
+
+	var additionalTypeRoots []explorationRoot
 	var methodBuf []gotype.Method
 	for tid := range typeIndex.allGoTypes() {
 		goType, err := typeTab.ParseGoType(tid)
@@ -261,6 +274,30 @@ func generateIR(
 			)
 			continue
 		}
+
+		// If this type was requested as an additional type, resolve it to
+		// a DWARF offset and add it to the type catalog for exploration.
+		if len(additionalTypeSet) > 0 {
+			name := goType.Name().UnsafeName()
+			if _, requested := additionalTypeSet[name]; requested {
+				if dwarfOffset, ok := typeIndex.resolveDwarfOffset(tid); ok {
+					t, addErr := typeCatalog.addType(dwarfOffset)
+					if addErr != nil {
+						log.Debugf(
+							"failed to add additional type %q at offset %#x: %v",
+							name, dwarfOffset, addErr,
+						)
+					} else {
+						additionalTypeRoots = append(additionalTypeRoots, explorationRoot{
+							typeID: t.GetID(),
+							budget: additionalTypeBudget,
+						})
+					}
+				}
+				delete(additionalTypeSet, name)
+			}
+		}
+
 		methodBuf, err = goType.Methods(methodBuf[:0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to get methods: %w", err)
@@ -362,6 +399,9 @@ func generateIR(
 	// Resolve placeholder types by a unified, budgeted expansion from
 	// exploration roots. Container internals are zero-cost.
 	{
+		// Include types discovered at runtime via interface decoding.
+		explorationRoots = append(explorationRoots, additionalTypeRoots...)
+
 		// Specialize any already-added container types before traversal.
 		if err := completeGoTypes(typeCatalog, 1, typeCatalog.idAlloc.alloc); err != nil {
 			return nil, err
@@ -778,6 +818,12 @@ func computeDepthBudgets(pending []*pendingSubprogram) map[ir.SubprogramID]uint3
 	}
 	return budgets
 }
+
+// additionalTypeBudget is the exploration budget assigned to types discovered
+// at runtime through interface decoding and fed back via WithAdditionalTypes.
+// A budget of 3 is enough to resolve fields and one level of indirection
+// without being excessively expensive.
+const additionalTypeBudget = 3
 
 // explorationRoot represents a type that should be explored with a budget.
 type explorationRoot struct {

--- a/pkg/dyninst/missing_type_recompilation_test.go
+++ b/pkg/dyninst/missing_type_recompilation_test.go
@@ -78,21 +78,6 @@ func TestMissingTypeRecompilation(t *testing.T) {
 			MaxBackoffTime: time.Millisecond.Seconds(),
 		},
 	}
-	// This is a hack to ensure that we get at least one message out of the
-	// uploader. Without this, the probe will be removed while we still have
-	// buffered messages in the uploader and they end up getting dropped because
-	// we don't flush on close.
-	//
-	// TODO: Removal of a probe should flush both the eBPF buffer and the
-	// uploader buffer. This was deemed not generally worth it because a process
-	// has to be alive for a bit just for RC subscriptions to be set up, and if
-	// we've removed the probe, then it's probably mostly due to process removal
-	// or shutdown. However, with the addition of this missing-type based
-	// recompilation, we need to revisit this logic, it'll mean we don't
-	// generally ever emit the logs for probes that had missing types.
-	moduleCfg.TestingKnobs.LogsUploaderOptions = []uploader.Option{
-		uploader.WithMaxBatchItems(1),
-	}
 
 	var sendUpdate fakeProcessSubscriber
 	moduleCfg.TestingKnobs.ProcessSubscriberOverride = func(

--- a/pkg/dyninst/missing_type_recompilation_test.go
+++ b/pkg/dyninst/missing_type_recompilation_test.go
@@ -1,0 +1,247 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package dyninst_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/DataDog/datadog-agent/pkg/dyninst/dyninsttest"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/process"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/procsubscribe"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+// TestMissingTypeRecompilation verifies the full missing-types feedback loop:
+// decode → discover missing types → recompile with additional types → capture actual values.
+//
+// The testAny probe on the sample binary probes main.testAny(a any). Types like
+// otherFirstBehavior, otherSecondBehavior, and lib_v2.V2Type produce
+// "notCapturedReason": "missing type information" on the first run because they
+// are not in the IR. After the actuator triggers recompilation with
+// WithAdditionalTypes, those types should be fully captured in a subsequent run.
+//
+// The test loops, launching a new process each iteration, until no events
+// contain missing type information — proving the feedback loop converges.
+func TestMissingTypeRecompilation(t *testing.T) {
+	dyninsttest.SkipIfKernelNotSupported(t)
+	current := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, current) })
+
+	cfgs := testprogs.MustGetCommonConfigs(t)
+
+	// Use the first config that matches our GOARCH.
+	var cfg testprogs.Config
+	cfgIdx := slices.IndexFunc(cfgs, func(c testprogs.Config) bool {
+		return c.GOARCH == runtime.GOARCH && strings.Contains(c.GOTOOLCHAIN, "go1.26")
+	})
+	require.NotEqual(t, -1, cfgIdx, "no config for current arch and go1.26")
+	cfg = cfgs[cfgIdx]
+	bin := testprogs.MustGetBinary(t, "sample", cfg)
+
+	tempDir, cleanup := dyninsttest.PrepTmpDir(t, "dyninst-missing-type-recomp")
+	defer cleanup()
+
+	testServer := newFakeAgent(t)
+	t.Cleanup(testServer.s.Close)
+
+	moduleCfg, err := module.NewConfig(nil)
+	require.NoError(t, err)
+	moduleCfg.DiskCacheConfig.DirPath = filepath.Join(tempDir, "disk-cache")
+	moduleCfg.LogUploaderURL = testServer.getLogsURL()
+	moduleCfg.DiagsUploaderURL = testServer.getDiagsURL()
+	moduleCfg.ProbeTombstoneFilePath = filepath.Join(tempDir, "tombstone.json")
+	moduleCfg.TestingKnobs.TombstoneSleepKnobs = tombstone.WaitTestingKnobs{
+		BackoffPolicy: &backoff.ExpBackoffPolicy{
+			MaxBackoffTime: time.Millisecond.Seconds(),
+		},
+	}
+	// This is a hack to ensure that we get at least one message out of the
+	// uploader. Without this, the probe will be removed while we still have
+	// buffered messages in the uploader and they end up getting dropped because
+	// we don't flush on close.
+	//
+	// TODO: Removal of a probe should flush both the eBPF buffer and the
+	// uploader buffer. This was deemed not generally worth it because a process
+	// has to be alive for a bit just for RC subscriptions to be set up, and if
+	// we've removed the probe, then it's probably mostly due to process removal
+	// or shutdown. However, with the addition of this missing-type based
+	// recompilation, we need to revisit this logic, it'll mean we don't
+	// generally ever emit the logs for probes that had missing types.
+	moduleCfg.TestingKnobs.LogsUploaderOptions = []uploader.Option{
+		uploader.WithMaxBatchItems(1),
+	}
+
+	var sendUpdate fakeProcessSubscriber
+	moduleCfg.TestingKnobs.ProcessSubscriberOverride = func(
+		real module.ProcessSubscriber,
+	) module.ProcessSubscriber {
+		real.(*procsubscribe.Subscriber).Close()
+		return &sendUpdate
+	}
+
+	m, err := module.NewModule(moduleCfg, nil)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+
+	// Get only the testAny probe.
+	allProbes := testprogs.MustGetProbeDefinitions(t, "sample")
+	var testAnyProbe ir.ProbeDefinition
+	for _, p := range allProbes {
+		if p.GetID() == "testAny" {
+			testAnyProbe = p
+			break
+		}
+	}
+	require.NotNil(t, testAnyProbe, "testAny probe not found")
+	probes := []ir.ProbeDefinition{testAnyProbe}
+
+	const service = "sample"
+
+	// runProcess launches the sample binary, sends a process update to the
+	// module, waits for probes to be installed, triggers execution, waits for
+	// the process to exit, then removes the process and waits for the actuator
+	// to settle (numPrograms == 0). Returns the logs produced during this run.
+	runProcess := func(runName string) []receivedLog {
+		t.Helper()
+		ctx := context.Background()
+		proc, stdin := dyninsttest.StartProcess(ctx, t, tempDir, bin)
+		pid := proc.Process.Pid
+		t.Logf("[%s] launched sample with pid %d", runName, pid)
+		defer func() {
+			_ = proc.Process.Kill()
+			_ = proc.Wait()
+		}()
+
+		exe, err := process.ResolveExecutable(kernel.ProcFSRoot(), int32(pid))
+		require.NoError(t, err)
+
+		// Track how many logs existed before this run.
+		logsBefore := len(testServer.getLogs())
+
+		runtimeID := "runtime-" + runName
+		sendUpdate(process.ProcessesUpdate{
+			Updates: []process.Config{{
+				Info: process.Info{
+					ProcessID:  process.ID{PID: int32(pid)},
+					Executable: exe,
+					Service:    service,
+				},
+				RuntimeID: runtimeID,
+				Probes:    slices.Clone(probes),
+			}},
+		})
+
+		// Wait for probes to be installed.
+		allProbeIDs := make(map[string]struct{}, len(probes))
+		for _, p := range probes {
+			allProbeIDs[p.GetID()] = struct{}{}
+		}
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			installed := make(map[string]struct{})
+			for _, d := range testServer.getDiags() {
+				if d.diagnosticMessage.Debugger.RuntimeID != runtimeID {
+					continue
+				}
+				if d.diagnosticMessage.Debugger.Status == uploader.StatusInstalled {
+					installed[d.diagnosticMessage.Debugger.ProbeID] = struct{}{}
+				}
+			}
+			assert.Equal(c, allProbeIDs, installed)
+		}, 180*time.Second, 100*time.Millisecond)
+
+		// Trigger function calls, give the uploader time to flush events,
+		// then wait for the process to exit.
+		t.Logf("[%s] triggering function calls", runName)
+		stdin.Write([]byte("\n"))
+		require.NoError(t, proc.Wait())
+
+		// Remove the process and wait for the actuator to fully settle. After
+		// removal and any in-flight recompilation attempts, numPrograms should
+		// reach 0.
+		sendUpdate(process.ProcessesUpdate{
+			Removals: []process.ID{{PID: int32(pid)}},
+		})
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			stats := m.GetStats()
+			actuatorStats, ok := stats["actuator"].(map[string]any)
+			if !assert.True(c, ok, "actuator stats missing") {
+				return
+			}
+			assert.Equal(c, uint64(0), actuatorStats["numPrograms"],
+				"expected numPrograms == 0 after cleanup")
+			assert.Equal(c, uint64(0), actuatorStats["numProcesses"],
+				"expected numProcesses == 0 after cleanup")
+		}, 30*time.Second, 100*time.Millisecond)
+
+		// Return only the logs from this run.
+		allLogs := testServer.getLogs()
+		runLogs := allLogs[logsBefore:]
+		t.Logf("[%s] got %d events", runName, len(runLogs))
+		return runLogs
+	}
+
+	// Loop: run the sample binary until we see no missing type information.
+	// The first run should have missing types. The actuator records them as
+	// discoveredTypes for the service, so subsequent runs compile with those
+	// types included. We expect convergence within a small number of runs.
+	const maxRuns = 5
+	var firstRunLogs []receivedLog
+	for i := 1; i <= maxRuns; i++ {
+		runName := fmt.Sprintf("run%d", i)
+		logs := runProcess(runName)
+		require.NotEmpty(t, logs, "[%s] expected at least one event", runName)
+
+		missingCount := 0
+		for _, log := range logs {
+			if bytes.Contains(log.body, []byte(`"missing type information"`)) {
+				missingCount++
+			}
+		}
+		t.Logf("[%s] %d events total, %d with missing types", runName, len(logs), missingCount)
+
+		if i == 1 {
+			firstRunLogs = logs
+			require.Greater(t, missingCount, 0,
+				"first run should have missing types to prove the test is meaningful")
+			continue
+		}
+
+		if missingCount == 0 {
+			t.Logf("converged after %d runs", i)
+			// Verify we got at least as many events as the first run.
+			require.GreaterOrEqual(t, len(logs), len(firstRunLogs),
+				"final run should produce at least as many events as the first")
+
+			// Verify the actuator recorded at least one type recompilation.
+			stats := m.GetStats()
+			actuatorStats := stats["actuator"].(map[string]any)
+			require.Greater(t, actuatorStats["typeRecompilationsTriggered"], uint64(0),
+				"expected at least one type recompilation to have been triggered")
+			return
+		}
+	}
+	t.Fatalf("still had missing types after %d runs", maxRuns)
+}

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
-	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
@@ -57,7 +56,6 @@ type Config struct {
 		IRGeneratorOverride       func(IRGenerator) IRGenerator
 		ProcessSubscriberOverride func(ProcessSubscriber) ProcessSubscriber
 		TombstoneSleepKnobs       tombstone.WaitTestingKnobs
-		LogsUploaderOptions       []uploader.Option
 	}
 }
 

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	sysconfig "github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
@@ -48,14 +49,15 @@ type Config struct {
 	// DiskCacheConfig is the configuration for the disk cache for debug info.
 	DiskCacheConfig object.DiskCacheConfig
 
-	// CircuitBreakerConfig is the configuration for the circuit breaker enforcing probe cpu-limits.
-	CircuitBreakerConfig actuator.CircuitBreakerConfig
+	// ActuatorConfig is the configuration for the actuator.
+	ActuatorConfig actuator.Config
 
 	TestingKnobs struct {
 		LoaderOptions             []loader.Option
 		IRGeneratorOverride       func(IRGenerator) IRGenerator
 		ProcessSubscriberOverride func(ProcessSubscriber) ProcessSubscriber
 		TombstoneSleepKnobs       tombstone.WaitTestingKnobs
+		LogsUploaderOptions       []uploader.Option
 	}
 }
 
@@ -77,7 +79,9 @@ func NewConfig(_ *sysconfigtypes.Config) (*Config, error) {
 		ProbeTombstoneFilePath: "/tmp/datadog-agent/system-probe/dynamic-instrumentation/debugger-probes-tombstone.json",
 		DiskCacheEnabled:       cacheEnabled,
 		DiskCacheConfig:        cacheConfig,
-		CircuitBreakerConfig:   getCircuitBreakerConfig(),
+		ActuatorConfig: actuator.Config{
+			CircuitBreakerConfig: getCircuitBreakerConfig(),
+		},
 	}
 	return c, nil
 }

--- a/pkg/dyninst/module/dependencies.go
+++ b/pkg/dyninst/module/dependencies.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dispatcher"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gotype"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/process"
@@ -53,6 +54,7 @@ type ProcessSubscriber interface {
 type IRGenerator interface {
 	GenerateIR(
 		_ ir.ProgramID, binaryPath string, _ []ir.ProbeDefinition,
+		options ...irgen.Option,
 	) (*ir.Program, error)
 }
 
@@ -81,10 +83,12 @@ type DecoderFactory interface {
 // Decoder is a decoder for a program.
 type Decoder interface {
 	// Decode writes the decoded event to the output writer and returns the
-	// relevant probe definition.
+	// relevant probe definition. If missingTypes is nil, missing types are
+	// silently ignored.
 	Decode(
 		event decode.Event,
 		symbolicator symbol.Symbolicator,
+		missingTypes decode.MissingTypeCollector,
 		out []byte,
 	) ([]byte, ir.ProbeDefinition, error)
 
@@ -143,6 +147,7 @@ func (f decoderFactory) NewDecoder(
 type Actuator interface {
 	HandleUpdate(update actuator.ProcessesUpdate)
 	SetRuntime(runtime actuator.Runtime)
+	ReportMissingTypes(processID actuator.ProcessID, typeNames []string)
 }
 
 // Dispatcher coordinates with the output dispatcher runtime.

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -105,6 +105,7 @@ func newUnstartedModule(deps dependencies, tombstoneFilePath string) *Module {
 	runtime := &runtimeImpl{
 		store:                    store,
 		diagnostics:              diagnostics,
+		actuator:                 deps.Actuator,
 		decoderFactory:           deps.DecoderFactory,
 		irGenerator:              deps.IRGenerator,
 		programCompiler:          deps.ProgramCompiler,
@@ -207,7 +208,12 @@ func makeRealDependencies(
 	if err != nil {
 		return ret, fmt.Errorf("error parsing log uploader URL: %w", err)
 	}
-	ret.logUploader = uploader.NewLogsUploaderFactory(uploader.WithURL(logUploaderURL))
+	ret.logUploader = uploader.NewLogsUploaderFactory(
+		append(
+			config.TestingKnobs.LogsUploaderOptions,
+			uploader.WithURL(logUploaderURL),
+		)...,
+	)
 
 	diagsUploaderURL, err := url.Parse(config.DiagsUploaderURL)
 	if err != nil {
@@ -223,7 +229,7 @@ func makeRealDependencies(
 			return ret, fmt.Errorf("error parsing SymDB uploader URL: %w", err)
 		}
 	}
-	ret.actuator = actuator.NewActuator(config.CircuitBreakerConfig)
+	ret.actuator = actuator.NewActuator(config.ActuatorConfig)
 
 	var loaderOpts []loader.Option
 	if config.TestingKnobs.LoaderOptions != nil {

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -209,10 +209,7 @@ func makeRealDependencies(
 		return ret, fmt.Errorf("error parsing log uploader URL: %w", err)
 	}
 	ret.logUploader = uploader.NewLogsUploaderFactory(
-		append(
-			config.TestingKnobs.LogsUploaderOptions,
-			uploader.WithURL(logUploaderURL),
-		)...,
+		uploader.WithURL(logUploaderURL),
 	)
 
 	diagsUploaderURL, err := url.Parse(config.DiagsUploaderURL)

--- a/pkg/dyninst/module/module_test.go
+++ b/pkg/dyninst/module/module_test.go
@@ -124,7 +124,7 @@ func TestProgramLifecycleFlow(t *testing.T) {
 	require.Equal(t, initialProbeVersions, collectReceived())
 
 	loaded, err := deps.actuator.runtime.Load(
-		program.ID, processUpdate.Executable, procID, processUpdate.Probes,
+		program.ID, processUpdate.Executable, procID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -171,7 +171,7 @@ func TestProgramLifecycleFlow(t *testing.T) {
 	require.Len(t, update.Processes, 1)
 	process := update.Processes[0]
 	loaded2, err := deps.actuator.runtime.Load(
-		program.ID, process.Executable, process.ProcessID, process.Probes,
+		program.ID, process.Executable, process.ProcessID, process.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -211,6 +211,7 @@ func TestIRGenerationFailure(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), irErr.Error())
@@ -242,6 +243,7 @@ func TestAttachmentFailure(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -275,6 +277,7 @@ func TestLoadingFailure(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "loading failed")
@@ -302,7 +305,7 @@ func TestDecoderCreationFailure(t *testing.T) {
 	deps.sendUpdates(processUpdate)
 
 	_, err := deps.actuator.runtime.Load(
-		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "decoder creation failed")
@@ -331,7 +334,7 @@ func TestEventDecodingSuccess(t *testing.T) {
 	deps.sendUpdates(processUpdate)
 
 	loaded, err := deps.actuator.runtime.Load(
-		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 	sink := deps.dispatcher.sinks[ir.ProgramID(42)]
@@ -368,7 +371,7 @@ func TestEventDecodingFailure(t *testing.T) {
 	deps.sendUpdates(processUpdate)
 
 	loaded, err := deps.actuator.runtime.Load(
-		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 	sink := deps.dispatcher.sinks[ir.ProgramID(42)]
@@ -407,7 +410,7 @@ func TestDecoderErrorHandling(t *testing.T) {
 
 	program := createTestProgram()
 	loaded, err := deps.actuator.runtime.Load(
-		program.ID, processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		program.ID, processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 	sink := deps.dispatcher.sinks[program.ID]
@@ -450,7 +453,7 @@ func TestStackPCsRecordedForEntryEvents(t *testing.T) {
 	deps.sendUpdates(processUpdate)
 
 	loaded, err := deps.actuator.runtime.Load(
-		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		ir.ProgramID(42), processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 	sink := deps.dispatcher.sinks[ir.ProgramID(42)]
@@ -589,7 +592,7 @@ func TestProbeIssueReporting(t *testing.T) {
 	deps.sendUpdates(processUpdate)
 
 	loaded, err := deps.actuator.runtime.Load(
-		program.ID, processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes,
+		program.ID, processUpdate.Executable, processUpdate.ProcessID, processUpdate.Probes, actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -620,11 +623,13 @@ func TestProbeIssueReporting(t *testing.T) {
 func TestNoSuccessfulProbes(t *testing.T) {
 	processUpdate := createTestProcessConfig()
 	fakeDeps := newFakeTestingDependencies(t)
-	a := actuator.NewActuator(actuator.CircuitBreakerConfig{
-		Interval:          1 * time.Second,
-		PerProbeCPULimit:  0.1,
-		AllProbesCPULimit: 0.5,
-		InterruptOverhead: 2 * time.Microsecond,
+	a := actuator.NewActuator(actuator.Config{
+		CircuitBreakerConfig: actuator.CircuitBreakerConfig{
+			Interval:          1 * time.Second,
+			PerProbeCPULimit:  0.1,
+			AllProbesCPULimit: 0.5,
+			InterruptOverhead: 2 * time.Microsecond,
+		},
 	})
 	t.Cleanup(func() { require.NoError(t, a.Shutdown()) })
 	deps := fakeDeps.toDeps()
@@ -719,7 +724,7 @@ type fakeIRGenerator struct {
 }
 
 func (f *fakeIRGenerator) GenerateIR(
-	programID ir.ProgramID, _ string, _ []ir.ProbeDefinition,
+	programID ir.ProgramID, _ string, _ []ir.ProbeDefinition, _ ...irgen.Option,
 ) (*ir.Program, error) {
 	if f == nil {
 		return &ir.Program{ID: programID}, nil
@@ -768,9 +773,10 @@ type failOnceDecoder struct {
 func (d *failOnceDecoder) Decode(
 	event decode.Event,
 	symbolicator symbol.Symbolicator,
+	missingTypes decode.MissingTypeCollector,
 	out []byte,
 ) ([]byte, ir.ProbeDefinition, error) {
-	bytes, probe, err := d.inner.Decode(event, symbolicator, out)
+	bytes, probe, err := d.inner.Decode(event, symbolicator, missingTypes, out)
 	if err != nil {
 		return bytes, probe, err
 	}
@@ -800,7 +806,7 @@ type decodeCall struct {
 }
 
 func (f *fakeDecoder) Decode(
-	event decode.Event, symbolicator symbol.Symbolicator, out []byte,
+	event decode.Event, symbolicator symbol.Symbolicator, _ decode.MissingTypeCollector, out []byte,
 ) ([]byte, ir.ProbeDefinition, error) {
 	f.decodeCalls = append(f.decodeCalls, decodeCall{event, symbolicator, out})
 	return []byte(f.output), f.probe, f.err
@@ -887,6 +893,8 @@ func (f *fakeActuator) SetRuntime(runtime actuator.Runtime) {
 	defer f.mu.Unlock()
 	f.runtime = runtime
 }
+
+func (f *fakeActuator) ReportMissingTypes(_ actuator.ProcessID, _ []string) {}
 
 type fakeTestingDependencies struct {
 	actuator          *fakeActuator
@@ -1031,6 +1039,7 @@ func TestDiagnosticRetentionAcrossProgramLoads(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -1099,6 +1108,7 @@ func TestDiagnosticRetentionAcrossProgramLoads(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdateP1Only.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -1150,6 +1160,7 @@ func TestDiagnosticRetentionAcrossProgramLoads(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -1231,6 +1242,7 @@ func TestDiagnosticRetentionSingleProbeRemoval(t *testing.T) {
 		processUpdateP1.Executable,
 		processUpdateP1.ProcessID,
 		processUpdateP1.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -1309,6 +1321,7 @@ func TestDiagnosticRetentionSingleProbeRemoval(t *testing.T) {
 		processUpdateP1.Executable,
 		processUpdateP1.ProcessID,
 		processUpdateP1.Probes,
+		actuator.LoadOptions{},
 	)
 	require.NoError(t, err)
 
@@ -1399,6 +1412,7 @@ func TestLoadReturnsErrorWhenProcessRemovedDuringLoad(t *testing.T) {
 		processUpdate.Executable,
 		processUpdate.ProcessID,
 		processUpdate.Probes,
+		actuator.LoadOptions{},
 	)
 
 	// Expect an error because the process has been removed.
@@ -1431,9 +1445,10 @@ func (r *interceptingRuntime) Load(
 	executable process.Executable,
 	processID process.ID,
 	probes []ir.ProbeDefinition,
+	opts actuator.LoadOptions,
 ) (actuator.LoadedProgram, error) {
 	if r.onLoad != nil {
 		r.onLoad()
 	}
-	return r.inner.Load(programID, executable, processID, probes)
+	return r.inner.Load(programID, executable, processID, probes, opts)
 }

--- a/pkg/dyninst/module/runtime_impl.go
+++ b/pkg/dyninst/module/runtime_impl.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/module/tombstone"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/uploader"
@@ -28,6 +29,7 @@ import (
 type runtimeImpl struct {
 	store                    *processStore
 	diagnostics              *diagnosticsManager
+	actuator                 Actuator
 	decoderFactory           DecoderFactory
 	irGenerator              IRGenerator
 	programCompiler          ProgramCompiler
@@ -76,6 +78,7 @@ func (rt *runtimeImpl) Load(
 	executable actuator.Executable,
 	processID actuator.ProcessID,
 	probes []ir.ProbeDefinition,
+	opts actuator.LoadOptions,
 ) (_ actuator.LoadedProgram, retErr error) {
 	if rt.tombstoneFilePath != "" {
 		// Write a tombstone file so that, if we crash in the middle of loading a
@@ -138,7 +141,11 @@ func (rt *runtimeImpl) Load(
 		}
 	}()
 
-	irProgram, err := rt.irGenerator.GenerateIR(programID, executable.Path, probes)
+	var irgenOpts []irgen.Option
+	if len(opts.AdditionalTypes) > 0 {
+		irgenOpts = append(irgenOpts, irgen.WithAdditionalTypes(opts.AdditionalTypes))
+	}
+	irProgram, err := rt.irGenerator.GenerateIR(programID, executable.Path, probes, irgenOpts...)
 	if err != nil {
 		return nil, &irGenFailedError{err: err}
 	}
@@ -193,6 +200,7 @@ func (rt *runtimeImpl) Load(
 		decoder:      decoder,
 		symbolicator: rt.store.getSymbolicator(programID),
 		programID:    programID,
+		processID:    processID,
 		service:      runtimeID.service,
 		logUploader: rt.logsFactory.GetUploader(uploader.LogsUploaderMetadata{
 			Tags:        tags,

--- a/pkg/dyninst/module/sink.go
+++ b/pkg/dyninst/module/sink.go
@@ -12,11 +12,13 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"sort"
 	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
 
+	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/decode"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/dispatcher"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
@@ -25,14 +27,49 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// missingTypeTracker collects type names that the decoder encounters in
+// interface values but cannot find in the IR type registry. It implements
+// decode.MissingTypeCollector and is drained by the sink after each Decode.
+type missingTypeTracker struct {
+	typeSet map[string]struct{}
+	nameBuf []string
+}
+
+// RecordMissingType implements decode.MissingTypeCollector.
+func (t *missingTypeTracker) RecordMissingType(typeName string) {
+	if t.typeSet == nil {
+		t.typeSet = make(map[string]struct{})
+	}
+	t.typeSet[typeName] = struct{}{}
+}
+
+// drain returns the accumulated type names and resets the tracker.
+// Returns nil if no types were collected. The returned slice is valid
+// only until the next call to drain.
+func (t *missingTypeTracker) drain() []string {
+	if len(t.typeSet) == 0 {
+		return nil
+	}
+	for name := range t.typeSet {
+		t.nameBuf = append(t.nameBuf, name)
+	}
+	clear(t.typeSet)
+	sort.Strings(t.nameBuf)
+	ret := t.nameBuf
+	t.nameBuf = t.nameBuf[:0]
+	return ret
+}
+
 type sink struct {
 	runtime      *runtimeImpl
 	decoder      Decoder
 	symbolicator symbol.Symbolicator
 	programID    ir.ProgramID
+	processID    actuator.ProcessID
 	service      string
 	logUploader  LogsUploader
 	tree         *bufferTree
+	missingTypes missingTypeTracker
 
 	// Probes is an ordered list of probes. The event header's probe_id is an
 	// index into this list.
@@ -162,7 +199,7 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 		EntryOrLine: entryEvent,
 		Return:      returnEvent,
 		ServiceName: s.service,
-	}, s.symbolicator, decodedBytes)
+	}, s.symbolicator, &s.missingTypes, decodedBytes)
 	if err != nil {
 		if probe != nil {
 			if reported := s.runtime.reportProbeError(
@@ -192,6 +229,9 @@ func (s *sink) HandleEvent(msg dispatcher.Message) error {
 	}
 	s.runtime.setProbeMaybeEmitting(s.programID, probe)
 	s.logUploader.Enqueue(json.RawMessage(decodedBytes))
+	if missingTypes := s.missingTypes.drain(); len(missingTypes) > 0 {
+		s.runtime.actuator.ReportMissingTypes(s.processID, missingTypes)
+	}
 	return nil
 }
 

--- a/pkg/dyninst/module/state.go
+++ b/pkg/dyninst/module/state.go
@@ -8,7 +8,6 @@
 package module
 
 import (
-	"io"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
@@ -20,12 +19,11 @@ import (
 
 type processState struct {
 	procRuntimeID
-	executable       actuator.Executable
-	symbolicator     symbol.Symbolicator
-	symbolicatorFile io.Closer
-	symbolicatorErr  error
-	gitInfo          process.GitInfo
-	containerInfo    process.ContainerInfo
+	executable      actuator.Executable
+	symbolicator    *refCountedSymbolicator
+	symbolicatorErr error
+	gitInfo         process.GitInfo
+	containerInfo   process.ContainerInfo
 }
 
 type processStore struct {
@@ -46,9 +44,9 @@ func (ps *processStore) remove(removals []process.ID, dm *diagnosticsManager) {
 	defer ps.mu.Unlock()
 	for _, pid := range removals {
 		if state, ok := ps.processes[pid]; ok {
-			if state.symbolicatorFile != nil {
-				if err := state.symbolicatorFile.Close(); err != nil {
-					log.Warnf("error closing symbolicator file for process %v: %v", pid, err)
+			if state.symbolicator != nil {
+				if err := state.symbolicator.Close(); err != nil {
+					log.Warnf("error closing symbolicator for process %v: %v", pid, err)
 				}
 			}
 			delete(ps.processes, pid)
@@ -123,14 +121,23 @@ func (ps *processStore) getSymbolicator(progID ir.ProgramID) symbol.Symbolicator
 		return noopSymbolicator{}
 	}
 	if proc.symbolicator != nil {
+		proc.symbolicator.addRef()
 		return proc.symbolicator
 	}
-
-	proc.symbolicator, proc.symbolicatorFile, proc.symbolicatorErr = newSymbolicator(proc.executable)
 	if proc.symbolicatorErr != nil {
-		log.Warnf("error creating symbolicator for %v: %v", proc.executable, proc.symbolicatorErr)
-		proc.symbolicator = noopSymbolicator{}
+		return noopSymbolicator{}
 	}
+
+	inner, file, err := newSymbolicator(proc.executable)
+	proc.symbolicatorErr = err
+	if err != nil {
+		log.Warnf("error creating symbolicator for %v: %v", proc.executable, err)
+		return noopSymbolicator{}
+	}
+	// refCount starts at 1 for the processState's own reference.
+	// addRef adds the caller's (sink's) reference.
+	proc.symbolicator = newRefCountedSymbolicator(inner, file)
+	proc.symbolicator.addRef()
 	return proc.symbolicator
 }
 

--- a/pkg/dyninst/module/symbol.go
+++ b/pkg/dyninst/module/symbol.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/actuator"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/gosym"
@@ -61,3 +62,44 @@ func newSymbolicator(executable actuator.Executable) (_ symbol.Symbolicator, c i
 	}
 	return cachingSymbolicator, symbolTable, nil
 }
+
+// refCountedSymbolicator wraps a Symbolicator and its backing file with
+// reference counting. The file is closed when the last reference is released.
+// Each call to addRef must be balanced by a call to Close.
+type refCountedSymbolicator struct {
+	inner    symbol.Symbolicator
+	file     io.Closer
+	mu       sync.Mutex
+	refCount int32
+}
+
+func newRefCountedSymbolicator(inner symbol.Symbolicator, file io.Closer) *refCountedSymbolicator {
+	return &refCountedSymbolicator{
+		inner:    inner,
+		file:     file,
+		refCount: 1,
+	}
+}
+
+func (r *refCountedSymbolicator) addRef() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCount++
+}
+
+func (r *refCountedSymbolicator) Symbolicate(stack []uint64, stackHash uint64) ([]symbol.StackFrame, error) {
+	return r.inner.Symbolicate(stack, stackHash)
+}
+
+func (r *refCountedSymbolicator) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refCount--
+	if r.refCount > 0 || r.file == nil {
+		return nil
+	}
+	return r.file.Close()
+}
+
+var _ symbol.Symbolicator = (*refCountedSymbolicator)(nil)
+var _ io.Closer = (*refCountedSymbolicator)(nil)

--- a/pkg/dyninst/uploader/batcher_snapshot_test.go
+++ b/pkg/dyninst/uploader/batcher_snapshot_test.go
@@ -97,7 +97,7 @@ func runSnapshotFile(t *testing.T, file string, envRewrite bool) {
 	events, err := parseBatcherEvents(eventsNode.Content)
 	require.NoError(t, err)
 
-	state := newBatcherState("test", cfg)
+	state := newBatcherState("test", cfg, &Metrics{})
 	virtualNow := time.Duration(0)
 
 	var outputs [][]byte

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -110,7 +110,7 @@ func NewDiagnosticsUploader(opts ...Option) *DiagnosticsUploader {
 	}
 	sender := newDiagnosticsSender(cfg.client, cfg.url.String())
 	return &DiagnosticsUploader{
-		batcher: newBatcher("diagnostics", sender, cfg.batcherConfig),
+		batcher: newBatcher("diagnostics", sender, cfg.batcherConfig, &Metrics{}),
 	}
 }
 

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -25,6 +25,7 @@ type LogsUploaderFactory struct {
 	uploaders     map[LogsUploaderMetadata]*refCountedUploader
 	maxUploaderID uint64
 	cfg           config
+	metrics       *Metrics
 }
 
 // LogsUploaderMetadata is the metadata applied to the requests sent by this
@@ -59,6 +60,7 @@ func NewLogsUploaderFactory(opts ...Option) *LogsUploaderFactory {
 	lu := &LogsUploaderFactory{
 		uploaders: make(map[LogsUploaderMetadata]*refCountedUploader),
 		cfg:       defaultConfig(),
+		metrics:   &Metrics{},
 	}
 	for _, opt := range opts {
 		opt(&lu.cfg)
@@ -126,7 +128,7 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 
 	sender := newLogSender(u.cfg.client, logsURL, headers)
 	taggedUploader := &LogsUploader{
-		batcher:  newBatcher(name, sender, u.cfg.batcherConfig),
+		batcher:  newBatcher(name, sender, u.cfg.batcherConfig, u.metrics),
 		metadata: metadata,
 		factory:  u,
 	}
@@ -180,17 +182,7 @@ func (u *LogsUploaderFactory) Stop() {
 
 // Stats returns the combined metrics of all managed uploaders.
 func (u *LogsUploaderFactory) Stats() map[string]int64 {
-	u.mu.Lock()
-	defer u.mu.Unlock()
-
-	totalStats := make(map[string]int64)
-	for _, rc := range u.uploaders {
-		stats := rc.state.metrics.Stats()
-		for k, v := range stats {
-			totalStats[k] += v
-		}
-	}
-	return totalStats
+	return u.metrics.Stats()
 }
 
 type logSender struct {

--- a/pkg/dyninst/uploader/testdata/snapshot/stop_partial_flush.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/stop_partial_flush.yaml
@@ -5,7 +5,7 @@ config:
 events:
   - !enqueue {value: "p"}
   - !enqueue {value: "q"}
-  - !stop {} 
+  - !stop {}
 ---
 now: 0s
 next_flush: 200ms
@@ -28,8 +28,10 @@ state:
 now: 0s
 event: !stop {}
 effects:
+  - !send-batch {id: 0, items: 2, bytes: 6}
   - !reset-timer {}
 state:
-  batch_len: 2
-  current_size: 6
+  batch_len: 0
+  current_size: 0
+  inflight: [0]
   timer_set: false

--- a/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush.yaml
@@ -46,8 +46,10 @@ metrics:
 now: 0s
 event: !stop {}
 effects:
+  - !send-batch {id: 1, items: 1, bytes: 3}
   - !reset-timer {}
 state:
-  batch_len: 1
-  current_size: 3
+  batch_len: 0
+  current_size: 0
+  inflight: [1]
   timer_set: false

--- a/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush_single_big_message.yaml
+++ b/pkg/dyninst/uploader/testdata/snapshot/threshold_size_flush_single_big_message.yaml
@@ -71,8 +71,10 @@ metrics:
 now: 0s
 event: !stop {}
 effects:
+  - !send-batch {id: 2, items: 1, bytes: 3}
   - !reset-timer {}
 state:
-  batch_len: 1
-  current_size: 3
+  batch_len: 0
+  current_size: 0
+  inflight: [2]
   timer_set: false


### PR DESCRIPTION
### What does this PR do?

See individual commits. The gist of it is that we don't know ahead of time
what might be in an `any` box, but after we find some type we didn't know
about, we're going to recompile the probe to know about that type. There's
details about when to recompile and how to track the full set of types. Also,
because we're now unhooking probes more, we want to flush data we've 
captured. Along the way, we fix a bug discovered by the test where the lifetime
of the symbolicator wasn't long enough.

### Motivation

Some users have complained about what they see when debugging code
involving `map[any]any`. 

### Describe how you validated your changes

There's a good deal of testing.

### Additional Notes

Resolves https://datadoghq.atlassian.net/browse/DEBUG-4528

One additional thing we may want to do is rate limit compilations, but leaving that for follow-up.