### PR TITLE
[WP] Serialize tracer metadata tags

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1467,6 +1467,13 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "array",
                     "description": "List of AWS Security Credentials that the process had access to"
+                },
+                "tracer": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object",
+                    "description": "Tags from an APM tracer instrumentation"
                 }
             },
             "additionalProperties": false,
@@ -1624,6 +1631,13 @@ Workload Protection events for Linux systems have the following JSON schema:
                     },
                     "type": "array",
                     "description": "List of AWS Security Credentials that the process had access to"
+                },
+                "tracer": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object",
+                    "description": "Tags from an APM tracer instrumentation"
                 },
                 "parent": {
                     "$ref": "#/$defs/Process",
@@ -4579,6 +4593,13 @@ Workload Protection events for Linux systems have the following JSON schema:
             },
             "type": "array",
             "description": "List of AWS Security Credentials that the process had access to"
+        },
+        "tracer": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "type": "object",
+            "description": "Tags from an APM tracer instrumentation"
         }
     },
     "additionalProperties": false,
@@ -4626,6 +4647,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `source` | Process source |
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |
+| `tracer` | Tags from an APM tracer instrumentation |
 
 | References |
 | ---------- |
@@ -4788,6 +4810,13 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "array",
             "description": "List of AWS Security Credentials that the process had access to"
         },
+        "tracer": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "type": "object",
+            "description": "Tags from an APM tracer instrumentation"
+        },
         "parent": {
             "$ref": "#/$defs/Process",
             "description": "Parent process"
@@ -4853,6 +4882,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `source` | Process source |
 | `syscalls` | List of syscalls captured to generate the event |
 | `aws_security_credentials` | List of AWS Security Credentials that the process had access to |
+| `tracer` | Tags from an APM tracer instrumentation |
 | `parent` | Parent process |
 | `ancestors` | Ancestor processes |
 | `variables` | Variables values |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1456,6 +1456,13 @@
           },
           "type": "array",
           "description": "List of AWS Security Credentials that the process had access to"
+        },
+        "tracer": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Tags from an APM tracer instrumentation"
         }
       },
       "additionalProperties": false,
@@ -1613,6 +1620,13 @@
           },
           "type": "array",
           "description": "List of AWS Security Credentials that the process had access to"
+        },
+        "tracer": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Tags from an APM tracer instrumentation"
         },
         "parent": {
           "$ref": "#/$defs/Process",

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -1231,6 +1231,30 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 				}
 				in.Delim(']')
 			}
