### PR TITLE
Fix(diskv2): make IO counter collection non-fatal to preserve partition metrics

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -500,7 +500,11 @@ func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
 func (c *Check) collectDiskMetrics(sender sender.Sender) {
 	iomap, err := c.diskIOCounters()
 	if err != nil {
-		log.Warnf("Unable to get disk iocounters: %s", err)
+		if isExpectedIOCounterError(err) {
+			log.Debugf("IO counter collection not supported on this system: %s", err)
+		} else {
+			log.Warnf("Unable to get disk IO counters: %s", err)
+		}
 		return
 	}
 	for deviceName, ioCounters := range iomap {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -172,10 +172,10 @@ func (c *Check) Run() error {
 	if err != nil {
 		return err
 	}
-	err = c.collectDiskMetrics(sender)
-	if err != nil {
-		return err
-	}
+	// IO counter collection is best-effort: on some systems (e.g. Windows Server 2016)
+	// the IOCTL_DISK_PERFORMANCE call may fail with ERROR_INVALID_FUNCTION.
+	// We should not discard partition/usage metrics when this happens.
+	c.collectDiskMetrics(sender)
 	sender.Commit()
 
 	return nil
@@ -497,19 +497,17 @@ func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
 	return nil
 }
 
-func (c *Check) collectDiskMetrics(sender sender.Sender) error {
+func (c *Check) collectDiskMetrics(sender sender.Sender) {
 	iomap, err := c.diskIOCounters()
 	if err != nil {
 		log.Warnf("Unable to get disk iocounters: %s", err)
-		return err
+		return
 	}
 	for deviceName, ioCounters := range iomap {
 		log.Debugf("Checking iocounters: [device: %s] [ioCounters: %s]", deviceName, ioCounters)
 		tags := c.buildDeviceTags(deviceName, deviceName)
 		c.sendDiskMetrics(sender, ioCounters, tags)
 	}
-
-	return nil
 }
 
 func (c *Check) sendPartitionMetrics(sender sender.Sender, usage *gopsutil_disk.UsageStat, tags []string) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix.go
@@ -49,6 +49,13 @@ func normalizeDeviceTag(deviceName string) string {
 	return deviceName
 }
 
+// isExpectedIOCounterError returns true for errors that are expected and
+// non-fatal for IO counter collection. On Linux/Unix, no such errors are
+// expected so this always returns false.
+func isExpectedIOCounterError(_ error) bool {
+	return false
+}
+
 func (c *Check) configureCreateMounts() {
 }
 

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -1862,7 +1862,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
-		return nil, errors.New("Incorrect function.")
+		return nil, errors.New("incorrect function")
 	})
 	m := mocksender.NewMockSender(diskCheck.ID())
 	m.SetupAcceptAll()

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -1857,3 +1857,29 @@ proc_mountinfo_path: /host/proc/1/mountinfo
 	// /dev/dm-0 should be resolved to friendly /dev/mapper/host-root name
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{"device:/dev/mapper/host-root", "device_name:host-root"})
 }
