### PR TITLE
Add more known environment variables to prevent false-positive warnings in the log

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2416,6 +2416,8 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		"DD_VERSION":                               {},
 		// this variable is used by the Kubernetes leader election mechanism
 		"DD_POD_NAME": {},
+		// other Kubernetes specific variables
+		"DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS":  {},
 		// this variable is used by tracers
 		"DD_INSTRUMENTATION_TELEMETRY_ENABLED": {},
 		// these variables are used by source code integration
@@ -2427,6 +2429,8 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		"DD_APM_NET_RECEIVER_FD":  {},
 		"DD_APM_UNIX_RECEIVER_FD": {},
 		"DD_OTLP_CONFIG_GRPC_FD":  {},
+		// DogStatsD specific variables
+		"DD_ENTITY_ID":  {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}


### PR DESCRIPTION
### What does this PR do?

It adds envionrment variables `DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS` and `DD_ENTITY_ID` to the set of known environment variables.

### Motivation

Prevent false-positive warnings (like the ones below) in the logs:

```
2026-02-16 08:31:05 UTC | CORE | WARN | (pkg/util/log/log.go:783 in func1) | Unknown environment variable: DD_ENTITY_ID
2026-02-16 08:31:05 UTC | CORE | WARN | (pkg/util/log/log.go:783 in func1) | Unknown environment variable: DD_KUBERNETES_KUBE_SERVICE_IGNORE_READINESS

```

### Describe how you validated your changes

I carefully reviewed them, but did not otherwise validate them as my changes contain no changes to logic.

### Additional Notes
