### PR TITLE
Enable static quality gates in merge queue

### DIFF
--- a/.gitlab/build/binary_build/cluster_agent.yml
+++ b/.gitlab/build/binary_build/cluster_agent.yml
@@ -30,11 +30,15 @@
 
 cluster_agent-build_amd64:
   extends: .cluster_agent-build_common
+  rules:
+    - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
 
 cluster_agent-build_arm64:
   extends: .cluster_agent-build_common
+  rules:
+    - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
 

--- a/.gitlab/build/binary_build/cws_instrumentation.yml
+++ b/.gitlab/build/binary_build/cws_instrumentation.yml
@@ -11,7 +11,6 @@
 
 .cws_instrumentation_amd64:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
@@ -23,7 +22,6 @@
 
 .cws_instrumentation_arm64:
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/build/binary_build/linux.yml
+++ b/.gitlab/build/binary_build/linux.yml
@@ -16,7 +16,6 @@ build_dogstatsd_static-binary_x64:
 build_dogstatsd_static-binary_arm64:
   stage: binary_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]

--- a/.gitlab/build/binary_build/sd_agent.yml
+++ b/.gitlab/build/binary_build/sd_agent.yml
@@ -4,7 +4,6 @@
     - .bazel:defs:cache:ephemeral
     - .rust_internal_registry
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   script:
     - bazelisk build --config=sd-agent-release //pkg/discovery/module/rust:sd-agent

--- a/.gitlab/build/binary_build/system_probe.yml
+++ b/.gitlab/build/binary_build/system_probe.yml
@@ -2,7 +2,6 @@
 .system-probe_build_common:
   extends: .bazel:defs:cache:ephemeral
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/build/package_build/heroku.yml
+++ b/.gitlab/build/package_build/heroku.yml
@@ -3,7 +3,6 @@
   extends: .bazel:defs:cache:omnibus-transition
   stage: package_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -69,18 +69,26 @@
 # build Agent 7 binaries for x86_64
 datadog-agent-7-x64:
   extends: [.agent_build_common, .agent_build_x86, .agent_base_flavor]
+  rules:
+    - when: on_success
 
 # build Agent 7 binaries for arm64
 datadog-agent-7-arm64:
   extends: [.agent_build_common, .agent_build_arm64, .agent_base_flavor]
+  rules:
+    - when: on_success
 
 # build Agent 7 binaries for x86_64 with FIPS
 datadog-agent-7-x64-fips:
   extends: [.agent_build_common, .agent_build_x86, .agent_fips_flavor]
+  rules:
+    - when: on_success
 
 # build Agent 7 binaries for arm64 with FIPS
 datadog-agent-7-arm64-fips:
   extends: [.agent_build_common, .agent_build_arm64, .agent_fips_flavor]
+  rules:
+    - when: on_success
 
 # Common to IoT, DDOT and dogstatsd
 .toolchain-common-x64:
@@ -113,12 +121,18 @@ datadog-agent-7-arm64-fips:
 
 iot-agent-x64:
   extends: [.iot-agent-common, .toolchain-common-x64]
+  rules:
+    - when: on_success
 
 iot-agent-arm64:
   extends: [.iot-agent-common, .toolchain-common-arm64]
+  rules:
+    - when: on_success
 
 iot-agent-armhf:
   extends: .iot-agent-common
+  rules:
+    - when: on_success
   # Run with platform:arm64 since no platform:armhf exists and arm64 should be backwards compatible
   tags: ["arch:arm64", "specific:true"]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/rpm_armhf$CI_IMAGE_RPM_ARMHF_SUFFIX:$CI_IMAGE_RPM_ARMHF
@@ -156,9 +170,13 @@ iot-agent-armhf:
 
 dogstatsd-x64:
   extends: [.dogstatsd_build_common, .toolchain-common-x64]
+  rules:
+    - when: on_success
 
 dogstatsd-arm64:
   extends: [.dogstatsd_build_common, .toolchain-common-arm64]
+  rules:
+    - when: on_success
 
 # ----- DDOT -----
 

--- a/.gitlab/build/package_build/windows.yml
+++ b/.gitlab/build/package_build/windows.yml
@@ -65,7 +65,6 @@
 windows_msi_and_bosh_zip_x64-a7:
   extends: .windows_main_agent_base
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     ARCH: "x64"

