### PR TITLE
sd-agent: Fix clippy lint

### DIFF
--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -305,8 +305,9 @@ pub unsafe extern "C" fn dd_discovery_get_services(
     heartbeat_pids: *const i32,
     heartbeat_pids_len: usize,
 ) -> *mut dd_discovery_result {
-    // SAFETY: caller guarantees new_pids and heartbeat_pids point to valid arrays.
+    // SAFETY: caller guarantees new_pids points to a valid array.
     let new = unsafe { pids_from_c(new_pids, new_pids_len) };
+    // SAFETY: caller guarantees heartbeat_pids points to valid array.
     let heartbeat = unsafe { pids_from_c(heartbeat_pids, heartbeat_pids_len) };
 
     let params = Params {


### PR DESCRIPTION
### What does this PR do?

Fix this:

```
 error: unsafe block missing a safety comment
    --> src/ffi.rs:310:21
     |
 310 |     let heartbeat = unsafe { pids_from_c(heartbeat_pids, heartbeat_pids_len) };
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: consider adding a safety comment on the preceding line
```

### Additional Notes

Checks will be run in CI after https://github.com/DataDog/datadog-agent/pull/46209
