### PR TITLE
Add RUM configuration fields to InstallerScriptEnv

### DIFF
--- a/pkg/config/example/application_monitoring.yaml.example
+++ b/pkg/config/example/application_monitoring.yaml.example
@@ -68,3 +68,28 @@
 #   # Enable debug logging for the tracer.
 #   # Docs: https://docs.datadoghq.com/tracing/troubleshooting/tracer_debug_logs
 #   DD_TRACE_DEBUG: false
+
+#   # @param DD_RUM_ENABLED - boolean - optional - default: false
+#   # Enable Real User Monitoring (RUM).
+#   # Docs: https://docs.datadoghq.com/real_user_monitoring/
+#   DD_RUM_ENABLED: false
+
+#   # @param DD_RUM_APPLICATION_ID - string - optional
+#   # The RUM application ID for this application.
+#   # Docs: https://docs.datadoghq.com/real_user_monitoring/browser/setup/
+#   DD_RUM_APPLICATION_ID: ""
+
+#   # @param DD_RUM_CLIENT_TOKEN - string - optional
+#   # The RUM client token for this application.
+#   # Note: This is a public token and safe to use in client-side code.
+#   # Docs: https://docs.datadoghq.com/real_user_monitoring/browser/setup/
+#   DD_RUM_CLIENT_TOKEN: ""
+
+#   # @param DD_RUM_REMOTE_CONFIGURATION_ID - string - optional
+#   # The RUM remote configuration ID for this application.
+#   DD_RUM_REMOTE_CONFIGURATION_ID: ""
+
+#   # @param DD_RUM_SITE - string - optional
+#   # The Datadog site to send RUM data to (e.g., datadoghq.com, datadoghq.eu).
+#   # Docs: https://docs.datadoghq.com/getting_started/site/
+#   DD_RUM_SITE: ""

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -61,6 +61,11 @@ const (
 	envAppsecScaEnabled            = "DD_APPSEC_SCA_ENABLED"
 	envInfrastructureMode          = "DD_INFRASTRUCTURE_MODE"
 	envTracerLogsCollectionEnabled = "DD_APP_LOGS_COLLECTION_ENABLED"
+	envRumEnabled                  = "DD_RUM_ENABLED"
+	envRumApplicationID            = "DD_RUM_APPLICATION_ID"
+	envRumClientToken              = "DD_RUM_CLIENT_TOKEN"
+	envRumRemoteConfigurationID    = "DD_RUM_REMOTE_CONFIGURATION_ID"
+	envRumSite                     = "DD_RUM_SITE"
 )
 
 // Windows MSI options
@@ -105,6 +110,11 @@ var defaultEnv = Env{
 		IastEnabled:               nil,
 		DataJobsEnabled:           nil,
 		AppsecScaEnabled:          nil,
+		RumEnabled:                nil,
+		RumApplicationID:          "",
+		RumClientToken:            "",
+		RumRemoteConfigurationID:  "",
+		RumSite:                   "",
 	},
 }
 
@@ -151,6 +161,13 @@ type InstallScriptEnv struct {
 	DataJobsEnabled             *bool
 	AppsecScaEnabled            *bool
 	TracerLogsCollectionEnabled *bool
+
+	// RUM configuration
+	RumEnabled               *bool
+	RumApplicationID         string
+	RumClientToken           string
+	RumRemoteConfigurationID string
+	RumSite                  string
 }
 
 // Env contains the configuration for the installer.
