### PR TITLE
Bump cluster-agent build job memory limits

### DIFF
--- a/.gitlab/build/binary_build/cluster_agent.yml
+++ b/.gitlab/build/binary_build/cluster_agent.yml
@@ -24,8 +24,8 @@
       - Dockerfiles/cluster-agent/security-agent-policies/.github/**/*
 
   variables:
-    KUBERNETES_MEMORY_REQUEST: "8Gi"
-    KUBERNETES_MEMORY_LIMIT: "8Gi"
+    KUBERNETES_MEMORY_REQUEST: "16Gi"
+    KUBERNETES_MEMORY_LIMIT: "16Gi"
     KUBERNETES_CPU_REQUEST: 6
 
 cluster_agent-build_amd64:


### PR DESCRIPTION
### What does this PR do?
Bump cluster-agent build job memory limits to 16Go.

### Motivation
The compiler is getting killed due to OOM more and more frequently in the build jobs.

### Describe how you validated your changes
CI

### Additional Notes
Other build jobs all use at least 16Go so I aligned on this value.
