### PR TITLE
[ACIX-1363] Try internal registry first for base Docker images used for fakeintake

### DIFF
--- a/.gitlab/deploy/container_build/fakeintake.yml
+++ b/.gitlab/deploy/container_build/fakeintake.yml
@@ -13,7 +13,8 @@ docker_build_fakeintake:
     DOCKERFILE: test/fakeintake/Dockerfile
     PLATFORMS: linux/amd64,linux/arm64
     BUILD_CONTEXT: .
+    BASE_IMAGE_REGISTRY: "registry.ddbuild.io/images/mirror"
   script:
     - !reference [.login_to_docker_readonly]
-    - docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
+    - docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=${BASE_IMAGE_REGISTRY} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
   retry: 2

--- a/.gitlab/deploy/container_build/fakeintake.yml
+++ b/.gitlab/deploy/container_build/fakeintake.yml
@@ -16,5 +16,15 @@ docker_build_fakeintake:
     BASE_IMAGE_REGISTRY: "registry.ddbuild.io/images/mirror"
   script:
     - !reference [.login_to_docker_readonly]
-    - docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=${BASE_IMAGE_REGISTRY} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
+    - |
+      set -o pipefail
+      BUILD_OUTPUT=$(mktemp)
+      if ! docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=${BASE_IMAGE_REGISTRY} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT 2>&1 | tee "$BUILD_OUTPUT"; then
+        if grep -qE 'failed to resolve reference|failed to resolve|manifest unknown|pull access denied|repository does not exist|failed to fetch' "$BUILD_OUTPUT"; then
+          echo "Build failed likely due to base image not yet in internal registry, retrying with docker.io..."
+          docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=docker.io --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
+        else
+          exit 1
+        fi
+      fi
   retry: 2

--- a/.gitlab/deploy/container_build/fakeintake.yml
+++ b/.gitlab/deploy/container_build/fakeintake.yml
@@ -15,16 +15,16 @@ docker_build_fakeintake:
     BUILD_CONTEXT: .
     BASE_IMAGE_REGISTRY: "registry.ddbuild.io/images/mirror"
   script:
+    - |
+      GO_VERSION=$(grep -E '^ARG GO_VERSION=' ${DOCKERFILE} | cut -d= -f2)
+      GOLANG_IMAGE="${BASE_IMAGE_REGISTRY}/library/golang:${GO_VERSION}"
+      if docker buildx imagetools inspect "${GOLANG_IMAGE}" > /dev/null 2>&1; then
+        echo "Base image ${GOLANG_IMAGE} found in internal registry, building..."
+        docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=${BASE_IMAGE_REGISTRY} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
+        exit 0
+      fi
     - !reference [.login_to_docker_readonly]
     - |
-      set -o pipefail
-      BUILD_OUTPUT=$(mktemp)
-      if ! docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=${BASE_IMAGE_REGISTRY} --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT 2>&1 | tee "$BUILD_OUTPUT"; then
-        if grep -qE 'failed to resolve reference|failed to resolve|manifest unknown|pull access denied|repository does not exist|failed to fetch' "$BUILD_OUTPUT"; then
-          echo "Build failed likely due to base image not yet in internal registry, retrying with docker.io..."
-          docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=docker.io --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
-        else
-          exit 1
-        fi
-      fi
+      echo "Base image ${GOLANG_IMAGE} not found in internal registry, falling back to docker.io..."
+      docker buildx build --push --pull --platform ${PLATFORMS} --build-arg=CI --build-arg=BASE_IMAGE_REGISTRY=docker.io --file ${DOCKERFILE} --tag ${TARGET} $BUILD_CONTEXT
   retry: 2

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -22,7 +22,7 @@ GO_VERSION_FILE = "./.go-version"
 GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     (GO_VERSION_FILE, "", "", True),  # the version is the only content of the file
     ("./tools/gdb/Dockerfile", "https://go.dev/dl/go", ".linux-", True),
-    ("./test/fakeintake/Dockerfile", "FROM golang:", "-alpine", True),
+    ("./test/fakeintake/Dockerfile", "FROM golang:", "", True),
     ("./tasks/unit_tests/modules_tests.py", 'Go": "', '",', False),
     ("./devenv/scripts/Install-DevEnv.ps1", '$go_version = "', '"', True),
     ("./tasks/go.py", '"go version go', ' linux/amd64"', True),

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -22,7 +22,7 @@ GO_VERSION_FILE = "./.go-version"
 GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     (GO_VERSION_FILE, "", "", True),  # the version is the only content of the file
     ("./tools/gdb/Dockerfile", "https://go.dev/dl/go", ".linux-", True),
