### PR TITLE
Remove bind_at_load linker flag on darwin

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -305,10 +305,6 @@ def get_build_flags(
         gcflags = "-N -l"
 
     if sys.platform == "darwin":
-        # On macOS work around https://github.com/golang/go/issues/38824
-        # as done in https://go-review.googlesource.com/c/go/+/372798
-        extldflags += "-Wl,-bind_at_load"
-
         # On macOS when using XCode 15 the -no_warn_duplicate_libraries linker flag is needed to avoid getting ld warnings
         # for duplicate libraries: `ld: warning: ignoring duplicate libraries: '-ldatadog-agent-rtloader', '-ldl'`.
         # Gotestsum sees the ld warnings as errors, breaking the test invoke task, so we have to remove them.

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -312,7 +312,7 @@ def get_build_flags(
         try:
             xcode_version = get_xcode_version(ctx)
             if int(xcode_version.split('.')[0]) >= 15:
-                extldflags += ",-no_warn_duplicate_libraries "
+                extldflags += "-Wl,-no_warn_duplicate_libraries "
         except ValueError:
             print(
                 color_message(


### PR DESCRIPTION
### What does this PR do?
Remove `bind_at_load` linker flag on darwin.

### Motivation
As per https://github.com/golang/go/issues/38824 which described the issue and investigation, this has been fixed for a long time, and we don't even have plugin anymore in the agent, so we can remove the flag.

### Describe how you validated your changes
CI

### Additional Notes
