### PR TITLE
APM: add lib to agent connection type tag

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -46,7 +46,7 @@ func ConfigHandler(r *api.HTTPReceiver, cf rcclient.ConfigFetcher, cfg *config.A
 	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())
-		tags := r.TagStats(api.V07, req.Header, "").AsTags()
+		tags := r.TagStats(api.V07, req, "").AsTags()
 		statusCode := http.StatusOK
 		defer func() {
 			tags = append(tags, fmt.Sprintf("status_code:%d", statusCode))

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -489,11 +489,13 @@ const (
 
 // TagStats returns the stats and tags coinciding with the information found in header.
 // For more information, check the "Datadog-Meta-*" HTTP headers defined in this file.
-func (r *HTTPReceiver) TagStats(v Version, header http.Header, service string) *info.TagStats {
-	return r.tagStats(v, header, service)
+func (r *HTTPReceiver) TagStats(v Version, req *http.Request, service string) *info.TagStats {
+	return r.tagStats(v, req, service)
 }
 
-func (r *HTTPReceiver) tagStats(v Version, httpHeader http.Header, service string) *info.TagStats {
+func (r *HTTPReceiver) tagStats(v Version, req *http.Request, service string) *info.TagStats {
+	httpHeader := req.Header
+	connectionType := GetConnectionType(req.Context())
 	return r.Stats.GetTagStats(info.Tags{
 		Lang:            httpHeader.Get(header.Lang),
 		LangVersion:     httpHeader.Get(header.LangVersion),
@@ -501,6 +503,7 @@ func (r *HTTPReceiver) tagStats(v Version, httpHeader http.Header, service strin
 		LangVendor:      httpHeader.Get(header.LangInterpreterVendor),
 		TracerVersion:   httpHeader.Get(header.TracerVersion),
 		EndpointVersion: string(v),
+		ConnectionType:  string(connectionType),
 		Service:         service,
 	})
 }
@@ -615,7 +618,7 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 	in := &pb.ClientStatsPayload{}
 	if err := msgp.Decode(rd, in); err != nil {
 		log.Errorf("Error decoding pb.ClientStatsPayload: %v", err)
-		tags := append(r.tagStats(V06, req.Header, "").AsTags(), "reason:decode")
+		tags := append(r.tagStats(V06, req, "").AsTags(), "reason:decode")
 		_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload_rejected", 1, tags, 1)
 		httpDecodingError(err, []string{"handler:stats", "codec:msgpack", "v:v0.6"}, w, r.statsd)
 		return
@@ -628,7 +631,7 @@ func (r *HTTPReceiver) handleStats(w http.ResponseWriter, req *http.Request) {
 		return cs.Stats[0].Stats[0].Service
 	}
 
-	ts := r.tagStats(V06, req.Header, firstService(in))
+	ts := r.tagStats(V06, req, firstService(in))
 	_ = r.statsd.Count("datadog.trace_agent.receiver.stats_payload", 1, ts.AsTags(), 1)
 	_ = r.statsd.Count("datadog.trace_agent.receiver.stats_bytes", rd.Count, ts.AsTags(), 1)
 	_ = r.statsd.Count("datadog.trace_agent.receiver.stats_buckets", int64(len(in.Stats)), ts.AsTags(), 1)
@@ -667,7 +670,7 @@ func (r *HTTPReceiver) handleTracesV1(w http.ResponseWriter, req *http.Request) 
 		// Either the client closed the connection, or we hit a middleware timeout
 		log.Debugf("request context timed out, payload dropped")
 		w.WriteHeader(http.StatusTooManyRequests)
-		r.tagStats(V10, req.Header, "").PayloadTimeout.Inc()
+		r.tagStats(V10, req, "").PayloadTimeout.Inc()
 		return
 	case <-time.After(time.Duration(r.conf.DecoderTimeout) * time.Millisecond):
 		log.Debugf("trace-agent is overwhelmed, a payload has been rejected")
@@ -675,7 +678,7 @@ func (r *HTTPReceiver) handleTracesV1(w http.ResponseWriter, req *http.Request) 
 		io.Copy(io.Discard, req.Body) //nolint:errcheck
 		w.WriteHeader(http.StatusTooManyRequests)
 		r.replyOK(req, V10, w)
-		r.tagStats(V10, req.Header, "").PayloadRefused.Inc()
+		r.tagStats(V10, req, "").PayloadRefused.Inc()
 		return
 	}
 	defer func() {
@@ -693,7 +696,7 @@ func (r *HTTPReceiver) handleTracesV1(w http.ResponseWriter, req *http.Request) 
 
 	start := time.Now()
 	tp, err := r.decodeTracerPayloadV1(req, r.containerIDProvider, r.conf)
-	ts := r.tagStats(V10, req.Header, firstService(tp))
+	ts := r.tagStats(V10, req, firstService(tp))
 	defer func(err error) {
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		_ = r.statsd.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)
@@ -766,7 +769,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		// Either the client closed the connection, or we hit a middleware timeout
 		log.Debugf("request context timed out, payload dropped")
 		w.WriteHeader(http.StatusTooManyRequests)
-		r.tagStats(v, req.Header, "").PayloadTimeout.Inc()
+		r.tagStats(v, req, "").PayloadTimeout.Inc()
 		return
 	case <-time.After(time.Duration(r.conf.DecoderTimeout) * time.Millisecond):
 		log.Debugf("trace-agent is overwhelmed, a payload has been rejected")
@@ -784,7 +787,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 			w.WriteHeader(r.rateLimiterResponse)
 		}
 		r.replyOK(req, v, w)
-		r.tagStats(v, req.Header, "").PayloadRefused.Inc()
+		r.tagStats(v, req, "").PayloadRefused.Inc()
 		return
 	}
 	defer func() {
@@ -802,7 +805,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 
 	start := time.Now()
 	tp, err := r.decodeTracerPayload(v, req, r.containerIDProvider, req.Header.Get(header.Lang), req.Header.Get(header.LangVersion), req.Header.Get(header.TracerVersion))
-	ts := r.tagStats(v, req.Header, firstService(tp))
+	ts := r.tagStats(v, req, firstService(tp))
 	defer func(err error) {
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		_ = r.statsd.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1234,7 +1234,7 @@ func TestHandleTraces(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 
 		// Get initial PayloadTimeout count
-		ts := receiver.tagStats(v04, req.Header, "")
+		ts := receiver.tagStats(v04, req, "")
 		initialTimeout := ts.PayloadTimeout.Load()
 
 		handler.ServeHTTP(rr, req)
@@ -1284,7 +1284,7 @@ func TestHandleTraces(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		ts := receiver.tagStats(V10, req.Header, "")
+		ts := receiver.tagStats(V10, req, "")
 		initialTimeout := ts.PayloadTimeout.Load()
 
 		handler.ServeHTTP(rr, req)

--- a/pkg/trace/api/connection_type.go
+++ b/pkg/trace/api/connection_type.go
@@ -17,6 +17,8 @@ const (
 	ConnectionTypeUDS ConnectionType = "uds"
 	// ConnectionTypePipe indicates a Windows named pipe connection.
 	ConnectionTypePipe ConnectionType = "pipe"
+	// ConnectionTypeUnknown indicates an unknown connection type (should not happen).
+	ConnectionTypeUnknown ConnectionType = "unknown"
 )
 
 type connectionTypeKey struct{}

--- a/pkg/trace/api/connection_type.go
+++ b/pkg/trace/api/connection_type.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package api
+
+import "context"
+
+// ConnectionType represents the type of network transport used for a connection.
+type ConnectionType string
+
+const (
+	// ConnectionTypeTCP indicates a TCP connection.
+	ConnectionTypeTCP ConnectionType = "tcp"
+	// ConnectionTypeUDS indicates a Unix Domain Socket connection.
+	ConnectionTypeUDS ConnectionType = "uds"
+	// ConnectionTypePipe indicates a Windows named pipe connection.
+	ConnectionTypePipe ConnectionType = "pipe"
+)
+
+type connectionTypeKey struct{}
+
+// withConnectionType stores the connection type in the context.
+func withConnectionType(ctx context.Context, ct ConnectionType) context.Context {
+	return context.WithValue(ctx, connectionTypeKey{}, ct)
+}
+
+// GetConnectionType retrieves the connection type from the context.
+// Returns an empty string if not set.
+func GetConnectionType(ctx context.Context) ConnectionType {
+	if ct, ok := ctx.Value(connectionTypeKey{}).(ConnectionType); ok {
+		return ct
+	}
+	return ""
+}

--- a/pkg/trace/api/connection_type_nix_test.go
+++ b/pkg/trace/api/connection_type_nix_test.go
@@ -52,3 +52,6 @@ func TestConnContextConnectionTypeUnix(t *testing.T) {
 		assert.Equal(t, ConnectionTypeUnknown, GetConnectionType(ctx))
 	})
 }
+
+// fakeConn implements net.Conn for testing the default/pipe branch.
+type fakeConn struct{ net.Conn }

--- a/pkg/trace/api/connection_type_nix_test.go
+++ b/pkg/trace/api/connection_type_nix_test.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build !windows
+
+package api
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnContextConnectionTypeUnix(t *testing.T) {
+
+	t.Run("uds connection", func(t *testing.T) {
+		sockPath := "/tmp/test-transport.sock"
+		os.Remove(sockPath)
+		t.Cleanup(func() { os.Remove(sockPath) })
+		ln, err := net.Listen("unix", sockPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+
+		done := make(chan net.Conn, 1)
+		go func() {
+			c, _ := ln.Accept()
+			done <- c
+		}()
+		clientConn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer clientConn.Close()
+		serverConn := <-done
+		defer serverConn.Close()
+
+		ctx := connContext(context.Background(), serverConn)
+		assert.Equal(t, ConnectionTypeUDS, GetConnectionType(ctx))
+	})
+
+	t.Run("unknown connection type defaults to ConnectionTypeUnknown", func(t *testing.T) {
+		// A connection type that is neither *net.TCPConn nor *net.UnixConn
+		// should fall through to the default case (ConnectionTypeUnknown on unix).
+		ctx := connContext(context.Background(), &fakeConn{})
+		assert.Equal(t, ConnectionTypeUnknown, GetConnectionType(ctx))
+	})
+}

--- a/pkg/trace/api/connection_type_test.go
+++ b/pkg/trace/api/connection_type_test.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package api
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConnectionType(t *testing.T) {
+	t.Run("empty context", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Equal(t, ConnectionType(""), GetConnectionType(ctx))
+	})
+
+	t.Run("tcp", func(t *testing.T) {
+		ctx := withConnectionType(context.Background(), ConnectionTypeTCP)
+		assert.Equal(t, ConnectionTypeTCP, GetConnectionType(ctx))
+	})
+
+	t.Run("uds", func(t *testing.T) {
+		ctx := withConnectionType(context.Background(), ConnectionTypeUDS)
+		assert.Equal(t, ConnectionTypeUDS, GetConnectionType(ctx))
+	})
+
+	t.Run("pipe", func(t *testing.T) {
+		ctx := withConnectionType(context.Background(), ConnectionTypePipe)
+		assert.Equal(t, ConnectionTypePipe, GetConnectionType(ctx))
+	})
+}
+
+func TestConnContextConnectionType(t *testing.T) {
+	t.Run("tcp connection", func(t *testing.T) {
+		// Create a real TCP listener/connection pair
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+
+		done := make(chan net.Conn, 1)
+		go func() {
+			c, _ := ln.Accept()
+			done <- c
+		}()
+		clientConn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer clientConn.Close()
+		serverConn := <-done
+		defer serverConn.Close()
+
+		ctx := connContext(context.Background(), serverConn)
+		assert.Equal(t, ConnectionTypeTCP, GetConnectionType(ctx))
+	})
+
+	t.Run("tcp connection wrapped in onCloseConn", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+
+		done := make(chan net.Conn, 1)
+		go func() {
+			c, _ := ln.Accept()
+			done <- c
+		}()
+		clientConn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer clientConn.Close()
+		serverConn := <-done
+		defer serverConn.Close()
+
+		wrapped := OnCloseConn(serverConn, func() {})
+		ctx := connContext(context.Background(), wrapped)
+		assert.Equal(t, ConnectionTypeTCP, GetConnectionType(ctx))
+	})
+
+	t.Run("uds connection", func(t *testing.T) {
+		sockPath := "/tmp/test-transport.sock"
+		os.Remove(sockPath)
+		t.Cleanup(func() { os.Remove(sockPath) })
+		ln, err := net.Listen("unix", sockPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ln.Close()
+
+		done := make(chan net.Conn, 1)
+		go func() {
+			c, _ := ln.Accept()
+			done <- c
+		}()
+		clientConn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer clientConn.Close()
+		serverConn := <-done
+		defer serverConn.Close()
+
+		ctx := connContext(context.Background(), serverConn)
+		assert.Equal(t, ConnectionTypeUDS, GetConnectionType(ctx))
+	})
+
+	t.Run("unknown connection defaults to pipe", func(t *testing.T) {
+		// A connection type that is neither *net.TCPConn nor *net.UnixConn
+		// should fall through to the default case (pipe).
+		ctx := connContext(context.Background(), &fakeConn{})
+		assert.Equal(t, ConnectionTypePipe, GetConnectionType(ctx))
+	})
+}
+
+// fakeConn implements net.Conn for testing the default/pipe branch.
+type fakeConn struct{ net.Conn }

--- a/pkg/trace/api/connection_type_test.go
+++ b/pkg/trace/api/connection_type_test.go
@@ -61,6 +61,3 @@ func TestConnContextConnectionType(t *testing.T) {
 		assert.Equal(t, ConnectionTypeTCP, GetConnectionType(ctx))
 	})
 }
-
-// fakeConn implements net.Conn for testing the default/pipe branch.
-type fakeConn struct{ net.Conn }

--- a/pkg/trace/api/container.go
+++ b/pkg/trace/api/container.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
@@ -28,7 +29,11 @@ func connContext(ctx context.Context, c net.Conn) context.Context {
 	case *net.TCPConn:
 		return withConnectionType(ctx, ConnectionTypeTCP)
 	default:
-		return withConnectionType(ctx, ConnectionTypePipe)
+		if runtime.GOOS == "windows" {
+			return withConnectionType(ctx, ConnectionTypePipe)
+		} else {
+			return withConnectionType(ctx, ConnectionTypeUnknown)
+		}
 	}
 }
 

--- a/pkg/trace/api/container.go
+++ b/pkg/trace/api/container.go
@@ -31,9 +31,8 @@ func connContext(ctx context.Context, c net.Conn) context.Context {
 	default:
 		if runtime.GOOS == "windows" {
 			return withConnectionType(ctx, ConnectionTypePipe)
-		} else {
-			return withConnectionType(ctx, ConnectionTypeUnknown)
 		}
+		return withConnectionType(ctx, ConnectionTypeUnknown)
 	}
 }
 

--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -40,7 +40,7 @@ func connContext(ctx context.Context, c net.Conn) context.Context {
 	case *net.TCPConn:
 		ctx = withConnectionType(ctx, ConnectionTypeTCP)
 	default:
-		ctx = withConnectionType(ctx, ConnectionTypePipe)
+		ctx = withConnectionType(ctx, ConnectionTypeUnknown)
 	}
 	s, ok := c.(*net.UnixConn)
 	if !ok {

--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -34,6 +34,14 @@ func connContext(ctx context.Context, c net.Conn) context.Context {
 	if oc, ok := c.(*onCloseConn); ok {
 		c = oc.Conn
 	}
+	switch c.(type) {
+	case *net.UnixConn:
+		ctx = withConnectionType(ctx, ConnectionTypeUDS)
+	case *net.TCPConn:
+		ctx = withConnectionType(ctx, ConnectionTypeTCP)
+	default:
+		ctx = withConnectionType(ctx, ConnectionTypePipe)
+	}
 	s, ok := c.(*net.UnixConn)
 	if !ok {
 		return ctx

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -573,6 +573,7 @@ func TestPublishReceiverStats(t *testing.T) {
 		[]interface{}{map[string]interface{}{
 			"ClientDroppedP0Spans":  8.0,
 			"ClientDroppedP0Traces": 7.0,
+			"ConnectionType":        "",
 			"EndpointVersion":       "",
 			"EventsExtracted":       13.0,
 			"EventsSampled":         14.0,

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -525,6 +525,7 @@ func (ts *TagStats) WarnString() string {
 type Tags struct {
 	Lang, LangVersion, LangVendor, Interpreter, TracerVersion string
 	EndpointVersion                                           string
+	ConnectionType                                            string
 	Service                                                   string
 }
 
@@ -550,6 +551,9 @@ func (t *Tags) toArray() []string {
 	}
 	if t.EndpointVersion != "" {
 		tags = append(tags, "endpoint_version:"+t.EndpointVersion)
+	}
+	if t.ConnectionType != "" {
+		tags = append(tags, "connection_type:"+t.ConnectionType)
 	}
 	if t.Service != "" {
 		tags = append(tags, "service:"+t.Service)

--- a/releasenotes/notes/apm-add-connection-type-tag-484173efde8e031e.yaml
+++ b/releasenotes/notes/apm-add-connection-type-tag-484173efde8e031e.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Agent's metric now include a connection_type tag with the value being either
-    ``tcp``, ``uds`` or ``pipe`` for the lib to agent communications
+    Agent metrics now include a ``connection_type`` tag with a value of
+    ``tcp``, ``uds``, or ``pipe`` for lib-to-agent communications.

--- a/releasenotes/notes/apm-add-connection-type-tag-484173efde8e031e.yaml
+++ b/releasenotes/notes/apm-add-connection-type-tag-484173efde8e031e.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Agent's metric now include a connection_type tag with the value being either
+    ``tcp``, ``uds`` or ``pipe`` for the lib to agent communications


### PR DESCRIPTION
### What does this PR do?
- Add a connection_type tag to per-request metrics with values `tcp`, `uds`, or `pipe` (Windows).
### Motivation

### Describe how you validated your changes

### Additional Notes
