### PR TITLE
omnibus: simplify datadog-security-agent-policies inclusion

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -230,16 +230,12 @@ if do_build
   dependency 'datadog-agent'
 
   # This depends on the agent and must be added after it
-  if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?
+  unless heroku_target? || osx_target?
     dependency 'datadog-security-agent-policies'
   end
 
   if osx_target?
     dependency 'datadog-agent-mac-app'
-  end
-
-  if linux_target?
-    dependency 'datadog-security-agent-policies'
   end
 
   # this dependency puts few files out of the omnibus install dir and move them

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -219,8 +219,7 @@ build do
   end
 
   # Security agent
-  secagent_support = (not heroku_target?) and (not windows_target? or (ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?))
-  if secagent_support
+  unless heroku_target?
     command "dda inv -- -e security-agent.build #{fips_args} --install-path=#{install_dir}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
     if windows_target?
       copy 'bin/security-agent/security-agent.exe', "#{install_dir}/bin/agent"


### PR DESCRIPTION
### What does this PR do?

Simplifying the conditional inclusion of `datadog-security-agent-policies` software

### Motivation

WINDOWS_DDPROCMON_DRIVER is now always set, so we can ajust the conditional inclusion to clarify this.
This also stops building the security policies for heroku since we don't ship the security agent there

### Describe how you validated your changes

### Additional Notes

This is preliminary to the bazel migration, in order to ensure I correctly understand the expected setup and limit the amount of simultaneous changes in case I don't.
