### PR TITLE
dyninst/uploader: set timeout sending requests

### DIFF
--- a/pkg/dyninst/uploader/config.go
+++ b/pkg/dyninst/uploader/config.go
@@ -19,6 +19,7 @@ const (
 	defaultMaxBatchItems     = 1024
 	defaultMaxBatchSizeBytes = 1 * 1024 * 1024 // 1MB
 	defaultMaxBufferDuration = 100 * time.Millisecond
+	defaultSendTimeout       = 60 * time.Second
 )
 
 type config struct {
@@ -27,6 +28,8 @@ type config struct {
 	url    *url.URL
 	// Key-value pairs to be added to all upload HTTP requests as headers.
 	headers [][2]string
+	// The timeout for sending a batch of messages.
+	sendTimeout time.Duration
 }
 
 type batcherConfig struct {
@@ -40,8 +43,9 @@ type batcherConfig struct {
 
 func defaultConfig() config {
 	return config{
-		client: http.DefaultClient,
-		url:    nil,
+		client:      http.DefaultClient,
+		url:         nil,
+		sendTimeout: defaultSendTimeout,
 
 		batcherConfig: batcherConfig{
 			maxBatchItems:     defaultMaxBatchItems,
@@ -86,5 +90,11 @@ func WithMaxBatchSizeBytes(maxSizeBytes int) Option {
 func WithMaxBufferDuration(d time.Duration) Option {
 	return func(c *config) {
 		c.batcherConfig.maxBufferDuration = d
+	}
+}
+
+func WithSendTimeout(d time.Duration) Option {
+	return func(c *config) {
+		c.sendTimeout = d
 	}
 }

--- a/pkg/dyninst/uploader/config_test.go
+++ b/pkg/dyninst/uploader/config_test.go
@@ -22,6 +22,7 @@ func TestConfig(t *testing.T) {
 		assert.Equal(t, defaultMaxBatchItems, c.batcherConfig.maxBatchItems)
 		assert.Equal(t, defaultMaxBatchSizeBytes, c.batcherConfig.maxBatchSizeBytes)
 		assert.Equal(t, defaultMaxBufferDuration, c.batcherConfig.maxBufferDuration)
+		assert.Equal(t, defaultSendTimeout, c.sendTimeout)
 	})
 
 	t.Run("with client", func(t *testing.T) {
@@ -47,5 +48,11 @@ func TestConfig(t *testing.T) {
 		c := defaultConfig()
 		WithMaxBufferDuration(10 * time.Millisecond)(&c)
 		assert.Equal(t, 10*time.Millisecond, c.batcherConfig.maxBufferDuration)
+	})
+
+	t.Run("with send timeout", func(t *testing.T) {
+		c := defaultConfig()
+		WithSendTimeout(10 * time.Millisecond)(&c)
+		assert.Equal(t, 10*time.Millisecond, c.sendTimeout)
 	})
 }

--- a/pkg/dyninst/uploader/diagnostics.go
+++ b/pkg/dyninst/uploader/diagnostics.go
@@ -108,7 +108,7 @@ func NewDiagnosticsUploader(opts ...Option) *DiagnosticsUploader {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	sender := newDiagnosticsSender(cfg.client, cfg.url.String())
+	sender := newDiagnosticsSender(cfg.client, cfg.url.String(), cfg.sendTimeout)
 	return &DiagnosticsUploader{
 		batcher: newBatcher("diagnostics", sender, cfg.batcherConfig),
 	}
@@ -136,14 +136,18 @@ func (u *DiagnosticsUploader) Stats() map[string]int64 {
 }
 
 type diagnosticsSender struct {
-	client *http.Client
-	url    string
+	client      *http.Client
+	url         string
+	sendTimeout time.Duration
 }
 
-func newDiagnosticsSender(client *http.Client, url string) *diagnosticsSender {
+func newDiagnosticsSender(
+	client *http.Client, url string, sendTimeout time.Duration,
+) *diagnosticsSender {
 	return &diagnosticsSender{
-		client: client,
-		url:    url,
+		client:      client,
+		url:         url,
+		sendTimeout: sendTimeout,
 	}
 }
 
@@ -165,7 +169,9 @@ func (s *diagnosticsSender) send(batch []json.RawMessage) error {
 		return fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.url, &buf)
+	ctx, cancel := context.WithTimeout(context.Background(), s.sendTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, &buf)
 	if err != nil {
 		return fmt.Errorf("failed to build request: %w", err)
 	}
@@ -175,13 +181,7 @@ func (s *diagnosticsSender) send(batch []json.RawMessage) error {
 	if err != nil {
 		return fmt.Errorf("failed to send batch: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("uploader received error response: status=%d", resp.StatusCode)
-	}
-
-	return nil
+	return responseToError(resp)
 }
 
 func encodeJSON(w io.Writer, data []json.RawMessage) error {

--- a/pkg/dyninst/uploader/logs.go
+++ b/pkg/dyninst/uploader/logs.go
@@ -12,9 +12,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -124,7 +126,7 @@ func (u *LogsUploaderFactory) GetUploader(metadata LogsUploaderMetadata) *LogsUp
 	name = fmt.Sprintf("logs:%d", uploaderID)
 	log.Debugf("creating uploader %s with metadata %v", name, metadata)
 
-	sender := newLogSender(u.cfg.client, logsURL, headers)
+	sender := newLogSender(u.cfg.client, logsURL, headers, u.cfg.sendTimeout)
 	taggedUploader := &LogsUploader{
 		batcher:  newBatcher(name, sender, u.cfg.batcherConfig),
 		metadata: metadata,
@@ -194,16 +196,23 @@ func (u *LogsUploaderFactory) Stats() map[string]int64 {
 }
 
 type logSender struct {
-	client  *http.Client
-	url     string
-	headers map[string]string
+	client      *http.Client
+	url         string
+	headers     map[string]string
+	sendTimeout time.Duration
 }
 
-func newLogSender(client *http.Client, url string, headers map[string]string) *logSender {
+func newLogSender(
+	client *http.Client,
+	url string,
+	headers map[string]string,
+	sendTimeout time.Duration,
+) *logSender {
 	return &logSender{
-		client:  client,
-		url:     url,
-		headers: headers,
+		client:      client,
+		url:         url,
+		headers:     headers,
+		sendTimeout: sendTimeout,
 	}
 }
 
@@ -213,7 +222,14 @@ func (s *logSender) send(batch []json.RawMessage) error {
 		return fmt.Errorf("failed to encode JSON: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, s.url, &buf)
+	ctx, cancel := context.WithTimeout(context.Background(), s.sendTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		s.url,
+		&buf,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create http request: %w", err)
 	}
@@ -226,11 +242,25 @@ func (s *logSender) send(batch []json.RawMessage) error {
 	if err != nil {
 		return fmt.Errorf("failed to send batch: %w", err)
 	}
+	return responseToError(resp)
+}
+
+// responseToError converts an HTTP response to an error. It closes the response
+// body.
+func responseToError(resp *http.Response) error {
 	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		return fmt.Errorf("uploader received error response: status=%d", resp.StatusCode)
+	if resp.StatusCode < 400 {
+		return nil
 	}
-
-	return nil
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return fmt.Errorf(
+			"logs uploader received error response: status=%d; failed to read body: %v",
+			resp.StatusCode, err,
+		)
+	}
+	return fmt.Errorf(
+		"logs uploader received error response: status=%d; body=%q",
+		resp.StatusCode, body,
+	)
 }


### PR DESCRIPTION
### What does this PR do?

Before this change, we wouldn't set any timeouts, so in situations where the network just blocks, we could prevent shutdown or otherwise impede progress. I chose 60s because we expect our messages to be under 2MiB (generally by a lot) which works out to 35KiB/s. I think it's reasonable to assume that the agent is going to see bigger problems than some failed debugger uploaders if we can't sustain a higher data rate than that.

### Motivation

I made closing of a batcher in https://github.com/DataDog/datadog-agent/pull/46418 wait for the final batch to flush as opposed to just throwing it away. This led me to worry about how long that could take. Technically we had the same problems before if a batch was already in flight because
we were waiting for them to complete. 

### Describe how you validated your changes

This code is exercised.

### Additional Notes

Relates to https://datadoghq.atlassian.net/browse/DEBUG-4114. 