### PR TITLE
APM: Obfuscate ACL redis command

### DIFF
--- a/pkg/obfuscate/redis.go
+++ b/pkg/obfuscate/redis.go
@@ -17,7 +17,8 @@ const maxRedisNbCommands = 3
 
 // Redis commands consisting in 2 words
 var redisCompoundCommandSet = map[string]bool{
-	"CLIENT": true, "CLUSTER": true, "COMMAND": true, "CONFIG": true, "DEBUG": true, "SCRIPT": true}
+	"CLIENT": true, "CLUSTER": true, "COMMAND": true, "CONFIG": true, "DEBUG": true, "SCRIPT": true,
+}
 
 // QuantizeRedisString returns a quantized version of a Redis query.
 //
@@ -131,6 +132,18 @@ func obfuscateRedisCmd(out *strings.Builder, cmd string, args ...string) {
 		if len(args) > 0 {
 			args[0] = "?"
 			args = args[:1]
+		}
+
+	case "ACL":
+		// Obfuscate all arguments after the subcommand
+		// • ACL SETUSER username on >password ~keys &channels +commands
+		// • ACL GETUSER username
+		// • ACL DELUSER username [username ...]
+		// • ACL LIST
+		// • ACL WHOAMI
+		if len(args) > 1 {
+			args[1] = "?"
+			args = args[:2]
 		}
 
 	case "APPEND", "GETSET", "LPUSHX", "GEORADIUSBYMEMBER", "RPUSHX",

--- a/pkg/obfuscate/redis_test.go
+++ b/pkg/obfuscate/redis_test.go
@@ -142,6 +142,38 @@ func TestRedisObfuscator(t *testing.T) {
 			"HELLO",
 		},
 		{
+			"ACL SETUSER alice on >password ~* &* +@all",
+			"ACL SETUSER ?",
+		},
+		{
+			"ACL SETUSER bob on >mysecretpassword ~keys:* resetchannels &channel:* +@all -@dangerous",
+			"ACL SETUSER ?",
+		},
+		{
+			"ACL GETUSER alice",
+			"ACL GETUSER ?",
+		},
+		{
+			"ACL DELUSER alice",
+			"ACL DELUSER ?",
+		},
+		{
+			"ACL DELUSER alice bob charlie",
+			"ACL DELUSER ?",
+		},
+		{
+			"ACL LIST",
+			"ACL LIST",
+		},
+		{
+			"ACL WHOAMI",
+			"ACL WHOAMI",
+		},
+		{
+			"ACL",
+			"ACL",
+		},
+		{
 			"APPEND key value",
 			"APPEND key ?",
 		},


### PR DESCRIPTION
### What does this PR do?

Small follow up on #46391 

Obfuscate all arguments after the subcommand
• ACL SETUSER username on >password ~keys &channels +commands • ACL GETUSER username
• ACL DELUSER username [username ...]
• ACL LIST
• ACL WHOAMI

### Motivation
Remove sensitive data from span metadata.

### Describe how you validated your changes
Added unit tests

### Additional Notes
