### PR TITLE
Add recently fixed targets to `bazel` tests in CI

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -7,22 +7,12 @@
 bazel:test:linux-amd64:
   extends: [ .bazel:test, .bazel:runner:linux-amd64 ]
   script:
-    #TODO(regis): fix and enable failing targets
-    - >-
-      bazel test //... --
-      -//pkg/discovery/module/rust:dd_discovery
-      -//pkg/discovery/module/rust:dd_discovery_test
-      -//pkg/discovery/module/rust:libdd_discovery
+    - bazel test //... -- -//pkg/discovery/module/rust:dd_discovery_test
 
 bazel:test:linux-arm64:
   extends: [ .bazel:test, .bazel:runner:linux-arm64 ]
   script:
-    #TODO(regis): fix and enable failing targets
-    - >-
-      bazel test //... --
-      -//pkg/discovery/module/rust:dd_discovery
-      -//pkg/discovery/module/rust:dd_discovery_test
-      -//pkg/discovery/module/rust:libdd_discovery
+    - bazel test //... -- -//pkg/discovery/module/rust:dd_discovery_test
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:runner:macos-amd64 ]


### PR DESCRIPTION
### What does this PR do?
Remove the following exclusions from `bazel test //...` on Linux:
- `-//pkg/discovery/module/rust:dd_discovery`
- `-//pkg/discovery/module/rust:libdd_discovery`

### Motivation
Secure the progress made by:
- #46463.

### Additional Notes
`//pkg/discovery/module/rust:dd_discovery_test` is still failing.