### PR TITLE
[WP] Fix variables serialization in custom events

### DIFF
--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -106,9 +106,13 @@ func (commonFields *CustomEventCommonFields) FillCustomEventCommonFields(acc *Ag
 }
 
 // NewCustomRule returns a new custom rule
-func NewCustomRule(id eval.RuleID, description string) *rules.Rule {
+func NewCustomRule(id eval.RuleID, description string, opts ...*eval.Opts) *rules.Rule {
+	var evalOpts *eval.Opts
+	if len(opts) > 0 {
+		evalOpts = opts[0]
+	}
 	return &rules.Rule{
-		Rule: &eval.Rule{ID: id},
+		Rule: &eval.Rule{ID: id, Opts: evalOpts},
 		PolicyRule: &rules.PolicyRule{
 			Def: &rules.RuleDefinition{ID: id, Description: description},
 		},

--- a/pkg/security/events/custom.go
+++ b/pkg/security/events/custom.go
@@ -106,13 +106,9 @@ func (commonFields *CustomEventCommonFields) FillCustomEventCommonFields(acc *Ag
 }
 
 // NewCustomRule returns a new custom rule
-func NewCustomRule(id eval.RuleID, description string, opts ...*eval.Opts) *rules.Rule {
-	var evalOpts *eval.Opts
-	if len(opts) > 0 {
-		evalOpts = opts[0]
-	}
+func NewCustomRule(id eval.RuleID, description string, opts *eval.Opts) *rules.Rule {
 	return &rules.Rule{
-		Rule: &eval.Rule{ID: id, Opts: evalOpts},
+		Rule: &eval.Rule{ID: id, Opts: opts},
 		PolicyRule: &rules.PolicyRule{
 			Def: &rules.RuleDefinition{ID: id, Description: description},
 		},

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -51,7 +52,7 @@ func (e FailedDNSEvent) ToJSON() ([]byte, error) {
 }
 
 // NewAbnormalEvent returns the rule and a populated custom event for an abnormal event
-func NewAbnormalEvent(acc *events.AgentContainerContext, id string, description string, event *model.Event, scrubber *utils.Scrubber, err error) (*rules.Rule, *events.CustomEvent) {
+func NewAbnormalEvent(acc *events.AgentContainerContext, id string, description string, event *model.Event, scrubber *utils.Scrubber, err error, opts *eval.Opts) (*rules.Rule, *events.CustomEvent) {
 	marshalerCtor := func() events.EventMarshaler {
 		evt := AbnormalEvent{
 			Event: serializers.NewEventSerializer(event, nil, scrubber),
@@ -64,11 +65,11 @@ func NewAbnormalEvent(acc *events.AgentContainerContext, id string, description 
 		return evt
 	}
 
-	return events.NewCustomRule(id, description), events.NewCustomEventLazy(model.CustomEventType, marshalerCtor)
+	return events.NewCustomRule(id, description, opts), events.NewCustomEventLazy(model.CustomEventType, marshalerCtor)
 }
 
 // NewFailedDNSEvent returns the rule and a populated custom event for a failed dns packet decoding
-func NewFailedDNSEvent(acc *events.AgentContainerContext, id string, description string, event *model.Event) (*rules.Rule, *events.CustomEvent) {
+func NewFailedDNSEvent(acc *events.AgentContainerContext, id string, description string, event *model.Event, opts *eval.Opts) (*rules.Rule, *events.CustomEvent) {
 	marshalerCtor := func() events.EventMarshaler {
 		evt := FailedDNSEvent{
 			Payload: base64.StdEncoding.EncodeToString(event.FailedDNS.Payload),
@@ -80,7 +81,7 @@ func NewFailedDNSEvent(acc *events.AgentContainerContext, id string, description
 		return evt
 	}
 
-	return events.NewCustomRule(id, description), events.NewCustomEventLazy(model.CustomEventType, marshalerCtor)
+	return events.NewCustomRule(id, description, opts), events.NewCustomEventLazy(model.CustomEventType, marshalerCtor)
 }
 
 // EBPFLessHelloMsgEvent defines a hello message

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -131,5 +131,5 @@ func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.H
 
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.EBPFLessHelloMessageRuleID, events.EBPFLessHelloMessageRuleDesc), events.NewCustomEvent(model.CustomEventType, evt)
+	return events.NewCustomRule(events.EBPFLessHelloMessageRuleID, events.EBPFLessHelloMessageRuleDesc, nil), events.NewCustomEvent(model.CustomEventType, evt)
 }

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -180,29 +180,31 @@ func (m *EBPFMonitors) ProcessEvent(event *model.Event, scrubber *utils.Scrubber
 		return
 	}
 
+	opts := m.ebpfProbe.evalOpts()
+
 	if errors.Is(event.Error, model.ErrFailedDNSPacketDecoding) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewFailedDNSEvent(m.ebpfProbe.GetAgentContainerContext(), events.FailedDNSRuleID, events.AbnormalPathRuleDesc, event),
+			NewFailedDNSEvent(m.ebpfProbe.GetAgentContainerContext(), events.FailedDNSRuleID, events.AbnormalPathRuleDesc, event, opts),
 		)
 	}
 
 	var pathErr *path.ErrPathResolution
 	if errors.As(event.Error, &pathErr) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.AbnormalPathRuleID, events.AbnormalPathRuleDesc, event, scrubber, pathErr.Err),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.AbnormalPathRuleID, events.AbnormalPathRuleDesc, event, scrubber, pathErr.Err, opts),
 		)
 	}
 
 	if errors.Is(event.Error, model.ErrNoProcessContext) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, scrubber, event.Error),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.NoProcessContextErrorRuleID, events.NoProcessContextErrorRuleDesc, event, scrubber, event.Error, opts),
 		)
 	}
 
 	var brokenLineageErr *model.ErrProcessBrokenLineage
 	if errors.As(event.Error, &brokenLineageErr) {
 		m.ebpfProbe.probe.DispatchCustomEvent(
-			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.BrokenProcessLineageErrorRuleID, events.BrokenProcessLineageErrorRuleDesc, event, scrubber, event.Error),
+			NewAbnormalEvent(m.ebpfProbe.GetAgentContainerContext(), events.BrokenProcessLineageErrorRuleID, events.BrokenProcessLineageErrorRuleDesc, event, scrubber, event.Error, opts),
 		)
 	}
 }

