### PR TITLE
Fix missing reference to configurable base image registry

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -9,7 +9,7 @@ COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c -lseccomp
 
-FROM ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS release-base
+FROM ${BASE_IMAGE_REGISTRY}/ubuntu:$BASE_IMAGE_UBUNTU_VERSION AS release-base
 ARG BASE_IMAGE_UBUNTU_VERSION=24.04
 ARG BASE_IMAGE_UBUNTU_NAME=noble
 LABEL maintainer "Datadog <package@datadoghq.com>"


### PR DESCRIPTION
### What does this PR do?

Adds a missing reference to the base image registry that lets us use our mirror in CI to reduce dependence on dockerhub.

### Motivation

Missed change from #45360.

### Describe how you validated your changes

CI

### Additional Notes
