### PR TITLE
[ABLD-317] Prevent `gazelle` from attempting to download in-repo modules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,7 +20,10 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude test
 # gazelle:exclude tools
 # gazelle:prefix github.com/DataDog/datadog-agent
-gazelle(name = "gazelle")
+gazelle(
+    name = "gazelle",
+    args = ["-external=static"],  # don't use the network: https://github.com/bazel-contrib/bazel-gazelle/issues/1385
+)
 
 # bazel run //:go -- ...
 alias(


### PR DESCRIPTION
### What does this PR do?
Configures Gazelle to run in `static` "external mode", preventing it from calling out to the network to download **internal** Go modules when resolving imports.

### Motivation
Facing errors where Gazelle attempts to fetch internal modules for which it can't generate `BUILD.bazel` files yet, [like](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1429408826):
```sh
bazel run //:gazelle
[...]
go: module github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock:
reading https://depot-read-api-go.us1.ddbuild.io/magicmirror/testing/@current/github.com/%21data%21dog/datadog-agent/comp/core/tagger/fx-mock/@v/list:
404 Not Found
```

In `static` "mode", Gazelle skips unknown imports instead of attempting to fetch them from the network, preventing 404 errors on internal module paths and ensuring all dependencies are explicitly declared.

### Describe how you validated your changes
Running `bazel run //:gazelle` no longer attempts to remotely resolve internal module paths.

### Additional Notes
- https://github.com/bazel-contrib/bazel-gazelle?tab=readme-ov-file#dependency-resolution
- https://github.com/bazel-contrib/bazel-gazelle/blob/master/language/go/reference.md
- https://github.com/bazel-contrib/bazel-gazelle/issues/1385