+		case "tracer":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.Tracer = make(map[string]string)
+				} else {
+					out.Tracer = nil
+				}
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v18 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v18 = string(in.String())
+					}
+					(out.Tracer)[key] = v18
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -1261,14 +1285,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		}
 		{
 			out.RawByte('[')
-			for v18, v19 := range in.Ancestors {
-				if v18 > 0 {
+			for v19, v20 := range in.Ancestors {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				if v19 == nil {
+				if v20 == nil {
 					out.RawString("null")
 				} else {
-					(*v19).MarshalEasyJSON(out)
+					(*v20).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -1389,11 +1413,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v20, v21 := range in.CapsAttempted {
-				if v20 > 0 {
+			for v21, v22 := range in.CapsAttempted {
+				if v21 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v21))
+				out.String(string(v22))
 			}
 			out.RawByte(']')
 		}
@@ -1403,11 +1427,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v22, v23 := range in.CapsUsed {
-				if v22 > 0 {
+			for v23, v24 := range in.CapsUsed {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v23))
+				out.String(string(v24))
 			}
 			out.RawByte(']')
 		}
@@ -1447,11 +1471,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v24, v25 := range in.Args {
-				if v24 > 0 {
+			for v25, v26 := range in.Args {
+				if v25 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v25))
+				out.String(string(v26))
 			}
 			out.RawByte(']')
 		}
@@ -1466,11 +1490,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v26, v27 := range in.Envs {
-				if v26 > 0 {
+			for v27, v28 := range in.Envs {
+				if v27 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v27))
+				out.String(string(v28))
 			}
 			out.RawByte(']')
 		}
@@ -1507,11 +1531,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v28, v29 := range *in.Syscalls {
-				if v28 > 0 {
+			for v29, v30 := range *in.Syscalls {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v29)
+				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v30)
 			}
 			out.RawByte(']')
 		}
@@ -1521,17 +1545,36 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v30, v31 := range in.AWSSecurityCredentials {
-				if v30 > 0 {
+			for v31, v32 := range in.AWSSecurityCredentials {
+				if v31 > 0 {
 					out.RawByte(',')
 				}
-				if v31 == nil {
+				if v32 == nil {
 					out.RawString("null")
 				} else {
-					(*v31).MarshalEasyJSON(out)
+					(*v32).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
+		}
+	}
+	if len(in.Tracer) != 0 {
+		const prefix string = ",\"tracer\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('{')
+			v33First := true
+			for v33Name, v33Value := range in.Tracer {
+				if v33First {
+					v33First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v33Name))
+				out.RawByte(':')
+				out.String(string(v33Value))
+			}
+			out.RawByte('}')
 		}
 	}
 	out.RawByte('}')
@@ -1710,21 +1753,21 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(i
 					out.Flows = (out.Flows)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v32 *FlowSerializer
+					var v34 *FlowSerializer
 					if in.IsNull() {
 						in.Skip()
-						v32 = nil
+						v34 = nil
 					} else {
-						if v32 == nil {
-							v32 = new(FlowSerializer)
+						if v34 == nil {
+							v34 = new(FlowSerializer)
 						}
 						if in.IsNull() {
 							in.Skip()
 						} else {
-							(*v32).UnmarshalEasyJSON(in)
+							(*v34).UnmarshalEasyJSON(in)
 						}
 					}
-					out.Flows = append(out.Flows, v32)
+					out.Flows = append(out.Flows, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1759,14 +1802,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(o
 		}
 		{
 			out.RawByte('[')
-			for v33, v34 := range in.Flows {
-				if v33 > 0 {
+			for v35, v36 := range in.Flows {
+				if v35 > 0 {
 					out.RawByte(',')
 				}
-				if v34 == nil {
+				if v36 == nil {
 					out.RawString("null")
 				} else {
-					(*v34).MarshalEasyJSON(out)
+					(*v36).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -2052,13 +2095,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 					out.Tags = (out.Tags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v35 string
+					var v37 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v35 = string(in.String())
+						v37 = string(in.String())
 					}
-					out.Tags = append(out.Tags, v35)
+					out.Tags = append(out.Tags, v37)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2115,11 +2158,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 		}
 		{
 			out.RawByte('[')
-			for v36, v37 := range in.Tags {
-				if v36 > 0 {
+			for v38, v39 := range in.Tags {
+				if v38 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v39))
 			}
 			out.RawByte(']')
 		}
@@ -2654,13 +2697,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.MatchedRules = (out.MatchedRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v38 MatchedRuleSerializer
+					var v40 MatchedRuleSerializer
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						(v38).UnmarshalEasyJSON(in)
+						(v40).UnmarshalEasyJSON(in)
 					}
-					out.MatchedRules = append(out.MatchedRules, v38)
+					out.MatchedRules = append(out.MatchedRules, v40)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2743,11 +2786,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		}
 		{
 			out.RawByte('[')
-			for v39, v40 := range in.MatchedRules {
-				if v39 > 0 {
+			for v41, v42 := range in.MatchedRules {
+				if v41 > 0 {
 					out.RawByte(',')
 				}
-				(v40).MarshalEasyJSON(out)
+				(v42).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -2566,6 +2566,30 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 				}
 				in.Delim(']')
 			}
+		case "tracer":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.Tracer = make(map[string]string)
+				} else {
+					out.Tracer = nil
+				}
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v18 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v18 = string(in.String())
+					}
+					(out.Tracer)[key] = v18
+					in.WantComma()
+				}
+				in.Delim('}')
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2671,11 +2695,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v18, v19 := range in.CapsAttempted {
-				if v18 > 0 {
+			for v19, v20 := range in.CapsAttempted {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v19))
+				out.String(string(v20))
 			}
 			out.RawByte(']')
 		}
@@ -2685,11 +2709,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v20, v21 := range in.CapsUsed {
-				if v20 > 0 {
+			for v21, v22 := range in.CapsUsed {
+				if v21 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v21))
+				out.String(string(v22))
 			}
 			out.RawByte(']')
 		}
@@ -2729,11 +2753,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v22, v23 := range in.Args {
-				if v22 > 0 {
+			for v23, v24 := range in.Args {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v23))
+				out.String(string(v24))
 			}
 			out.RawByte(']')
 		}
@@ -2748,11 +2772,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v24, v25 := range in.Envs {
-				if v24 > 0 {
+			for v25, v26 := range in.Envs {
+				if v25 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v25))
+				out.String(string(v26))
 			}
 			out.RawByte(']')
 		}
@@ -2789,11 +2813,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v26, v27 := range *in.Syscalls {
-				if v26 > 0 {
+			for v27, v28 := range *in.Syscalls {
+				if v27 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v27)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v28)
 			}
 			out.RawByte(']')
 		}
@@ -2803,17 +2827,36 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v28, v29 := range in.AWSSecurityCredentials {
-				if v28 > 0 {
+			for v29, v30 := range in.AWSSecurityCredentials {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				if v29 == nil {
+				if v30 == nil {
 					out.RawString("null")
 				} else {
-					(*v29).MarshalEasyJSON(out)
+					(*v30).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
+		}
+	}
+	if len(in.Tracer) != 0 {
+		const prefix string = ",\"tracer\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('{')
+			v31First := true
+			for v31Name, v31Value := range in.Tracer {
+				if v31First {
+					v31First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v31Name))
+				out.RawByte(':')
+				out.String(string(v31Value))
+			}
+			out.RawByte('}')
 		}
 	}
 	out.RawByte('}')
@@ -2997,13 +3040,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 string
+					var v32 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v30 = string(in.String())
+						v32 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v30)
+					out.CapEffective = append(out.CapEffective, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3024,13 +3067,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 string
+					var v33 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v31 = string(in.String())
+						v33 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v31)
+					out.CapPermitted = append(out.CapPermitted, v33)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3138,11 +3181,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.CapEffective {
-				if v32 > 0 {
+			for v34, v35 := range in.CapEffective {
+				if v34 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v33))
+				out.String(string(v35))
 			}
 			out.RawByte(']')
 		}
@@ -3154,11 +3197,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v34, v35 := range in.CapPermitted {
-				if v34 > 0 {
+			for v36, v37 := range in.CapPermitted {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v35))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -3662,13 +3705,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 					out.Argv = (out.Argv)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v36 string
+					var v38 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v36 = string(in.String())
+						v38 = string(in.String())
 					}
-					out.Argv = append(out.Argv, v36)
+					out.Argv = append(out.Argv, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3716,11 +3759,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v37, v38 := range in.Argv {
-				if v37 > 0 {
+			for v39, v40 := range in.Argv {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v38))
+				out.String(string(v40))
 			}
 			out.RawByte(']')
 		}
@@ -3969,13 +4012,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 					out.K8SGroups = (out.K8SGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v39 string
+					var v41 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v39 = string(in.String())
+						v41 = string(in.String())
 					}
-					out.K8SGroups = append(out.K8SGroups, v39)
+					out.K8SGroups = append(out.K8SGroups, v41)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3993,34 +4036,34 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v40 []string
+					var v42 []string
 					if in.IsNull() {
 						in.Skip()
-						v40 = nil
+						v42 = nil
 					} else {
 						in.Delim('[')
-						if v40 == nil {
+						if v42 == nil {
 							if !in.IsDelim(']') {
-								v40 = make([]string, 0, 4)
+								v42 = make([]string, 0, 4)
 							} else {
-								v40 = []string{}
+								v42 = []string{}
 							}
 						} else {
-							v40 = (v40)[:0]
+							v42 = (v42)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v41 string
+							var v43 string
 							if in.IsNull() {
 								in.Skip()
 							} else {
-								v41 = string(in.String())
+								v43 = string(in.String())
 							}
-							v40 = append(v40, v41)
+							v42 = append(v42, v43)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.K8SExtra)[key] = v40
+					(out.K8SExtra)[key] = v42
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4075,11 +4118,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('[')
-			for v42, v43 := range in.K8SGroups {
-				if v42 > 0 {
+			for v44, v45 := range in.K8SGroups {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v43))
+				out.String(string(v45))
 			}
 			out.RawByte(']')
 		}
@@ -4094,24 +4137,24 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('{')
-			v44First := true
-			for v44Name, v44Value := range in.K8SExtra {
-				if v44First {
-					v44First = false
+			v46First := true
+			for v46Name, v46Value := range in.K8SExtra {
+				if v46First {
+					v46First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v44Name))
+				out.String(string(v46Name))
 				out.RawByte(':')
-				if v44Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v46Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v45, v46 := range v44Value {
-						if v45 > 0 {
+					for v47, v48 := range v46Value {
+						if v47 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v46))
+						out.String(string(v48))
 					}
 					out.RawByte(']')
 				}
@@ -4283,13 +4326,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v47 string
+					var v49 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v47 = string(in.String())
+						v49 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v47)
+					out.Flags = append(out.Flags, v49)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4400,13 +4443,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v48 string
+					var v50 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v48 = string(in.String())
+						v50 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v48)
+					out.Hashes = append(out.Hashes, v50)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4617,11 +4660,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v49, v50 := range in.Flags {
-				if v49 > 0 {
+			for v51, v52 := range in.Flags {
+				if v51 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v50))
+				out.String(string(v52))
 			}
 			out.RawByte(']')
 		}
@@ -4681,11 +4724,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v51, v52 := range in.Hashes {
-				if v51 > 0 {
+			for v53, v54 := range in.Hashes {
+				if v53 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v52))
+				out.String(string(v54))
 			}
 			out.RawByte(']')
 		}
