### PR TITLE
Add qa_dca_fips dep to fips compliance test

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -404,6 +404,7 @@ new-e2e-fips-compliance-test:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7-fips
     - qa_agent_fips_linux
+    - qa_dca_fips
   rules:
     - !reference [.on_arun_or_e2e_changes]
     - !reference [.dynamic_tests] # The job will always be created on any Go code modification, tests are skipped dynamically in the job


### PR DESCRIPTION
<!-- dd-meta {"pullId":"52db5a59-7967-4bd3-bad1-3718d496dd53","source":"chat","resourceId":"d9df0183-08fa-4ce3-b257-16d705da425c","workflowId":"45ef81db-c6cf-441a-9e2e-b48ee55784c9","codeChangeId":"45ef81db-c6cf-441a-9e2e-b48ee55784c9","sourceType":"slack"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/d9df0183-08fa-4ce3-b257-16d705da425c)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Adds `qa_dca_fips` to the `needs` list of `new-e2e-fips-compliance-test` so the e2e job waits for the cluster agent FIPS QA image to be built and published before running.

### Motivation

The `TestFIPSCiphersClusterAgentSuite` test matrix entry in `new-e2e-fips-compliance-test` pulls the `cluster-agent-qa` image from the QA registry, but the job did not declare a dependency on `qa_dca_fips` (which publishes that image). This caused the e2e test to fail with an infrastructure error when `cluster_agent_fips-build_amd64` failed, since the image was never published.

Pipeline failure: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/96774545

### Describe how you validated your changes

Verified the dependency chain: `cluster_agent_fips-build_amd64` → `docker_build_cluster_agent_fips_amd64` → `qa_dca_fips` → `new-e2e-fips-compliance-test`. The test code in `cluster_agent_fips_test.go` constructs the image path as `cluster-agent-qa:<pipeline>-<sha>-fips`, which matches the `IMG_DESTINATIONS` of the `qa_dca_fips` job.

### Additional Notes

This follows the existing pattern where `qa_agent_fips_linux` is already declared as a dependency for the agent FIPS image.