### PR TITLE
Add copyright header year review guideline to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,7 @@ tasks.
 ### Testing Issues
 - **Flaky tests**: Check `flakes.yaml` for known issues
 - **Coverage issues**: Use `--coverage` flag
+
+## Review guidelines
+
+- **Copyright header year**: New files must use the current year in the copyright header, not a year copied from another file.


### PR DESCRIPTION
### What does this PR do?
Adds a review guideline to AGENTS.md instructing that new files must use the current year in the copyright header, not a year copied from another file.

### Motivation
AI code review tools (like Codex) use AGENTS.md to inform their reviews. This guideline enables them to automatically flag PRs where new files have a stale copyright year copied from an existing file.

### Describe how you validated your changes

### Additional Notes
