### PR TITLE
Remove redundant build from `bazel:test:linux-amd64`

### DIFF
--- a/.gitlab/build/bazel/tests.yml
+++ b/.gitlab/build/bazel/tests.yml
@@ -13,7 +13,6 @@ bazel:test:linux-amd64:
       -//pkg/discovery/module/rust:dd_discovery
       -//pkg/discovery/module/rust:dd_discovery_test
       -//pkg/discovery/module/rust:libdd_discovery
-    - bazel build //packages/agent/linux:debian
 
 bazel:test:linux-arm64:
   extends: [ .bazel:test, .bazel:runner:linux-arm64 ]


### PR DESCRIPTION
### What does this PR do?
Remove the redundant `bazel build //packages/agent/linux:debian` command from the `bazel:test:linux-amd64` CI job.

### Motivation
`bazel test //...` already builds all targets matching the pattern, including `//packages/agent/linux:debian`. This is as [documented](https://bazel.build/docs/user-manual#running-tests):
> By default, this command performs simultaneous build and test activity, building all specified targets (**including any non-test targets** specified on the command line)

### Describe how you validated your changes
Ran `bazel clean && bazel test //...` and confirmed the `.deb` got rebuilt.