### PR TITLE
dyninst/decode: serialize size into slices even when empty

### DIFF
--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -1541,17 +1541,17 @@ func (s *goSliceHeaderType) encodeValueFields(
 		)
 	}
 	length := binary.NativeEndian.Uint64(data[8:16])
-	if length == 0 {
-		return writeTokens(enc,
-			jsontext.String("elements"),
-			jsontext.BeginArray,
-			jsontext.EndArray)
-	}
 	if err := writeTokens(enc,
 		jsontext.String("size"),
 		jsontext.String(strconv.FormatInt(int64(length), 10)),
 	); err != nil {
 		return err
+	}
+	if length == 0 {
+		return writeTokens(enc,
+			jsontext.String("elements"),
+			jsontext.BeginArray,
+			jsontext.EndArray)
 	}
 
 	elementSize := int(s.Data.Element.GetByteSize())

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySlice.json
@@ -52,6 +52,7 @@
             "arguments": {
               "u": {
                 "type": "[]uint",
+                "size": "0",
                 "elements": []
               }
             }

--- a/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
+++ b/pkg/dyninst/testdata/decoded/sample/testEmptySliceOfStructs.json
@@ -52,6 +52,7 @@
             "arguments": {
               "xs": {
                 "type": "[]main.structWithNoStrings",
+                "size": "0",
                 "elements": []
               },
               "a": {

--- a/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
+++ b/pkg/dyninst/testdata/decoded/sample/testStructWithCyclicSlices.json
@@ -94,6 +94,7 @@
                     "elements": [
                       {
                         "type": "[]main.structWithCyclicSlices",
+                        "size": "0",
                         "elements": []
                       },
                       {
@@ -139,6 +140,7 @@
                     "elements": [
                       {
                         "type": "[][]main.structWithCyclicSlices",
+                        "size": "0",
                         "elements": []
                       },
                       {
@@ -147,6 +149,7 @@
                         "elements": [
                           {
                             "type": "[]main.structWithCyclicSlices",
+                            "size": "0",
                             "elements": []
                           }
                         ]
@@ -200,6 +203,7 @@
                     "elements": [
                       {
                         "type": "[][][]main.structWithCyclicSlices",
+                        "size": "0",
                         "elements": []
                       },
                       {
@@ -208,6 +212,7 @@
                         "elements": [
                           {
                             "type": "[][]main.structWithCyclicSlices",
+                            "size": "0",
                             "elements": []
                           }
                         ]
@@ -222,6 +227,7 @@
                             "elements": [
                               {
                                 "type": "[]main.structWithCyclicSlices",
+                                "size": "0",
                                 "elements": []
                               }
                             ]
@@ -283,6 +289,7 @@
                     "elements": [
                       {
                         "type": "[][][][]main.structWithCyclicSlices",
+                        "size": "0",
                         "elements": []
                       },
                       {
@@ -291,6 +298,7 @@
                         "elements": [
                           {
                             "type": "[][][]main.structWithCyclicSlices",
+                            "size": "0",
                             "elements": []
                           }
                         ]
@@ -305,6 +313,7 @@
                             "elements": [
                               {
                                 "type": "[][]main.structWithCyclicSlices",
+                                "size": "0",
                                 "elements": []
                               }
                             ]
@@ -325,6 +334,7 @@
                                 "elements": [
                                   {
                                     "type": "[]main.structWithCyclicSlices",
+                                    "size": "0",
                                     "elements": []
                                   }
                                 ]
@@ -347,6 +357,7 @@
                                 "elements": [
                                   {
                                     "type": "[]main.structWithCyclicSlices",
+                                    "size": "0",
                                     "elements": []
                                   }
                                 ]
@@ -363,6 +374,7 @@
                     "elements": [
                       {
                         "type": "[][][][][]main.structWithCyclicSlices",
+                        "size": "0",
                         "elements": []
                       },
                       {
@@ -371,6 +383,7 @@
                         "elements": [
                           {
                             "type": "[][][][]main.structWithCyclicSlices",
+                            "size": "0",
                             "elements": []
                           }
                         ]
@@ -385,6 +398,7 @@
                             "elements": [
                               {
                                 "type": "[][][]main.structWithCyclicSlices",
+                                "size": "0",
                                 "elements": []
                               }
                             ]
@@ -405,6 +419,7 @@
                                 "elements": [
                                   {
                                     "type": "[][]main.structWithCyclicSlices",
+                                    "size": "0",
                                     "elements": []
                                   }
                                 ]
@@ -427,6 +442,7 @@
                                 "elements": [
                                   {
                                     "type": "[][]main.structWithCyclicSlices",
+                                    "size": "0",
                                     "elements": []
                                   }
                                 ]
@@ -453,6 +469,7 @@
                                     "elements": [
                                       {
                                         "type": "[]main.structWithCyclicSlices",
+                                        "size": "0",
                                         "elements": []
                                       }
                                     ]


### PR DESCRIPTION
### What does this PR do

Serializes the `"size"` key into slice outputs even when they are empty. I don't think we were intentionally omitting this. It rendered strangely in the UI because empty lists are removed entirely.

### Motivation

The empty slices looked weird before because they didn't have a size.

### Describe how you validated your changes

There's testing