@@ -5085,13 +5128,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v53 string
+					var v55 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v53 = string(in.String())
+						v55 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v53)
+					out.Flags = append(out.Flags, v55)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5202,13 +5245,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v54 string
+					var v56 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v54 = string(in.String())
+						v56 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v54)
+					out.Hashes = append(out.Hashes, v56)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5459,11 +5502,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v55, v56 := range in.Flags {
-				if v55 > 0 {
+			for v57, v58 := range in.Flags {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v56))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -5523,11 +5566,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v57, v58 := range in.Hashes {
-				if v57 > 0 {
+			for v59, v60 := range in.Hashes {
+				if v59 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v58))
+				out.String(string(v60))
 			}
 			out.RawByte(']')
 		}
@@ -5904,9 +5947,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 						*out.SyscallsEventSerializer = (*out.SyscallsEventSerializer)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v59 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v59)
-						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v59)
+						var v61 SyscallSerializer
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v61)
+						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v61)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -6334,11 +6377,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v60, v61 := range *in.SyscallsEventSerializer {
-				if v60 > 0 {
+			for v62, v63 := range *in.SyscallsEventSerializer {
+				if v62 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v61)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v63)
 			}
 			out.RawByte(']')
 		}
@@ -6691,13 +6734,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v62 string
+					var v64 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v62 = string(in.String())
+						v64 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v62)
+					out.CapEffective = append(out.CapEffective, v64)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6718,13 +6761,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v63 string
+					var v65 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v63 = string(in.String())
+						v65 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v63)
+					out.CapPermitted = append(out.CapPermitted, v65)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6815,11 +6858,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v64, v65 := range in.CapEffective {
-				if v64 > 0 {
+			for v66, v67 := range in.CapEffective {
+				if v66 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v65))
+				out.String(string(v67))
 			}
 			out.RawByte(']')
 		}
