### PR TITLE
Remove fleet codeowner for installer go mod

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -866,9 +866,6 @@
 /internal/tools/**/go.mod                @DataDog/agent-devx
 /internal/tools/**/go.sum                @DataDog/agent-devx
 
-/pkg/fleet/installer/go.mod              @DataDog/fleet
-/pkg/fleet/installer/go.sum              @DataDog/fleet
-
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 


### PR DESCRIPTION
### What does this PR do?
Remove fleet codeowner for installer go mod

### Motivation
They are currently required for many reviews when it's not really useful.

### Describe how you validated your changes

### Additional Notes
