### PR TITLE
[ACTP] persist hostname with enrollment result

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname"

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -208,11 +208,8 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
-	now := time.Now().UTC()
-	formattedTime := now.Format("20060102150405")
-	runnerName := runnerHostname + "-" + formattedTime
 
-	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerName, apiKey, appKey)
+	enrollmentResult, err := enrollment.SelfEnroll(ctx, ddSite, runnerHostname, apiKey, appKey)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)
 	}
@@ -246,7 +243,7 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 			tagsProvider := autoconnections.NewTagsProvider(p.tagger)
 			creator := autoconnections.NewConnectionsCreator(*client, tagsProvider)
 
-			if err := creator.AutoCreateConnections(ctx, urnParts.RunnerID, runnerHostname, runnerName, actionsAllowlist); err != nil {
+			if err := creator.AutoCreateConnections(ctx, urnParts.RunnerID, enrollmentResult, actionsAllowlist); err != nil {
 				p.logger.Warnf("Failed to auto-create connections: %v", err)
 			}
 		}

--- a/pkg/privateactionrunner/autoconnections/connections_creator_test.go
+++ b/pkg/privateactionrunner/autoconnections/connections_creator_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/enrollment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -162,11 +163,13 @@ func TestAutoCreateConnections_AllBundlesSuccess(t *testing.T) {
 
 	creator := NewConnectionsCreator(*testClient, provider)
 
+	enrollmentResult := &enrollment.Result{
+		RunnerName: "runner-abc123",
+		Hostname:   "test-hostname",
+	}
 	runnerID := "144500f1-474a-4856-aa0a-6fd22e005893"
-	hostname := "test-hostname"
-	runnerName := "runner-abc123"
 
-	err := creator.AutoCreateConnections(context.Background(), runnerID, hostname, runnerName, actionsAllowlist)
+	err := creator.AutoCreateConnections(context.Background(), runnerID, enrollmentResult, actionsAllowlist)
 
 	require.NoError(t, err, "AutoCreateConnections should return nil")
 	assert.Len(t, createdConnections, 2, "Should create 2 connections")
@@ -211,11 +214,13 @@ func TestAutoCreateConnections_PartialFailures(t *testing.T) {
 
 	creator := NewConnectionsCreator(*testClient, provider)
 
+	enrollmentResult := &enrollment.Result{
+		RunnerName: "runner-abc123",
+		Hostname:   "test-hostname",
+	}
 	runnerID := "144500f1-474a-4856-aa0a-6fd22e005893"
-	hostname := "test-hostname"
-	runnerName := "runner-abc123"
 
-	err := creator.AutoCreateConnections(context.Background(), runnerID, hostname, runnerName, actionsAllowlist)
+	err := creator.AutoCreateConnections(context.Background(), runnerID, enrollmentResult, actionsAllowlist)
 
 	// Should return nil even with failures (non-blocking)
 	require.NoError(t, err, "AutoCreateConnections should not propagate errors")
@@ -247,11 +252,13 @@ func TestAutoCreateConnections_NoRelevantBundles(t *testing.T) {
 
 	creator := NewConnectionsCreator(*testClient, provider)
 
+	enrollmentResult := &enrollment.Result{
+		RunnerName: "runner-abc123",
+		Hostname:   "test-hostname",
+	}
 	runnerID := "144500f1-474a-4856-aa0a-6fd22e005893"
-	hostname := "test-hostname"
-	runnerName := "runner-abc123"
 
-	err := creator.AutoCreateConnections(context.Background(), runnerID, hostname, runnerName, actionsAllowlist)
+	err := creator.AutoCreateConnections(context.Background(), runnerID, enrollmentResult, actionsAllowlist)
 
 	require.NoError(t, err, "AutoCreateConnections should return nil")
 	assert.Equal(t, 0, requestCount, "Should not make any HTTP requests")
@@ -284,11 +291,13 @@ func TestAutoCreateConnections_PartialAllowlist(t *testing.T) {
 
 	creator := NewConnectionsCreator(*testClient, provider)
 
+	enrollmentResult := &enrollment.Result{
+		RunnerName: "runner-abc123",
+		Hostname:   "test-hostname",
+	}
 	runnerID := "144500f1-474a-4856-aa0a-6fd22e005893"
-	hostname := "test-hostname"
-	runnerName := "runner-abc123"
 
-	err := creator.AutoCreateConnections(context.Background(), runnerID, hostname, runnerName, actionsAllowlist)
+	err := creator.AutoCreateConnections(context.Background(), runnerID, enrollmentResult, actionsAllowlist)
 
 	require.NoError(t, err, "AutoCreateConnections should return nil")
 	assert.Len(t, createdConnections, 1, "Should create 2 connections")

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
@@ -22,15 +23,22 @@ const defaultIdentityFileName = "privateactionrunner_private_identity.json"
 type Result struct {
 	PrivateKey *ecdsa.PrivateKey
 	URN        string
+	Hostname   string
+	RunnerName string
 }
 
 type PersistedIdentity struct {
 	PrivateKey string `json:"private_key"`
 	URN        string `json:"urn"`
+	Hostname   string `json:"hostname,omitempty"`
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
-func SelfEnroll(ctx context.Context, ddSite, runnerName, apiKey, appKey string) (*Result, error) {
+func SelfEnroll(ctx context.Context, ddSite, runnerHostname, apiKey, appKey string) (*Result, error) {
+	now := time.Now().UTC()
+	formattedTime := now.Format("20060102150405")
+	runnerName := runnerHostname + "-" + formattedTime
+
 	privateJwk, publicJwk, err := util.GenerateKeys()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key pair: %w", err)
@@ -59,5 +67,7 @@ func SelfEnroll(ctx context.Context, ddSite, runnerName, apiKey, appKey string) 
 	return &Result{
 		PrivateKey: privateJwk.Key.(*ecdsa.PrivateKey),
 		URN:        urn,
+		Hostname:   runnerHostname,
+		RunnerName: runnerName,
 	}, nil
 }

--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -30,7 +30,7 @@ type Result struct {
 type PersistedIdentity struct {
 	PrivateKey string `json:"private_key"`
 	URN        string `json:"urn"`
-	Hostname   string `json:"hostname,omitempty"`
+	Hostname   string `json:"hostname"`
 }
 
 // SelfEnroll performs self-registration of a private action runner using API credentials

--- a/pkg/privateactionrunner/enrollment/storage.go
+++ b/pkg/privateactionrunner/enrollment/storage.go
@@ -80,6 +80,7 @@ func persistIdentityToFile(cfg configModel.Reader, result *Result) error {
 	jsonData, err := json.Marshal(PersistedIdentity{
 		PrivateKey: base64.RawURLEncoding.EncodeToString(marshalledPrivateKey),
 		URN:        result.URN,
+		Hostname:   result.Hostname,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to marshal identity content to JSON: %w", err)


### PR DESCRIPTION
### What does this PR do?

Persists the hostname that was used as part of the enrollment result when doing self enrollment

### Motivation

We might want to reenroll in case we see the hostname changing as it might make routing tasks break

### Describe how you validated your changes

Ran self enrollement locally

### Additional Notes

A few adjustments on functions signature to reuse the EnrollmentResult 