--- a/pkg/security/probe/remediations_linux.go
+++ b/pkg/security/probe/remediations_linux.go
@@ -350,7 +350,7 @@ func (p *EBPFProbe) SendRemediationEvent(re *RemediationEvent) {
 	if re == nil {
 		return
 	}
-	customRule := events.NewCustomRule(events.RemediationStatusRuleID, events.RemediationStatusRuleDesc)
+	customRule := events.NewCustomRule(events.RemediationStatusRuleID, events.RemediationStatusRuleDesc, p.evalOpts())
 	customEvent := events.NewCustomEvent(model.CustomEventType, re)
 	p.probe.DispatchCustomEvent(customRule, customEvent)
 

--- a/pkg/security/probe/selftests/self_tests.go
+++ b/pkg/security/probe/selftests/self_tests.go
@@ -57,7 +57,7 @@ func NewSelfTestEvent(acc *events.AgentContainerContext, success []eval.RuleID, 
 	}
 	evt.FillCustomEventCommonFields(acc)
 
-	return events.NewCustomRule(events.SelfTestRuleID, events.SelfTestRuleDesc),
+	return events.NewCustomRule(events.SelfTestRuleID, events.SelfTestRuleDesc, nil),
 		events.NewCustomEvent(model.CustomEventType, evt)
 }
 

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -509,7 +509,7 @@ func NewRuleSetLoadedEvent(acc *events.AgentContainerContext, rs *rules.RuleSet,
 	evt.FillCustomEventCommonFields(acc)
 
 	return RulesetLoadedEventBundle{
-		Rule:  events.NewCustomRule(events.RulesetLoadedRuleID, events.RulesetLoadedRuleDesc),
+		Rule:  events.NewCustomRule(events.RulesetLoadedRuleID, events.RulesetLoadedRuleDesc, nil),
 		Event: events.NewCustomEvent(model.CustomEventType, evt),
 	}
 }