--- a/.gitlab/build/package_deps_build/package_deps_build.yml
+++ b/.gitlab/build/package_deps_build/package_deps_build.yml
@@ -5,7 +5,6 @@
 .generate_minimized_btfs_common:
   stage: package_deps_build
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$CI_IMAGE_BTF_GEN_SUFFIX:$CI_IMAGE_BTF_GEN
   tags: ["arch:amd64", "specific:true"]

--- a/.gitlab/build/packaging/deb.yml
+++ b/.gitlab/build/packaging/deb.yml
@@ -40,7 +40,6 @@ include:
 agent_deb-x64-a7:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["datadog-agent-7-x64"]
   variables:
@@ -59,7 +58,6 @@ agent_deb-arm64-a7:
 agent_deb-x64-a7-fips:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["datadog-agent-7-x64-fips"]
   variables:
@@ -133,7 +131,6 @@ installer_deb-arm64:
 .package_iot_deb_common:
   extends: .bazel:defs:cache:omnibus-transition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   stage: packaging
   script:
@@ -186,7 +183,6 @@ iot_agent_deb-armhf:
 dogstatsd_deb-x64:
   extends: [.package_deb_common, .package_deb_x86]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["dogstatsd-x64"]
   variables:
@@ -199,7 +195,6 @@ dogstatsd_deb-x64:
 dogstatsd_deb-arm64:
   extends: [.package_deb_common, .package_deb_arm64]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   needs: ["dogstatsd-arm64"]
   variables:

--- a/.gitlab/build/packaging/rpm.yml
+++ b/.gitlab/build/packaging/rpm.yml
@@ -61,6 +61,8 @@ include:
 agent_rpm-x64-a7:
   extends: [.package_rpm_common, .package_rpm_x86]
   tags: ["arch:amd64", "specific:true"]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-x64"]
   variables:
     DD_PROJECT: agent
@@ -68,6 +70,8 @@ agent_rpm-x64-a7:
 
 agent_rpm-arm64-a7:
   extends: [.package_rpm_common, .package_rpm_arm64]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-arm64"]
   variables:
     DD_PROJECT: agent
@@ -75,6 +79,8 @@ agent_rpm-arm64-a7:
 
 agent_suse-x64-a7:
   extends: [.package_suse_rpm_common, .package_rpm_x86]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-x64"]
   variables:
     DD_PROJECT: agent
@@ -82,6 +88,8 @@ agent_suse-x64-a7:
 
 agent_suse-arm64-a7:
   extends: [.package_suse_rpm_common, .package_rpm_arm64]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-arm64"]
   variables:
     DD_PROJECT: agent
@@ -101,6 +109,8 @@ installer_rpm-amd64:
 agent_rpm-x64-a7-fips:
   extends: [.package_rpm_common, .package_rpm_x86]
   tags: ["arch:amd64", "specific:true"]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-x64-fips"]
   variables:
     OMNIBUS_EXTRA_ARGS: "--host-distribution rhel --flavor fips"
@@ -109,6 +119,8 @@ agent_rpm-x64-a7-fips:
 
 agent_rpm-arm64-a7-fips:
   extends: [.package_rpm_common, .package_rpm_arm64]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-arm64-fips"]
   variables:
     OMNIBUS_EXTRA_ARGS: "--host-distribution rhel --flavor fips"
@@ -117,6 +129,8 @@ agent_rpm-arm64-a7-fips:
 
 agent_suse-x64-a7-fips:
   extends: [.package_suse_rpm_common, .package_rpm_x86]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-x64-fips"]
   variables:
     OMNIBUS_EXTRA_ARGS: "--host-distribution=suse --flavor fips"
@@ -125,6 +139,8 @@ agent_suse-x64-a7-fips:
 
 agent_suse-arm64-a7-fips:
   extends: [.package_suse_rpm_common, .package_rpm_arm64]
+  rules:
+    - when: on_success
   needs: ["datadog-agent-7-arm64-fips"]
   variables:
     OMNIBUS_EXTRA_ARGS: "--host-distribution=suse --flavor fips"
@@ -206,7 +222,6 @@ installer_suse_rpm-arm64:
 .package_iot_rpm_common:
   extends: .bazel:defs:cache:omnibus-transition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   script:
     - !reference [.cache_omnibus_ruby_deps, setup]
@@ -280,6 +295,8 @@ iot_agent_suse-x64:
 
 dogstatsd_rpm-x64:
   extends: [.package_rpm_common, .package_rpm_x86]
+  rules:
+    - when: on_success
   needs: ["dogstatsd-x64"]
   variables:
     DD_PROJECT: dogstatsd