@@ -272,6 +289,11 @@ func FromEnv() *Env {
 			DataJobsEnabled:             getBoolEnv(envDataJobsEnabled),
 			AppsecScaEnabled:            getBoolEnv(envAppsecScaEnabled),
 			TracerLogsCollectionEnabled: getBoolEnv(envTracerLogsCollectionEnabled),
+			RumEnabled:                  getBoolEnv(envRumEnabled),
+			RumApplicationID:            getEnvOrDefault(envRumApplicationID, ""),
+			RumClientToken:              getEnvOrDefault(envRumClientToken, ""),
+			RumRemoteConfigurationID:    getEnvOrDefault(envRumRemoteConfigurationID, ""),
+			RumSite:                     getEnvOrDefault(envRumSite, ""),
 		},
 
 		Tags: append(
@@ -317,6 +339,11 @@ func (e *InstallScriptEnv) ToEnv(env []string) []string {
 	env = appendBoolEnv(env, envIastEnabled, e.IastEnabled)
 	env = appendBoolEnv(env, envDataJobsEnabled, e.DataJobsEnabled)
 	env = appendBoolEnv(env, envAppsecScaEnabled, e.AppsecScaEnabled)
+	env = appendBoolEnv(env, envRumEnabled, e.RumEnabled)
+	env = appendStringEnv(env, envRumApplicationID, e.RumApplicationID, "")
+	env = appendStringEnv(env, envRumClientToken, e.RumClientToken, "")
+	env = appendStringEnv(env, envRumRemoteConfigurationID, e.RumRemoteConfigurationID, "")
+	env = appendStringEnv(env, envRumSite, e.RumSite, "")
 	return env
 }
 

--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -402,6 +402,26 @@ func (a *InjectorInstaller) addLocalStableConfig(ctx context.Context) (err error
 				hasChanged = true
 				cfg.Default.LogsCollectionEnabled = a.Env.InstallScript.TracerLogsCollectionEnabled
 			}
+			if a.Env.InstallScript.RumEnabled != nil {
+				hasChanged = true
+				cfg.Default.RumEnabled = a.Env.InstallScript.RumEnabled
+			}
+			if a.Env.InstallScript.RumApplicationID != "" {
+				hasChanged = true
+				cfg.Default.RumApplicationID = a.Env.InstallScript.RumApplicationID
+			}
+			if a.Env.InstallScript.RumClientToken != "" {
+				hasChanged = true
+				cfg.Default.RumClientToken = a.Env.InstallScript.RumClientToken
+			}
+			if a.Env.InstallScript.RumRemoteConfigurationID != "" {
+				hasChanged = true
+				cfg.Default.RumRemoteConfigurationID = a.Env.InstallScript.RumRemoteConfigurationID
+			}
+			if a.Env.InstallScript.RumSite != "" {
+				hasChanged = true
+				cfg.Default.RumSite = a.Env.InstallScript.RumSite
+			}
 
 			// Avoid creating a .backup file and overwriting the existing file if no changes were made
 			if hasChanged {

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -271,6 +271,11 @@ type APMConfigurationDefault struct {
 	DataJobsEnabled               *bool   `yaml:"DD_DATA_JOBS_ENABLED,omitempty"`
 	AppsecScaEnabled              *bool   `yaml:"DD_APPSEC_SCA_ENABLED,omitempty"`
 	LogsCollectionEnabled         *bool   `yaml:"DD_APP_LOGS_COLLECTION_ENABLED,omitempty"`
+	RumEnabled                    *bool   `yaml:"DD_RUM_ENABLED,omitempty"`
+	RumApplicationID              string  `yaml:"DD_RUM_APPLICATION_ID,omitempty"`
+	RumClientToken                string  `yaml:"DD_RUM_CLIENT_TOKEN,omitempty"`
+	RumRemoteConfigurationID      string  `yaml:"DD_RUM_REMOTE_CONFIGURATION_ID,omitempty"`
+	RumSite                       string  `yaml:"DD_RUM_SITE,omitempty"`
 }
 
 // DelayedAgentRestartConfig represents the config to restart the agent with a delay at the end of the install


### PR DESCRIPTION
## What does this PR do?

Adds support for RUM (Real User Monitoring) configuration fields to the installer script environment, allowing these values to be set via environment variables and written to `application_monitoring.yaml` during installation.

## Motivation

Enables RUM configuration at install time through environment variables, following the same pattern as existing APM configuration fields.

## Changes

### Added Environment Variables
- `DD_RUM_ENABLED` - Enable/disable RUM (boolean)
- `DD_RUM_APPLICATION_ID` - RUM application identifier (string)
- `DD_RUM_CLIENT_TOKEN` - RUM client token (string, public token safe for client-side use)
- `DD_RUM_REMOTE_CONFIGURATION_ID` - RUM remote configuration identifier (string)
- `DD_RUM_SITE` - Datadog site for RUM data (string)

### Modified Files
- `pkg/fleet/installer/env/env.go` - Added RUM env var parsing
- `pkg/fleet/installer/setup/config/config.go` - Added RUM fields to APMConfigurationDefault struct
- `pkg/fleet/installer/packages/apminject/apm_inject.go` - Added RUM field mapping to application_monitoring.yaml
- `pkg/config/example/application_monitoring.yaml.example` - Added documentation for RUM fields

## Security Note

The `DD_RUM_CLIENT_TOKEN` is a public token intended for client-side use (browsers, mobile apps), not a sensitive credential like `DD_API_KEY`. It is safe to store in `application_monitoring.yaml` with 0644 permissions.

## Testing

- ✅ All packages compile successfully
- ✅ Unit tests pass for env package
- ✅ Follows existing pattern for APM configuration fields