@@ -6831,11 +6874,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v66, v67 := range in.CapPermitted {
-				if v66 > 0 {
+			for v68, v69 := range in.CapPermitted {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v67))
+				out.String(string(v69))
 			}
 			out.RawByte(']')
 		}
@@ -6888,13 +6931,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v68 string
+					var v70 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v68 = string(in.String())
+						v70 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v68)
+					out.Hostnames = append(out.Hostnames, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6931,11 +6974,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v69, v70 := range in.Hostnames {
-				if v69 > 0 {
+			for v71, v72 := range in.Hostnames {
+				if v71 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v70))
+				out.String(string(v72))
 			}
 			out.RawByte(']')
 		}
@@ -6987,13 +7030,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v71 string
+					var v73 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v71 = string(in.String())
+						v73 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v71)
+					out.CapEffective = append(out.CapEffective, v73)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7014,13 +7057,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v72 string
+					var v74 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v72 = string(in.String())
+						v74 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v72)
+					out.CapPermitted = append(out.CapPermitted, v74)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7046,11 +7089,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v73, v74 := range in.CapEffective {
-				if v73 > 0 {
+			for v75, v76 := range in.CapEffective {
+				if v75 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v74))
+				out.String(string(v76))
 			}
 			out.RawByte(']')
 		}
