### PR TITLE
claude: add claude skills for several parts of the agent codebase

### DIFF
--- a/.claude/skills/create-component/SKILL.md
+++ b/.claude/skills/create-component/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: create-component
+description: Create a new Fx component using the modern def/fx/impl pattern (NOT legacy)
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+argument-hint: "<bundle>/<component-name> [--team team-name] [--with-params] [--with-lifecycle] [--with-mock]"
+---
+
+Create a new Fx component following the **modern** (new-style) pattern with separate `def/`, `fx/`, and `impl/` sub-packages.
+
+**IMPORTANT**: NEVER use the legacy pattern (single-directory with `fx.Provide` directly). Always use the new-style pattern described below.
+
+## Instructions
+
+1. **Parse `$ARGUMENTS`** to determine:
+   - `<bundle>/<component-name>`: e.g., `core/remoteflags` means bundle=core, component=remoteflags
+   - `--team <team-name>`: optional team ownership tag (default: ask the user)
+   - `--with-params`: include a `Params` struct in the def package
+   - `--with-lifecycle`: include `compdef.Lifecycle` in the Requires struct (for start/stop hooks)
+   - `--with-mock`: also generate a `mock/` sub-package
+
+2. **Ask the user** (if not provided via arguments):
+   - What is the component's interface? (what methods should it expose?)
+   - Which team owns it? (for the `// team:` comment)
+   - Does it need lifecycle hooks (start/stop)?
+   - Does it need a Params struct?
+   - What are its dependencies (other components it requires)?
+
+3. **Create the directory structure** under `comp/<bundle>/<component>/`:
+
+```
+comp/<bundle>/<component>/
+├── def/
+│   ├── go.mod
+│   ├── component.go     # Interface definition + team tag
+│   └── params.go        # (optional) Params struct
+├── fx/
+│   ├── go.mod
+│   └── fx.go            # Module() function
+└── impl/
+    ├── go.mod
+    └── <component>.go   # Requires, Provides, NewComponent()
+```
+
+4. **Create each file** following the templates below.
+
+5. **Register the modules** in `modules.yml` — add entries for `comp/<bundle>/<component>/def`, `comp/<bundle>/<component>/fx`, and `comp/<bundle>/<component>/impl` (and `comp/<bundle>/<component>/mock` if applicable).
+
+6. **Run `dda inv modules.add-all-replace`** to generate the `replace` directives in all `go.mod` files. Then run `dda inv tidy` to tidy everything.
+
+7. **Wire into a bundle** if appropriate — add the component's `Module()` to the relevant `comp/<bundle>/bundle.go`. If the component needs a `Params`, add a `fx.Provide` bridge from `BundleParams` to the component's `Params` type.
+
+8. **Validate the component** by running the linters that check component correctness:
+   ```bash
+   dda inv lint-components lint-fxutil-oneshot-test github.lint-codeowner
+   ```
+   These linters verify the component structure, fxutil usage, and CODEOWNERS entries. Fix any errors they report and re-run until clean — this is your feedback loop to ensure the component is correct.
+
+## File Templates
+
+### `def/component.go` — Interface definition
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package <component> defines the interface for the <component> component.
+package <component>
+
+// team: <team-name>
+
+// Component is the component type.
+type Component interface {
+	// <exported methods here>
+}
+```
+
+Key rules:
+- Package name = component name (e.g., `package remoteflags`)
+- Include the `// team:` comment right after the package declaration
+- Only define the interface here, no implementation details
+- Keep imports minimal (ideally none or just standard library)
+
+### `def/params.go` — Parameters (optional)
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package <component>
+
+// Params defines the parameters for the <component> component.
+type Params struct {
+	// <fields here>
+}
+```
+
+### `def/go.mod`
+
+```
+module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def
+
+go 1.24.0
+```
+
+Keep this module as thin as possible — the def package should have minimal dependencies.
+
+### `fx/fx.go` — Fx wiring
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx defines the fx options for this component.
+package fx
+
+import (
+	<component>impl "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			<component>impl.NewComponent,
+		),
+	)
+}
+```
+
+Key rules:
+- **Always use `fxutil.ProvideComponentConstructor`**, NEVER raw `fx.Provide`
+- Import the impl package with an alias like `<component>impl`
+- The `Module()` function returns `fxutil.Module` (not `fx.Module`)
+- This file should be very short — just wiring, no logic
+
+### `fx/go.mod`
+
+```
+module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/fx
+
+go 1.24.0
+
+require (
+	github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl v0.0.0
+	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.0.0
+)
+```
+
+### `impl/<component>.go` — Implementation
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package <component>impl implements the <component> component.
+package <component>impl
+
+import (
+	<component>def "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+)
+
+// Requires defines the dependencies for the <component> component.
+type Requires struct {
+	Lc compdef.Lifecycle // include only if --with-lifecycle or if the component needs start/stop hooks
+
+	// Add other component dependencies here, e.g.:
+	// Config config.Component
+	// Log    logdef.Component
+}
+
+// Provides defines the output of the <component> component.
+type Provides struct {
+	Comp <component>def.Component
+}
+
+// <unexportedType> implements the Component interface.
+type <unexportedType> struct {
+	// internal fields
+}
+
+// NewComponent creates a new <component> component.
+func NewComponent(deps Requires) (Provides, error) {
+	instance := &<unexportedType>{
+		// initialize fields from deps
+	}
+
+	// If using lifecycle hooks:
+	// deps.Lc.Append(compdef.Hook{
+	//     OnStart: func(ctx context.Context) error { return instance.start(ctx) },
+	//     OnStop:  func(ctx context.Context) error { return instance.stop(ctx) },
+	// })
+
+	return Provides{
+		Comp: instance,
+	}, nil
+}
+
+// Implement the Component interface methods on the unexported type
+```
+
+Key rules:
+- Package name = `<component>impl` (e.g., `package remoteflagsimpl`)
+- The `Requires` struct lists dependencies using their `def` types. Do NOT embed `compdef.In` — `ProvideComponentConstructor` handles that automatically via reflection
+- The `Provides` struct lists what the component provides. Do NOT embed `compdef.Out` — same reason
+- Constructor signature is `func NewComponent(deps Requires) (Provides, error)` — plain Go, no fx types
+- The implementation type is **unexported** (e.g., `type remoteFlagsImpl struct`)
+- Import the def package with an alias: `<component>def`
+- Import `compdef "github.com/DataDog/datadog-agent/comp/def"` for `Lifecycle` and `Hook`
+
+### `impl/go.mod`
+
+```
+module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl
+
+go 1.24.0
+
+require (
+	github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def v0.0.0
+	github.com/DataDog/datadog-agent/comp/def v0.0.0
+)
+```
+
+## Critical Rules (NEW-STYLE vs LEGACY)
+
+### DO (new-style):
+- Use `def/`, `fx/`, `impl/` sub-packages, each with its own `go.mod`
+- Use `fxutil.ProvideComponentConstructor` in `fx/fx.go`
+- Write plain Go constructor: `func NewComponent(deps Requires) (Provides, error)`
+- Keep `Requires`/`Provides` as plain structs (no `fx.In`/`fx.Out` embedding)
+- Keep the def package thin (just interfaces and params)
+
+### DON'T (legacy):
+- Put everything in a single directory with one `go.mod`
+- Use `fx.Provide(newComponent)` directly
+- Embed `fx.In` or `fx.Out` in your structs
+- Put implementation details in the def package
+- Use `compdef.In` or `compdef.Out` in Requires/Provides (these are marker types only used internally by `ProvideComponentConstructor`)
+
+## modules.yml Registration
+
+Add entries under the `modules:` key:
+
+```yaml
+  comp/<bundle>/<component>/def: default
+  comp/<bundle>/<component>/fx: default
+  comp/<bundle>/<component>/impl: default
+```
+
+Use `default` for standard modules, or `used_by_otel: true` if the component is used by the OTel collector.
+
+## Bundle Wiring
+
+If the component should be part of a bundle (e.g., `comp/core/bundle.go`):
+
+```go
+import (
+    <component>fx "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/fx"
+)
+
+func Bundle() fxutil.BundleOptions {
+    return fxutil.Bundle(
+        // ... existing components ...
+
+        // If the component has Params:
+        fx.Provide(func(params BundleParams) <component>def.Params { return params.<Component>Params }),
+        <component>fx.Module(),
+    )
+}
+```
+
+If the component does NOT have Params, just add `<component>fx.Module()` without the `fx.Provide` bridge.
+
+## Usage
+
+- `/create-component core/myfeature --team agent-runtimes --with-lifecycle`
+- `/create-component metadata/hostinfo --team agent-metrics --with-params`
+- `/create-component core/remoteflags --team remote-config --with-lifecycle --with-mock`
+
+## Output
+
+After creating all files, summarize what was created, then:
+1. Run `dda inv modules.add-all-replace` to generate replace directives
+2. Run `dda inv tidy` to tidy go modules
+3. Run `dda inv lint-components lint-fxutil-oneshot-test github.lint-codeowner` to validate the component — fix any errors and re-run until clean
+4. Remind the user to implement the interface methods on the unexported type in `impl/`
+5. Wire the component into the appropriate bundle if needed

--- a/.claude/skills/create-component/SKILL.md
+++ b/.claude/skills/create-component/SKILL.md
@@ -15,7 +15,7 @@ Create a new Fx component following the **modern** (new-style) pattern with sepa
    - `<bundle>/<component-name>`: e.g., `core/remoteflags` means bundle=core, component=remoteflags
    - `--team <team-name>`: optional team ownership tag (default: ask the user)
    - `--with-params`: include a `Params` struct in the def package
-   - `--with-lifecycle`: include `compdef.Lifecycle` in the Requires struct (for start/stop hooks)
+   - `--with-lifecycle`: include `compdef.Lifecycle` in the Requires struct
    - `--with-mock`: also generate a `mock/` sub-package
 
 2. **Ask the user** (if not provided via arguments):
@@ -25,272 +25,51 @@ Create a new Fx component following the **modern** (new-style) pattern with sepa
    - Does it need a Params struct?
    - What are its dependencies (other components it requires)?
 
-3. **Create the directory structure** under `comp/<bundle>/<component>/`:
+3. **Read reference examples** before writing any code. Find a recent component under `comp/` using the `def/fx/impl` pattern (e.g. `comp/core/remoteagentregistry/`). Read:
+   - `def/component.go` — interface definition with `// team:` comment
+   - `fx/fx.go` — Module() with `fxutil.ProvideComponentConstructor`
+   - `impl/<name>.go` — Requires/Provides structs, NewComponent constructor
 
-```
-comp/<bundle>/<component>/
-├── def/
-│   ├── go.mod
-│   ├── component.go     # Interface definition + team tag
-│   └── params.go        # (optional) Params struct
-├── fx/
-│   ├── go.mod
-│   └── fx.go            # Module() function
-└── impl/
-    ├── go.mod
-    └── <component>.go   # Requires, Provides, NewComponent()
-```
+4. **Create the directory structure** under `comp/<bundle>/<component>/`:
+   ```
+   comp/<bundle>/<component>/
+   ├── def/
+   │   ├── go.mod
+   │   ├── component.go     # Interface definition + team tag
+   │   └── params.go        # (optional) Params struct
+   ├── fx/
+   │   ├── go.mod
+   │   └── fx.go            # Module() function
+   └── impl/
+       ├── go.mod
+       └── <component>.go   # Requires, Provides, NewComponent()
+   ```
 
-4. **Create each file** following the templates below.
+5. **Create each file** following the patterns from the reference. Key rules:
+   - `def/component.go`: Package name = component name, include `// team:` comment, only interfaces
+   - `fx/fx.go`: Use `fxutil.ProvideComponentConstructor` (NEVER raw `fx.Provide`), returns `fxutil.Module`
+   - `impl/<component>.go`: Plain Go constructor `func NewComponent(deps Requires) (Provides, error)`, **no** `fx.In`/`fx.Out`/`compdef.In`/`compdef.Out` embedding in Requires/Provides, unexported implementation type
+   - `go.mod` files: Use `v0.0.0` for inter-module dependencies, match Go version from root `go.mod`
 
-5. **Register the modules** in `modules.yml` — add entries for `comp/<bundle>/<component>/def`, `comp/<bundle>/<component>/fx`, and `comp/<bundle>/<component>/impl` (and `comp/<bundle>/<component>/mock` if applicable).
+6. **Register the modules** in `modules.yml` — add entries for `def`, `fx`, and `impl` (use `default` or `used_by_otel: true`).
 
-6. **Run `dda inv modules.add-all-replace`** to generate the `replace` directives in all `go.mod` files. Then run `dda inv tidy` to tidy everything.
+7. **Run `dda inv create-module --path=comp/<bundle>/<component>/def`** (and for `fx`, `impl`) or manually add to `modules.yml` and run `dda inv tidy`.
 
-7. **Wire into a bundle** if appropriate — add the component's `Module()` to the relevant `comp/<bundle>/bundle.go`. If the component needs a `Params`, add a `fx.Provide` bridge from `BundleParams` to the component's `Params` type.
+8. **Wire into a bundle** if appropriate — add the component's `Module()` to the relevant `comp/<bundle>/bundle.go`.
 
-8. **Validate the component** by running the linters that check component correctness:
+9. **Validate**:
    ```bash
    dda inv lint-components lint-fxutil-oneshot-test github.lint-codeowner
    ```
-   These linters verify the component structure, fxutil usage, and CODEOWNERS entries. Fix any errors they report and re-run until clean — this is your feedback loop to ensure the component is correct.
+   Fix any errors and re-run until clean.
 
-## File Templates
+## Critical Rules (New-Style vs Legacy)
 
-### `def/component.go` — Interface definition
+**DO**: `def/fx/impl` sub-packages, `fxutil.ProvideComponentConstructor`, plain Go constructor, plain Requires/Provides structs, thin def package.
 
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-// Package <component> defines the interface for the <component> component.
-package <component>
-
-// team: <team-name>
-
-// Component is the component type.
-type Component interface {
-	// <exported methods here>
-}
-```
-
-Key rules:
-- Package name = component name (e.g., `package remoteflags`)
-- Include the `// team:` comment right after the package declaration
-- Only define the interface here, no implementation details
-- Keep imports minimal (ideally none or just standard library)
-
-### `def/params.go` — Parameters (optional)
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package <component>
-
-// Params defines the parameters for the <component> component.
-type Params struct {
-	// <fields here>
-}
-```
-
-### `def/go.mod`
-
-```
-module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def
-
-go 1.24.0
-```
-
-Keep this module as thin as possible — the def package should have minimal dependencies.
-
-### `fx/fx.go` — Fx wiring
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-// Package fx defines the fx options for this component.
-package fx
-
-import (
-	<component>impl "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-)
-
-// Module defines the fx options for this component.
-func Module() fxutil.Module {
-	return fxutil.Component(
-		fxutil.ProvideComponentConstructor(
-			<component>impl.NewComponent,
-		),
-	)
-}
-```
-
-Key rules:
-- **Always use `fxutil.ProvideComponentConstructor`**, NEVER raw `fx.Provide`
-- Import the impl package with an alias like `<component>impl`
-- The `Module()` function returns `fxutil.Module` (not `fx.Module`)
-- This file should be very short — just wiring, no logic
-
-### `fx/go.mod`
-
-```
-module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/fx
-
-go 1.24.0
-
-require (
-	github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl v0.0.0
-	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.0.0
-)
-```
-
-### `impl/<component>.go` — Implementation
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-// Package <component>impl implements the <component> component.
-package <component>impl
-
-import (
-	<component>def "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def"
-	compdef "github.com/DataDog/datadog-agent/comp/def"
-)
-
-// Requires defines the dependencies for the <component> component.
-type Requires struct {
-	Lc compdef.Lifecycle // include only if --with-lifecycle or if the component needs start/stop hooks
-
-	// Add other component dependencies here, e.g.:
-	// Config config.Component
-	// Log    logdef.Component
-}
-
-// Provides defines the output of the <component> component.
-type Provides struct {
-	Comp <component>def.Component
-}
-
-// <unexportedType> implements the Component interface.
-type <unexportedType> struct {
-	// internal fields
-}
-
-// NewComponent creates a new <component> component.
-func NewComponent(deps Requires) (Provides, error) {
-	instance := &<unexportedType>{
-		// initialize fields from deps
-	}
-
-	// If using lifecycle hooks:
-	// deps.Lc.Append(compdef.Hook{
-	//     OnStart: func(ctx context.Context) error { return instance.start(ctx) },
-	//     OnStop:  func(ctx context.Context) error { return instance.stop(ctx) },
-	// })
-
-	return Provides{
-		Comp: instance,
-	}, nil
-}
-
-// Implement the Component interface methods on the unexported type
-```
-
-Key rules:
-- Package name = `<component>impl` (e.g., `package remoteflagsimpl`)
-- The `Requires` struct lists dependencies using their `def` types. Do NOT embed `compdef.In` — `ProvideComponentConstructor` handles that automatically via reflection
-- The `Provides` struct lists what the component provides. Do NOT embed `compdef.Out` — same reason
-- Constructor signature is `func NewComponent(deps Requires) (Provides, error)` — plain Go, no fx types
-- The implementation type is **unexported** (e.g., `type remoteFlagsImpl struct`)
-- Import the def package with an alias: `<component>def`
-- Import `compdef "github.com/DataDog/datadog-agent/comp/def"` for `Lifecycle` and `Hook`
-
-### `impl/go.mod`
-
-```
-module github.com/DataDog/datadog-agent/comp/<bundle>/<component>/impl
-
-go 1.24.0
-
-require (
-	github.com/DataDog/datadog-agent/comp/<bundle>/<component>/def v0.0.0
-	github.com/DataDog/datadog-agent/comp/def v0.0.0
-)
-```
-
-## Critical Rules (NEW-STYLE vs LEGACY)
-
-### DO (new-style):
-- Use `def/`, `fx/`, `impl/` sub-packages, each with its own `go.mod`
-- Use `fxutil.ProvideComponentConstructor` in `fx/fx.go`
-- Write plain Go constructor: `func NewComponent(deps Requires) (Provides, error)`
-- Keep `Requires`/`Provides` as plain structs (no `fx.In`/`fx.Out` embedding)
-- Keep the def package thin (just interfaces and params)
-
-### DON'T (legacy):
-- Put everything in a single directory with one `go.mod`
-- Use `fx.Provide(newComponent)` directly
-- Embed `fx.In` or `fx.Out` in your structs
-- Put implementation details in the def package
-- Use `compdef.In` or `compdef.Out` in Requires/Provides (these are marker types only used internally by `ProvideComponentConstructor`)
-
-## modules.yml Registration
-
-Add entries under the `modules:` key:
-
-```yaml
-  comp/<bundle>/<component>/def: default
-  comp/<bundle>/<component>/fx: default
-  comp/<bundle>/<component>/impl: default
-```
-
-Use `default` for standard modules, or `used_by_otel: true` if the component is used by the OTel collector.
-
-## Bundle Wiring
-
-If the component should be part of a bundle (e.g., `comp/core/bundle.go`):
-
-```go
-import (
-    <component>fx "github.com/DataDog/datadog-agent/comp/<bundle>/<component>/fx"
-)
-
-func Bundle() fxutil.BundleOptions {
-    return fxutil.Bundle(
-        // ... existing components ...
-
-        // If the component has Params:
-        fx.Provide(func(params BundleParams) <component>def.Params { return params.<Component>Params }),
-        <component>fx.Module(),
-    )
-}
-```
-
-If the component does NOT have Params, just add `<component>fx.Module()` without the `fx.Provide` bridge.
+**DON'T**: Single directory, `fx.Provide(newComponent)`, `fx.In`/`fx.Out` embedding, implementation in def package.
 
 ## Usage
 
 - `/create-component core/myfeature --team agent-runtimes --with-lifecycle`
 - `/create-component metadata/hostinfo --team agent-metrics --with-params`
-- `/create-component core/remoteflags --team remote-config --with-lifecycle --with-mock`
-
-## Output
-
-After creating all files, summarize what was created, then:
-1. Run `dda inv modules.add-all-replace` to generate replace directives
-2. Run `dda inv tidy` to tidy go modules
-3. Run `dda inv lint-components lint-fxutil-oneshot-test github.lint-codeowner` to validate the component — fix any errors and re-run until clean
-4. Remind the user to implement the interface methods on the unexported type in `impl/`
-5. Wire the component into the appropriate bundle if needed

--- a/.claude/skills/create-config-field/SKILL.md
+++ b/.claude/skills/create-config-field/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: create-config-field
+description: Add a new configuration field to the Datadog Agent (datadog.yaml)
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[config.key.name]"
+---
+
+Add a new configuration field to a Datadog Agent. This involves registering the key with defaults/env bindings in Go, and optionally documenting it in the config template.
+
+There are **two separate config objects**, each with their own Go init function. Within the core agent config, many **subsystems** have dedicated setup functions and template sections.
+
+### Config objects
+
+| Config object | Config file | Go init function |
+|---|---|---|
+| Core Agent | `datadog.yaml` | `InitConfig()` in `pkg/config/setup/config.go` |
+| System Probe | `system-probe.yaml` | `InitSystemProbeConfig()` in `pkg/config/setup/system_probe.go` |
+
+### Core Agent subsystems
+
+The core agent config is organized into subsystem setup functions. Each has its own template conditional for documentation. When adding a field, register it in the right subsystem function and document it under the matching template section.
+
+| Subsystem | Go setup function | Template conditional | Key prefix examples |
+|---|---|---|---|
+| Common / General | `agent()` or inline in `InitConfig()` | `.Common`, `.Agent` | `api_key`, `hostname`, `site` |
+| Logs Agent | `logsagent()` | `.LogsAgent` | `logs_config.*`, `logs_enabled` |
+| APM / Trace Agent | `setupAPM()` in `apm.go` | `.TraceAgent` | `apm_config.*` |
+| Process Agent | `setupProcesses()` in `process.go` | `.ProcessAgent` | `process_config.*` |
+| DogStatsD | `dogstatsd()` | `.Dogstatsd` | `dogstatsd_*`, `statsd_*` |
+| Security Agent | via `InitConfig()` | `.SecurityAgent`, `.Compliance` | `security_agent.*`, `compliance_config.*` |
+| Cluster Agent | via `InitConfig()` | `.ClusterAgent` | `cluster_agent.*` |
+| OTLP | `OTLP()` in `otlp.go` | `.OTLP` | `otlp_config.*` |
+| Network Path | via `InitConfig()` | `.NetworkPath` | `network_path.*` |
+
+### System Probe subsystems
+
+| Subsystem | Go setup function | Template conditional | Key prefix examples |
+|---|---|---|---|
+| General | `InitSystemProbeConfig()` in `system_probe.go` | `.SystemProbe` | `system_probe_config.*` |
+| CWS | `initCWSSystemProbeConfig()` in `system_probe_cws.go` | `.SecurityModule` | `runtime_security_config.*` |
+| USM | `initUSMSystemProbeConfig()` in `system_probe_usm.go` | `.UniversalServiceMonitoringModule` | `service_monitoring_config.*` |
+| Network | via `InitSystemProbeConfig()` | `.NetworkModule` | `network_config.*` |
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the config key name, skip that question.
+
+1. **Target config**: Which config object is this field for?
+   - **Core Agent** (`datadog.yaml`) — the main agent config, most common case. Also used by Security Agent, Cluster Agent, and other agents that share the core config.
+   - **System Probe** (`system-probe.yaml`) — system-level eBPF monitoring, has a completely separate config object and init function (`InitSystemProbeConfig`).
+
+2. **Subsystem**: Which subsystem does this field belong to? This determines which Go setup function to add it to and which template conditional to use for documentation. Refer to the tables above. If unsure, look at related existing config keys using `Grep` to find which function they're registered in.
+
+2. **Config key** (dot-separated, e.g. `my_feature.enabled`, `logs_config.use_compression`): the YAML path in the config file.
+
+3. **Value type**: What type of value does this field hold?
+   - Boolean (`true`/`false`)
+   - String
+   - Integer
+   - Float
+   - Duration (e.g. `30 * time.Second`)
+   - String slice (list of strings)
+   - Map (e.g. `map[string]interface{}`)
+
+4. **Default value**: What should the default be?
+
+5. **Description**: A human-readable description of what this config field controls.
+
+6. **Scope**: Where should this field be registered?
+   - **Inline** — add directly in the appropriate init function (small additions)
+   - **Dedicated setup file** — for a group of related fields belonging to a feature (`pkg/config/setup/<feature>.go`)
+   - **Existing setup file** — to add to an already existing feature's setup file
+
+7. **Serverless-compatible?** (only relevant for Core Agent fields): Is this config reachable by the serverless agent?
+   - **Yes** — register via the `serverlessConfigComponents` slice (a function in `pkg/config/setup/config.go`)
+   - **No** (default) — register directly in `InitConfig`
+
+8. **User-facing?**: Should this field be documented in the config template (`pkg/config/config_template.yaml`)?
+   - **Yes** — add `@param`/`@env` documentation to the template
+   - **No** (default for internal/hidden fields) — skip template documentation
+
+9. **Custom env var name?**: By default, `BindEnvAndSetDefault` auto-generates `DD_<KEY_UPPERCASED>` (dots become underscores). Does it need a custom env var name override?
+
+### Step 2: Register the config key
+
+Based on the target config and subsystem, add the field to the appropriate Go function.
+
+#### Option A: Add to an existing subsystem function
+
+This is the most common case. Find the right function from the tables above and add the binding there. For example:
+- For a `logs_config.*` field: add to `logsagent()` in `config.go`
+- For an `apm_config.*` field: add to `setupAPM()` in `apm.go`
+- For a `system_probe_config.*` field: add to `InitSystemProbeConfig()` in `system_probe.go`
+- For a `runtime_security_config.*` field: add to `initCWSSystemProbeConfig()` in `system_probe_cws.go`
+
+```go
+config.BindEnvAndSetDefault("my_feature.enabled", false)
+```
+
+#### Option B: Add inline in the main init function
+
+For standalone fields that don't belong to a specific subsystem, add directly in:
+- `InitConfig()` in `config.go` — for core agent fields
+- `InitSystemProbeConfig()` in `system_probe.go` — for system-probe fields
+
+Place it near related fields (look for a logical grouping).
+
+#### Option C: Dedicated setup file
+
+For a **group of related fields** belonging to a new feature, create a new file `pkg/config/setup/<feature>.go`:
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package setup
+
+import (
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+const (
+	// FeatureEnabled is the config key for enabling the feature
+	FeatureEnabled = "my_feature.enabled"
+	// FeatureTimeout is the config key for the feature timeout
+	FeatureTimeout = "my_feature.timeout"
+)
+
+// setupMyFeature registers all configuration keys for my feature
+func setupMyFeature(config pkgconfigmodel.Setup) {
+	config.BindEnvAndSetDefault(FeatureEnabled, false)
+	config.BindEnvAndSetDefault(FeatureTimeout, 30)
+}
+```
+
+Then call the function from the appropriate place:
+- **Core agent, serverless-compatible**: add to the `serverlessConfigComponents` slice in `config.go`
+- **Core agent, not serverless-compatible**: call directly inside `InitConfig` in `config.go`
+- **System probe**: call from `InitSystemProbeConfig` in `system_probe.go`
+
+### Step 3: (Optional) Document in the config template
+
+If the field is **user-facing**, add documentation to `pkg/config/config_template.yaml`.
+
+The template uses Go template conditionals to control which agent components see each section. Check the `context` struct in `pkg/config/render_config.go` for available conditionals. The most common ones are:
+
+| Conditional | Included in |
+|---|---|
+| `.Common` | All agents (agent, dogstatsd, cluster-agent, etc.) |
+| `.Agent` | Core agent only |
+| `.LogsAgent` | Agents with log collection |
+| `.TraceAgent` | APM trace agent |
+| `.ProcessAgent` | Process agent |
+| `.SystemProbe` | System probe |
+| `.ClusterAgent` | Cluster agent |
+| `.Dogstatsd` | DogStatsD |
+| `.SecurityAgent` | Security agent |
+
+**Documentation format:**
+
+For an optional field with default:
+```yaml
+## @param my_feature.enabled - boolean - optional - default: false
+## @env DD_MY_FEATURE_ENABLED - boolean - optional - default: false
+## Description of what this field controls.
+## Additional details if needed.
+#
+# my_feature.enabled: false
+```
+
+For a required field:
+```yaml
+## @param my_feature.api_endpoint - string - required
+## @env DD_MY_FEATURE_API_ENDPOINT - string - required
+## The API endpoint for my feature.
+#
+# my_feature.api_endpoint:
+```
+
+For a field with a nested object:
+```yaml
+## @param my_feature - custom object - optional
+## Configuration for my feature.
+#
+# my_feature:
+#   enabled: false
+#   timeout: 30
+```
+
+**Type names for `@param`/`@env`:** `boolean`, `string`, `integer`, `number`, `list of strings`, `custom object`
+
+Place the documentation inside the appropriate conditional block. For example, if it applies to all agents, place it inside `{{- if .Common -}}...{{ end -}}`. If it's agent-specific, place it inside `{{ if .Agent }}...{{ end -}}`.
+
+### Step 4: Accessing the config in code
+
+Show the user how to read the new config value. The accessor method depends on the type:
+
+| Type | Accessor |
+|---|---|
+| Boolean | `config.GetBool("my_feature.enabled")` |
+| String | `config.GetString("my_feature.name")` |
+| Integer | `config.GetInt("my_feature.timeout")` |
+| Float | `config.GetFloat64("my_feature.ratio")` |
+| Duration | `config.GetDuration("my_feature.interval")` |
+| String slice | `config.GetStringSlice("my_feature.items")` |
+| Map | `config.GetStringMap("my_feature.options")` |
+
+The config object is typically accessed via:
+- `pkgconfig.Datadog()` from `pkg/config` (global access)
+- A `config.Component` dependency injected via Fx
+
+If a constant was defined for the key, remind the user to use it instead of a raw string.
+
+### Step 5: Verify
+
+1. Build to check for compilation errors:
+   - Core agent: `dda inv agent.build --build-exclude=systemd`
+   - System probe: `dda inv system-probe.build`
+
+2. Run the linter:
+   ```bash
+   dda inv linter.go
+   ```
+
+3. If the config template was modified, verify it renders correctly:
+   ```bash
+   dda inv generate-config
+   ```
+
+4. Report the results to the user. If the build or linting fails, fix the issues.
+
+## Key Methods Reference
+
+The `pkgconfigmodel.Setup` interface provides these methods for registering config keys:
+
+- **`BindEnvAndSetDefault(key, default, envVars...)`** — Preferred. Registers the key as known, sets a default value, and binds the auto-generated `DD_*` env var (plus optional custom env vars).
+- **`SetDefault(key, value)`** — Sets a default without env var binding.
+- **`BindEnv(key, envVars...)`** — Binds env vars without setting a default.
+- **`SetKnown(key)`** — Deprecated. Only marks the key as known. Prefer `BindEnvAndSetDefault`.
+
+**Environment variable naming:** `BindEnvAndSetDefault("my_feature.timeout", 30)` automatically creates `DD_MY_FEATURE_TIMEOUT`. To add a custom alias: `BindEnvAndSetDefault("my_feature.timeout", 30, "DD_MY_TIMEOUT")`.
+
+## Important Notes
+
+- Keys registered with `BindEnvAndSetDefault` are automatically "known" — the agent's validation system won't warn about them at startup.
+- The config priority order is: `default < file < environment-variable < fleet-policies < agent-runtime < remote-config < cli`. Higher priority sources override lower ones.
+- Always define **exported string constants** for config keys when creating a dedicated setup file. This prevents typos and makes the keys greppable.
+- Do NOT use `SetKnown` for new fields — it's deprecated. Use `BindEnvAndSetDefault` instead.
+
+## Usage
+
+- `/create-config-field` — Interactive: prompts for all details
+- `/create-config-field my_feature.enabled` — Pre-fills the key name, prompts for the rest

--- a/.claude/skills/create-config-field/SKILL.md
+++ b/.claude/skills/create-config-field/SKILL.md
@@ -18,25 +18,22 @@ There are **two separate config objects**, each with their own Go init function.
 
 ### Core Agent subsystems
 
-The core agent config is organized into subsystem setup functions. Each has its own template conditional for documentation. When adding a field, register it in the right subsystem function and document it under the matching template section.
-
 | Subsystem | Go setup function | Template conditional | Key prefix examples |
 |---|---|---|---|
 | Common / General | `agent()` or inline in `InitConfig()` | `.Common`, `.Agent` | `api_key`, `hostname`, `site` |
-| Logs Agent | `logsagent()` | `.LogsAgent` | `logs_config.*`, `logs_enabled` |
+| Logs Agent | `logsagent()` | `.LogsAgent` | `logs_config.*` |
 | APM / Trace Agent | `setupAPM()` in `apm.go` | `.TraceAgent` | `apm_config.*` |
 | Process Agent | `setupProcesses()` in `process.go` | `.ProcessAgent` | `process_config.*` |
-| DogStatsD | `dogstatsd()` | `.Dogstatsd` | `dogstatsd_*`, `statsd_*` |
-| Security Agent | via `InitConfig()` | `.SecurityAgent`, `.Compliance` | `security_agent.*`, `compliance_config.*` |
+| DogStatsD | `dogstatsd()` | `.Dogstatsd` | `dogstatsd_*` |
+| Security Agent | via `InitConfig()` | `.SecurityAgent` | `security_agent.*` |
 | Cluster Agent | via `InitConfig()` | `.ClusterAgent` | `cluster_agent.*` |
 | OTLP | `OTLP()` in `otlp.go` | `.OTLP` | `otlp_config.*` |
-| Network Path | via `InitConfig()` | `.NetworkPath` | `network_path.*` |
 
 ### System Probe subsystems
 
 | Subsystem | Go setup function | Template conditional | Key prefix examples |
 |---|---|---|---|
-| General | `InitSystemProbeConfig()` in `system_probe.go` | `.SystemProbe` | `system_probe_config.*` |
+| General | `InitSystemProbeConfig()` | `.SystemProbe` | `system_probe_config.*` |
 | CWS | `initCWSSystemProbeConfig()` in `system_probe_cws.go` | `.SecurityModule` | `runtime_security_config.*` |
 | USM | `initUSMSystemProbeConfig()` in `system_probe_usm.go` | `.UniversalServiceMonitoringModule` | `service_monitoring_config.*` |
 | Network | via `InitSystemProbeConfig()` | `.NetworkModule` | `network_config.*` |
@@ -47,211 +44,53 @@ The core agent config is organized into subsystem setup functions. Each has its 
 
 Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the config key name, skip that question.
 
-1. **Target config**: Which config object is this field for?
-   - **Core Agent** (`datadog.yaml`) — the main agent config, most common case. Also used by Security Agent, Cluster Agent, and other agents that share the core config.
-   - **System Probe** (`system-probe.yaml`) — system-level eBPF monitoring, has a completely separate config object and init function (`InitSystemProbeConfig`).
-
-2. **Subsystem**: Which subsystem does this field belong to? This determines which Go setup function to add it to and which template conditional to use for documentation. Refer to the tables above. If unsure, look at related existing config keys using `Grep` to find which function they're registered in.
-
-2. **Config key** (dot-separated, e.g. `my_feature.enabled`, `logs_config.use_compression`): the YAML path in the config file.
-
-3. **Value type**: What type of value does this field hold?
-   - Boolean (`true`/`false`)
-   - String
-   - Integer
-   - Float
-   - Duration (e.g. `30 * time.Second`)
-   - String slice (list of strings)
-   - Map (e.g. `map[string]interface{}`)
-
-4. **Default value**: What should the default be?
-
-5. **Description**: A human-readable description of what this config field controls.
-
-6. **Scope**: Where should this field be registered?
-   - **Inline** — add directly in the appropriate init function (small additions)
-   - **Dedicated setup file** — for a group of related fields belonging to a feature (`pkg/config/setup/<feature>.go`)
-   - **Existing setup file** — to add to an already existing feature's setup file
-
-7. **Serverless-compatible?** (only relevant for Core Agent fields): Is this config reachable by the serverless agent?
-   - **Yes** — register via the `serverlessConfigComponents` slice (a function in `pkg/config/setup/config.go`)
-   - **No** (default) — register directly in `InitConfig`
-
-8. **User-facing?**: Should this field be documented in the config template (`pkg/config/config_template.yaml`)?
-   - **Yes** — add `@param`/`@env` documentation to the template
-   - **No** (default for internal/hidden fields) — skip template documentation
-
-9. **Custom env var name?**: By default, `BindEnvAndSetDefault` auto-generates `DD_<KEY_UPPERCASED>` (dots become underscores). Does it need a custom env var name override?
+1. **Target config**: Core Agent (`datadog.yaml`) or System Probe (`system-probe.yaml`)?
+2. **Subsystem**: Which subsystem does this field belong to? (see tables above)
+3. **Config key** (dot-separated, e.g. `my_feature.enabled`): the YAML path.
+4. **Value type**: Boolean, String, Integer, Float, Duration, String slice, or Map.
+5. **Default value**: What should the default be?
+6. **Description**: Human-readable description of what this field controls.
+7. **Scope**: Add inline in the subsystem function, or create a dedicated setup file (`pkg/config/setup/<feature>.go`) for a group of related fields?
+8. **User-facing?**: Should it be documented in `pkg/config/config_template.yaml`?
 
 ### Step 2: Register the config key
 
-Based on the target config and subsystem, add the field to the appropriate Go function.
-
-#### Option A: Add to an existing subsystem function
-
-This is the most common case. Find the right function from the tables above and add the binding there. For example:
-- For a `logs_config.*` field: add to `logsagent()` in `config.go`
-- For an `apm_config.*` field: add to `setupAPM()` in `apm.go`
-- For a `system_probe_config.*` field: add to `InitSystemProbeConfig()` in `system_probe.go`
-- For a `runtime_security_config.*` field: add to `initCWSSystemProbeConfig()` in `system_probe_cws.go`
+Find the right subsystem function from the tables above and add the binding. Use `Grep` if unsure where related keys live.
 
 ```go
 config.BindEnvAndSetDefault("my_feature.enabled", false)
 ```
 
-#### Option B: Add inline in the main init function
+For a **group of related fields**, create `pkg/config/setup/<feature>.go` with a dedicated setup function, then call it from the appropriate init function. Read an existing setup file (e.g. `pkg/config/setup/apm.go`) for the pattern.
 
-For standalone fields that don't belong to a specific subsystem, add directly in:
-- `InitConfig()` in `config.go` — for core agent fields
-- `InitSystemProbeConfig()` in `system_probe.go` — for system-probe fields
-
-Place it near related fields (look for a logical grouping).
-
-#### Option C: Dedicated setup file
-
-For a **group of related fields** belonging to a new feature, create a new file `pkg/config/setup/<feature>.go`:
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package setup
-
-import (
-	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-)
-
-const (
-	// FeatureEnabled is the config key for enabling the feature
-	FeatureEnabled = "my_feature.enabled"
-	// FeatureTimeout is the config key for the feature timeout
-	FeatureTimeout = "my_feature.timeout"
-)
-
-// setupMyFeature registers all configuration keys for my feature
-func setupMyFeature(config pkgconfigmodel.Setup) {
-	config.BindEnvAndSetDefault(FeatureEnabled, false)
-	config.BindEnvAndSetDefault(FeatureTimeout, 30)
-}
-```
-
-Then call the function from the appropriate place:
-- **Core agent, serverless-compatible**: add to the `serverlessConfigComponents` slice in `config.go`
-- **Core agent, not serverless-compatible**: call directly inside `InitConfig` in `config.go`
-- **System probe**: call from `InitSystemProbeConfig` in `system_probe.go`
+For **serverless-compatible** core agent fields, register via the `serverlessConfigComponents` slice in `config.go` instead of directly in `InitConfig`.
 
 ### Step 3: (Optional) Document in the config template
 
-If the field is **user-facing**, add documentation to `pkg/config/config_template.yaml`.
+If user-facing, add documentation to `pkg/config/config_template.yaml` inside the appropriate conditional block (see Template conditional column in tables above). Read existing entries nearby for the exact format (`@param`, `@env` annotations).
 
-The template uses Go template conditionals to control which agent components see each section. Check the `context` struct in `pkg/config/render_config.go` for available conditionals. The most common ones are:
+### Step 4: Verify
 
-| Conditional | Included in |
-|---|---|
-| `.Common` | All agents (agent, dogstatsd, cluster-agent, etc.) |
-| `.Agent` | Core agent only |
-| `.LogsAgent` | Agents with log collection |
-| `.TraceAgent` | APM trace agent |
-| `.ProcessAgent` | Process agent |
-| `.SystemProbe` | System probe |
-| `.ClusterAgent` | Cluster agent |
-| `.Dogstatsd` | DogStatsD |
-| `.SecurityAgent` | Security agent |
-
-**Documentation format:**
-
-For an optional field with default:
-```yaml
-## @param my_feature.enabled - boolean - optional - default: false
-## @env DD_MY_FEATURE_ENABLED - boolean - optional - default: false
-## Description of what this field controls.
-## Additional details if needed.
-#
-# my_feature.enabled: false
-```
-
-For a required field:
-```yaml
-## @param my_feature.api_endpoint - string - required
-## @env DD_MY_FEATURE_API_ENDPOINT - string - required
-## The API endpoint for my feature.
-#
-# my_feature.api_endpoint:
-```
-
-For a field with a nested object:
-```yaml
-## @param my_feature - custom object - optional
-## Configuration for my feature.
-#
-# my_feature:
-#   enabled: false
-#   timeout: 30
-```
-
-**Type names for `@param`/`@env`:** `boolean`, `string`, `integer`, `number`, `list of strings`, `custom object`
-
-Place the documentation inside the appropriate conditional block. For example, if it applies to all agents, place it inside `{{- if .Common -}}...{{ end -}}`. If it's agent-specific, place it inside `{{ if .Agent }}...{{ end -}}`.
-
-### Step 4: Accessing the config in code
-
-Show the user how to read the new config value. The accessor method depends on the type:
-
-| Type | Accessor |
-|---|---|
-| Boolean | `config.GetBool("my_feature.enabled")` |
-| String | `config.GetString("my_feature.name")` |
-| Integer | `config.GetInt("my_feature.timeout")` |
-| Float | `config.GetFloat64("my_feature.ratio")` |
-| Duration | `config.GetDuration("my_feature.interval")` |
-| String slice | `config.GetStringSlice("my_feature.items")` |
-| Map | `config.GetStringMap("my_feature.options")` |
-
-The config object is typically accessed via:
-- `pkgconfig.Datadog()` from `pkg/config` (global access)
-- A `config.Component` dependency injected via Fx
-
-If a constant was defined for the key, remind the user to use it instead of a raw string.
-
-### Step 5: Verify
-
-1. Build to check for compilation errors:
-   - Core agent: `dda inv agent.build --build-exclude=systemd`
-   - System probe: `dda inv system-probe.build`
-
-2. Run the linter:
-   ```bash
-   dda inv linter.go
-   ```
-
-3. If the config template was modified, verify it renders correctly:
-   ```bash
-   dda inv generate-config
-   ```
-
-4. Report the results to the user. If the build or linting fails, fix the issues.
+1. Build: `dda inv agent.build --build-exclude=systemd` (or `dda inv system-probe.build`)
+2. Lint: `dda inv linter.go`
+3. If the template was modified: `dda inv generate-config`
+4. Report the results to the user.
 
 ## Key Methods Reference
 
-The `pkgconfigmodel.Setup` interface provides these methods for registering config keys:
+- **`BindEnvAndSetDefault(key, default, envVars...)`** — Preferred. Registers key, sets default, binds `DD_*` env var.
+- **`SetDefault(key, value)`** — Default without env binding.
+- **`BindEnv(key, envVars...)`** — Env binding without default.
 
-- **`BindEnvAndSetDefault(key, default, envVars...)`** — Preferred. Registers the key as known, sets a default value, and binds the auto-generated `DD_*` env var (plus optional custom env vars).
-- **`SetDefault(key, value)`** — Sets a default without env var binding.
-- **`BindEnv(key, envVars...)`** — Binds env vars without setting a default.
-- **`SetKnown(key)`** — Deprecated. Only marks the key as known. Prefer `BindEnvAndSetDefault`.
-
-**Environment variable naming:** `BindEnvAndSetDefault("my_feature.timeout", 30)` automatically creates `DD_MY_FEATURE_TIMEOUT`. To add a custom alias: `BindEnvAndSetDefault("my_feature.timeout", 30, "DD_MY_TIMEOUT")`.
+`BindEnvAndSetDefault("my_feature.timeout", 30)` auto-creates `DD_MY_FEATURE_TIMEOUT`. Custom alias: `BindEnvAndSetDefault("my_feature.timeout", 30, "DD_MY_TIMEOUT")`.
 
 ## Important Notes
 
-- Keys registered with `BindEnvAndSetDefault` are automatically "known" — the agent's validation system won't warn about them at startup.
-- The config priority order is: `default < file < environment-variable < fleet-policies < agent-runtime < remote-config < cli`. Higher priority sources override lower ones.
-- Always define **exported string constants** for config keys when creating a dedicated setup file. This prevents typos and makes the keys greppable.
-- Do NOT use `SetKnown` for new fields — it's deprecated. Use `BindEnvAndSetDefault` instead.
+- Do NOT use `SetKnown` for new fields — it's deprecated. Use `BindEnvAndSetDefault`.
+- Config priority: `default < file < env-var < fleet-policies < agent-runtime < remote-config < cli`.
+- Define exported string constants for keys when creating a dedicated setup file.
 
 ## Usage
 
 - `/create-config-field` — Interactive: prompts for all details
-- `/create-config-field my_feature.enabled` — Pre-fills the key name, prompts for the rest
+- `/create-config-field my_feature.enabled` — Pre-fills the key name

--- a/.claude/skills/create-core-check/SKILL.md
+++ b/.claude/skills/create-core-check/SKILL.md
@@ -1,0 +1,440 @@
+---
+name: create-core-check
+description: Create a new Go core check that collects metrics and sends them to Datadog
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[check-name]"
+---
+
+Create a new Go-based core check for the Datadog Agent. Core checks collect metrics, service checks, or events and send them to Datadog at regular intervals.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the check name, skip that question.
+
+1. **Check name**: The identifier for the check (e.g. `uptime`, `memory`, `ntp`). Used as the package name, registration key, and config directory name.
+
+2. **Check category**: Where should the check live under `pkg/collector/corechecks/`?
+   - `system/` — System-level checks (CPU, memory, uptime, disk)
+   - `net/` — Network checks (NTP, DNS)
+   - `containers/` — Container-related checks
+   - `ebpf/` — eBPF-based checks (these are more complex, see `pkg/collector/corechecks/ebpf/AGENTS.md`)
+   - `embed/` — Embedded service checks
+   - Top-level under `corechecks/` — For standalone checks
+
+3. **What does it collect?**: Describe the metrics, service checks, or events it produces.
+
+4. **Configuration**: Does it need instance-level configuration?
+   - **No config** — Single instance, no user parameters (like `uptime`)
+   - **Simple config** — A few YAML parameters (like `memory` with `collect_memory_pressure`)
+   - **Multi-instance** — Supports multiple configured instances (like `ntp` with different servers)
+
+5. **Component dependencies**: Does the check need injected components?
+   - **None** — Simple check, no external dependencies
+   - **Tagger** — Needs to tag metrics with container/host tags
+   - **WorkloadMeta** — Needs access to workload metadata store
+   - **Other** — Specify which components
+
+6. **Long-running?**: Does the check run continuously in the background?
+   - **No** (default) — `Run()` is called at regular intervals (default 15s)
+   - **Yes** — `Run()` never returns, processes events in a loop
+
+7. **Platform restrictions**: Does the check only work on certain platforms?
+   - All platforms (default)
+   - Linux only
+   - Windows only
+   - Linux + macOS (not Windows)
+
+### Step 2: Create the check package
+
+**Directory:** `pkg/collector/corechecks/<category>/<checkname>/`
+
+#### Basic check (no config, no dependencies)
+
+**File:** `pkg/collector/corechecks/<category>/<checkname>/<checkname>.go`
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package <checkname>
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const CheckName = "<checkname>"
+
+// Check implements the <checkname> check.
+type Check struct {
+	core.CheckBase
+}
+
+// Factory returns the check factory.
+func Factory() option.Option[func() check.Check] {
+	return option.New(newCheck)
+}
+
+func newCheck() check.Check {
+	return &Check{
+		CheckBase: core.NewCheckBase(CheckName),
+	}
+}
+
+// Configure configures the check.
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
+	if err != nil {
+		return err
+	}
+
+	s, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+	s.FinalizeCheckServiceTag()
+
+	return nil
+}
+
+// Run executes the check.
+func (c *Check) Run() error {
+	sender, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+
+	// Collect and send metrics
+	// sender.Gauge("my_check.metric_name", value, "", nil)
+
+	sender.Commit()
+	return nil
+}
+```
+
+#### Check with instance configuration
+
+Add a config struct and parse it in `Configure`:
+
+```go
+import "gopkg.in/yaml.v2"
+
+type instanceConfig struct {
+	MyParam    string   `yaml:"my_param"`
+	SomeFlag   bool     `yaml:"some_flag"`
+	ItemList   []string `yaml:"item_list"`
+}
+
+type Check struct {
+	core.CheckBase
+	config instanceConfig
+}
+
+func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
+	if err != nil {
+		return err
+	}
+
+	s, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+	s.FinalizeCheckServiceTag()
+
+	return yaml.Unmarshal(rawInstance, &c.config)
+}
+```
+
+#### Multi-instance check
+
+Call `BuildID` **before** `CommonConfigure` to create a unique ID per instance:
+
+```go
+func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+	c.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
+
+	err := c.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
+	if err != nil {
+		return err
+	}
+
+	s, err := c.GetSender()
+	if err != nil {
+		return err
+	}
+	s.FinalizeCheckServiceTag()
+
+	return yaml.Unmarshal(rawInstance, &c.config)
+}
+```
+
+#### Check with component dependencies
+
+Components are injected via the Factory function:
+
+```go
+import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+type Check struct {
+	core.CheckBase
+	tagger tagger.Component
+	store  workloadmeta.Component
+}
+
+func Factory(tagger tagger.Component, store workloadmeta.Component) option.Option[func() check.Check] {
+	return option.New(func() check.Check {
+		return &Check{
+			CheckBase: core.NewCheckBase(CheckName),
+			tagger:    tagger,
+			store:     store,
+		}
+	})
+}
+```
+
+#### Long-running check
+
+For checks that process events continuously:
+
+```go
+import core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+
+type Check struct {
+	core.CheckBase
+	stopCh chan struct{}
+}
+
+func Factory() option.Option[func() check.Check] {
+	return option.New(func() check.Check {
+		return core.NewLongRunningCheckWrapper(&Check{
+			CheckBase: core.NewCheckBase(CheckName),
+			stopCh:    make(chan struct{}),
+		})
+	})
+}
+
+func (c *Check) Run() error {
+	// This never returns — runs until Stop() is called
+	for {
+		select {
+		case <-c.stopCh:
+			return nil
+		case event := <-someEventChannel:
+			sender, _ := c.GetSender()
+			// Process event, send metrics
+			sender.Commit()
+		}
+	}
+}
+
+func (c *Check) Stop() {
+	close(c.stopCh)
+}
+
+func (c *Check) Interval() time.Duration {
+	return 0 // 0 signals long-running check
+}
+```
+
+#### Platform-specific check
+
+Add build tags and create stub files for unsupported platforms:
+
+**Main file** (`<checkname>.go`):
+```go
+//go:build linux
+
+package <checkname>
+// ... full implementation
+```
+
+**Stub file** (`<checkname>_nolinux.go`):
+```go
+//go:build !linux
+
+package <checkname>
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const CheckName = "<checkname>"
+
+// Factory returns an empty Option on unsupported platforms.
+func Factory() option.Option[func() check.Check] {
+	return option.None[func() check.Check]()
+}
+```
+
+### Step 3: Register the check
+
+Edit `pkg/commonchecks/corechecks.go`:
+
+1. Add an import for the check package:
+   ```go
+   <checkname> "github.com/DataDog/datadog-agent/pkg/collector/corechecks/<category>/<checkname>"
+   ```
+
+2. Add a `RegisterCheck` call in the `RegisterChecks` function:
+   ```go
+   // Simple check (no dependencies)
+   corecheckLoader.RegisterCheck(<checkname>.CheckName, <checkname>.Factory())
+
+   // Check with dependencies
+   corecheckLoader.RegisterCheck(<checkname>.CheckName, <checkname>.Factory(tagger, store))
+   ```
+
+   Match the Factory arguments to the component parameters available in `RegisterChecks`.
+
+### Step 4: Create the default configuration
+
+**File:** `cmd/agent/dist/conf.d/<checkname>.d/conf.yaml.default`
+
+For a check with no user configuration:
+```yaml
+init_config:
+
+instances:
+  - {}
+```
+
+For a check with configuration:
+```yaml
+init_config:
+
+instances:
+    ## @param my_param - string - optional - default: ""
+    ## Description of what my_param does.
+    #
+    # - my_param: ""
+
+    ## @param some_flag - boolean - optional - default: false
+    ## Description of some_flag.
+    #
+    # - some_flag: false
+```
+
+### Step 5: Write tests
+
+**File:** `pkg/collector/corechecks/<category>/<checkname>/<checkname>_test.go`
+
+```go
+package <checkname>
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+)
+
+func TestRun(t *testing.T) {
+	// Create mock sender before Configure
+	mockSender := mocksender.NewMockSender("")
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	// Create and configure check
+	c := new(Check)
+	err := c.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	require.NoError(t, err)
+
+	// Register mock sender with the check's ID
+	mocksender.SetSender(mockSender, c.ID())
+
+	// Set expectations for metrics
+	mockSender.On("Gauge", "my_check.metric", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
+	mockSender.On("Commit").Return().Times(1)
+
+	// Run
+	err = c.Run()
+	require.NoError(t, err)
+
+	// Verify
+	mockSender.AssertExpectations(t)
+}
+
+func TestConfigure(t *testing.T) {
+	mockSender := mocksender.NewMockSender("")
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	c := new(Check)
+	rawInstance := []byte(`
+my_param: "test_value"
+some_flag: true
+`)
+	err := c.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstance, nil, "test")
+	require.NoError(t, err)
+	assert.Equal(t, "test_value", c.config.MyParam)
+	assert.True(t, c.config.SomeFlag)
+}
+```
+
+### Step 6: Verify
+
+1. Run the check tests:
+   ```bash
+   dda inv test --targets=./pkg/collector/corechecks/<category>/<checkname>
+   ```
+
+2. Build the agent:
+   ```bash
+   dda inv agent.build --build-exclude=systemd
+   ```
+
+3. Run the linter:
+   ```bash
+   dda inv linter.go
+   ```
+
+4. Report the results to the user.
+
+## Sender Methods Reference
+
+The sender (`c.GetSender()`) provides these methods for submitting data:
+
+| Method | Description |
+|---|---|
+| `Gauge(metric, value, hostname, tags)` | Submit a gauge metric |
+| `Rate(metric, value, hostname, tags)` | Submit a rate metric |
+| `Count(metric, value, hostname, tags)` | Submit a count metric |
+| `MonotonicCount(metric, value, hostname, tags)` | Submit a monotonic count |
+| `Histogram(metric, value, hostname, tags)` | Submit a histogram metric |
+| `Distribution(metric, value, hostname, tags)` | Submit a distribution metric |
+| `ServiceCheck(name, status, hostname, tags, message)` | Submit a service check |
+| `Event(event)` | Submit an event |
+| `Commit()` | Flush all submitted data — **must be called at end of Run()** |
+
+- Pass `""` for hostname to use the agent's default hostname.
+- Pass `nil` for tags if no tags are needed.
+- Service check statuses: `servicecheck.ServiceCheckOK`, `ServiceCheckWarning`, `ServiceCheckCritical`, `ServiceCheckUnknown` (from `pkg/metrics/servicecheck`).
+
+## Important Notes
+
+- `CheckBase` provides default implementations for most `Check` interface methods. You only need to override `Run()` and optionally `Configure()`, `Stop()`, and `Interval()`.
+- `CommonConfigure` (called via `c.CommonConfigure(...)`) handles standard configuration: collection interval (`min_collection_interval`), custom tags, service tag, etc.
+- `FinalizeCheckServiceTag()` must be called after `CommonConfigure` to apply the service tag to the sender.
+- Always call `sender.Commit()` at the end of `Run()` to flush data.
+- For multi-instance checks, `BuildID()` must be called **before** `CommonConfigure()`.
+- The `option.None[func() check.Check]()` pattern is used for platform stubs — the loader skips checks with no factory.
+- `integration.FakeConfigHash` is the constant to use in tests for the config digest parameter.
+
+## Usage
+
+- `/create-core-check` — Interactive: prompts for all details
+- `/create-core-check my_check` — Pre-fills the check name

--- a/.claude/skills/create-go-module/SKILL.md
+++ b/.claude/skills/create-go-module/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: create-go-module
+description: Create a new Go module in the agent repository
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[module-path]"
+---
+
+Create a new Go module in the datadog-agent multi-module repository. This repo has 100+ Go modules managed via `modules.yml` and inter-module `replace` directives.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the path, skip that question.
+
+1. **Module path**: The path relative to the repo root (e.g. `comp/core/mything/def`, `pkg/util/mypkg`). This becomes `github.com/DataDog/datadog-agent/<path>`.
+
+2. **Does the directory already contain Go code?**: If yes, the tool will also update dependent modules. If no, it just creates the `go.mod` and registers the module.
+
+### Step 2: Ensure clean git state
+
+The `create-module` task requires all changes to be committed. Check with `git status` and warn the user if there are uncommitted changes.
+
+### Step 3: Run the create-module task
+
+```bash
+dda inv create-module --path=<module-path>
+```
+
+This task automatically:
+- Creates `go.mod` with the correct module path and Go version
+- Adds `replace` directives for inter-module dependencies
+- Registers the module in `modules.yml` as `independent: true`
+- Runs `tidy` across all modules
+- Runs linters (`internal-deps-checker`, `check-mod-tidy`, `check-go-mod-replaces`)
+
+### Step 4: Adjust modules.yml if needed
+
+Read `modules.yml` and review the new entry. The task sets `independent: true` by default. Adjust if needed:
+
+| Field | Values | Notes |
+|---|---|---|
+| `independent` | `true`/`false` | `true` = tagged and tested independently |
+| `used_by_otel` | `true` | Set if the module is used by the OTel agent build |
+| `should_tag` | `false` | Set for internal tooling modules that shouldn't be tagged |
+| `should_test_condition` | `never`/`always` | Override test behavior |
+| `lint_targets` / `test_targets` | list of paths | Override default targets |
+
+Most modules use `default` (no special config) or just set `used_by_otel: true`.
+
+### Step 5: Report results
+
+Report whether the task succeeded or failed. If it failed, read the error output and help fix the issue.
+
+## Important Notes
+
+- All changes must be committed before running `create-module` — the task may restore files on failure.
+- After creation, the module is automatically added to `go.work` and all necessary `replace` directives are set up.
+- To see the current module list: `modules.yml` or `dda inv modules.show`.
+
+## Usage
+
+- `/create-go-module` — Interactive: prompts for the module path
+- `/create-go-module comp/core/mything/def` — Pre-fills the path

--- a/.claude/skills/create-invoke-task/SKILL.md
+++ b/.claude/skills/create-invoke-task/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: create-invoke-task
+description: Create a new Python invoke task for the dda CLI
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[namespace] [task-name]"
+---
+
+Create a new invoke task accessible via `dda inv <namespace>.<task-name>`.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides values, skip those questions.
+
+1. **Task name**: The function name (e.g. `build`, `refresh_assets`). Underscores become hyphens in the CLI.
+
+2. **Namespace**: Which task module does it belong to?
+   - **Existing module** — Add to an existing file in `tasks/` (e.g. `agent`, `linter`, `dogstatsd`). Check `tasks/__init__.py` for the full list.
+   - **New module** — Create a new `tasks/<name>.py` file and register it.
+
+3. **What does the task do?**: Brief description (becomes the docstring / help text).
+
+4. **Parameters**: What CLI flags does the task need? (name, type, default value, description)
+
+### Step 2: Read a reference
+
+Read an existing task file matching the desired complexity:
+- **Simple task** (no params): `tasks/auth.py`
+- **Task with params**: Pick any task from `tasks/agent.py` or `tasks/linter.py`
+- **Registration**: `tasks/__init__.py` — to see how modules and tasks are registered
+
+### Step 3: Create the task
+
+Add the `@task` decorated function to the appropriate file. Follow the patterns from Step 2.
+
+Key rules:
+- First parameter is always `ctx` (the invoke `Context`)
+- Use `ctx.run("command")` to execute shell commands
+- Docstring first line = short description shown in `dda inv --list`
+- Import from `invoke`: `task`, `Exit` (for errors), `Context`
+
+### Step 4: Register (new modules only)
+
+If you created a new module file, edit `tasks/__init__.py`:
+
+1. Add the import in the `from tasks import (...)` block (alphabetical order)
+2. Register it:
+   - **As a namespace** (most common): `ns.add_collection(<module>)` — creates `dda inv <module>.<task>`
+   - **As a root task**: `ns.add_task(<task>)` — creates `dda inv <task>`
+
+If adding to an existing module, no registration is needed — invoke auto-discovers `@task` functions.
+
+### Step 5: Verify
+
+Test the task:
+```bash
+dda inv <namespace>.<task-name> --help
+```
+
+## Usage
+
+- `/create-invoke-task` — Interactive: prompts for all details
+- `/create-invoke-task agent my-task` — Pre-fills namespace and name

--- a/.claude/skills/create-release-note/SKILL.md
+++ b/.claude/skills/create-release-note/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: create-release-note
+description: Create a reno release note for a PR or change
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[topic]"
+---
+
+Create a release note file using the reno format. Release notes are **mandatory** for all PRs unless labeled `changelog/no-changelog`.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the topic, skip that question.
+
+1. **Topic**: A short kebab-case identifier for the change (e.g. `fix-ntp-timeout`, `add-gpu-metrics`). Used in the filename.
+
+2. **Section**: Which section does this change belong to?
+   - `features` — New functionality (e.g. "Add support for GPU metrics collection")
+   - `enhancements` — Small improvements to existing features (e.g. "Improve log rotation performance")
+   - `fixes` — Bug fixes (e.g. "Fix memory leak in forwarder")
+   - `deprecations` — Deprecation notices (e.g. "Deprecate `log_enabled` in favor of `logs_enabled`")
+   - `upgrade` — Breaking changes requiring user action (must include steps for users to identify if affected)
+   - `security` — Security fixes or improvements
+   - `issues` — Known issues or limitations
+   - `other` — Miscellaneous (rarely used)
+
+3. **Content**: A user-facing description of the change. This is read by customers, not developers. Ask the user to describe what changed and why.
+
+4. **Target**: Which release notes directory?
+   - `releasenotes/notes/` — Main agent (default, most common)
+   - `releasenotes-dca/notes/` — Cluster Agent (DCA)
+   - `releasenotes-installscript/notes/` — Install script
+
+5. **APM-related?**: If the change affects `cmd/trace-agent` or `pkg/trace`, the content must be prefixed with `APM : ` and the topic should be prefixed with `apm-`.
+
+### Step 2: Create the release note file
+
+Generate the file using reno:
+
+```bash
+reno new <topic> --no-edit
+```
+
+Or for non-default directories:
+```bash
+reno --rel-notes-dir <directory> new <topic> --no-edit
+```
+
+This creates a file at `<directory>/notes/<topic>-<hash>.yaml` with a template.
+
+Then **replace the template content** with only the relevant section. Remove all unused sections (don't leave them commented out — reno template comments are noisy).
+
+**Final file format:**
+
+```yaml
+---
+<section>:
+  - |
+    Description of the change written for end users.
+    Can span multiple lines.
+```
+
+### Step 3: Content formatting rules
+
+Release note content must follow these rules:
+
+1. **ReStructuredText (RST) format**, NOT Markdown:
+   - Links: `` `link text <https://example.com>`_ `` (NOT `[text](url)`)
+   - Bold: `**text**`
+   - Inline code: ``` ``code`` ``` (double backticks, NOT single)
+   - Code blocks: use `.. code-block:: <lang>` directive
+
+2. **User-facing language**: Write for Datadog customers, not developers. Describe the impact, not the implementation.
+
+3. **Self-contained**: Each note must be readable independently. Don't reference other release notes.
+
+4. **For APM changes**: Prefix with `APM : ` (e.g. `APM : Fix trace sampling rate calculation`).
+
+5. **Multiple items**: Use separate list items in the same section:
+   ```yaml
+   fixes:
+     - |
+       Fix memory leak when collecting Docker container metrics.
+     - |
+       Fix panic in log agent when file is rotated during read.
+   ```
+
+### Step 4: Verify
+
+Run the release note linter to validate:
+
+```bash
+dda inv linter.releasenote
+```
+
+This checks:
+- Valid YAML structure
+- Only known sections are used
+- No empty items
+- Valid RST formatting (no Markdown patterns)
+- No Markdown links `[text](url)`, headers `#`, or single-backtick code
+
+If linting fails, fix the issues and re-run.
+
+## Section Guidelines
+
+| Section | When to use | Example |
+|---|---|---|
+| `features` | Wholly new capabilities | "Add Windows support for the Process Agent" |
+| `enhancements` | Improvements too small to be features | "Add PDH data to Windows flare" |
+| `fixes` | Bug fixes | "Fix EC2 tags collection with multiple marketplaces" |
+| `deprecations` | Deprecation notices | "The `log_enabled` config option is deprecated, use `logs_enabled`" |
+| `upgrade` | Breaking changes needing user action | "The `--config` flag format has changed. Users must update..." |
+| `security` | Security fixes | "Enforce bearer token authentication for API endpoints" |
+| `issues` | Known issues | "Kubernetes 1.3 is not fully supported in this release" |
+| `other` | Misc (rarely used) | "Update internal CI tooling" |
+
+## When to skip (use `changelog/no-changelog` label)
+
+- Documentation-only changes
+- Test-only changes
+- CI/CD configuration changes
+- Code comment changes
+- Developer tooling changes that don't affect the agent binary
+
+## Usage
+
+- `/create-release-note` — Interactive: prompts for all details
+- `/create-release-note fix-ntp-timeout` — Pre-fills the topic

--- a/.claude/skills/create-runtime-setting/SKILL.md
+++ b/.claude/skills/create-runtime-setting/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: create-runtime-setting
+description: Create a new RuntimeSetting that can be changed at runtime via `agent config set/get` and the config API
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[setting-name]"
+---
+
+Create a new RuntimeSetting implementation for the Datadog Agent. RuntimeSettings are settings that can be read and changed at runtime via:
+- The CLI: `agent config get <setting>`, `agent config set <setting> <value>`, `agent config list-runtime`
+- The HTTP API: `GET /config/{setting}`, `POST /config/{setting}`
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the setting name, skip that question.
+
+1. **Setting name** (the config key, e.g. `log_payloads`, `dogstatsd_stats`): the name used to register and access the setting via the API.
+
+2. **Value type**: What type of value does this setting hold?
+   - Boolean (true/false)
+   - Integer
+   - String
+   - String slice (list of strings)
+
+3. **Description**: A human-readable description of what this setting controls (shown in `/config/list-runtime`).
+
+4. **Hidden**: Should this setting be hidden from the public runtime settings list? (default: false)
+
+5. **Scope**: Where should this setting live?
+   - **Shared** (`pkg/config/settings/`) — Used by multiple agent services (agent, trace-agent, process-agent, etc.)
+   - **Agent-specific** (`cmd/agent/subcommands/run/internal/settings/`) — Only used by the core agent
+
+6. **Config key**: The `datadog.yaml` config key this setting maps to (e.g. `log_payloads`, `internal_profiling.enabled`). Often the same as the setting name, but can differ.
+
+7. **Which services should register it**: Ask which services should have this setting registered:
+   - Core Agent (`cmd/agent/subcommands/run/command.go`)
+   - Cluster Agent (`cmd/cluster-agent/subcommands/start/command.go`)
+   - Trace Agent (`cmd/trace-agent/subcommands/run/command.go`)
+   - Process Agent (`cmd/process-agent/subcommands/run/command.go`)
+   - Security Agent (`cmd/security-agent/subcommands/runtime/command.go`)
+   - System Probe (`cmd/system-probe/subcommands/run/command.go`)
+   - DogStatsD (`cmd/dogstatsd/subcommands/start/command.go`)
+
+### Step 2: Create the RuntimeSetting implementation file
+
+Based on the collected information, create the implementation file.
+
+**File naming convention**: `runtime_setting_<feature_name>.go`
+
+**File location**:
+- Shared: `pkg/config/settings/runtime_setting_<feature>.go`
+- Agent-specific: `cmd/agent/subcommands/run/internal/settings/runtime_setting_<feature>.go`
+
+Use this template, adapting it based on the value type:
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package settings
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+// <StructName>RuntimeSetting wraps operations to change <description> at runtime.
+type <StructName>RuntimeSetting struct {
+	ConfigKey string
+}
+
+// New<StructName>RuntimeSetting returns a new <StructName>RuntimeSetting
+func New<StructName>RuntimeSetting() *<StructName>RuntimeSetting {
+	return &<StructName>RuntimeSetting{ConfigKey: "<config_key>"}
+}
+
+// Description returns the runtime setting's description
+func (s *<StructName>RuntimeSetting) Description() string {
+	return "<description>"
+}
+
+// Hidden returns whether this setting is hidden from the list of runtime settings
+func (s *<StructName>RuntimeSetting) Hidden() bool {
+	return <true|false>
+}
+
+// Name returns the name of the runtime setting
+func (s *<StructName>RuntimeSetting) Name() string {
+	return s.ConfigKey
+}
+
+// Get returns the current value of the runtime setting
+func (s *<StructName>RuntimeSetting) Get(config config.Component) (interface{}, error) {
+	return config.Get<Type>(s.ConfigKey), nil
+}
+
+// Set changes the value of the runtime setting
+func (s *<StructName>RuntimeSetting) Set(config config.Component, v interface{}, source model.Source) error {
+	var newValue <type>
+	var err error
+
+	if newValue, err = Get<Type>(v); err != nil {
+		return fmt.Errorf("<StructName>RuntimeSetting: %v", err)
+	}
+
+	config.Set(s.ConfigKey, newValue, source)
+	return nil
+}
+```
+
+**Type-specific patterns for Set/Get**:
+
+- **Boolean**: Use `GetBool(v)` helper from `pkg/config/settings`, `config.GetBool(key)` for Get
+- **Integer**: Use `GetInt(v)` helper from `pkg/config/settings`, `config.GetInt(key)` for Get
+- **String**: Use type assertion `v.(string)`, `config.GetString(key)` for Get
+- **String slice**: Use `config.GetStringSlice(key)` for Get
+
+For **agent-specific** settings, the import path for the helper functions changes:
+```go
+import (
+    settings "github.com/DataDog/datadog-agent/pkg/config/settings"
+)
+// Then use: settings.GetBool(v), settings.GetInt(v)
+```
+
+### Step 3: Create a unit test file
+
+Create a test file alongside the implementation: `runtime_setting_<feature>_test.go`
+
+The test should verify:
+- `Get` returns the correct value from config
+- `Set` with a valid value updates the config
+- `Set` with a string representation works (e.g. "true"/"false" for bools, string numbers for ints)
+- `Set` with an invalid value returns an error
+- `Description()` returns the expected string
+- `Hidden()` returns the expected value
+- `Name()` returns the expected name
+
+For shared settings (in `pkg/config/settings/`), use this simpler test pattern with `configmock`:
+
+```go
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/comp/core"
+)
+
+func Test<StructName>RuntimeSetting(t *testing.T) {
+	config := fxutil.Test[config.Component](t, core.MockBundle())
+	s := New<StructName>RuntimeSetting()
+
+	// Test metadata
+	assert.Equal(t, "<config_key>", s.Name())
+	assert.Equal(t, "<description>", s.Description())
+	assert.Equal(t, <true|false>, s.Hidden())
+
+	// Test Set and Get
+	err := s.Set(config, <valid_value>, model.SourceCLI)
+	require.NoError(t, err)
+	v, err := s.Get(config)
+	require.NoError(t, err)
+	assert.Equal(t, <expected_value>, v)
+
+	// Test Set with string representation
+	err = s.Set(config, "<string_value>", model.SourceCLI)
+	require.NoError(t, err)
+	v, err = s.Get(config)
+	require.NoError(t, err)
+	assert.Equal(t, <expected_value>, v)
+}
+```
+
+### Step 4: Register the setting
+
+Find the `settings.Params` provider in the appropriate `command.go` file(s) for each selected service. Add the new setting to the `Settings` map:
+
+```go
+"<setting_name>": commonsettings.New<StructName>RuntimeSetting(),
+```
+
+For shared settings, the import alias is typically `commonsettings`:
+```go
+commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
+```
+
+For agent-specific settings, the import alias is typically `internalsettings`:
+```go
+internalsettings "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run/internal/settings"
+```
+
+### Step 5: Verify
+
+1. Run the new test:
+   ```bash
+   dda inv test --targets=<package_path>
+   ```
+
+2. Run the linter on changed files:
+   ```bash
+   dda inv linter.go
+   ```
+
+3. Report the results to the user. If tests or linting fail, fix the issues.
+
+## Important Notes
+
+- The `RuntimeSetting` interface is defined in `comp/core/settings/component.go`
+- Helper functions `GetBool` and `GetInt` are in `pkg/config/settings/runtime_setting.go`
+- All `Set` methods receive a `model.Source` parameter for config source tracking — always pass it through to `config.Set()`
+- Settings are exposed via HTTP at `/config/{setting_name}` (GET to read, POST to write) and via the CLI: `agent config get <setting>`, `agent config set <setting> <value>`, `agent config list-runtime`
+- Follow existing code style: use the same comment patterns, error formatting, and naming conventions as existing RuntimeSettings
+
+## Usage
+
+- `/create-runtime-setting` — Interactive: prompts for all details
+- `/create-runtime-setting my_new_setting` — Pre-fills the setting name, prompts for the rest

--- a/.claude/skills/create-status-provider/SKILL.md
+++ b/.claude/skills/create-status-provider/SKILL.md
@@ -7,271 +7,50 @@ argument-hint: "[provider-name]"
 
 Add a new status provider to the Datadog Agent. Status providers contribute sections to the `agent status` output in JSON, plain text, and HTML formats.
 
-## Provider Types
-
-There are two provider interfaces defined in `comp/core/status/component.go`:
-
-- **Provider** — Regular status section. Grouped by `Section()`, sorted alphabetically by `Name()` within each section.
-- **HeaderProvider** — Appears at the top of the status output, ordered by `Index()`. Used for critical agent-wide info (hostname, version, etc.). Rarely needed for new features.
-
 ## Instructions
 
 ### Step 1: Gather information from the user
 
 Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the provider name, skip that question.
 
-1. **Provider name**: Display name for this status section (e.g. `"DogStatsD"`, `"Forwarder"`, `"APM Agent"`).
-
-2. **Section name**: Grouping key for the section. Providers with the same section are grouped together. Often matches the provider name. Note: `"collector"` is a special section that always appears first.
-
-3. **What data to display**: What information should this status section show? (metrics, state, counts, configuration values, etc.)
-
-4. **Placement**: Where should the provider live?
-   - **Inside an existing component** — Add to the component's `Provides` struct (most common)
-   - **Standalone module** — Create a new status sub-package (for larger/independent status sections)
-
+1. **Provider name**: Display name for this status section (e.g. `"DogStatsD"`, `"Forwarder"`).
+2. **Section name**: Grouping key. Providers with the same section are grouped. `"collector"` always appears first.
+3. **What data to display**: What information should this section show?
+4. **Placement**: Inside an existing component's `Provides` struct (most common) or standalone module?
 5. **Conditional?**: Should the provider only appear when a feature is enabled?
 
-### Step 2: Implement the status provider
+### Step 2: Read reference examples
 
-#### File structure
+Before writing any code, read the appropriate reference files to follow existing patterns:
 
-For a standalone status module:
-```
-comp/<bundle>/<component>/status/
-├── statusimpl/
-│   ├── status.go
-│   └── status_templates/
-│       ├── <name>.tmpl        # Text template
-│       └── <name>HTML.tmpl    # HTML template
-```
-
-For adding to an existing component, create the templates directory alongside the implementation and add the provider to the existing `Provides` struct.
-
-#### Provider implementation
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package statusimpl
-
-import (
-	"embed"
-	"io"
-
-	"github.com/DataDog/datadog-agent/comp/core/status"
-)
-
-//go:embed status_templates
-var templatesFS embed.FS
-
-type statusProvider struct {
-	// Add fields for data sources (config, component references, etc.)
-}
-
-func (s statusProvider) Name() string {
-	return "<ProviderName>"
-}
-
-func (s statusProvider) Section() string {
-	return "<SectionName>"
-}
-
-func (s statusProvider) JSON(_ bool, stats map[string]interface{}) error {
-	s.populateStatus(stats)
-	return nil
-}
-
-func (s statusProvider) Text(_ bool, buffer io.Writer) error {
-	return status.RenderText(templatesFS, "<name>.tmpl", buffer, s.getStatusInfo())
-}
-
-func (s statusProvider) HTML(_ bool, buffer io.Writer) error {
-	return status.RenderHTML(templatesFS, "<name>HTML.tmpl", buffer, s.getStatusInfo())
-}
-
-func (s statusProvider) getStatusInfo() map[string]interface{} {
-	stats := make(map[string]interface{})
-	s.populateStatus(stats)
-	return stats
-}
-
-func (s statusProvider) populateStatus(stats map[string]interface{}) {
-	// Gather data and populate the stats map
-	// Example:
-	// stats["myFeatureStats"] = map[string]interface{}{
-	//     "enabled": true,
-	//     "count":   42,
-	// }
-}
-```
-
-**Key points:**
-- `JSON()` populates an existing `stats` map (shared across all providers)
-- `Text()` and `HTML()` render into a buffer using templates
-- `getStatusInfo()` creates a fresh map for template rendering
-- `populateStatus()` is shared between JSON and template rendering
-- The `verbose` parameter can be used to include extra detail
-
-#### Conditional provider
-
-To conditionally include a provider (e.g., only when a feature is enabled):
-
-```go
-func newProvider(config config.Component) status.Provider {
-	if !config.GetBool("my_feature.enabled") {
-		return nil // Returning nil excludes the provider from status output
-	}
-	return statusProvider{config: config}
-}
-```
-
-### Step 3: Create text and HTML templates
-
-Templates are stored in a `status_templates/` directory and embedded via `//go:embed`.
-
-#### Text template (`status_templates/<name>.tmpl`)
-
-```
-{{- if .myFeatureStats -}}
-==========
-My Feature
-==========
-  Enabled: {{.myFeatureStats.enabled}}
-  Items processed: {{humanize .myFeatureStats.count}}
-  {{- if .myFeatureStats.lastError}}
-  Last Error: {{.myFeatureStats.lastError}}
-  {{- end}}
-
-{{- end -}}
-```
-
-#### HTML template (`status_templates/<name>HTML.tmpl`)
-
-```
-{{- if .myFeatureStats -}}
-<div class="stat">
-  <span class="stat_title">My Feature</span>
-  <span class="stat_data">
-    Enabled: {{.myFeatureStats.enabled}}<br>
-    Items processed: {{humanize .myFeatureStats.count}}<br>
-    {{- if .myFeatureStats.lastError}}
-    Last Error: {{.myFeatureStats.lastError}}<br>
-    {{- end}}
-  </span>
-</div>
-{{- end -}}
-```
-
-#### Available template helper functions
-
-Defined in `comp/core/status/render_helpers.go`:
-
-| Function | Description |
+| What | Reference file |
 |---|---|
-| `humanize` | Format large numbers with commas |
-| `humanizeDuration` | Format durations readably |
-| `formatUnixTime` | Format Unix timestamp |
-| `formatTitle` | Split camelCase into words |
-| `status` | Format check status with colors |
-| `redText`, `yellowText`, `greenText` | Colored text (text templates) |
-| `formatJSON` | Pretty-print a value as JSON |
-| `percent` | Format as percentage |
-| `printDashes` | Print separator dashes |
-| `add` | Add two integers |
-| `doNotEscape` | Mark HTML as safe (HTML templates only) |
+| Provider interface | `comp/core/status/component.go` |
+| Provider implementation + templates | `comp/dogstatsd/status/statusimpl/status.go` and its `status_templates/` directory |
+| Registration in component Provides | `comp/trace/status/statusimpl/status.go` |
+| Template helpers (humanize, etc.) | `comp/core/status/render_helpers.go` |
+
+### Step 3: Implement the provider
+
+Create the provider implementation following the reference. Also create the `status_templates/<name>.tmpl` and `status_templates/<name>HTML.tmpl` files following the templates in the reference's `status_templates/` directory.
+
+To make a provider conditional, return `nil` from the constructor when the feature is disabled.
 
 ### Step 4: Register the provider
 
-#### Option A: Add to an existing component's Provides struct
-
-This is the most common pattern. Add `status.InformationProvider` to the component's `Provides`:
-
-```go
-import "github.com/DataDog/datadog-agent/comp/core/status"
-
-type Provides struct {
-	fx.Out
-
-	Comp           mycomponent.Component
-	StatusProvider status.InformationProvider
-}
-
-func NewComponent(deps Requires) (Provides, error) {
-	instance := &myImpl{/* ... */}
-	return Provides{
-		Comp:           instance,
-		StatusProvider: status.NewInformationProvider(statusProvider{/* deps */}),
-	}, nil
-}
-```
-
-The `status.InformationProvider` wrapper uses fx group injection (`group:"status"`) so it's automatically collected by the status component.
-
-#### Option B: Standalone status module
-
-Create a dedicated module function:
-
-```go
-package statusimpl
-
-import (
-	"go.uber.org/fx"
-
-	"github.com/DataDog/datadog-agent/comp/core/status"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-)
-
-func Module() fxutil.Module {
-	return fxutil.Component(
-		fx.Provide(newProvider),
-	)
-}
-
-type dependencies struct {
-	fx.In
-	Config config.Component
-}
-
-type provides struct {
-	fx.Out
-	StatusProvider status.InformationProvider
-}
-
-func newProvider(deps dependencies) provides {
-	return provides{
-		StatusProvider: status.NewInformationProvider(statusProvider{config: deps.Config}),
-	}
-}
-```
-
-Then add `statusimpl.Module()` to the relevant bundle's `Bundle()` function.
+Register using `status.NewInformationProvider(yourProvider{...})` — either in an existing component's `Provides` struct (most common) or as a standalone `Module()`. The reference files show both patterns.
 
 ### Step 5: Verify
 
-1. Build:
-   ```bash
-   dda inv agent.build --build-exclude=systemd
-   ```
-
-2. Run the linter:
-   ```bash
-   dda inv linter.go
-   ```
-
-3. Report the results to the user. If the build or linting fails, fix the issues.
+1. Build: `dda inv agent.build --build-exclude=systemd`
+2. Lint: `dda inv linter.go`
+3. Report the results to the user.
 
 ## Important Notes
 
-- The `status.RenderText` and `status.RenderHTML` functions read templates from the embedded filesystem at path `status_templates/<filename>`. The directory name must be exactly `status_templates`.
-- Template data is always `map[string]interface{}`. Use a top-level key (e.g. `"myFeatureStats"`) to namespace your data within the shared stats map.
-- The `verbose` bool parameter is passed to all three methods. Use it to conditionally include more detail.
-- Sections are sorted alphabetically, except `"collector"` which always appears first.
-- Providers within the same section are sorted alphabetically by `Name()`.
-- For `HeaderProvider`, use `NewHeaderInformationProvider()` instead and the `Index()` method controls ordering (lower = higher on page).
+- Template directory must be named exactly `status_templates` and embedded via `//go:embed status_templates`.
+- Use a top-level key (e.g. `"myFeatureStats"`) to namespace data in the shared stats map.
+- For `HeaderProvider` (rarely needed), use `NewHeaderInformationProvider()` instead.
 
 ## Usage
 

--- a/.claude/skills/create-status-provider/SKILL.md
+++ b/.claude/skills/create-status-provider/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: create-status-provider
+description: Add a new section to the agent status output (agent status command)
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[provider-name]"
+---
+
+Add a new status provider to the Datadog Agent. Status providers contribute sections to the `agent status` output in JSON, plain text, and HTML formats.
+
+## Provider Types
+
+There are two provider interfaces defined in `comp/core/status/component.go`:
+
+- **Provider** — Regular status section. Grouped by `Section()`, sorted alphabetically by `Name()` within each section.
+- **HeaderProvider** — Appears at the top of the status output, ordered by `Index()`. Used for critical agent-wide info (hostname, version, etc.). Rarely needed for new features.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides the provider name, skip that question.
+
+1. **Provider name**: Display name for this status section (e.g. `"DogStatsD"`, `"Forwarder"`, `"APM Agent"`).
+
+2. **Section name**: Grouping key for the section. Providers with the same section are grouped together. Often matches the provider name. Note: `"collector"` is a special section that always appears first.
+
+3. **What data to display**: What information should this status section show? (metrics, state, counts, configuration values, etc.)
+
+4. **Placement**: Where should the provider live?
+   - **Inside an existing component** — Add to the component's `Provides` struct (most common)
+   - **Standalone module** — Create a new status sub-package (for larger/independent status sections)
+
+5. **Conditional?**: Should the provider only appear when a feature is enabled?
+
+### Step 2: Implement the status provider
+
+#### File structure
+
+For a standalone status module:
+```
+comp/<bundle>/<component>/status/
+├── statusimpl/
+│   ├── status.go
+│   └── status_templates/
+│       ├── <name>.tmpl        # Text template
+│       └── <name>HTML.tmpl    # HTML template
+```
+
+For adding to an existing component, create the templates directory alongside the implementation and add the provider to the existing `Provides` struct.
+
+#### Provider implementation
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package statusimpl
+
+import (
+	"embed"
+	"io"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+)
+
+//go:embed status_templates
+var templatesFS embed.FS
+
+type statusProvider struct {
+	// Add fields for data sources (config, component references, etc.)
+}
+
+func (s statusProvider) Name() string {
+	return "<ProviderName>"
+}
+
+func (s statusProvider) Section() string {
+	return "<SectionName>"
+}
+
+func (s statusProvider) JSON(_ bool, stats map[string]interface{}) error {
+	s.populateStatus(stats)
+	return nil
+}
+
+func (s statusProvider) Text(_ bool, buffer io.Writer) error {
+	return status.RenderText(templatesFS, "<name>.tmpl", buffer, s.getStatusInfo())
+}
+
+func (s statusProvider) HTML(_ bool, buffer io.Writer) error {
+	return status.RenderHTML(templatesFS, "<name>HTML.tmpl", buffer, s.getStatusInfo())
+}
+
+func (s statusProvider) getStatusInfo() map[string]interface{} {
+	stats := make(map[string]interface{})
+	s.populateStatus(stats)
+	return stats
+}
+
+func (s statusProvider) populateStatus(stats map[string]interface{}) {
+	// Gather data and populate the stats map
+	// Example:
+	// stats["myFeatureStats"] = map[string]interface{}{
+	//     "enabled": true,
+	//     "count":   42,
+	// }
+}
+```
+
+**Key points:**
+- `JSON()` populates an existing `stats` map (shared across all providers)
+- `Text()` and `HTML()` render into a buffer using templates
+- `getStatusInfo()` creates a fresh map for template rendering
+- `populateStatus()` is shared between JSON and template rendering
+- The `verbose` parameter can be used to include extra detail
+
+#### Conditional provider
+
+To conditionally include a provider (e.g., only when a feature is enabled):
+
+```go
+func newProvider(config config.Component) status.Provider {
+	if !config.GetBool("my_feature.enabled") {
+		return nil // Returning nil excludes the provider from status output
+	}
+	return statusProvider{config: config}
+}
+```
+
+### Step 3: Create text and HTML templates
+
+Templates are stored in a `status_templates/` directory and embedded via `//go:embed`.
+
+#### Text template (`status_templates/<name>.tmpl`)
+
+```
+{{- if .myFeatureStats -}}
+==========
+My Feature
+==========
+  Enabled: {{.myFeatureStats.enabled}}
+  Items processed: {{humanize .myFeatureStats.count}}
+  {{- if .myFeatureStats.lastError}}
+  Last Error: {{.myFeatureStats.lastError}}
+  {{- end}}
+
+{{- end -}}
+```
+
+#### HTML template (`status_templates/<name>HTML.tmpl`)
+
+```
+{{- if .myFeatureStats -}}
+<div class="stat">
+  <span class="stat_title">My Feature</span>
+  <span class="stat_data">
+    Enabled: {{.myFeatureStats.enabled}}<br>
+    Items processed: {{humanize .myFeatureStats.count}}<br>
+    {{- if .myFeatureStats.lastError}}
+    Last Error: {{.myFeatureStats.lastError}}<br>
+    {{- end}}
+  </span>
+</div>
+{{- end -}}
+```
+
+#### Available template helper functions
+
+Defined in `comp/core/status/render_helpers.go`:
+
+| Function | Description |
+|---|---|
+| `humanize` | Format large numbers with commas |
+| `humanizeDuration` | Format durations readably |
+| `formatUnixTime` | Format Unix timestamp |
+| `formatTitle` | Split camelCase into words |
+| `status` | Format check status with colors |
+| `redText`, `yellowText`, `greenText` | Colored text (text templates) |
+| `formatJSON` | Pretty-print a value as JSON |
+| `percent` | Format as percentage |
+| `printDashes` | Print separator dashes |
+| `add` | Add two integers |
+| `doNotEscape` | Mark HTML as safe (HTML templates only) |
+
+### Step 4: Register the provider
+
+#### Option A: Add to an existing component's Provides struct
+
+This is the most common pattern. Add `status.InformationProvider` to the component's `Provides`:
+
+```go
+import "github.com/DataDog/datadog-agent/comp/core/status"
+
+type Provides struct {
+	fx.Out
+
+	Comp           mycomponent.Component
+	StatusProvider status.InformationProvider
+}
+
+func NewComponent(deps Requires) (Provides, error) {
+	instance := &myImpl{/* ... */}
+	return Provides{
+		Comp:           instance,
+		StatusProvider: status.NewInformationProvider(statusProvider{/* deps */}),
+	}, nil
+}
+```
+
+The `status.InformationProvider` wrapper uses fx group injection (`group:"status"`) so it's automatically collected by the status component.
+
+#### Option B: Standalone status module
+
+Create a dedicated module function:
+
+```go
+package statusimpl
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fx.Provide(newProvider),
+	)
+}
+
+type dependencies struct {
+	fx.In
+	Config config.Component
+}
+
+type provides struct {
+	fx.Out
+	StatusProvider status.InformationProvider
+}
+
+func newProvider(deps dependencies) provides {
+	return provides{
+		StatusProvider: status.NewInformationProvider(statusProvider{config: deps.Config}),
+	}
+}
+```
+
+Then add `statusimpl.Module()` to the relevant bundle's `Bundle()` function.
+
+### Step 5: Verify
+
+1. Build:
+   ```bash
+   dda inv agent.build --build-exclude=systemd
+   ```
+
+2. Run the linter:
+   ```bash
+   dda inv linter.go
+   ```
+
+3. Report the results to the user. If the build or linting fails, fix the issues.
+
+## Important Notes
+
+- The `status.RenderText` and `status.RenderHTML` functions read templates from the embedded filesystem at path `status_templates/<filename>`. The directory name must be exactly `status_templates`.
+- Template data is always `map[string]interface{}`. Use a top-level key (e.g. `"myFeatureStats"`) to namespace your data within the shared stats map.
+- The `verbose` bool parameter is passed to all three methods. Use it to conditionally include more detail.
+- Sections are sorted alphabetically, except `"collector"` which always appears first.
+- Providers within the same section are sorted alphabetically by `Name()`.
+- For `HeaderProvider`, use `NewHeaderInformationProvider()` instead and the `Index()` method controls ordering (lower = higher on page).
+
+## Usage
+
+- `/create-status-provider` — Interactive: prompts for all details
+- `/create-status-provider "My Feature"` — Pre-fills the provider name

--- a/.claude/skills/create-subcommand/SKILL.md
+++ b/.claude/skills/create-subcommand/SKILL.md
@@ -7,18 +7,16 @@ argument-hint: "[agent] [subcommand-name]"
 
 Add a new CLI subcommand to a Datadog Agent binary. Each agent binary uses Cobra commands registered via a central `subcommands.go` file.
 
-## Agent Binaries & Their Command Packages
+## Agent Binaries
 
-| Agent | Command package | Subcommands dir | Registration file |
-|---|---|---|---|
-| Core Agent | `cmd/agent/command` | `cmd/agent/subcommands/` | `cmd/agent/subcommands/subcommands.go` |
-| Cluster Agent | `cmd/cluster-agent/command` | `cmd/cluster-agent/subcommands/` | `cmd/cluster-agent/subcommands/subcommands.go` |
-| Process Agent | `cmd/process-agent/command` | `cmd/process-agent/subcommands/` | `cmd/process-agent/subcommands/subcommands.go` |
-| Security Agent | `cmd/security-agent/command` | `cmd/security-agent/subcommands/` | `cmd/security-agent/subcommands/subcommands.go` |
-| System Probe | `cmd/system-probe/command` | `cmd/system-probe/subcommands/` | `cmd/system-probe/subcommands/subcommands.go` |
-| DogStatsD | `cmd/dogstatsd/command` | `cmd/dogstatsd/subcommands/` | `cmd/dogstatsd/subcommands/subcommands.go` |
-
-Each agent defines a `GlobalParams` struct and a `SubcommandFactory` type in its command package.
+| Agent | Subcommands dir | Registration file |
+|---|---|---|
+| Core Agent | `cmd/agent/subcommands/` | `cmd/agent/subcommands/subcommands.go` |
+| Cluster Agent | `cmd/cluster-agent/subcommands/` | `cmd/cluster-agent/subcommands/subcommands.go` |
+| Process Agent | `cmd/process-agent/subcommands/` | `cmd/process-agent/subcommands/subcommands.go` |
+| Security Agent | `cmd/security-agent/subcommands/` | `cmd/security-agent/subcommands/subcommands.go` |
+| System Probe | `cmd/system-probe/subcommands/` | `cmd/system-probe/subcommands/subcommands.go` |
+| DogStatsD | `cmd/dogstatsd/subcommands/` | `cmd/dogstatsd/subcommands/subcommands.go` |
 
 ## Instructions
 
@@ -26,280 +24,37 @@ Each agent defines a `GlobalParams` struct and a `SubcommandFactory` type in its
 
 Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides values, skip those questions.
 
-1. **Target agent**: Which agent binary should this subcommand be added to? (Core Agent is most common)
+1. **Target agent**: Which agent binary? (Core Agent is most common)
+2. **Subcommand name**: e.g. `health`, `hostname`, `flare`
+3. **Description**: What does the subcommand do?
+4. **Complexity**: Simple (no Fx, e.g. `version`) or with config/IPC (`fxutil.OneShot`, e.g. `hostname`)?
+5. **Shared across agents?**: Yes → `pkg/cli/subcommands/<name>/`, No → `cmd/<agent>/subcommands/<name>/`
 
-2. **Subcommand name**: The command name (e.g. `health`, `hostname`, `flare`).
+### Step 2: Read reference examples
 
-3. **Description**: What does the subcommand do? (used for `Short` in cobra.Command)
+Read the reference matching the chosen pattern, plus the target agent's registration file:
 
-4. **Complexity level**: This determines the pattern to use:
-   - **Simple** — No Fx components needed. Pure logic, prints output, exits. (e.g. `version`)
-   - **With config/IPC** — Needs agent configuration and/or to query the running agent via IPC. Uses `fxutil.OneShot` with `core.Bundle()`. (e.g. `hostname`, `health`)
+| Pattern | Reference file |
+|---|---|
+| Simple (no Fx) | `cmd/agent/subcommands/version/command.go` |
+| With config/IPC | `cmd/agent/subcommands/hostname/command.go` |
+| Shared across agents | `pkg/cli/subcommands/health/command.go` + `cmd/agent/subcommands/health/command.go` |
 
-5. **Shared across agents?**: Should the implementation be shared with other agent binaries?
-   - **Yes** — Create shared implementation in `pkg/cli/subcommands/<name>/`
-   - **No** — Implement directly in `cmd/<agent>/subcommands/<name>/`
+Also read the target agent's `command/command.go` for available `GlobalParams` fields.
 
-6. **Flags**: Does the subcommand need any CLI flags? If so, what are their names, types, defaults, and descriptions?
+### Step 3: Create the subcommand
 
-### Step 2: Create the subcommand package
+Create `cmd/<agent>/subcommands/<name>/command.go` following the reference patterns exactly.
 
-Create the directory and `command.go` file.
+### Step 4: Register
 
-#### Pattern A: Simple command (no Fx)
-
-For commands that don't need config, logging, or IPC.
-
-**File:** `cmd/<agent>/subcommands/<name>/command.go`
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package <name>
-
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
-)
-
-// Commands returns the subcommand.
-func Commands(_ *command.GlobalParams) []*cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "<name>",
-		Short: "<description>",
-		Long:  `<longer description>`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			// Implementation here
-			fmt.Println("output")
-			return nil
-		},
-	}
-	return []*cobra.Command{cmd}
-}
-```
-
-#### Pattern B: Command with Fx components (config/IPC)
-
-For commands that need to load config, use logging, or query the running agent.
-
-**File:** `cmd/<agent>/subcommands/<name>/command.go`
-
-```go
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package <name>
-
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-	"go.uber.org/fx"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
-	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-)
-
-type cliParams struct {
-	*command.GlobalParams
-	logLevelDefaultOff command.LogLevelDefaultOff
-	// Add custom flags here
-}
-
-// Commands returns the subcommand.
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cliParams := &cliParams{
-		GlobalParams: globalParams,
-	}
-
-	cmd := &cobra.Command{
-		Use:   "<name>",
-		Short: "<description>",
-		Long:  `<longer description>`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fxutil.OneShot(run,
-				fx.Supply(cliParams),
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath,
-						config.WithExtraConfFiles(globalParams.ExtraConfFilePath),
-						config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
-					LogParams: log.ForOneShot(command.LoggerName, cliParams.logLevelDefaultOff.Value(), true),
-				}),
-				core.Bundle(),
-				secretsnoopfx.Module(),
-				ipcfx.ModuleReadOnly(),
-			)
-		},
-	}
-
-	cliParams.logLevelDefaultOff.Register(cmd)
-	// Add custom flags:
-	// cmd.Flags().BoolVarP(&cliParams.myFlag, "flag-name", "f", false, "flag description")
-
-	return []*cobra.Command{cmd}
-}
-
-func run(_ log.Component, _ config.Component, cliParams *cliParams, client ipc.HTTPClient) error {
-	// Implementation here
-	// Use client.NewIPCEndpoint("/agent/<endpoint>") to query the running agent
-	fmt.Println("output")
-	return nil
-}
-```
-
-**IPC module variants** (pick the right one):
-- `ipcfx.ModuleReadOnly()` — Read-only IPC client (most common for subcommands)
-- `ipcfx.ModuleInsecure()` — Insecure IPC (for commands not needing auth)
-- `ipcfx.Module()` — Full secure IPC client
-
-#### Pattern C: Shared implementation
-
-If the command is shared across multiple agents, create the core logic in `pkg/cli/subcommands/<name>/command.go` with its own `GlobalParams` struct, then create thin wrappers per agent.
-
-**Shared impl:** `pkg/cli/subcommands/<name>/command.go`
-```go
-package <name>
-
-import (
-	"github.com/spf13/cobra"
-	"go.uber.org/fx"
-
-	"github.com/DataDog/datadog-agent/comp/core"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-)
-
-// GlobalParams contains the values of agent-level configuration passed in by each agent binary.
-type GlobalParams struct {
-	ConfFilePath string
-	ConfigName   string
-	LoggerName   string
-}
-
-// MakeCommand returns a *cobra.Command for this subcommand.
-func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "<name>",
-		Short: "<description>",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			globalParams := globalParamsGetter()
-			return fxutil.OneShot(run,
-				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath,
-						config.WithConfigName(globalParams.ConfigName)),
-					LogParams: log.ForOneShot(globalParams.LoggerName, "off", true),
-				}),
-				core.Bundle(),
-			)
-		},
-	}
-	return cmd
-}
-
-func run(_ log.Component, _ config.Component) error {
-	// Shared implementation
-	return nil
-}
-```
-
-**Agent wrapper:** `cmd/agent/subcommands/<name>/command.go`
-```go
-package <name>
-
-import (
-	"github.com/spf13/cobra"
-
-	"github.com/DataDog/datadog-agent/cmd/agent/command"
-	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/<name>"
-)
-
-// Commands returns the subcommand.
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
-	cmd := <name>.MakeCommand(func() <name>.GlobalParams {
-		return <name>.GlobalParams{
-			ConfFilePath: globalParams.ConfFilePath,
-			ConfigName:   command.ConfigName,
-			LoggerName:   command.LoggerName,
-		}
-	})
-	return []*cobra.Command{cmd}
-}
-```
-
-### Step 3: Register the subcommand
-
-Edit the agent's `subcommands.go` file to import and register the new command.
-
-1. Add an import with the `cmd<Name>` alias convention:
-   ```go
-   cmd<Name> "github.com/DataDog/datadog-agent/cmd/<agent>/subcommands/<name>"
-   ```
-
-2. Add `cmd<Name>.Commands` to the factory slice returned by the registration function (e.g. `AgentSubcommands()`).
-
-### Step 4: Add flags (if needed)
-
-Add flags in the `Commands` function before returning:
-
-```go
-// Boolean flag
-cmd.Flags().BoolVarP(&cliParams.verbose, "verbose", "v", false, "Enable verbose output")
-
-// String flag
-cmd.Flags().StringVarP(&cliParams.output, "output", "o", "", "Output file path")
-
-// Int flag
-cmd.Flags().IntVarP(&cliParams.timeout, "timeout", "t", 30, "Timeout in seconds")
-
-// Persistent flag (inherited by subcommands)
-cmd.PersistentFlags().BoolVarP(&cliParams.json, "json", "j", false, "Output as JSON")
-```
-
-For log level override (common pattern), use:
-```go
-cliParams.logLevelDefaultOff.Register(cmd)
-```
+Edit the agent's `subcommands.go`: add an import with the `cmd<Name>` alias convention and add `cmd<Name>.Commands` to the factory slice. Follow the existing entries.
 
 ### Step 5: Verify
 
-1. Build:
-   ```bash
-   dda inv agent.build --build-exclude=systemd
-   ```
-
-2. Test the command:
-   ```bash
-   ./bin/agent/agent <name> --help
-   ```
-
-3. Run the linter:
-   ```bash
-   dda inv linter.go
-   ```
-
-4. Report the results to the user.
-
-## Important Notes
-
-- The `fxutil.OneShot` pattern runs the Fx dependency injection container, calls the handler function, then shuts down. It's the standard pattern for CLI commands that do one thing and exit.
-- The handler function's parameters are injected by Fx — declare what you need (log, config, IPC client, etc.) and Fx provides them.
-- `command.LogLevelDefaultOff` is a helper that adds a `--log_level` flag defaulting to `"off"` — useful for subcommands that shouldn't produce log output by default.
-- Each agent has slightly different `GlobalParams` fields. Always check the target agent's `command/command.go` for available fields.
+1. Build: `dda inv agent.build --build-exclude=systemd`
+2. Test: `./bin/agent/agent <name> --help`
+3. Lint: `dda inv linter.go`
 
 ## Usage
 

--- a/.claude/skills/create-subcommand/SKILL.md
+++ b/.claude/skills/create-subcommand/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: create-subcommand
+description: Add a new CLI subcommand to an agent binary (agent, cluster-agent, etc.)
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+argument-hint: "[agent] [subcommand-name]"
+---
+
+Add a new CLI subcommand to a Datadog Agent binary. Each agent binary uses Cobra commands registered via a central `subcommands.go` file.
+
+## Agent Binaries & Their Command Packages
+
+| Agent | Command package | Subcommands dir | Registration file |
+|---|---|---|---|
+| Core Agent | `cmd/agent/command` | `cmd/agent/subcommands/` | `cmd/agent/subcommands/subcommands.go` |
+| Cluster Agent | `cmd/cluster-agent/command` | `cmd/cluster-agent/subcommands/` | `cmd/cluster-agent/subcommands/subcommands.go` |
+| Process Agent | `cmd/process-agent/command` | `cmd/process-agent/subcommands/` | `cmd/process-agent/subcommands/subcommands.go` |
+| Security Agent | `cmd/security-agent/command` | `cmd/security-agent/subcommands/` | `cmd/security-agent/subcommands/subcommands.go` |
+| System Probe | `cmd/system-probe/command` | `cmd/system-probe/subcommands/` | `cmd/system-probe/subcommands/subcommands.go` |
+| DogStatsD | `cmd/dogstatsd/command` | `cmd/dogstatsd/subcommands/` | `cmd/dogstatsd/subcommands/subcommands.go` |
+
+Each agent defines a `GlobalParams` struct and a `SubcommandFactory` type in its command package.
+
+## Instructions
+
+### Step 1: Gather information from the user
+
+Use `AskUserQuestion` to collect the following. If `$ARGUMENTS` provides values, skip those questions.
+
+1. **Target agent**: Which agent binary should this subcommand be added to? (Core Agent is most common)
+
+2. **Subcommand name**: The command name (e.g. `health`, `hostname`, `flare`).
+
+3. **Description**: What does the subcommand do? (used for `Short` in cobra.Command)
+
+4. **Complexity level**: This determines the pattern to use:
+   - **Simple** — No Fx components needed. Pure logic, prints output, exits. (e.g. `version`)
+   - **With config/IPC** — Needs agent configuration and/or to query the running agent via IPC. Uses `fxutil.OneShot` with `core.Bundle()`. (e.g. `hostname`, `health`)
+
+5. **Shared across agents?**: Should the implementation be shared with other agent binaries?
+   - **Yes** — Create shared implementation in `pkg/cli/subcommands/<name>/`
+   - **No** — Implement directly in `cmd/<agent>/subcommands/<name>/`
+
+6. **Flags**: Does the subcommand need any CLI flags? If so, what are their names, types, defaults, and descriptions?
+
+### Step 2: Create the subcommand package
+
+Create the directory and `command.go` file.
+
+#### Pattern A: Simple command (no Fx)
+
+For commands that don't need config, logging, or IPC.
+
+**File:** `cmd/<agent>/subcommands/<name>/command.go`
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package <name>
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+)
+
+// Commands returns the subcommand.
+func Commands(_ *command.GlobalParams) []*cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "<name>",
+		Short: "<description>",
+		Long:  `<longer description>`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// Implementation here
+			fmt.Println("output")
+			return nil
+		},
+	}
+	return []*cobra.Command{cmd}
+}
+```
+
+#### Pattern B: Command with Fx components (config/IPC)
+
+For commands that need to load config, use logging, or query the running agent.
+
+**File:** `cmd/<agent>/subcommands/<name>/command.go`
+
+```go
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package <name>
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
+	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+type cliParams struct {
+	*command.GlobalParams
+	logLevelDefaultOff command.LogLevelDefaultOff
+	// Add custom flags here
+}
+
+// Commands returns the subcommand.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cliParams := &cliParams{
+		GlobalParams: globalParams,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "<name>",
+		Short: "<description>",
+		Long:  `<longer description>`,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fxutil.OneShot(run,
+				fx.Supply(cliParams),
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath,
+						config.WithExtraConfFiles(globalParams.ExtraConfFilePath),
+						config.WithFleetPoliciesDirPath(globalParams.FleetPoliciesDirPath)),
+					LogParams: log.ForOneShot(command.LoggerName, cliParams.logLevelDefaultOff.Value(), true),
+				}),
+				core.Bundle(),
+				secretsnoopfx.Module(),
+				ipcfx.ModuleReadOnly(),
+			)
+		},
+	}
+
+	cliParams.logLevelDefaultOff.Register(cmd)
+	// Add custom flags:
+	// cmd.Flags().BoolVarP(&cliParams.myFlag, "flag-name", "f", false, "flag description")
+
+	return []*cobra.Command{cmd}
+}
+
+func run(_ log.Component, _ config.Component, cliParams *cliParams, client ipc.HTTPClient) error {
+	// Implementation here
+	// Use client.NewIPCEndpoint("/agent/<endpoint>") to query the running agent
+	fmt.Println("output")
+	return nil
+}
+```
+
+**IPC module variants** (pick the right one):
+- `ipcfx.ModuleReadOnly()` — Read-only IPC client (most common for subcommands)
+- `ipcfx.ModuleInsecure()` — Insecure IPC (for commands not needing auth)
+- `ipcfx.Module()` — Full secure IPC client
+
+#### Pattern C: Shared implementation
+
+If the command is shared across multiple agents, create the core logic in `pkg/cli/subcommands/<name>/command.go` with its own `GlobalParams` struct, then create thin wrappers per agent.
+
+**Shared impl:** `pkg/cli/subcommands/<name>/command.go`
+```go
+package <name>
+
+import (
+	"github.com/spf13/cobra"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// GlobalParams contains the values of agent-level configuration passed in by each agent binary.
+type GlobalParams struct {
+	ConfFilePath string
+	ConfigName   string
+	LoggerName   string
+}
+
+// MakeCommand returns a *cobra.Command for this subcommand.
+func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "<name>",
+		Short: "<description>",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			globalParams := globalParamsGetter()
+			return fxutil.OneShot(run,
+				fx.Supply(core.BundleParams{
+					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath,
+						config.WithConfigName(globalParams.ConfigName)),
+					LogParams: log.ForOneShot(globalParams.LoggerName, "off", true),
+				}),
+				core.Bundle(),
+			)
+		},
+	}
+	return cmd
+}
+
+func run(_ log.Component, _ config.Component) error {
+	// Shared implementation
+	return nil
+}
+```
+
+**Agent wrapper:** `cmd/agent/subcommands/<name>/command.go`
+```go
+package <name>
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/<name>"
+)
+
+// Commands returns the subcommand.
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cmd := <name>.MakeCommand(func() <name>.GlobalParams {
+		return <name>.GlobalParams{
+			ConfFilePath: globalParams.ConfFilePath,
+			ConfigName:   command.ConfigName,
+			LoggerName:   command.LoggerName,
+		}
+	})
+	return []*cobra.Command{cmd}
+}
+```
+
+### Step 3: Register the subcommand
+
+Edit the agent's `subcommands.go` file to import and register the new command.
+
+1. Add an import with the `cmd<Name>` alias convention:
+   ```go
+   cmd<Name> "github.com/DataDog/datadog-agent/cmd/<agent>/subcommands/<name>"
+   ```
+
+2. Add `cmd<Name>.Commands` to the factory slice returned by the registration function (e.g. `AgentSubcommands()`).
+
+### Step 4: Add flags (if needed)
+
+Add flags in the `Commands` function before returning:
+
+```go
+// Boolean flag
+cmd.Flags().BoolVarP(&cliParams.verbose, "verbose", "v", false, "Enable verbose output")
+
+// String flag
+cmd.Flags().StringVarP(&cliParams.output, "output", "o", "", "Output file path")
+
+// Int flag
+cmd.Flags().IntVarP(&cliParams.timeout, "timeout", "t", 30, "Timeout in seconds")
+
+// Persistent flag (inherited by subcommands)
+cmd.PersistentFlags().BoolVarP(&cliParams.json, "json", "j", false, "Output as JSON")
+```
+
+For log level override (common pattern), use:
+```go
+cliParams.logLevelDefaultOff.Register(cmd)
+```
+
+### Step 5: Verify
+
+1. Build:
+   ```bash
+   dda inv agent.build --build-exclude=systemd
+   ```
+
+2. Test the command:
+   ```bash
+   ./bin/agent/agent <name> --help
+   ```
+
+3. Run the linter:
+   ```bash
+   dda inv linter.go
+   ```
+
+4. Report the results to the user.
+
+## Important Notes
+
+- The `fxutil.OneShot` pattern runs the Fx dependency injection container, calls the handler function, then shuts down. It's the standard pattern for CLI commands that do one thing and exit.
+- The handler function's parameters are injected by Fx — declare what you need (log, config, IPC client, etc.) and Fx provides them.
+- `command.LogLevelDefaultOff` is a helper that adds a `--log_level` flag defaulting to `"off"` — useful for subcommands that shouldn't produce log output by default.
+- Each agent has slightly different `GlobalParams` fields. Always check the target agent's `command/command.go` for available fields.
+
+## Usage
+
+- `/create-subcommand` — Interactive: prompts for all details
+- `/create-subcommand agent my-command` — Pre-fills agent and name


### PR DESCRIPTION
### What does this PR do?

Add Claude skills to guide the creation of a new component, new config fields, new runtime settings, new changelog entries, etc.

### Motivation

E.g. for the components skill, empower Claude to create components, avoiding the legacy structure, and make it a smoother experience. 