-    ("./test/fakeintake/Dockerfile", "FROM golang:", "", True),
+    ("./test/fakeintake/Dockerfile", "GO_VERSION=", "", True),
     ("./tasks/unit_tests/modules_tests.py", 'Go": "', '",', False),
     ("./devenv/scripts/Install-DevEnv.ps1", '$go_version = "', '"', True),
     ("./tasks/go.py", '"go version go', ' linux/amd64"', True),

--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE_REGISTRY}/library/golang:${GO_VERSION} AS build
 
 # need gcc to build with CGO_ENABLED=1
 # need musl-dev to get stdlib.h
-RUN apt update && apt install -y musl-dev gcc
+RUN apt update && apt install -y musl-dev gcc musl-tools
 
 WORKDIR /app
 
@@ -28,8 +28,9 @@ RUN go mod download
 
 COPY test/fakeintake .
 
-# need to explicitely run with CGO enabled
+# need to explicitely run with CGO enabled and link against musl
 ENV CGO_ENABLED=1
+ENV CC=musl-gcc
 ARG CI
 RUN go build -o /fakeintake cmd/server/main.go
 

--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE_REGISTRY}/library/golang:${GO_VERSION} AS build
 
 # need gcc to build with CGO_ENABLED=1
 # need musl-dev to get stdlib.h
-RUN apt update && apt install -y musl-dev gcc musl-tools
+RUN apt update && apt install --no-install-recommends -y musl-dev gcc musl-tools && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -1,5 +1,6 @@
 ## Based on https://docs.docker.com/language/golang/build-images/
 # syntax=docker/dockerfile:1
+ARG BASE_IMAGE_REGISTRY=docker.io
 
 ## Build
 FROM golang:1.25.7-alpine3.22 AS build
@@ -32,7 +33,7 @@ ARG CI
 RUN go build -o /fakeintake cmd/server/main.go
 
 ## Deploy
-FROM alpine:3.21
+FROM ${BASE_IMAGE_REGISTRY}/library/alpine:3.21.3
 
 RUN apk add curl
 

--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -1,9 +1,10 @@
 ## Based on https://docs.docker.com/language/golang/build-images/
 # syntax=docker/dockerfile:1
 ARG BASE_IMAGE_REGISTRY=docker.io
+ARG GO_VERSION=1.25.7
 
 ## Build
-FROM golang:1.25.7 AS build
+FROM ${BASE_IMAGE_REGISTRY}/library/golang:${GO_VERSION} AS build
 
 # need gcc to build with CGO_ENABLED=1
 # need musl-dev to get stdlib.h

--- a/test/fakeintake/Dockerfile
+++ b/test/fakeintake/Dockerfile
@@ -3,11 +3,11 @@
 ARG BASE_IMAGE_REGISTRY=docker.io
 
 ## Build
-FROM golang:1.25.7-alpine3.22 AS build
+FROM golang:1.25.7 AS build
 
 # need gcc to build with CGO_ENABLED=1
 # need musl-dev to get stdlib.h
-RUN apk add musl-dev gcc
+RUN apt update && apt install -y musl-dev gcc
 
 WORKDIR /app
 


### PR DESCRIPTION
### What does this PR do?
Updates `test/fakeintake/Dockerfile` to try registry.ddbuild.io as a source first instead of an upstream repo for base `golang` and `alpine` images

Also update the `update-go` invoke task and corresponding CI job.

### Motivation
Avoiding rate limits and increasing CI reliability.

### Describe how you validated your changes
- Passing CI
- Building the image locally
- Verifying fallback logic works properly by using a `golang` base image that does not exist in `registry.ddbuild.io` (`1.25.4` to be precise)

### Additional Notes
1. Pinned `golang` images are only available as non-alpine flavor from `registry.ddbuild.io` and we don't really care about the _build_ image being heavy or not - as long as the final stage is light. Therefore we switch to an ubuntu base for the build stage
2. Since we are often quite quick to update the go versions in our images, it is possible that we try to update the golang version used in the base image faster than Renovate can update the upstream on DataDog/images. In that case we don't want to be unable to build the fakeintake in CI, so we fallback to `docker.io` in that case.