### PR TITLE
Drop unused files from cluster agent image

### DIFF
--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -42,7 +42,13 @@ ENV PATH="/opt/datadog-agent/bin/:$PATH" \
 RUN apt-get update \
     && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser\
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf \
+      /var/cache/debconf/* \
+      /var/lib/apt/lists/* \
+      /var/log/* \
+      /tmp/* \
+      /var/tmp/* \
+      /usr/share/man/*
 
 COPY ./conf.d /etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog-cluster.yaml

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -43,12 +43,11 @@ RUN apt-get update \
     && apt full-upgrade -y \
     && apt-get install --no-install-recommends -y ca-certificates curl libseccomp2 tzdata adduser\
     && rm -rf \
-      /var/cache/debconf/* \
+      /var/cache/debconf/*-old \
       /var/lib/apt/lists/* \
       /var/log/* \
       /tmp/* \
-      /var/tmp/* \
-      /usr/share/man/*
+      /var/tmp/*
 
 COPY ./conf.d /etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog-cluster.yaml


### PR DESCRIPTION
### What does this PR do?

Drops a few files from the cluster agent image to try scrap a few bytes for the gates.

### Motivation

#incident-49543 where we hit the gates. Even though we fixed it with a revert, that prompted some investigation and we can take an extra small buffer out of it.

### Describe how you validated your changes

### Additional Notes

As per my analysis with [dive](https://github.com/wagoodman/dive) on the amd64 image:
- `/var/cache/debconf` accounts for 1.6 MB. But they're probably not safe to entirely remove (see [this discussion](https://github.com/debuerreotype/debuerreotype/issues/95), for instance). However, the `-old` backups should be safe, accounting for close to half of that.
- `/var/logs` accounts for 298 KB.

I took some inspiration from https://github.com/kubernetes-sigs/kind/blob/9145d421e0d4f7abf58905ef9e3029912404a56e/images/base/files/usr/local/bin/clean-install, but I'm being more conservative here because I don't want to prevent `apt` from working on the final image.