### PR TITLE
Fix redundant leading slash in CODEOWNERS pattern

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 /bazel/configs/sdagent.bazelrc               @DataDog/agent-discovery
 /MODULE.bazel*                          @DataDog/agent-build
 # Temporary during Bazel migration
-/**/BUILD.bazel                         @DataDog/agent-build
+**/BUILD.bazel                          @DataDog/agent-build
 /deps/                                  @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.


### PR DESCRIPTION
### What does this PR do?
Remove the redundant leading slash from the `/**/BUILD.bazel` pattern in CODEOWNERS.

### Motivation
According to `.gitignore` pattern syntax (which CODEOWNERS follows), the pattern `**/BUILD.bazel` already matches `BUILD.bazel` files at any directory level. The leading slash is redundant and might affect the matching.

### Describe how you validated your changes
Verified against Git's official gitignore documentation which states that `**/foo` matches file or directory `foo` anywhere.

### Additional Notes
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
- https://git-scm.com/docs/gitignore