### PR TITLE
sd-agent: fix clippy warning

### DIFF
--- a/pkg/discovery/module/rust/src/apm.rs
+++ b/pkg/discovery/module/rust/src/apm.rs
@@ -329,7 +329,7 @@ mod tests {
 
         use memmap2::Mmap;
 
-        let current_pid = std::process::id() as i32;
+        let current_pid = std::process::id().cast_signed();
         let cmdline = cmdline![];
         let envs = HashMap::new();
 
@@ -365,7 +365,7 @@ mod tests {
 
         use memmap2::Mmap;
 
-        let current_pid = std::process::id() as i32;
+        let current_pid = std::process::id().cast_signed();
         let cmdline = cmdline![];
         let envs = HashMap::new(); // No env vars set
 

--- a/pkg/discovery/module/rust/src/envs.rs
+++ b/pkg/discovery/module/rust/src/envs.rs
@@ -106,7 +106,7 @@ mod tests {
     fn test_get_target_envs_self() {
         // Test reading our own environment variables
         // This should succeed unless we don't have permission to read our own /proc/self/environ
-        let result = get_target_envs(std::process::id() as i32);
+        let result = get_target_envs(std::process::id().cast_signed());
         assert!(result.is_ok());
 
         let env_vars = result.unwrap();
@@ -132,7 +132,7 @@ mod tests {
         cmd.env("SHELL", "/bin/bash");
 
         let mut child = cmd.spawn().expect("Failed to spawn test process");
-        let pid = child.id() as i32;
+        let pid = child.id().cast_signed();
 
         // Wait for process to be fully initialized and environ to be readable
         assert_eventually(Duration::from_secs(5), Duration::from_millis(10), || {

--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -305,8 +305,9 @@ pub unsafe extern "C" fn dd_discovery_get_services(
     heartbeat_pids: *const i32,
     heartbeat_pids_len: usize,
 ) -> *mut dd_discovery_result {
-    // SAFETY: caller guarantees new_pids and heartbeat_pids point to valid arrays.
+    // SAFETY: caller guarantees new_pids points to a valid array.
     let new = unsafe { pids_from_c(new_pids, new_pids_len) };
+    // SAFETY: caller guarantees heartbeat_pids points to a valid array.
     let heartbeat = unsafe { pids_from_c(heartbeat_pids, heartbeat_pids_len) };
 
     let params = Params {
@@ -513,7 +514,12 @@ unsafe fn free_dd_tracer_metadata(metadata: &dd_tracer_metadata) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::undocumented_unsafe_blocks,
+    clippy::bool_assert_comparison,
+    clippy::indexing_slicing
+)]
 mod tests {
     use super::*;
     use crate::service_name::ServiceNameSource;
@@ -524,7 +530,7 @@ mod tests {
         if s.data.is_null() {
             return "";
         }
-        let slice = unsafe { std::slice::from_raw_parts(s.data as *const u8, s.len) };
+        let slice = unsafe { std::slice::from_raw_parts(s.data, s.len) };
         std::str::from_utf8(slice).unwrap()
     }
 

--- a/pkg/discovery/module/rust/src/language.rs
+++ b/pkg/discovery/module/rust/src/language.rs
@@ -553,7 +553,7 @@ mod tests {
 
         use memmap2::Mmap;
 
-        let current_pid = std::process::id() as i32;
+        let current_pid = std::process::id().cast_signed();
 
         // Negative test: current process should NOT be detected as .NET initially
         let result = Language::from_dotnet(current_pid);
@@ -601,7 +601,7 @@ mod tests {
             c.wait().ok();
         });
 
-        let pid = child.id() as i32;
+        let pid = child.id().cast_signed();
 
         // Wait for the "READY" signal from the Go process to ensure it's fully started
         let stdout = child.stdout.as_mut().expect("Failed to get stdout");
@@ -625,7 +625,7 @@ mod tests {
     #[test]
     fn test_from_go_with_non_go_binary() {
         // Test with current process (Rust binary) - should NOT be detected as Go
-        let current_pid = std::process::id() as i32;
+        let current_pid = std::process::id().cast_signed();
         let result = Language::from_go(current_pid);
         assert_eq!(
             result, None,

--- a/pkg/discovery/module/rust/src/procfs/fd.rs
+++ b/pkg/discovery/module/rust/src/procfs/fd.rs
@@ -537,7 +537,7 @@ mod tests {
                 .open(&valid_log)
                 .expect("Failed to reopen valid log");
 
-            let pid = std::process::id() as i32;
+            let pid = std::process::id().cast_signed();
 
             let open_files_info = get_open_files_info(pid).expect("Failed to collect open files");
 

--- a/pkg/discovery/module/rust/src/service_name/context.rs
+++ b/pkg/discovery/module/rust/src/service_name/context.rs
@@ -149,7 +149,7 @@ mod tests {
             .current_dir(&cwd_dir)
             .spawn()
             .expect("failed to spawn child process");
-        let child_pid = child.id() as i32;
+        let child_pid = child.id().cast_signed();
         defer! {
             let _ = child.kill();
             let _ = child.wait();

--- a/pkg/discovery/module/rust/src/services.rs
+++ b/pkg/discovery/module/rust/src/services.rs
@@ -196,7 +196,7 @@ mod tests {
 
             std::fs::write(&log_path, "Service started\n").expect("Failed to write to log");
 
-            let pid = std::process::id() as i32;
+            let pid = std::process::id().cast_signed();
 
             let open_files_info =
                 procfs::fd::get_open_files_info(pid).expect("Failed to collect open files");
@@ -233,7 +233,7 @@ mod tests {
                 .open(&log_path)
                 .expect("Failed to open log file");
 
-            let pid = std::process::id() as i32;
+            let pid = std::process::id().cast_signed();
 
             let proc_path = procfs::root_path().join(pid.to_string());
             assert!(
@@ -284,7 +284,7 @@ mod tests {
                 .open(&log_path)
                 .expect("Failed to open log file 2");
 
-            let pid = std::process::id() as i32;
+            let pid = std::process::id().cast_signed();
 
             let proc_path = procfs::root_path().join(pid.to_string());
             assert!(


### PR DESCRIPTION
### What does this PR do?

Fixes all remaining clippy warnings in `sd-agent`, mostly in tests.

### Motivation

### Describe how you validated your changes

`cargo clippy --all-targets`

### Additional Notes
