### PR TITLE
Factor out `bazel:lint` jobs with clearer hints

### DIFF
--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -4,9 +4,7 @@
     - |-
       if [ $CI_JOB_STATUS = failed ]; then
         echo >&2 "💡 To fix the above problem, please consider running the following command:"
-        echo >&2 "$(printf "%${#FIX_COMMAND}s" | tr ' ' 'v')"
         echo >&2 "$FIX_COMMAND"
-        echo >&2 "$(printf "%${#FIX_COMMAND}s" | tr ' ' '^')"
       fi
 
 bazel:mod-deps:

--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -1,6 +1,16 @@
-bazel:mod-deps:
-  extends: .bazel:runner:linux-amd64
+.bazel:lint:
   stage: lint
+  after_script:
+    - |-
+      if [ $CI_JOB_STATUS = failed ]; then
+        echo >&2 "💡 To fix the above problem, please consider running the following command:"
+        echo >&2 "$(printf "%${#FIX_COMMAND}s" | tr ' ' 'v')"
+        echo >&2 "$FIX_COMMAND"
+        echo >&2 "$(printf "%${#FIX_COMMAND}s" | tr ' ' '^')"
+      fi
+
+bazel:mod-deps:
+  extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
     # Why not `bazel mod deps --lockfile_mode=error`:
     # 1. `bazel` servers on persistent runners cache non-local repository rules, causing stale checks (#incident-46079),
@@ -14,53 +24,34 @@ bazel:mod-deps:
     # 3. use `git diff --exit-code` to still fail on any discrepancies while printing them exhaustively.
     - bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
     - git diff --exit-code
-  after_script:
-    - |-
-      if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel mod deps --repo_env=REPIN=1"
-      fi
+  variables:
+    FIX_COMMAND: "bazel mod deps --repo_env=REPIN=1"
 
 bazel:mod-tidy:
-  extends: .bazel:runner:linux-amd64
-  stage: lint
+  extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
     - bazel mod tidy --lockfile_mode=off
     - git diff --exit-code
-  after_script:
-    - |-
-      if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel mod tidy"
-      fi
+  variables:
+    FIX_COMMAND: "bazel mod tidy"
 
 bazel:run-buildifier-test:
-  extends: .bazel:runner:linux-amd64
-  stage: lint
+  extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
     - bazel run //bazel/buildifier:test
-  after_script:
-    - |-
-      if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel run //bazel/buildifier"
-      fi
+  variables:
+    FIX_COMMAND: "bazel run //bazel/buildifier"
 
 bazel:run-gazelle:
-  extends: .bazel:runner:linux-amd64
-  stage: lint
+  extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
     - bazel run //:gazelle -- -mode=diff -strict
-  after_script:
-    - |-
-      if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel run //:gazelle"
-      fi
+  variables:
+    FIX_COMMAND: "bazel run //:gazelle"
 
 bazel:run-go-mod-tidy:
-  extends: .bazel:runner:linux-amd64
-  stage: lint
+  extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
     - bazel run //:go mod tidy -- -diff
-  after_script:
-    - |-
-      if [ $CI_JOB_STATUS = failed ]; then
-        echo >&2 "💡 bazel run //:go mod tidy"
-      fi
+  variables:
+    FIX_COMMAND: "bazel run //:go mod tidy"


### PR DESCRIPTION
### What does this PR do?
Refactor `.gitlab/build/bazel/lint.yml` by extracting common patterns into a `.bazel:lint` base job that all lint jobs extend while improving visibility and purpose of suggested remediation commands.

### Motivation
Previous PR review comments indicated that remediation hints were not immediately obvious:
- https://github.com/DataDog/datadog-agent/pull/45629#discussion_r1926043685
- https://github.com/DataDog/datadog-agent/pull/45629#discussion_r1926043686

The new format uses and explicit messaging to make it clear that failed jobs provide a local command to fix the issue, for instance:
```
💡 To fix the above problem, please consider running the following command:
bazel mod deps --repo_env=REPIN=1
```
### Describe how you validated your changes
The refactored jobs maintain identical behavior (while reducing duplication).