### PR TITLE
[workloadmeta/server] Decouple event receiving from grpc sending

### DIFF
--- a/comp/core/workloadmeta/server/server.go
+++ b/comp/core/workloadmeta/server/server.go
@@ -8,6 +8,8 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -19,20 +21,27 @@ import (
 )
 
 const (
-	workloadmetaStreamSendTimeout = 1 * time.Minute
+	streamSendTimeout             = 1 * time.Minute
 	workloadmetaKeepAliveInterval = 9 * time.Minute
+	sendQueueSize                 = 50
+	sendQueueTimeout              = 30 * time.Second
 )
 
 // NewServer returns a new server with a workloadmeta instance
 func NewServer(store workloadmeta.Component) *Server {
 	return &Server{
-		wmeta: store,
+		wmeta:             store,
+		streamSendTimeout: streamSendTimeout,
+		sendQueueTimeout:  sendQueueTimeout,
 	}
 }
 
 // Server is a grpc server that streams workloadmeta entities
 type Server struct {
-	wmeta workloadmeta.Component
+	wmeta             workloadmeta.Component
+	streamSendTimeout time.Duration
+	sendQueueTimeout  time.Duration
+	sendQueueSize     int
 }
 
 // StreamEntities streams entities from the workloadmeta store applying the given filter
@@ -45,12 +54,48 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 	workloadmetaEventsChannel := s.wmeta.Subscribe("stream-client", workloadmeta.NormalPriority, filter)
 	defer s.wmeta.Unsubscribe(workloadmetaEventsChannel)
 
-	ticker := time.NewTicker(workloadmetaKeepAliveInterval)
-	defer ticker.Stop()
+	ctx, cancel := context.WithCancel(out.Context())
+	defer cancel()
 