+
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallReturnsError_ThenPartitionMetricsAreStillCommitted(t *testing.T) {
+	setupDefaultMocks()
+	diskCheck := createDiskCheck(t)
+	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
+		return nil, errors.New("Incorrect function.")
+	})
+	m := mocksender.NewMockSender(diskCheck.ID())
+	m.SetupAcceptAll()
+
+	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	err := diskCheck.Run()
+
+	// Check should succeed — partition metrics must be committed despite IOCounters failure
+	assert.Nil(t, err)
+	// Partition/usage metrics should still be reported
+	m.AssertMetric(t, "Gauge", "system.disk.total", float64(97656250), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.used", float64(68359375), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.free", float64(29296875), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.total", float64(48828125), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	m.AssertMetric(t, "Gauge", "system.disk.used", float64(29296875), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	m.AssertMetric(t, "Gauge", "system.disk.free", float64(19531250), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	// IO metrics should NOT be reported
+	m.AssertNotCalled(t, "MonotonicCount", "system.disk.read_time", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+	m.AssertNotCalled(t, "MonotonicCount", "system.disk.write_time", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+}

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -285,7 +285,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndUsageSystemCallReturns
 
 }
 
-func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallReturnsError_ThenErrorIsReturnedAndNoUsageMetricsAreReported(t *testing.T) {
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallReturnsError_ThenNoErrorIsReturnedAndNoIOMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
@@ -294,14 +294,50 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	m := mocksender.NewMockSender(diskCheck.ID())
 	m.SetupAcceptAll()
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
-	err := diskCheck.Run()
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	logger, err := log.LoggerFromWriterWithMinLevelAndLvlMsgFormat(w, log.DebugLvl)
+	assert.Nil(t, err)
+	log.SetupLogger(logger, "debug")
 
-	assert.NotNil(t, err)
+	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	err = diskCheck.Run()
+
+	// IO counter failure should NOT cause the check to fail
+	assert.Nil(t, err)
+	// IO metrics should not be reported
 	m.AssertNotCalled(t, "MonotonicCount", "system.disk.read_time", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "MonotonicCount", "system.disk.write_time", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Rate", "system.disk.read_time_pct", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Rate", "system.disk.write_time_pct", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+
+	w.Flush()
+	assert.Contains(t, b.String(), "Unable to get disk iocounters: error calling diskIOCounters")
+}
+
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallReturnsError_ThenPartitionMetricsAreStillCommitted(t *testing.T) {
+	setupDefaultMocks()
+	diskCheck := createDiskCheck(t)
+	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
+		return nil, errors.New("Incorrect function.")
+	})
+	m := mocksender.NewMockSender(diskCheck.ID())
+	m.SetupAcceptAll()
+
+	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	err := diskCheck.Run()
+
+	// Check should succeed — partition metrics must be committed despite IOCounters failure
+	assert.Nil(t, err)
+	// Partition/usage metrics should still be reported
+	m.AssertMetric(t, "Gauge", "system.disk.total", float64(97656250), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.used", float64(68359375), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.free", float64(29296875), "", []string{"device:/dev/sda1", "device_name:sda1"})
+	m.AssertMetric(t, "Gauge", "system.disk.total", float64(48828125), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	m.AssertMetric(t, "Gauge", "system.disk.used", float64(29296875), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	m.AssertMetric(t, "Gauge", "system.disk.free", float64(19531250), "", []string{"device:/dev/sda2", "device_name:sda2"})
+	// Commit should have been called
+	m.AssertCalled(t, "Commit")
 }
 
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -312,7 +312,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	m.AssertNotCalled(t, "Rate", "system.disk.write_time_pct", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 
 	w.Flush()
-	assert.Contains(t, b.String(), "Unable to get disk iocounters: error calling diskIOCounters")
+	assert.Contains(t, b.String(), "Unable to get disk IO counters: error calling diskIOCounters")
 }
 
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -315,7 +315,6 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	assert.Contains(t, b.String(), "Unable to get disk iocounters: error calling diskIOCounters")
 }
 
-
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -791,7 +791,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
-		return nil, errors.New("Incorrect function.")
+		return nil, errors.New("incorrect function")
 	})
 	m := mocksender.NewMockSender(diskCheck.ID())
 	m.SetupAcceptAll()

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -18,6 +18,7 @@ import (
 	gopsutil_disk "github.com/shirou/gopsutil/v4/disk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/sys/windows"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -787,11 +788,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionHasEmptyFstype_ThenPartit
 	m.AssertMetricTaggedWith(t, "Gauge", "system.disk.total", []string{`device:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`, `device_name:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`})
 }
 
-func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallReturnsError_ThenPartitionMetricsAreStillCommitted(t *testing.T) {
+func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersReturnsErrorInvalidFunction_ThenPartitionMetricsAreStillCommitted(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
-		return nil, errors.New("incorrect function")
+		return nil, windows.ERROR_INVALID_FUNCTION
 	})
 	m := mocksender.NewMockSender(diskCheck.ID())
 	m.SetupAcceptAll()
@@ -799,7 +800,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
 	err := diskCheck.Run()
 
-	// Check should succeed — partition metrics must be committed despite IOCounters failure
+	// ERROR_INVALID_FUNCTION is expected on systems where disk perf counters are disabled
 	assert.Nil(t, err)
 	// Partition/usage metrics should still be reported
 	m.AssertMetric(t, "Gauge", "system.disk.total", float64(97656250), "", []string{`device:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`, `device_name:?\volume{a1b2c3d4-e5f6-7890-abcd-ef1234567890}`})

--- a/releasenotes/notes/diskv2-iocounters-non-fatal-7b9a543dc644ebea.yaml
+++ b/releasenotes/notes/diskv2-iocounters-non-fatal-7b9a543dc644ebea.yaml
@@ -6,5 +6,7 @@ fixes:
     ``DeviceIoControl`` on Windows Server 2016) caused all disk metrics to be
     discarded, including successfully collected partition/usage metrics such as
     ``system.disk.total``, ``system.disk.used``, and ``system.disk.free``.