@@ -7062,11 +7105,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v75, v76 := range in.CapPermitted {
-				if v75 > 0 {
+			for v77, v78 := range in.CapPermitted {
+				if v77 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v76))
+				out.String(string(v78))
 			}
 			out.RawByte(']')
 		}
@@ -7113,13 +7156,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsAttempted = (out.CapsAttempted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v77 string
+					var v79 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v77 = string(in.String())
+						v79 = string(in.String())
 					}
-					out.CapsAttempted = append(out.CapsAttempted, v77)
+					out.CapsAttempted = append(out.CapsAttempted, v79)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7140,13 +7183,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsUsed = (out.CapsUsed)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v78 string
+					var v80 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v78 = string(in.String())
+						v80 = string(in.String())
 					}
-					out.CapsUsed = append(out.CapsUsed, v78)
+					out.CapsUsed = append(out.CapsUsed, v80)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7171,11 +7214,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v79, v80 := range in.CapsAttempted {
-				if v79 > 0 {
+			for v81, v82 := range in.CapsAttempted {
+				if v81 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v80))
+				out.String(string(v82))
 			}
 			out.RawByte(']')
 		}
@@ -7190,11 +7233,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		}
 		{
 			out.RawByte('[')
-			for v81, v82 := range in.CapsUsed {
-				if v81 > 0 {
+			for v83, v84 := range in.CapsUsed {
+				if v83 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v82))
+				out.String(string(v84))
 			}
 			out.RawByte(']')
 		}
@@ -7403,13 +7446,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 					out.Helpers = (out.Helpers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v83 string
+					var v85 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v83 = string(in.String())
+						v85 = string(in.String())
 					}
-					out.Helpers = append(out.Helpers, v83)
+					out.Helpers = append(out.Helpers, v85)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7474,11 +7517,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 		}
 		{
 			out.RawByte('[')
-			for v84, v85 := range in.Helpers {
-				if v84 > 0 {
+			for v86, v87 := range in.Helpers {
+				if v86 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v85))
+				out.String(string(v87))
 			}
 			out.RawByte(']')
 		}
