### PR TITLE
[CWS] Avoid cgroup resolver segfault

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -305,6 +305,7 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 	if !cgroupContext.IsNull() {
 		var cacheEntryFound *cgroupModel.CacheEntry
 
+		var cgroupsToClean []*cgroupModel.CacheEntry
 		cr.iterateCacheEntries(func(cacheEntry *cgroupModel.CacheEntry) bool {
 			if cacheEntry == nil {
 				return false
@@ -314,15 +315,18 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 				cacheEntry.AddPID(pid)
 				cacheEntryFound = cacheEntry
 			} else if cacheEntry.ContainsPID(pid) {
-				// the cgroup context is different, but the pid is already present in the cache entry, remove it.
-				// it means that the process has been migrated to a different cgroup.
-				if cacheEntry.RemovePID(pid) == 0 {
-					// try to sync the cgroup with the pid in order to detect the migration.
-					cr.syncOrDeleteCaheEntry(cacheEntry, pid)
-				}
+				cgroupsToClean = append(cgroupsToClean, cacheEntry)
 			}
 			return false
 		})
+		for cacheEntry := range cgroupsToClean {
+			// the cgroup context is different, but the pid is already present in the cache entry, remove it.
+			// it means that the process has been migrated to a different cgroup.
+			if cacheEntry.RemovePID(pid) == 0 {
+				// try to sync the cgroup with the pid in order to detect the migration.
+				cr.syncOrDeleteCaheEntry(cacheEntry, pid)
+			}
+		}
 
 		// found the cache entry
 		if cacheEntryFound != nil {

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -307,9 +307,6 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 
 		var cgroupsToClean []*cgroupModel.CacheEntry
 		cr.iterateCacheEntries(func(cacheEntry *cgroupModel.CacheEntry) bool {
-			if cacheEntry == nil {
-				return false
-			}
 			if cc := cacheEntry.GetCGroupContext(); cc.Equals(&cgroupContext) {
 				// if the cgroup context is the same, add the pid to the cache entry
 				cacheEntry.AddPID(pid)
@@ -319,7 +316,7 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 			}
 			return false
 		})
-		for cacheEntry := range cgroupsToClean {
+		for _, cacheEntry := range cgroupsToClean {
 			// the cgroup context is different, but the pid is already present in the cache entry, remove it.
 			// it means that the process has been migrated to a different cgroup.
 			if cacheEntry.RemovePID(pid) == 0 {

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -306,6 +306,9 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 		var cacheEntryFound *cgroupModel.CacheEntry
 
 		cr.iterateCacheEntries(func(cacheEntry *cgroupModel.CacheEntry) bool {
+			if cacheEntry == nil {
+				return false
+			}
 			if cc := cacheEntry.GetCGroupContext(); cc.Equals(&cgroupContext) {
 				// if the cgroup context is the same, add the pid to the cache entry
 				cacheEntry.AddPID(pid)


### PR DESCRIPTION
### What does this PR do?

Do not update the cgroup slice while iterating on it.

### Motivation

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1790e40]
goroutine 1073 [running]:
github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model.(*CacheEntry).GetCGroupContext(...)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model/model.go:54
github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup.(*Resolver).AddPID.func1(0x0)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/resolver.go:330 +0x20
slices.IndexFunc[...](...)
	slices/slices.go:109
slices.ContainsFunc[...](...)
	slices/slices.go:124
github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup.(*Resolver).iterateCacheEntries(0x40020fb320, 0x400181b9c8)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/resolver.go:364 +0x250
github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup.(*Resolver).AddPID(0x40020fb320, 0x24d54f, 0x1a639c, {0x3cfba80?, 0x2afb39ee?, 0x3cfba80?}, {0x0, {0x0, 0x0}, {0xe56, ...}, ...})
	github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/resolver.go:329 +0xd8
github.com/DataDog/datadog-agent/pkg/security/resolvers/process.(*EBPFResolver).insertEntry(0x4001e89e00, 0x400633f508, {0x0, {0x0, 0x0}, {0xe56, 0xb039, 0x0}, 0x0}, 0x2)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/process/resolver_ebpf.go:572 +0x188
github.com/DataDog/datadog-agent/pkg/security/resolvers/process.(*EBPFResolver).insertForkEntry(0x4001e89e00, 0x400633f508, 0x7ea53, {0x0, {0x0, 0x0}, {0xe56, 0xb039, 0x0}, 0x0}, ...)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/process/resolver_ebpf.go:621 +0x25c
github.com/DataDog/datadog-agent/pkg/security/resolvers/process.(*EBPFResolver).AddForkEntry(0x4001e89e00, 0x4004226a08, {0x0, {0x0, 0x0}, {0xe56, 0xb039, 0x0}, 0x0}, 0x400181be80)
	github.com/DataDog/datadog-agent/pkg/security/resolvers/process/resolver_ebpf.go:304 +0x128
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleBeforeProcessContext(0x400210e408, 0x4004226a08, {0x40044cb180?, 0x188, 0x40044cb180?}, 0x58, 0x188, {0x0, {0x0, 0x0}, ...}, ...)
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1634 +0x128
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent(0x400210e408, 0x0, {0x40044cb180, 0x188, 0x505})
	github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1168 +0x350
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent(0x4003162138, 0x4006a0d6a0, 0x40039f0000?, 0x400181bf30?)
	github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go:60 +0x3c
github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
	github.com/DataDog/ebpf-manager@v0.7.15/ringbuffer.go:138 +0x15c
created by github.com/DataDog/ebpf-manager.(*RingBuffer).Start in goroutine 1
	github.com/DataDog/ebpf-manager@v0.7.15/ringbuffer.go:108 +0x140
```

### Describe how you validated your changes

### Additional Notes
