### PR TITLE
[KXP] otel: Add NodeName to CollectorManifest

### DIFF
--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator.go
@@ -126,6 +126,21 @@ func BuildManifestFromK8sResource(k8sResource map[string]interface{}, isTerminat
 
 	resourceVersion, _ := metadata["resourceVersion"].(string)
 	apiVersion, _ := k8sResource["apiVersion"].(string)
+	var nodeName string
+	switch kind {
+	case "Pod":
+		if spec, ok := k8sResource["spec"].(map[string]interface{}); ok {
+			if n, ok := spec["nodeName"].(string); ok {
+				nodeName = n
+			}
+		}
+	case "Node":
+		if n, ok := metadata["name"].(string); ok {
+			nodeName = n
+		}
+	default:
+		nodeName = ""
+	}
 
 	// Convert the Kubernetes resource to JSON bytes for the manifest content
 	content, err := json.Marshal(k8sResource)
@@ -151,6 +166,7 @@ func BuildManifestFromK8sResource(k8sResource map[string]interface{}, isTerminat
 		IsTerminated:    isTerminated,
 		ApiVersion:      apiVersion,
 		Kind:            kind,
+		NodeName:        nodeName,
 	}
 	return manifest, nil
 }

--- a/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator_test.go
+++ b/pkg/opentelemetry-mapping-go/otlp/logs/orchestrator_test.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildManifestFromK8sResource_NodeName(t *testing.T) {
+	tests := []struct {
+		name             string
+		k8sResource      map[string]interface{}
+		expectedNodeName string
+	}{
+		{
+			name: "Pod with nodeName in spec",
+			k8sResource: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"uid":             "pod-uid-123",
+					"resourceVersion": "1",
+				},
+				"spec": map[string]interface{}{
+					"nodeName": "worker-1",
+				},
+			},
+			expectedNodeName: "worker-1",
+		},
+		{
+			name: "Pod without spec",
+			k8sResource: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"uid":             "pod-uid-456",
+					"resourceVersion": "1",
+				},
+			},
+			expectedNodeName: "",
+		},
+		{
+			name: "Pod with spec but no nodeName",
+			k8sResource: map[string]interface{}{
+				"kind":       "Pod",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"uid":             "pod-uid-789",
+					"resourceVersion": "1",
+				},
+				"spec": map[string]interface{}{
+					"containers": []interface{}{},
+				},
+			},
+			expectedNodeName: "",
+		},
+		{
+			name: "Node uses metadata.name as nodeName",
+			k8sResource: map[string]interface{}{
+				"kind":       "Node",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"name":            "node-1",
+					"uid":             "node-uid-789",
+					"resourceVersion": "1",
+				},
+			},
+			expectedNodeName: "node-1",
+		},
+		{
+			name: "Node without metadata.name",
+			k8sResource: map[string]interface{}{
+				"kind":       "Node",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"uid":             "node-uid-101",
+					"resourceVersion": "1",
+				},
+			},
+			expectedNodeName: "",
+		},
+		{
+			name: "Deployment has empty nodeName",
+			k8sResource: map[string]interface{}{
+				"kind":       "Deployment",
+				"apiVersion": "apps/v1",
+				"metadata": map[string]interface{}{
+					"uid":             "deploy-uid-202",
+					"resourceVersion": "1",
+				},
+			},
+			expectedNodeName: "",
+		},
+		{
+			name: "Service has empty nodeName",
+			k8sResource: map[string]interface{}{
+				"kind":       "Service",
+				"apiVersion": "v1",
+				"metadata": map[string]interface{}{
+					"uid":             "svc-uid-303",
+					"resourceVersion": "1",
+				},
+			},
+			expectedNodeName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest, err := BuildManifestFromK8sResource(tt.k8sResource, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedNodeName, manifest.NodeName)
+		})
+	}
+}

--- a/releasenotes/notes/releasenotes-595ec2ec3e582234.yaml
+++ b/releasenotes/notes/releasenotes-595ec2ec3e582234.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add missing node name to the manifests for Kubernetes resources in the OTEL logs agent exporter.


### PR DESCRIPTION
### What does this PR do?

CAP-3427

Adding NodeName allows us to perform tag enrichment for Nodes and Terminated Pods.

Tested in a private cluster.