### PR TITLE
[ACTP] Move PAR self enrolment to runner Start

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -182,13 +182,17 @@ func (p *PrivateActionRunner) Start(ctx context.Context) error {
 }
 
 func (p *PrivateActionRunner) Stop(ctx context.Context) error {
-	err := p.workflowRunner.Stop(ctx)
-	if err != nil {
-		return err
+	if p.workflowRunner != nil {
+		err := p.workflowRunner.Stop(ctx)
+		if err != nil {
+			return err
+		}
 	}
-	err = p.commonRunner.Stop(ctx)
-	if err != nil {
-		return err
+	if p.commonRunner != nil {
+		err := p.commonRunner.Stop(ctx)
+		if err != nil {
+			return err
+		}
 	}
 	p.drain()
 	return nil

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -67,9 +67,18 @@ type Provides struct {
 }
 
 type PrivateActionRunner struct {
+	coreConfig     model.ReaderWriter
+	hostnameGetter hostnameinterface.Component
+	rcClient       pkgrcclient.Client
+	logger         log.Component
+	tagger         tagger.Component
+	traceroute     traceroute.Component
+	eventPlatform  eventplatform.Component
+
 	workflowRunner *runners.WorkflowRunner
 	commonRunner   *runners.CommonRunner
-	drain          func()
+
+	drain func()
 }
 
 // NewComponent creates a new privateactionrunner component
@@ -92,7 +101,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 }
 
 func NewPrivateActionRunner(
-	ctx context.Context,
+	_ context.Context,
 	coreConfig model.ReaderWriter,
 	hostnameGetter hostnameinterface.Component,
 	rcClient pkgrcclient.Client,
@@ -101,58 +110,71 @@ func NewPrivateActionRunner(
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
 ) (*PrivateActionRunner, error) {
-	persistedIdentity, err := enrollment.GetIdentityFromPreviousEnrollment(ctx, coreConfig)
+	return &PrivateActionRunner{
+		coreConfig:     coreConfig,
+		hostnameGetter: hostnameGetter,
+		rcClient:       rcClient,
+		logger:         logger,
+		tagger:         taggerComp,
+		traceroute:     tracerouteComp,
+		eventPlatform:  eventPlatform,
+	}, nil
+}
+
+func (p *PrivateActionRunner) getRunnerConfig(ctx context.Context) (*parconfig.Config, error) {
+	persistedIdentity, err := enrollment.GetIdentityFromPreviousEnrollment(ctx, p.coreConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get identity: %w", err)
 	}
 	if persistedIdentity != nil {
-		coreConfig.Set(parPrivateKey, persistedIdentity.PrivateKey, model.SourceAgentRuntime)
-		coreConfig.Set(parUrn, persistedIdentity.URN, model.SourceAgentRuntime)
+		p.coreConfig.Set(parPrivateKey, persistedIdentity.PrivateKey, model.SourceAgentRuntime)
+		p.coreConfig.Set(parUrn, persistedIdentity.URN, model.SourceAgentRuntime)
 	}
 
-	cfg, err := parconfig.FromDDConfig(coreConfig)
+	cfg, err := parconfig.FromDDConfig(p.coreConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	canSelfEnroll := coreConfig.GetBool(parSelfEnroll)
+	canSelfEnroll := p.coreConfig.GetBool(parSelfEnroll)
 	if cfg.IdentityIsIncomplete() && canSelfEnroll {
-		logger.Info("Identity not found and self-enrollment enabled. Self-enrolling private action runner")
-		updatedCfg, err := performSelfEnrollment(ctx, logger, coreConfig, hostnameGetter, taggerComp, cfg)
+		p.logger.Info("Identity not found and self-enrollment enabled. Self-enrolling private action runner")
+		updatedCfg, err := p.performSelfEnrollment(ctx, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("self-enrollment failed: %w", err)
 		}
-		coreConfig.Set(parPrivateKey, updatedCfg.PrivateKey, model.SourceAgentRuntime)
-		coreConfig.Set(parUrn, updatedCfg.Urn, model.SourceAgentRuntime)
+		p.coreConfig.Set(parPrivateKey, updatedCfg.PrivateKey, model.SourceAgentRuntime)
+		p.coreConfig.Set(parUrn, updatedCfg.Urn, model.SourceAgentRuntime)
 		cfg = updatedCfg
 	} else if cfg.IdentityIsIncomplete() {
 		return nil, errors.New("identity not found and self-enrollment disabled. Please provide a valid URN and private key")
 	}
-	logger.Info("Private action runner starting")
-	logger.Info("==> Version : " + parversion.RunnerVersion)
-	logger.Info("==> Site : " + cfg.DatadogSite)
-	logger.Info("==> URN : " + cfg.Urn)
+	return cfg, nil
+}
 
-	keysManager := taskverifier.NewKeyManager(rcClient)
+func (p *PrivateActionRunner) Start(ctx context.Context) error {
+	cfg, err := p.getRunnerConfig(ctx)
+	if err != nil {
+		return err
+	}
+	p.logger.Info("Private action runner starting")
+	p.logger.Info("==> Version : " + parversion.RunnerVersion)
+	p.logger.Info("==> Site : " + cfg.DatadogSite)
+	p.logger.Info("==> URN : " + cfg.Urn)
+
+	keysManager := taskverifier.NewKeyManager(p.rcClient)
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	opmsClient := opms.NewClient(cfg)
 
-	r, err := runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, tracerouteComp, eventPlatform)
+	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.traceroute, p.eventPlatform)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	runner := &PrivateActionRunner{
-		workflowRunner: r,
-		commonRunner:   runners.NewCommonRunner(cfg),
-	}
-	return runner, nil
-}
-
-func (p *PrivateActionRunner) Start(_ context.Context) error {
+	p.commonRunner = runners.NewCommonRunner(cfg)
 	// Use background context to avoid inheriting any deadlines from component lifecycle which stop the PAR loop
-	ctx, cancel := context.WithCancel(context.Background())
-	p.drain = cancel
-	err := p.commonRunner.Start(ctx)
+	ctx, mainCtxCancel := context.WithCancel(context.Background())
+	p.drain = mainCtxCancel
+	err = p.commonRunner.Start(ctx)
 	if err != nil {
 		return err
 	}
@@ -164,17 +186,21 @@ func (p *PrivateActionRunner) Stop(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	err = p.commonRunner.Stop(ctx)
+	if err != nil {
+		return err
+	}
 	p.drain()
 	return nil
 }
 
 // performSelfEnrollment handles the self-registration of a private action runner
-func performSelfEnrollment(ctx context.Context, log log.Component, ddConfig config.Component, hostnameComp hostnameinterface.Component, taggerComp tagger.Component, cfg *parconfig.Config) (*parconfig.Config, error) {
-	ddSite := ddConfig.GetString("site")
-	apiKey := ddConfig.GetString("api_key")
-	appKey := ddConfig.GetString("app_key")
+func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *parconfig.Config) (*parconfig.Config, error) {
+	ddSite := p.coreConfig.GetString("site")
+	apiKey := p.coreConfig.GetString("api_key")
+	appKey := p.coreConfig.GetString("app_key")
 
-	runnerHostname, err := hostnameComp.Get(ctx)
+	runnerHostname, err := p.hostnameGetter.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
@@ -186,9 +212,9 @@ func performSelfEnrollment(ctx context.Context, log log.Component, ddConfig conf
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}
-	log.Info("Self-enrollment successful")
+	p.logger.Info("Self-enrollment successful")
 
-	if err := enrollment.PersistIdentity(ctx, ddConfig, enrollmentResult); err != nil {
+	if err := enrollment.PersistIdentity(ctx, p.coreConfig, enrollmentResult); err != nil {
 		return nil, fmt.Errorf("failed to persist enrollment identity: %w", err)
 	}
 
@@ -209,15 +235,15 @@ func performSelfEnrollment(ctx context.Context, log log.Component, ddConfig conf
 	}
 
 	if len(actionsAllowlist) > 0 {
-		client, err := autoconnections.NewConnectionsAPIClient(ddConfig, ddSite, apiKey, appKey)
+		client, err := autoconnections.NewConnectionsAPIClient(p.coreConfig, ddSite, apiKey, appKey)
 		if err != nil {
-			log.Warnf("Failed to create connections API client: %v", err)
+			p.logger.Warnf("Failed to create connections API client: %v", err)
 		} else {
-			tagsProvider := autoconnections.NewTagsProvider(taggerComp)
+			tagsProvider := autoconnections.NewTagsProvider(p.tagger)
 			creator := autoconnections.NewConnectionsCreator(*client, tagsProvider)
 
-			if err := creator.AutoCreateConnections(context.Background(), urnParts.RunnerID, runnerHostname, runnerName, actionsAllowlist); err != nil {
-				log.Warnf("Failed to auto-create connections: %v", err)
+			if err := creator.AutoCreateConnections(ctx, urnParts.RunnerID, runnerHostname, runnerName, actionsAllowlist); err != nil {
+				p.logger.Warnf("Failed to auto-create connections: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Move PAR identity retrieval from constructor to startup.

### Motivation
https://github.com/DataDog/datadog-agent/pull/46225 is introducing a long running self enrollment. In order to not block other processes, we could start the PAR in a go routine and it will be beneficial to have enrollment at startup time instead of at PAR creation.

### Describe how you validated your changes
Build locally and ran the PAR

### Additional Notes