@@ -526,7 +526,7 @@ func newHeartbeatEvents(acc *events.AgentContainerContext, policies []*PolicySta
 		evts = append(evts, events.NewCustomEvent(model.CustomEventType, evt))
 	}
 
-	return events.NewCustomRule(events.HeartbeatRuleID, events.HeartbeatRuleDesc),
+	return events.NewCustomRule(events.HeartbeatRuleID, events.HeartbeatRuleDesc, nil),
 		evts
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -289,6 +289,14 @@ func (rs *RuleSet) GetVariables() map[string]eval.SECLVariable {
 	return rs.evalOpts.VariableStore.Variables
 }
 
+// GetVariableStore returns the variable store
+func (rs *RuleSet) GetVariableStore() *eval.VariableStore {
+	if rs.evalOpts == nil {
+		return nil
+	}
+	return rs.evalOpts.VariableStore
+}
+
 // AddMacros parses the macros AST and adds them to the list of macros of the ruleset
 func (rs *RuleSet) AddMacros(macros []*PolicyMacro) *multierror.Error {
 	var result *multierror.Error

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -541,7 +541,7 @@ func newRuleContext(e *model.Event, rule *rules.Rule, scrubber *utils.Scrubber) 
 }
 
 func newVariablesContext(e *model.Event, rule *rules.Rule, prefix string) (variables Variables) {
-	if rule != nil && rule.Opts.VariableStore != nil {
+	if rule != nil && rule.Opts != nil && rule.Opts.VariableStore != nil {
 		store := rule.Opts.VariableStore
 		for name, variable := range store.Variables {
 			// do not serialize hardcoded variables like process.pid

--- a/pkg/security/serializers/serializers_linux_test.go
+++ b/pkg/security/serializers/serializers_linux_test.go
@@ -1,0 +1,258 @@
+//go:build linux
+
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package serializers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+func newTestScrubber(t *testing.T) *utils.Scrubber {
+	t.Helper()
+	scrubber, err := utils.NewScrubber(nil, nil)
+	require.NoError(t, err)
+	return scrubber
+}
+
+func newAnomalyEvent() *model.Event {
+	event := model.NewFakeEvent()
+	event.Type = uint32(model.FileOpenEventType)
+	event.AddToFlags(model.EventFlagsAnomalyDetectionEvent)
+	return event
+}
+
+func TestCustomEventVariables_WithVariableStore(t *testing.T) {
+	// Create a variable store with a boolean variable, simulating what a rule's
+	// "set" action would populate during evaluation.
+	store := &eval.VariableStore{}
+	boolVar := eval.NewBoolVariable(true, eval.VariableOpts{})
+	boolVar.Set(nil, true)
+	store.Add("my_flag", boolVar)
+
+	// Create the custom rule the same way sendAnomalyDetection does, passing the
+	// variable store through eval.Opts.
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+	event.Rules = append(event.Rules, &model.MatchedRule{
+		RuleID:      "test_rule",
+		RuleVersion: "1.0",
+		PolicyName:  "test_policy",
+	})
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	// The non-scoped variable "my_flag" should appear in the event context variables.
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["my_flag"])
+}
+
+func TestCustomEventVariables_WithoutVariableStore(t *testing.T) {
+	// Create a custom rule without a variable store (the old behavior).
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+	)
+
+	event := newAnomalyEvent()
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	// Without a variable store, no variables should be serialized.
+	assert.Nil(t, s.EventContextSerializer.Variables)
+}
+
+func TestCustomEventVariables_NilRule(t *testing.T) {
+	// Simulate the old EventMarshallerCtor path where rule was nil.
+	event := newAnomalyEvent()
+
+	s := NewEventSerializer(event, nil, newTestScrubber(t))
+
+	assert.Nil(t, s.EventContextSerializer.Variables)
+}
+
+func TestCustomEventVariables_MultipleTypes(t *testing.T) {
+	store := &eval.VariableStore{}
+
+	boolVar := eval.NewBoolVariable(false, eval.VariableOpts{})
+	boolVar.Set(nil, true)
+	store.Add("is_suspicious", boolVar)
+
+	strVar := eval.NewStringVariable("", eval.VariableOpts{})
+	strVar.Set(nil, "malware.exe")
+	store.Add("threat_name", strVar)
+
+	intVar := eval.NewIntVariable(0, eval.VariableOpts{})
+	intVar.Set(nil, 42)
+	store.Add("hit_count", intVar)
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["is_suspicious"])
+	assert.Equal(t, "malware.exe", s.EventContextSerializer.Variables["threat_name"])
+	assert.Equal(t, 42, s.EventContextSerializer.Variables["hit_count"])
+}
+
+func TestCustomEventVariables_PrivateExcluded(t *testing.T) {
+	store := &eval.VariableStore{}
+
+	publicVar := eval.NewBoolVariable(true, eval.VariableOpts{})
+	store.Add("visible", publicVar)
+
+	privateVar := eval.NewBoolVariable(true, eval.VariableOpts{Private: true})
+	store.Add("hidden", privateVar)
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["visible"])
+	_, found := s.EventContextSerializer.Variables["hidden"]
+	assert.False(t, found, "private variables should not be serialized")
+}
+
+func TestCustomEventVariables_ScopedProcessVariable(t *testing.T) {
+	store := &eval.VariableStore{}
+
+	// A non-scoped variable (no dot in name) should appear in event context.
+	globalVar := eval.NewBoolVariable(true, eval.VariableOpts{})
+	store.Add("global_flag", globalVar)
+
+	// A process-scoped variable should appear in process context, not event context.
+	// For global (non-scoped) variables in the store, a name with "process." prefix
+	// is filtered by the prefix logic: prefix="" excludes names with dots,
+	// prefix="process." includes only names starting with "process.".
+	processVar := eval.NewStringVariable("", eval.VariableOpts{})
+	processVar.Set(nil, "test_value")
+	store.Add("process.my_var", processVar)
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+	// Set a non-zero PID so that newProcessContextSerializer doesn't return nil.
+	event.ProcessContext.Pid = 1234
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	// Event context (prefix="") should have global_flag but NOT process.my_var.
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["global_flag"])
+	_, found := s.EventContextSerializer.Variables["process.my_var"]
+	assert.False(t, found, "scoped variable should not appear in event context")
+
+	// Process context (prefix="process.") should have my_var (trimmed of prefix).
+	require.NotNil(t, s.ProcessContextSerializer)
+	require.NotNil(t, s.ProcessContextSerializer.Variables)
+	assert.Equal(t, "test_value", s.ProcessContextSerializer.Variables["my_var"])
+}
+
+func TestCustomEventVariables_MatchedRulesSerialized(t *testing.T) {
+	store := &eval.VariableStore{}
+	boolVar := eval.NewBoolVariable(true, eval.VariableOpts{})
+	store.Add("flagged", boolVar)
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+	event.Rules = append(event.Rules,
+		&model.MatchedRule{
+			RuleID:        "rule_1",
+			RuleVersion:   "1.0",
+			RuleTags:      map[string]string{"severity": "high"},
+			PolicyName:    "my_policy",
+			PolicyVersion: "2.0",
+		},
+		&model.MatchedRule{
+			RuleID:      "rule_2",
+			RuleVersion: "1.1",
+			PolicyName:  "my_policy",
+		},
+	)
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	// Variables should be present.
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["flagged"])
+
+	// Matched rules should also be serialized for anomaly detection events.
+	require.Len(t, s.EventContextSerializer.MatchedRules, 2)
+	assert.Equal(t, "rule_1", s.EventContextSerializer.MatchedRules[0].ID)
+	assert.Equal(t, "rule_2", s.EventContextSerializer.MatchedRules[1].ID)
+}
+
+func TestCustomEventVariables_SECLVariablesExcluded(t *testing.T) {
+	store := &eval.VariableStore{}
+
+	// Add a user variable.
+	userVar := eval.NewBoolVariable(true, eval.VariableOpts{})
+	store.Add("user_flag", userVar)
+
+	// Add a variable with the same name as a SECLVariable — these are hardcoded
+	// variables like "process.pid" and should be excluded from serialization.
+	for name := range model.SECLVariables {
+		fakeVar := eval.NewIntVariable(999, eval.VariableOpts{})
+		store.Add(name, fakeVar)
+		break // just need one to test
+	}
+
+	rule := events.NewCustomRule(
+		events.AnomalyDetectionRuleID,
+		events.AnomalyDetectionRuleDesc,
+		&eval.Opts{VariableStore: store},
+	)
+
+	event := newAnomalyEvent()
+
+	s := NewEventSerializer(event, rule, newTestScrubber(t))
+
+	require.NotNil(t, s.EventContextSerializer.Variables)
+	assert.Equal(t, true, s.EventContextSerializer.Variables["user_flag"])
+
+	// SECLVariable names should not appear in serialized variables.
+	for name := range model.SECLVariables {
+		_, found := s.EventContextSerializer.Variables[name]
+		assert.False(t, found, "SECLVariable %q should not be serialized", name)
+	}
+}
+