@@ -290,6 +307,8 @@ dogstatsd_rpm-x64:
 
 dogstatsd_suse-x64:
   extends: [.package_suse_rpm_common, .package_rpm_x86]
+  rules:
+    - when: on_success
   needs: ["dogstatsd-x64"]
   variables:
     DD_PROJECT: dogstatsd

--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -160,6 +160,8 @@
 
 docker_build_agent7:
   extends: [.docker_build_amd64, .docker_build_agent7]
+  rules:
+    - when: on_success
   needs:
     - job: datadog-agent-7-x64
   variables:
@@ -197,6 +199,8 @@ single_machine_performance-full-amd64-a7:
 
 docker_build_agent7_arm64:
   extends: [.docker_build_arm64, .docker_build_agent7]
+  rules:
+    - when: on_success
   needs:
     - job: datadog-agent-7-arm64
   variables:
@@ -224,6 +228,8 @@ docker_build_fips_agent7_arm64:
 # build agent7 jmx image
 docker_build_agent7_jmx:
   extends: [.docker_build_amd64, .docker_build_agent7]
+  rules:
+    - when: on_success
   needs:
     - job: datadog-agent-7-x64
   variables:
@@ -233,6 +239,8 @@ docker_build_agent7_jmx:
 
 docker_build_agent7_jmx_arm64:
   extends: [.docker_build_arm64, .docker_build_agent7]
+  rules:
+    - when: on_success
   needs:
     - job: datadog-agent-7-arm64
   variables:
@@ -420,6 +428,8 @@ docker_build_agent7_fips_full_arm64:
 
 docker_build_cluster_agent_amd64:
   extends: [.docker_build_amd64, .docker_build_cluster_agent]
+  rules:
+    - when: on_success
   needs:
     - job: cluster_agent-build_amd64
       artifacts: true
@@ -432,6 +442,8 @@ docker_build_cluster_agent_amd64:
 
 docker_build_cluster_agent_arm64:
   extends: [.docker_build_arm64, .docker_build_cluster_agent]
+  rules:
+    - when: on_success
   needs:
     - job: cluster_agent-build_arm64
       artifacts: true
@@ -474,7 +486,6 @@ docker_build_cluster_agent_fips_arm64:
 .docker_build_cws_instrumentation:
   extends: .docker_build_job_definition
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/cws-instrumentation
@@ -502,7 +513,6 @@ docker_build_cws_instrumentation_arm64:
 .docker_build_dogstatsd:
   extends: [.docker_build_job_definition, .docker_build_s3]
   rules:
-    - !reference [.except_mergequeue]
     - when: on_success
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/dogstatsd

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -3,8 +3,8 @@ static_quality_gates:
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
     - !reference [.on_main_or_release_branch]
-    - !reference [.on_dev_branches_with_artifact_changes]
     - !reference [.on_mergequeue]
+    - !reference [.on_dev_branches_with_artifact_changes]
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64

--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -4,6 +4,7 @@ static_quality_gates:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate
     - !reference [.on_main_or_release_branch]
     - !reference [.on_dev_branches_with_artifact_changes]
+    - !reference [.on_mergequeue]
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64


### PR DESCRIPTION
### What does this PR do?

Adds Static Quality Gates, alongside with the builds for the artifacts to be measured, to the Merge Queue.

### Motivation

[ABLD-82](https://datadoghq.atlassian.net/browse/ABLD-82)

We want to prevent accidentally landing commits that end up breaking the static quality gates in main. In contrast with other workloads that run on CI which are fairly resistant to parallel changes, static quality gates measure an additive magnitude to which every change can contribute.

When we're close to the limit, not even being strict about ancestor age would really prevent us from ending up with commits that push some size over the limit.

### Describe how you validated your changes

### Additional Notes

I made [this little notebook](https://app.datadoghq.com/notebook/13912613/static-quality-gates-vs-merge-queue-in-datadog-agent?refresh_mode=sliding&from_ts=1770714048590&to_ts=1771318848590) to illustrate the expected effect on merge queue pipelines. The conclusion was:

> The numbers look reasonable: at the time of this writing the effect on the p50 would be an increase from 30 to 38 minutes, with the rest of the distribution falling in favor of the time-to-SQG metric.

Which looks like a reasonable tradeoff.

We can always roll back if we see this is unsustainable.

[ABLD-82]: https://datadoghq.atlassian.net/browse/ABLD-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