+	queueSize := sendQueueSize
+	if s.sendQueueSize > 0 {
+		queueSize = s.sendQueueSize
+	}
+	sendQueue := make(chan []*pb.WorkloadmetaEvent, queueSize)
+
+	// Receiver goroutine: drains the workloadmeta subscription channel quickly
+	// (to avoid blocking other workloadmeta subscribers) and enqueues protobuf
+	// events into the send queue.
+	workloadmetaReceiverErrCh := make(chan error, 1)
+	go func() {
+		defer close(sendQueue)
+		recvErr := s.receiveEvents(ctx, workloadmetaEventsChannel, sendQueue)
+		if recvErr != nil {
+			cancel() // stop sendEvents to unsubscribe promptly
+		}
+		workloadmetaReceiverErrCh <- recvErr
+	}()
+
+	sendErr := s.sendEvents(ctx, out, sendQueue)
+	cancel() // sending finished; stop the workloadmeta receiver
+
+	// Wait for the workloadmeta receiver to finish
+	recvErr := <-workloadmetaReceiverErrCh
+
+	if sendErr != nil {
+		return sendErr
+	}
+	return recvErr
+}
+
+// receiveEvents drains events from the workloadmeta subscription, converts them
+// to protobuf, and enqueues them into sendQueue.
+func (s *Server) receiveEvents(ctx context.Context, eventsCh chan workloadmeta.EventBundle, sendQueue chan<- []*pb.WorkloadmetaEvent) error {
 	for {
 		select {
-		case eventBundle, ok := <-workloadmetaEventsChannel:
+		case <-ctx.Done():
+			return nil
+		case eventBundle, ok := <-eventsCh:
 			if !ok {
 				return nil
 			}
@@ -71,22 +116,49 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 				}
 			}
 
-			if len(protobufEvents) > 0 {
-				err := grpc.DoWithTimeout(func() error {
-					return out.Send(&pb.WorkloadmetaStreamResponse{
-						Events: protobufEvents,
-					})
-				}, workloadmetaStreamSendTimeout)
-
-				if err != nil {
-					log.Warnf("error sending workloadmeta event: %s", err)
-					telemetry.RemoteServerErrors.Inc()
-					return err
-				}
-
-				ticker.Reset(workloadmetaKeepAliveInterval)
+			if len(protobufEvents) == 0 {
+				continue
 			}
-		case <-out.Context().Done():
+
+			select {
+			case sendQueue <- protobufEvents:
+			case <-time.After(s.sendQueueTimeout):
+				return fmt.Errorf("send queue full for %s, disconnecting client", s.sendQueueTimeout)
+			case <-ctx.Done():
+				return nil
+			}
+		}
+	}
+}
+
+// sendEvents reads protobuf responses from sendQueue and sends them over gRPC.
+// It also sends periodic keep-alive messages.
+func (s *Server) sendEvents(ctx context.Context, out pb.AgentSecure_WorkloadmetaStreamEntitiesServer, sendQueue <-chan []*pb.WorkloadmetaEvent) error {
+	ticker := time.NewTicker(workloadmetaKeepAliveInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case events, ok := <-sendQueue:
+			if !ok {
+				return nil
+			}
+
+			err := grpc.DoWithTimeout(func() error {
+				return out.Send(&pb.WorkloadmetaStreamResponse{
+					Events: events,
+				})
+			}, s.streamSendTimeout)
+
+			if err != nil {
+				log.Warnf("error sending workloadmeta event: %s", err)
+				telemetry.RemoteServerErrors.Inc()
+				return err
+			}
+
+			ticker.Reset(workloadmetaKeepAliveInterval)
+
+		case <-ctx.Done():
 			return nil
 
 		// The remote workloadmeta client has a timeout that closes the
@@ -96,11 +168,11 @@ func (s *Server) StreamEntities(in *pb.WorkloadmetaStreamRequest, out pb.AgentSe
 		// goal is only to keep the connection alive without losing the
 		// protection against “half” closed connections brought by the timeout.
 		case <-ticker.C:
-			err = grpc.DoWithTimeout(func() error {
+			err := grpc.DoWithTimeout(func() error {
 				return out.Send(&pb.WorkloadmetaStreamResponse{
 					Events: []*pb.WorkloadmetaEvent{},
 				})
-			}, workloadmetaStreamSendTimeout)
+			}, s.streamSendTimeout)
 
 			if err != nil {
 				log.Warnf("error sending workloadmeta keep-alive: %s", err)

--- a/comp/core/workloadmeta/server/server_test.go
+++ b/comp/core/workloadmeta/server/server_test.go
@@ -1,0 +1,283 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type mockStream struct {
+	ctx context.Context
+
+	mu   sync.Mutex
+	sent []*pb.WorkloadmetaStreamResponse
+
+	// sendFunc overrides the default Send behavior
+	sendFunc func(*pb.WorkloadmetaStreamResponse) error
+}
+
+func (m *mockStream) Send(resp *pb.WorkloadmetaStreamResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sendFunc != nil {
+		return m.sendFunc(resp)
+	}
+	m.sent = append(m.sent, resp)
+	return nil
+}
+
+func (m *mockStream) getSent() []*pb.WorkloadmetaStreamResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*pb.WorkloadmetaStreamResponse, len(m.sent))
+	copy(result, m.sent)
+	return result
+}
+
+func (m *mockStream) Context() context.Context     { return m.ctx }
+func (m *mockStream) SetHeader(metadata.MD) error  { return nil }
+func (m *mockStream) SendHeader(metadata.MD) error { return nil }
+func (m *mockStream) SetTrailer(metadata.MD)       {}
+func (m *mockStream) SendMsg(any) error            { return nil }
+func (m *mockStream) RecvMsg(any) error            { return nil }
+
+func TestStreamEntities(t *testing.T) {
+	t.Run("streams events to the client", func(t *testing.T) {
+		store := newWorkloadmetaMock(t)
+		server := newTestServer(store)
+		testContainerID := "container-1"
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		stream := &mockStream{ctx: ctx}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- server.StreamEntities(&pb.WorkloadmetaStreamRequest{}, stream)
+		}()
+
+		store.Set(&workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: testContainerID},
+		})
+
+		assert.Eventually(t, func() bool {
+			sent := stream.getSent()
+
+			// The first Send is the initial snapshot from Subscribe (might be
+			// empty). Look for at least one response containing the test
+			// container ID.
+			for _, resp := range sent {
+				for _, ev := range resp.Events {
+					if ev.GetContainer().GetEntityId().GetId() == testContainerID {
+						return true
+					}
+				}
+			}
+
+			return false
+		}, 5*time.Second, 50*time.Millisecond)
+
+		cancel()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("StreamEntities did not return after context cancellation")
+		}
+	})
+
+	t.Run("filters events by kind", func(t *testing.T) {
+		store := newWorkloadmetaMock(t)
+		s := newTestServer(store)
+		testContainerID := "container-1"
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		stream := &mockStream{ctx: ctx}
+
+		// Subscribe only to containers
+		req := &pb.WorkloadmetaStreamRequest{
+			Filter: &pb.WorkloadmetaFilter{
+				Kinds: []pb.WorkloadmetaKind{pb.WorkloadmetaKind_CONTAINER},
+			},
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.StreamEntities(req, stream)
+		}()
+
+		// Store both a pod and a container
+		store.Set(&workloadmeta.KubernetesPod{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindKubernetesPod, ID: "pod-1"},
+		})
+		store.Set(&workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: testContainerID},
+		})
+
+		assert.Eventually(t, func() bool {
+			for _, resp := range stream.getSent() {
+				for _, ev := range resp.Events {
+					if ev.GetContainer().GetEntityId().GetId() == testContainerID {
+						return true
+					}
+				}
+			}
+			return false
+		}, 5*time.Second, 50*time.Millisecond)
+
+		// Verify that the filter worked and the pod was not sent
+		for _, resp := range stream.getSent() {
+			for _, ev := range resp.Events {
+				assert.Nil(t, ev.GetKubernetesPod())
+			}
+		}
+
+		cancel()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("StreamEntities did not return after context cancellation")
+		}
+	})
+
+	t.Run("returns error when send fails", func(t *testing.T) {
+		store := newWorkloadmetaMock(t)
+		s := newTestServer(store)
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+
+		stream := &mockStream{
+			ctx:      ctx,
+			sendFunc: func(*pb.WorkloadmetaStreamResponse) error { return errors.New("test error") },
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.StreamEntities(&pb.WorkloadmetaStreamRequest{}, stream)
+		}()
+
+		store.Set(&workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: "container-1"},
+		})
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "test error")
+		case <-time.After(5 * time.Second):
+			t.Fatal("StreamEntities did not return after send error")
+		}
+	})
+
+	t.Run("returns without error when context is cancelled", func(t *testing.T) {
+		store := newWorkloadmetaMock(t)
+		s := newTestServer(store)
+		ctx, cancel := context.WithCancel(context.TODO())
+		stream := &mockStream{ctx: ctx}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.StreamEntities(&pb.WorkloadmetaStreamRequest{}, stream)
+		}()
+
+		cancel()
+
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("StreamEntities did not return after context cancellation")
+		}
+	})
+
+	t.Run("returns error when send queue is full", func(t *testing.T) {
+		store := newWorkloadmetaMock(t)
+		s := newTestServer(store)
+		s.sendQueueSize = 1 // Size 1 to test easily the queue full case
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+
+		// Slow sender: takes longer than sendQueueTimeout to process each
+		// event, to fill the queue.
+		sendStarted := make(chan struct{}, 1)
+		stream := &mockStream{
+			ctx: ctx,
+			sendFunc: func(*pb.WorkloadmetaStreamResponse) error {
+				select {
+				case sendStarted <- struct{}{}:
+				default:
+				}
+				time.Sleep(2 * s.sendQueueTimeout)
+				return nil
+			},
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			done <- s.StreamEntities(&pb.WorkloadmetaStreamRequest{}, stream)
+		}()
+
+		// Push the first event and wait for it to reach sendEvents (which
+		// confirms StreamEntities has subscribed and events are flowing).
+		store.Set(&workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: "container-0"},
+		})
+		select {
+		case <-sendStarted:
+		case <-time.After(5 * time.Second):
+			t.Fatal("first event was not sent")
+		}
+
+		// Now sendEvents is blocked on the slow Send. Push 2 more events: the
+		// first fills the queue, the second triggers the timeout.
+		for _, container := range []string{"container-1", "container-2"} {
+			store.Set(&workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{Kind: workloadmeta.KindContainer, ID: container},
+			})
+		}
+
+		select {
+		case err := <-done:
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "send queue full")
+		case <-time.After(5 * time.Second):
+			t.Fatal("StreamEntities did not return after send queue timeout")
+		}
+	})
+}
+
+func newWorkloadmetaMock(t *testing.T) workloadmetamock.Mock {
+	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.TODO()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+}
+
+func newTestServer(store workloadmeta.Component) *Server {
+	return &Server{
+		wmeta:             store,
+		streamSendTimeout: time.Second,
+		sendQueueTimeout:  100 * time.Millisecond,
+	}
+}