--- a/pkg/security/serializers/serializers_linux_test.go
+++ b/pkg/security/serializers/serializers_linux_test.go
@@ -1,9 +1,9 @@
-//go:build linux
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
+//go:build linux
 
 package serializers
 

--- a/pkg/security/serializers/serializers_linux_test.go
+++ b/pkg/security/serializers/serializers_linux_test.go
@@ -68,6 +68,7 @@ func TestCustomEventVariables_WithoutVariableStore(t *testing.T) {
 	rule := events.NewCustomRule(
 		events.AnomalyDetectionRuleID,
 		events.AnomalyDetectionRuleDesc,
+		nil,
 	)
 
 	event := newAnomalyEvent()
@@ -255,4 +256,3 @@ func TestCustomEventVariables_SECLVariablesExcluded(t *testing.T) {
 		assert.False(t, found, "SECLVariable %q should not be serialized", name)
 	}
 }
-

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -479,7 +479,7 @@ func TestAnomalyDetectionVariables(t *testing.T) {
 			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
 			_, err = cmd.CombinedOutput()
 			return err
-		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
+		}, func(_ *rules.Rule, customEvent *events.CustomEvent) bool {
 			// Verify the anomaly detection custom event carries the variable.
 			eventJSON, jsonErr := customEvent.MarshalJSON()
 			if jsonErr != nil {

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -385,6 +385,124 @@ func TestAnomalyDetection(t *testing.T) {
 	})
 }
 