@@ -7739,13 +7782,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v86 string
+					var v88 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v86 = string(in.String())
+						v88 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v86)
+					out.Hostnames = append(out.Hostnames, v88)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7776,11 +7819,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v87, v88 := range in.Hostnames {
-				if v87 > 0 {
+			for v89, v90 := range in.Hostnames {
+				if v89 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v88))
+				out.String(string(v90))
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/tests/tracer_memfd_test.go
+++ b/pkg/security/tests/tracer_memfd_test.go
@@ -9,25 +9,30 @@
 package tests
 
 import (
+	"encoding/json"
 	"os/exec"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/serializers"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // tracerMemfdConsumer is a test consumer that captures TracerMemfdSeal events
 type tracerMemfdConsumer struct {
-	capturedPid   atomic.Uint32
-	capturedFd    atomic.Uint32
-	capturedTags  []string
-	capturedMutex sync.Mutex
-	eventReceived atomic.Bool
+	capturedPid            atomic.Uint32
+	capturedFd             atomic.Uint32
+	capturedTags           []string
+	capturedSerializedJSON []byte
+	capturedMutex          sync.Mutex
+	eventReceived          atomic.Bool
 }
 
 // ID returns the ID of this consumer
@@ -67,15 +72,17 @@ func (c *tracerMemfdConsumer) HandleEvent(event any) {
 	c.capturedFd.Store(ev.fd)
 	c.capturedMutex.Lock()
 	c.capturedTags = ev.tracerTags
+	c.capturedSerializedJSON = ev.serializedJSON
 	c.capturedMutex.Unlock()
 	c.eventReceived.Store(true)
 }
 
 // tracerMemfdEvent is a minimal copy of the event fields we care about
 type tracerMemfdEvent struct {
-	pid        uint32
-	fd         uint32
-	tracerTags []string
+	pid            uint32
+	fd             uint32
+	tracerTags     []string
+	serializedJSON []byte
 }
 
 // Copy returns a copy of the event for this consumer
@@ -94,6 +101,12 @@ func (c *tracerMemfdConsumer) Copy(ev *model.Event) any {
 	if len(tracerTags) > 0 {
 		event.tracerTags = make([]string, len(tracerTags))
 		copy(event.tracerTags, tracerTags)
+	}
+
+	// Serialize the event to JSON for validation
+	scrubber, err := utils.NewScrubber(nil, nil)
+	if err == nil {
+		event.serializedJSON, _ = serializers.MarshalEvent(ev, nil, scrubber)
 	}
 
 	return event
@@ -156,5 +169,38 @@ func TestTracerMemfd(t *testing.T) {
 		}
 
 		require.ElementsMatch(t, tracerTags, expectedTags, "TracerTags")
+	})
+
+	test.RunMultiMode(t, "validate-tracer-serialization", func(t *testing.T, _ wrapperType, cmd func(bin string, args []string, envs []string) *exec.Cmd) {
+		consumer.eventReceived.Store(false)
+		consumer.capturedPid.Store(0)
+		consumer.capturedFd.Store(0)
+
+		cmdExec := cmd(syscallTester, []string{"tracer-memfd"}, nil)
+		_ = cmdExec.Run()
+
+		require.Eventually(t, consumer.eventReceived.Load, 2*time.Second, 200*time.Millisecond, "tracer-memfd event should be received")
+
+		consumer.capturedMutex.Lock()
+		serializedJSON := consumer.capturedSerializedJSON
+		consumer.capturedMutex.Unlock()
+
+		require.NotEmpty(t, serializedJSON, "serialized JSON should not be empty")
+
+		// Unmarshal the serialized event and validate the tracer field
+		var data map[string]interface{}
+		err := json.Unmarshal(serializedJSON, &data)
+		require.NoError(t, err, "failed to unmarshal serialized event")
+
+		processData, ok := data["process"].(map[string]interface{})
+		require.True(t, ok, "process field should be present in serialized event")
+
+		tracerData, ok := processData["tracer"].(map[string]interface{})
+		require.True(t, ok, "tracer field should be present in serialized process, got: %v", processData)
+
+		assert.Equal(t, "test-service", tracerData["tracer_service_name"], "tracer_service_name mismatch")
+		assert.Equal(t, "test-env", tracerData["tracer_service_env"], "tracer_service_env mismatch")
+		assert.Equal(t, "1.0.0", tracerData["tracer_service_version"], "tracer_service_version mismatch")
+		assert.Equal(t, "value", tracerData["custom.tag"], "custom.tag mismatch")
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR serializes the `TracerTags` field from the `Process` struct into the `ProcessSerializer` as a `map[string]string` field. The tags (stored as "key:value" strings from APM tracer instrumentation) are split and converted into a map so they are included in the JSON output sent to the backend and easy to use in DD backend queries.

### Motivation

The `TracerTags` field on `Process` is populated by the `EBPFResolver.AddTracerMetadata` method when a tracer registers its metadata via a memfd seal event, but the tags were never serialized. This means APM tracer tags (service name, env, version, custom process tags) were collected but silently dropped before reaching the serialization.