--- a/releasenotes/notes/wmeta-stream-decouple-send-recv-5efdbc977e152350.yaml
+++ b/releasenotes/notes/wmeta-stream-decouple-send-recv-5efdbc977e152350.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Avoid blocking workloadmeta collectors when streaming events to remote
+    agents.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in workloadmeta caused by the subscriber that streams workloadmeta entities to other agents.

The subscriber receives workloadmeta events, acknowledges them, and then sends events via grpc with a timeout of 1 minute. This means that in some cases it can take 1 minute to take the next event from workloadmeta (although I hope it’s not very common), which will make workloadmeta block (including collectors like kubelet, meaning tags could be delayed).

When this happens there are errors like this one in the agent:
```
collector "stream-client" dropped 1 event(s) after 10s timeout, subscriber is not reading from channel. This may cause data inconsistency for this subscriber.
```

This PR fixes the issue by refactoring the subscriber so that it decouples receiving workloadmeta events from sending: a receiver goroutine drains events from workloadmeta immediately into a buffered queue, and a separate sender goroutine handles the grpc sends independently.

### Describe how you validated your changes

I added unit tests. There were no tests for the affected workloadmeta subscriber.
I also tried on a kind cluster. I deployed with a minimal values.yaml that enables system-probe, security-agent and process-agent because those are the agents that use remote workloadmeta:
```yaml
datadog:
  kubelet:
    tlsVerify: false

  networkMonitoring:
    enabled: true

  securityAgent:
    runtime:
      enabled: true
    compliance:
      enabled: true
```

For security-agent, I ran `security-agent workload-list` and for the process-agent, I ran `process-agent workload-list` to verify that workloadmeta entities are there with the source set to `remote_workloadmeta`.
