### PR TITLE
sd-agent: ffi: always cast dd_str data to u8 slice

### DIFF
--- a/pkg/discovery/module/rust/src/ffi.rs
+++ b/pkg/discovery/module/rust/src/ffi.rs
@@ -530,7 +530,7 @@ mod tests {
         if s.data.is_null() {
             return "";
         }
-        let slice = unsafe { std::slice::from_raw_parts(s.data, s.len) };
+        let slice = unsafe { std::slice::from_raw_parts(s.data.cast::<u8>(), s.len) };
         std::str::from_utf8(slice).unwrap()
     }
 


### PR DESCRIPTION
### What does this PR do?

Fix a type error when building on amd64. This is due to us using the C character type (`c_char`) in `dd_str` for the FFI interface. However, Rust's `from_utf8` only expects u8. The fix is simply casting the pointer type to `u8`.

### Motivation

Fix build issue on amd64

### Describe how you validated your changes

CI check using changes in #46471

### Additional Notes