-    IO counter collection is now best-effort: failures are logged as warnings
-    but no longer prevent partition metrics from being reported.
+    IO counter collection is now best-effort: known errors such as
+    ``ERROR_INVALID_FUNCTION`` are logged at debug level, while unexpected
+    errors are logged as warnings. Neither prevent partition metrics from
+    being reported.

--- a/releasenotes/notes/diskv2-iocounters-non-fatal-7b9a543dc644ebea.yaml
+++ b/releasenotes/notes/diskv2-iocounters-non-fatal-7b9a543dc644ebea.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed a regression in the Go-native disk check (diskv2) where a failure
+    in IO counter collection (e.g. ``ERROR_INVALID_FUNCTION`` from
+    ``DeviceIoControl`` on Windows Server 2016) caused all disk metrics to be
+    discarded, including successfully collected partition/usage metrics such as
+    ``system.disk.total``, ``system.disk.used``, and ``system.disk.free``.
+    IO counter collection is now best-effort: failures are logged as warnings
+    but no longer prevent partition metrics from being reported.


### PR DESCRIPTION
### What does this PR do?
Makes `collectDiskMetrics()` in the diskv2 check best-effort instead of fatal. Previously, if `gopsutil`'s `disk.IOCounters()` failed, `Run()` returned early before calling `sender.Commit()`, discarding **all** metrics — including the partition/usage metrics (`system.disk.total`, `system.disk.used`, `system.disk.free`, etc.) that were successfully collected by `collectPartitionMetrics()`.

After this change:
- `collectDiskMetrics()` no longer returns an error — it logs a warning and returns early on failure
- `Run()` always calls `sender.Commit()`, ensuring partition/space metrics are preserved even when IO counters are unavailable
### Motivation
After upgrading the Datadog Agent from 7.72.4 to 7.75.2, customers on Windows Server 2016 experience a **100% failure rate** on the disk check with 0 metrics collected:

```
Instance ID: disk [ERROR]
Total Runs: 1,829 | Total Errors: 1,829
Metric Samples: Total: 0
Last Successful Execution Date: Never
Error: Incorrect function.
```

The root cause is that on Windows Server 2016 (with disk performance counters disabled), `DeviceIoControl` with `IOCTL_DISK_PERFORMANCE` returns `ERROR_INVALID_FUNCTION`. The `gopsutil` library propagates this as a fatal error from `disk.IOCounters()`, unlike `psutil` (used by the old Python disk check) which explicitly handles this error by skipping the affected drive:

```c
// psutil/arch/windows/disk.c — graceful handling
else if (GetLastError() == ERROR_INVALID_FUNCTION) {
    psutil_debug("DeviceIoControl -> ERROR_INVALID_FUNCTION; ignore PhysicalDrive%i", devNum);
    goto next;  // skip this drive, continue
}
```

```go
// gopsutil/disk/disk_windows.go — no special handling
err = windows.DeviceIoControl(h, IOCTL_DISK_PERFORMANCE, ...)
if err != nil {
    return drivemap, err  // aborts entirely
}
```

This is a behavior regression from the Python check, where IO counter failures never prevented space metrics from being reported. A complementary fix should also be submitted to [shirou/gopsutil](https://github.com/shirou/gopsutil) to handle `ERROR_INVALID_FUNCTION` and `ERROR_NOT_SUPPORTED` gracefully in `IOCountersWithContext()`.

### Describe how you validated your changes
- Updated the existing unit test (`TestGivenADiskCheck...IOCountersSystemCallReturnsError`) to assert that `Run()` returns `nil` instead of an error when IOCounters fails, and verifies the warning is logged
- Added a new unit test (`TestGivenADiskCheck...IOCountersSystemCallReturnsError_ThenPartitionMetricsAreStillCommitted`) that simulates the exact "Incorrect function." error from Windows, asserts partition metrics (`system.disk.total/used/free`) are still reported for all partitions, and `Commit()` is called
- Manual validation pending on Windows Server 2016 with disk performance counters disabled
### Additional Notes
- This fix addresses from the regression analysis: making the diskv2 check resilient to IO counter failures
- Making `gopsutil` handle `ERROR_INVALID_FUNCTION` gracefully should be submitted separately to [shirou/gopsutil](https://github.com/shirou/gopsutil) — that would allow IO metrics to also be collected on affected systems by skipping only the problematic drives
- Immediate customer workaround is setting `use_diskv2_check: false` in `datadog.yaml` to fall back to the Python disk check, or running `diskperf -y` on the host to enable disk performance counters