### PR TITLE
TMP: DONOTMERGE: use /usr/opt/datadog-agent instead of /opt

### DIFF
--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -1,6 +1,7 @@
 .agent_build_script:
   - !reference [.retrieve_linux_go_deps]
   - !reference [.cache_omnibus_ruby_deps, setup]
+  - export INSTALL_DIR=/usr/opt/datadog-agent
   # remove artifacts from previous pipelines that may come from the cache
   - rm -rf $OMNIBUS_PACKAGE_DIR/*
   # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.

--- a/.gitlab/build/packaging/deb.yml
+++ b/.gitlab/build/packaging/deb.yml
@@ -7,6 +7,7 @@ include:
   stage: packaging
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]
+    - export INSTALL_DIR=/usr/opt/datadog-agent
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --target-project ${DD_PROJECT} ${OMNIBUS_EXTRA_ARGS}
     - !reference [.create_signature_and_lint_linux_packages]
   after_script:

--- a/.gitlab/build/packaging/rpm.yml
+++ b/.gitlab/build/packaging/rpm.yml
@@ -10,6 +10,7 @@ include:
   before_script:
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]
+    - export INSTALL_DIR=/usr/opt/datadog-agent
     - dda inv -- -e omnibus.build --base-dir $OMNIBUS_BASE_DIR --skip-deps --target-project=${DD_PROJECT} ${OMNIBUS_EXTRA_ARGS}
     - ls -la $OMNIBUS_PACKAGE_DIR/
     - !reference [.create_signature_and_lint_linux_packages]

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -7,7 +7,8 @@
 #                                                                        #
 ##########################################################################
 
-INSTALL_DIR=/opt/datadog-agent
+# FIXME: DONOTMERGE: hardcoded install dir, should be templated
+INSTALL_DIR=/usr/opt/datadog-agent
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then

--- a/omnibus/package-scripts/agent-deb/postrm
+++ b/omnibus/package-scripts/agent-deb/postrm
@@ -4,7 +4,8 @@
 #
 # .deb: STEP 3 of 5
 
-INSTALL_DIR=/opt/datadog-agent
+# FIXME: DONOTMERGE: hardcoded install dir, should be templated
+INSTALL_DIR=/usr/opt/datadog-agent
 LOG_DIR=/var/log/datadog
 CONFIG_DIR=/etc/datadog-agent
 

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -7,7 +7,8 @@
 #                                                                        #
 ##########################################################################
 
-INSTALL_DIR=/opt/datadog-agent
+# FIXME: DONOTMERGE: hardcoded install dir, should be templated
+INSTALL_DIR=/usr/opt/datadog-agent
 
 # Run FIPS installation script if available. Mandatory to execute the agent binary in FIPS mode.
 if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -7,7 +7,8 @@
 #                                                                        #
 ##########################################################################
 
-INSTALL_DIR=/opt/datadog-agent
+# FIXME: DONOTMERGE: hardcoded install dir, should be templated
+INSTALL_DIR=/usr/opt/datadog-agent
 
 set -e
 

--- a/pkg/fleet/installer/commands/hooks.go
+++ b/pkg/fleet/installer/commands/hooks.go
@@ -9,10 +9,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/spf13/cobra"
 )
+
+func packageInstallDir() string {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "/opt/datadog-agent"
+	}
+	installDir := filepath.Clean(filepath.Join(filepath.Dir(execPath), "..", ".."))
+	if _, err := os.Stat(installDir); err != nil {
+		return "/opt/datadog-agent"
+	}
+	return installDir
+}
 
 func isPrermSupportedCommand() *cobra.Command {
 	return &cobra.Command{
@@ -67,7 +80,7 @@ func postinstCommand() *cobra.Command {
 				Context:     i.ctx,
 				Hook:        "postInstall",
 				Package:     pkg,
-				PackagePath: "/opt/datadog-agent",
+				PackagePath: packageInstallDir(),
 				PackageType: packageType,
 				Upgrade:     false,
 				WindowsArgs: nil,
@@ -98,7 +111,7 @@ func prermCommand() *cobra.Command {
 				Context:     i.ctx,
 				Hook:        "preRemove",
 				Package:     pkg,
-				PackagePath: "/opt/datadog-agent",
+				PackagePath: packageInstallDir(),
 				PackageType: packageType,
 				Upgrade:     upgrade,
 				WindowsArgs: nil,

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -639,9 +639,6 @@ func (s *datadogAgentService) StopStable(ctx HookContext) error {
 
 // WriteStable writes the stable units to the system and reloads the systemd daemon
 func (s *datadogAgentService) WriteStable(ctx HookContext) error {
-	if err := s.checkPlatformSupport(ctx); err != nil {
-		return err
-	}
 	switch service.GetServiceManagerType() {
 	case service.SystemdType:
 		return writeEmbeddedUnitsAndReload(ctx, s.SystemdUnitsStable...)
@@ -649,6 +646,10 @@ func (s *datadogAgentService) WriteStable(ctx HookContext) error {
 		return nil // Nothing to do, files are embedded in the package
 	case service.SysvinitType:
 		return nil // Nothing to do, files are embedded in the package
+	case service.UnknownType:
+		if ctx.PackageType == PackageTypeDEB || ctx.PackageType == PackageTypeRPM {
+			return writeEmbeddedUnitsAndReload(ctx, s.SystemdUnitsStable...)
+		}
 	}
 	return errors.New("unsupported service manager")
 }

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -639,6 +639,9 @@ func (s *datadogAgentService) StopStable(ctx HookContext) error {
 
 // WriteStable writes the stable units to the system and reloads the systemd daemon
 func (s *datadogAgentService) WriteStable(ctx HookContext) error {
+	if err := s.checkPlatformSupport(ctx); err != nil {
+		return err
+	}
 	switch service.GetServiceManagerType() {
 	case service.SystemdType:
 		return writeEmbeddedUnitsAndReload(ctx, s.SystemdUnitsStable...)
@@ -646,10 +649,6 @@ func (s *datadogAgentService) WriteStable(ctx HookContext) error {
 		return nil // Nothing to do, files are embedded in the package
 	case service.SysvinitType:
 		return nil // Nothing to do, files are embedded in the package
-	case service.UnknownType:
-		if ctx.PackageType == PackageTypeDEB || ctx.PackageType == PackageTypeRPM {
-			return writeEmbeddedUnitsAndReload(ctx, s.SystemdUnitsStable...)
-		}
 	}
 	return errors.New("unsupported service manager")
 }


### PR DESCRIPTION
This is for testing with RHEL on edge devices which forbids packages to write to /opt directly

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
