### PR TITLE
[AGENTRUN-1010] fix(config): data race in configuration initialization when running config tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -328,12 +328,6 @@ linters:
         - pattern: ^model.NewConfig.*$
           pkg: ^github.com/DataDog/datadog-agent/pkg/config/model$
           msg: use pkg/config/mock instead in tests or the config component
-        - pattern: ^setup.SetDatadog.*$
-          pkg: ^github.com/DataDog/datadog-agent/pkg/config/setup$
-          msg: use pkg/config/mock instead for tests or the config component
-        - pattern: ^setup.SetSystemProbe.*$
-          pkg: ^github.com/DataDog/datadog-agent/pkg/config/setup$
-          msg: use pkg/config/mock instead for tests or the config component
         - pattern: ^.*\.BindEnv$
           pkg: ^github.com/DataDog/datadog-agent/pkg/config/model$
           msg: use BindEnvAndSetDefault instead of BindEnv to ensure proper defaults are set

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -44,13 +44,13 @@ func New(t testing.TB) model.BuildableConfig {
 		m.Lock()
 		defer m.Unlock()
 		isConfigMocked = false
-		setup.SetDatadog(originalDatadogConfig) // nolint: forbidigo // legitimate use of SetDatadog
+		setup.SetDatadog(originalDatadogConfig)
 	})
 
 	// Configure Datadog global configuration
 	newCfg := create.NewConfig("datadog", "")
 	// Configuration defaults
-	setup.SetDatadog(newCfg) // nolint forbidigo legitimate use of SetDatadog
+	setup.SetDatadog(newCfg)
 	setup.InitConfig(newCfg)
 	newCfg.BuildSchema()
 	newCfg.SetTestOnlyDynamicSchema(true)
@@ -95,12 +95,12 @@ func NewSystemProbe(t testing.TB) model.BuildableConfig {
 			m.Lock()
 			defer m.Unlock()
 			isSystemProbeConfigMocked = false
-			setup.SetSystemProbe(originalConfig) // nolint forbidigo legitimate use of SetSystemProbe
+			setup.SetSystemProbe(originalConfig)
 		})
 	}
 
 	// Configure Datadog global configuration
-	setup.SetSystemProbe(create.NewConfig("system-probe", "")) // nolint forbidigo legitimate use of SetSystemProbe
+	setup.SetSystemProbe(create.NewConfig("system-probe", ""))
 	// Configuration defaults
 	setup.InitSystemProbeConfig(setup.GlobalSystemProbeConfigBuilder())
 	setup.SystemProbe().SetTestOnlyDynamicSchema(true)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -159,8 +159,6 @@ var (
 )
 
 // SetDatadog sets the the reference to the agent configuration.
-// This is currently used by the legacy converter and config mocks and should not be user anywhere else. Once the
-// legacy converter and mock have been migrated we will remove this function.
 func SetDatadog(cfg pkgconfigmodel.BuildableConfig) {
 	datadogMutex.Lock()
 	defer datadogMutex.Unlock()
@@ -168,8 +166,6 @@ func SetDatadog(cfg pkgconfigmodel.BuildableConfig) {
 }
 
 // SetSystemProbe sets the the reference to the systemProbe configuration.
-// This is currently used by the config mocks and should not be user anywhere else. Once the mocks have been migrated we
-// will remove this function.
 func SetSystemProbe(cfg pkgconfigmodel.BuildableConfig) {
 	systemProbeMutex.Lock()
 	defer systemProbeMutex.Unlock()
@@ -309,8 +305,8 @@ func InitConfigObjects(cliPath string, defaultDir string) {
 	// We first load the configuration to see which config library should be used.
 	configLib := resolveConfigLibType(cliPath, defaultDir)
 
-	datadog = create.NewConfig("datadog", configLib)
-	systemProbe = create.NewConfig("system-probe", configLib)
+	SetDatadog(create.NewConfig("datadog", configLib))
+	SetSystemProbe(create.NewConfig("system-probe", configLib))
 
 	// Configuration defaults
 	initConfig()


### PR DESCRIPTION
### What does this PR do?

Fix a data race in configuration initialization when running config package tests, where the agent and system probe configs are set within each test.

### Motivation

### Describe how you validated your changes

### Additional Notes