+func TestAnomalyDetectionVariables(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	// skip test that are about to be run on docker (to avoid trying spawning docker in docker)
+	if testEnvironment == DockerEnvironment {
+		t.Skip("Skip test spawning docker containers on docker")
+	}
+	if _, err := whichNonFatal("docker"); err != nil {
+		t.Skip("Skip test where docker is unavailable")
+	}
+	if !IsDedicatedNodeForAD() {
+		t.Skip("Skip test when not run in dedicated env")
+	}
+
+	var expectedFormats = []string{"profile"}
+	var testActivityDumpTracedEventTypes = []string{"exec", "open", "syscalls", "dns", "bind"}
+
+	outputDir := t.TempDir()
+	os.MkdirAll(outputDir, 0755)
+	defer os.RemoveAll(outputDir)
+
+	// Define a rule with a "set" action that matches exec events.
+	// When both the rule and anomaly detection fire on the same event,
+	// the variable set by the rule should be present in the anomaly
+	// detection custom event.
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_ad_variable_rule",
+			Expression: `exec.file.name == "getconf"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Name:  "ad_test_var",
+						Value: true,
+					},
+				},
+			},
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{
+		enableActivityDump:                      true,
+		activityDumpRateLimiter:                 200,
+		activityDumpTracedCgroupsCount:          3,
+		activityDumpDuration:                    testActivityDumpDuration,
+		activityDumpLocalStorageDirectory:       outputDir,
+		activityDumpLocalStorageCompression:     false,
+		activityDumpLocalStorageFormats:         expectedFormats,
+		activityDumpTracedEventTypes:            testActivityDumpTracedEventTypes,
+		enableSecurityProfile:                   true,
+		securityProfileDir:                      outputDir,
+		securityProfileWatchDir:                 true,
+		enableAnomalyDetection:                  true,
+		anomalyDetectionEventTypes:              []string{"exec", "dns"},
+		anomalyDetectionMinimumStablePeriodExec: time.Second,
+		anomalyDetectionMinimumStablePeriodDNS:  time.Second,
+		anomalyDetectionWarmupPeriod:            time.Second,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("anomaly-detection-variable-in-event", func(t *testing.T) {
+		dockerInstance, dump, err := test.StartADockerGetDump()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer dockerInstance.stop()
+
+		// Run the syscall_tester to populate the activity dump baseline.
+		cmd := dockerInstance.Command(syscallTester, []string{"sleep", "1"}, []string{})
+		_, err = cmd.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(1 * time.Second) // let events be added to the dump
+
+		err = test.StopActivityDump(dump.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(6 * time.Second) // let the profile load (5s debounce + 1s spare)
+
+		// "getconf" is not in the baseline, so it triggers anomaly detection.
+		// It also matches the rule "test_ad_variable_rule" which sets ad_test_var=true.
+		err = test.GetCustomEventSent(t, func() error {
+			cmd := dockerInstance.Command("getconf", []string{"-a"}, []string{})
+			_, err = cmd.CombinedOutput()
+			return err
+		}, func(rule *rules.Rule, customEvent *events.CustomEvent) bool {
+			// Verify the anomaly detection custom event carries the variable.
+			eventJSON, jsonErr := customEvent.MarshalJSON()
+			if jsonErr != nil {
+				t.Errorf("failed to marshal custom event: %v", jsonErr)
+				return false
+			}
+
+			jsonStr := string(eventJSON)
+
+			// The event JSON should contain the variable set by the rule.
+			if !assert.Contains(t, jsonStr, `"ad_test_var"`, "anomaly detection event should contain the variable name") {
+				t.Logf("event JSON: %s", jsonStr)
+				return false
+			}
+
+			return true
+		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestAnomalyDetectionWarmup(t *testing.T) {
 	SkipIfNotAvailable(t)
 


### PR DESCRIPTION
### What does this PR do?

Ensures that SecL rule variables are properly serialized in all custom events, including anomaly detection events. Previously, `events.NewCustomRule()` created rules without a reference to the ruleset's `VariableStore` in its `eval.Opts`, which meant `newVariablesContext` in the serializer could never access variable values for these events.

Changes:                                                  
  - `NewCustomRule()` now accepts an optional `*eval.Opts` parameter and sets it on the underlying `eval.Rule`
  - All call sites pass the current `VariableStore` via `*eval.Opts`
  - `RuleSet.GetVariableStore()` added to expose the variable store
  - `EBPFProbe` captures the `VariableStore` reference in `OnNewRuleSetLoaded`
  - For the anomaly detection path specifically, the custom rule is also passed to the event serializer (via `EventMarshallerCtorWithRule`) so that `newVariablesContext` receives a non-nil rule with the store

### Motivation

Variables set by SecL rule actions (e.g. set actions) were not included in anomaly detection events or any other custom event. Variables are required to expose the proper `correlation key` on anomaly detection events, and could be an important context for other custom events (like kill or abnormal events).

### Describe how you validated your changes

Unit tests were added.
