### PR TITLE
[NETPATH] Add sendToBackend support to networkpath private action

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -22,12 +22,15 @@ import (
 	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	privateactionrunnerfx "github.com/DataDog/datadog-agent/comp/privateactionrunner/fx"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient/rcclientimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
+	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -72,6 +75,9 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 		fx.Supply(rcclient.Params{AgentName: "private-action-runner", AgentVersion: version.AgentVersion}),
 		getTaggerModule(),
 		remotetraceroute.Module(),
+		logscompressionfx.Module(),
+		eventplatformreceiverimpl.Module(),
+		eventplatformimpl.Module(eventplatformimpl.NewDefaultParams()),
 		privateactionrunnerfx.Module(),
 	}
 

--- a/pkg/privateactionrunner/bundles/networkpath/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/networkpath/entrypoint.go
@@ -6,6 +6,7 @@
 package com_datadoghq_ddagent_networkpath
 
 import (
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 )
@@ -14,10 +15,10 @@ type NetworkPathBundle struct {
 	actions map[string]types.Action
 }
 
-func NewNetworkPath(traceroute traceroute.Component) types.Bundle {
+func NewNetworkPath(traceroute traceroute.Component, epForwarder eventplatform.Component) types.Bundle {
 	return &NetworkPathBundle{
 		actions: map[string]types.Action{
-			"getNetworkPath": NewGetNetworkPathHandler(traceroute),
+			"getNetworkPath": NewGetNetworkPathHandler(traceroute, epForwarder),
 		},
 	}
 }

--- a/pkg/privateactionrunner/bundles/networkpath/get_network_path.go
+++ b/pkg/privateactionrunner/bundles/networkpath/get_network_path.go
@@ -41,6 +41,7 @@ type GetNetworkPathInputs struct {
 	TracerouteQueries  int               `json:"tracerouteQueries,omitempty"`
 	E2eQueries         int               `json:"e2eQueries,omitempty"`
 	Namespace          string            `json:"namespace,omitempty"`
+	SendToBackend      bool              `json:"sendToBackend,omitempty"`
 }
 
 func (h *GetNetworkPathHandler) Run(

--- a/pkg/privateactionrunner/bundles/networkpath/get_network_path_test.go
+++ b/pkg/privateactionrunner/bundles/networkpath/get_network_path_test.go
@@ -67,6 +67,7 @@ func TestGetNetworkPathHandlerRun(t *testing.T) {
 			"tracerouteQueries":  3,
 			"e2eQueries":         10,
 			"namespace":          "default",
+			"sendToBackend":      true,
 		},
 	}
 

--- a/pkg/privateactionrunner/bundles/registry.go
+++ b/pkg/privateactionrunner/bundles/registry.go
@@ -8,6 +8,7 @@
 package privatebundles
 
 import (
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
@@ -50,7 +51,7 @@ type Registry struct {
 	Bundles map[string]types.Bundle
 }
 
-func NewRegistry(configuration *config.Config, traceroute traceroute.Component) *Registry {
+func NewRegistry(configuration *config.Config, traceroute traceroute.Component, epForwarder eventplatform.Component) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),
@@ -82,7 +83,7 @@ func NewRegistry(configuration *config.Config, traceroute traceroute.Component) 
 			"com.datadoghq.kubernetes.core":            com_datadoghq_kubernetes_core.NewKubernetesCore(),
 			"com.datadoghq.kubernetes.customresources": com_datadoghq_kubernetes_customresources.NewKubernetesCustomResources(),
 			"com.datadoghq.mongodb":                    com_datadoghq_mongodb.NewMongoDB(),
-			"com.datadoghq.ddagent.networkpath":        com_datadoghq_ddagent_networkpath.NewNetworkPath(traceroute),
+			"com.datadoghq.ddagent.networkpath":        com_datadoghq_ddagent_networkpath.NewNetworkPath(traceroute, epForwarder),
 			"com.datadoghq.postgresql":                 com_datadoghq_postgresql.NewPostgreSQL(),
 			"com.datadoghq.script":                     com_datadoghq_script.NewScript(),
 			"com.datadoghq.temporal":                   com_datadoghq_temporal.NewTemporal(),

--- a/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
+++ b/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
@@ -9,6 +9,7 @@
 package privatebundles
 
 import (
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
@@ -50,7 +51,7 @@ type Registry struct {
 	Bundles map[string]types.Bundle
 }
 
-func NewRegistry(configuration *config.Config, _ traceroute.Component) *Registry {
+func NewRegistry(configuration *config.Config, _ traceroute.Component, _ eventplatform.Component) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
@@ -42,9 +43,10 @@ func NewWorkflowRunner(
 	verifier *taskverifier.TaskVerifier,
 	opmsClient opms.Client,
 	traceroute traceroute.Component,
+	epForwarder eventplatform.Component,
 ) (*WorkflowRunner, error) {
 	return &WorkflowRunner{
-		registry:     privatebundles.NewRegistry(configuration, traceroute),
+		registry:     privatebundles.NewRegistry(configuration, traceroute, epForwarder),
 		opmsClient:   opmsClient,
 		resolver:     resolver.NewPrivateCredentialResolver(),
 		config:       configuration,


### PR DESCRIPTION
### What does this PR do?

Adds a `sendToBackend` boolean input field to the networkpath private action runner action (`getNetworkPath`). When enabled, the traceroute result (network path payload) is sent to the event platform intake on the `network-path` track, similar to how the networkpath core check (`pkg/collector/corechecks/networkpath`) sends data.

### Changes

- Added `sendToBackend` boolean input to `GetNetworkPathInputs`
- When `sendToBackend` is `true`, the handler marshals the `NetworkPath` payload and sends it via the event platform forwarder (`EventTypeNetworkPath`)
- Threaded `eventplatform.Component` through the PAR dependency chain (component → workflow runner → registry → bundle → handler)
- Added `eventplatformimpl`, `eventplatformreceiverimpl`, and `logscompression` modules to the standalone PAR binary
- Updated cluster-agent PAR wiring to pass the event platform forwarder

### Motivation

Allow the private action runner to optionally forward traceroute data to the Datadog network path backend, enabling on-demand network path visibility from PAR-triggered actions.

### Describe how you validated your changes

- Unit tests pass (`go test ./pkg/privateactionrunner/bundles/networkpath/...`)
- Added `TestGetNetworkPathHandlerRunSendToBackend` — verifies event is sent to the forwarder with correct event type
- Added `TestGetNetworkPathHandlerRunSendToBackendForwarderNotAvailable` — verifies error when forwarder is unavailable