### PR TITLE
[WINA-2113] add PAR to MSI package

### DIFF
--- a/releasenotes/notes/windows-par-msi-service-registration-a4b7e2c1d9f03856.yaml
+++ b/releasenotes/notes/windows-par-msi-service-registration-a4b7e2c1d9f03856.yaml
@@ -1,0 +1,8 @@
+features:
+  - |
+    On Windows, the private action runner binary is now included in the MSI
+    installer and registered as the ``datadog-private-action-runner`` Windows
+    service. The service is installed as demand-start with a dependency on the
+    main Agent service, and its credentials and ACLs are managed alongside the
+    other Agent services during install, upgrade, and repair.
+

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -35,23 +35,23 @@ static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 703.39 MiB
   max_on_wire_size: 164.13 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 821.99 MiB
-  max_on_wire_size: 279.41 MiB
+  max_on_disk_size: 821.08 MiB
+  max_on_wire_size: 279.11 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 828.52 MiB
-  max_on_wire_size: 267.96 MiB
+  max_on_disk_size: 827.71 MiB
+  max_on_wire_size: 267.7 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1012.87 MiB
-  max_on_wire_size: 348.04 MiB
+  max_on_disk_size: 1011.96 MiB
+  max_on_wire_size: 347.74 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 1008.12 MiB
-  max_on_wire_size: 332.56 MiB
+  max_on_disk_size: 1007.31 MiB
+  max_on_wire_size: 332.3 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 191.32 MiB
-  max_on_wire_size: 67.22 MiB
+  max_on_disk_size: 192.54 MiB
+  max_on_wire_size: 67.47 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 208.19 MiB
-  max_on_wire_size: 63.64 MiB
+  max_on_disk_size: 209.45 MiB
+  max_on_wire_size: 63.88 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB
   max_on_wire_size: 3.33 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -9,7 +9,7 @@ static_quality_gate_agent_heroku_amd64:
   max_on_wire_size: 88.44 MiB
 static_quality_gate_agent_msi:
   max_on_disk_size: 1073.22 MiB
-  max_on_wire_size: 143.47 MiB
+  max_on_wire_size: 154.47 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 759.64 MiB
   max_on_wire_size: 189.17 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -35,23 +35,23 @@ static_quality_gate_agent_suse_arm64_fips:
   max_on_disk_size: 703.39 MiB
   max_on_wire_size: 164.13 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 821.08 MiB
-  max_on_wire_size: 279.11 MiB
+  max_on_disk_size: 821.99 MiB
+  max_on_wire_size: 279.41 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 827.71 MiB
-  max_on_wire_size: 267.7 MiB
+  max_on_disk_size: 828.52 MiB
+  max_on_wire_size: 267.96 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1011.96 MiB
-  max_on_wire_size: 347.74 MiB
+  max_on_disk_size: 1012.87 MiB
+  max_on_wire_size: 348.04 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 1007.31 MiB
-  max_on_wire_size: 332.3 MiB
+  max_on_disk_size: 1008.12 MiB
+  max_on_wire_size: 332.56 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 192.54 MiB
-  max_on_wire_size: 67.47 MiB
+  max_on_disk_size: 191.32 MiB
+  max_on_wire_size: 67.22 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 209.45 MiB
-  max_on_wire_size: 63.88 MiB
+  max_on_disk_size: 208.19 MiB
+  max_on_wire_size: 63.64 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB
   max_on_wire_size: 3.33 MiB

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -209,7 +209,10 @@ namespace Datadog.CustomActions
             }
             _serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
             _serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
-            _serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
+            if (_serviceController.ServiceExists(Constants.PrivateActionRunnerServiceName))
+            {
+                _serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
+            }
 
             // SYSTEM
             // LocalSystem is a SCM specific shorthand that doesn't need to be localized
@@ -246,10 +249,13 @@ namespace Datadog.CustomActions
                 Constants.ProcessAgentServiceName,
                 Constants.SystemProbeServiceName,
                 Constants.TraceAgentServiceName,
-                Constants.PrivateActionRunnerServiceName,
                 Constants.AgentServiceName,
                 Constants.InstallerServiceName,
             };
+            if (_serviceController.ServiceExists(Constants.PrivateActionRunnerServiceName))
+            {
+                services.Add(Constants.PrivateActionRunnerServiceName);
+            }
 
             services.Add(Constants.SecurityAgentServiceName);
 

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs
@@ -209,6 +209,7 @@ namespace Datadog.CustomActions
             }
             _serviceController.SetCredentials(Constants.AgentServiceName, ddAgentUserName, ddAgentUserPassword);
             _serviceController.SetCredentials(Constants.TraceAgentServiceName, ddAgentUserName, ddAgentUserPassword);
+            _serviceController.SetCredentials(Constants.PrivateActionRunnerServiceName, ddAgentUserName, ddAgentUserPassword);
 
             // SYSTEM
             // LocalSystem is a SCM specific shorthand that doesn't need to be localized
@@ -245,6 +246,7 @@ namespace Datadog.CustomActions
                 Constants.ProcessAgentServiceName,
                 Constants.SystemProbeServiceName,
                 Constants.TraceAgentServiceName,
+                Constants.PrivateActionRunnerServiceName,
                 Constants.AgentServiceName,
                 Constants.InstallerServiceName,
             };

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentBinaries.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentBinaries.cs
@@ -9,6 +9,7 @@ namespace WixSetup.Datadog_Agent
         public string Tray => $@"{_binSource}\ddtray.exe";
         public Id TrayId => new("ddtray");
         public string ProcessAgent => $@"{_binSource}\process-agent.exe";
+        public string PrivateActionRunner => $@"{_binSource}\privateactionrunner.exe";
         public string SystemProbe => $@"{_binSource}\system-probe.exe";
         public string TraceAgent => $@"{_binSource}\trace-agent.exe";
         public string SecretGenericConnector => $@"{_binSource}\secret-generic-connector.exe";

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -587,6 +587,13 @@ namespace WixSetup.Datadog_Agent
                 "[DDAGENTUSER_PROCESSED_FQ_NAME]",
                 "[DDAGENTUSER_PROCESSED_PASSWORD]",
                 "--config=\"[APPLICATIONDATADIRECTORY]\\datadog.yaml\"");
+            var privateActionRunnerService = GenerateDependentServiceInstaller(
+                new Id("ddagentprivaterunnerservice"),
+                Constants.PrivateActionRunnerServiceName,
+                "Datadog Private Action Runner",
+                "Execute private actions for Datadog",
+                "[DDAGENTUSER_PROCESSED_FQ_NAME]",
+                "[DDAGENTUSER_PROCESSED_PASSWORD]");
             var systemProbeService = GenerateDependentServiceInstaller(
                 new Id("ddagentsysprobeservice"),
                 Constants.SystemProbeServiceName,
@@ -600,7 +607,14 @@ namespace WixSetup.Datadog_Agent
                     ),
                     new WixSharp.File(_agentBinaries.TrayId, _agentBinaries.Tray),
                     new WixSharp.File(_agentBinaries.ProcessAgent, processAgentService),
-                    new WixSharp.File(_agentBinaries.PrivateActionRunner),
+                    new WixSharp.File(_agentBinaries.PrivateActionRunner, privateActionRunnerService),
+                    new EventSource
+                    {
+                        Name = Constants.PrivateActionRunnerServiceName,
+                        Log = "Application",
+                        EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.PrivateActionRunner)}",
+                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
+                    },
                     new EventSource
                     {
                         Name = Constants.ProcessAgentServiceName,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -600,6 +600,7 @@ namespace WixSetup.Datadog_Agent
                     ),
                     new WixSharp.File(_agentBinaries.TrayId, _agentBinaries.Tray),
                     new WixSharp.File(_agentBinaries.ProcessAgent, processAgentService),
+                    new WixSharp.File(_agentBinaries.PrivateActionRunner),
                     new EventSource
                     {
                         Name = Constants.ProcessAgentServiceName,

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentInstaller.cs
@@ -587,13 +587,6 @@ namespace WixSetup.Datadog_Agent
                 "[DDAGENTUSER_PROCESSED_FQ_NAME]",
                 "[DDAGENTUSER_PROCESSED_PASSWORD]",
                 "--config=\"[APPLICATIONDATADIRECTORY]\\datadog.yaml\"");
-            var privateActionRunnerService = GenerateDependentServiceInstaller(
-                new Id("ddagentprivaterunnerservice"),
-                Constants.PrivateActionRunnerServiceName,
-                "Datadog Private Action Runner",
-                "Execute private actions for Datadog",
-                "[DDAGENTUSER_PROCESSED_FQ_NAME]",
-                "[DDAGENTUSER_PROCESSED_PASSWORD]");
             var systemProbeService = GenerateDependentServiceInstaller(
                 new Id("ddagentsysprobeservice"),
                 Constants.SystemProbeServiceName,
@@ -607,14 +600,6 @@ namespace WixSetup.Datadog_Agent
                     ),
                     new WixSharp.File(_agentBinaries.TrayId, _agentBinaries.Tray),
                     new WixSharp.File(_agentBinaries.ProcessAgent, processAgentService),
-                    new WixSharp.File(_agentBinaries.PrivateActionRunner, privateActionRunnerService),
-                    new EventSource
-                    {
-                        Name = Constants.PrivateActionRunnerServiceName,
-                        Log = "Application",
-                        EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.PrivateActionRunner)}",
-                        AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
-                    },
                     new EventSource
                     {
                         Name = Constants.ProcessAgentServiceName,
@@ -660,6 +645,24 @@ namespace WixSetup.Datadog_Agent
                 AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
             }
             );
+            if (_agentFlavor.FlavorName != Constants.FipsFlavor)
+            {
+                var privateActionRunnerService = GenerateDependentServiceInstaller(
+                    new Id("ddagentprivaterunnerservice"),
+                    Constants.PrivateActionRunnerServiceName,
+                    "Datadog Private Action Runner",
+                    "Execute private actions for Datadog",
+                    "[DDAGENTUSER_PROCESSED_FQ_NAME]",
+                    "[DDAGENTUSER_PROCESSED_PASSWORD]");
+                agentBinDir.AddFile(new WixSharp.File(_agentBinaries.PrivateActionRunner, privateActionRunnerService));
+                agentBinDir.Add(new EventSource
+                {
+                    Name = Constants.PrivateActionRunnerServiceName,
+                    Log = "Application",
+                    EventMessageFile = $"[AGENT]{Path.GetFileName(_agentBinaries.PrivateActionRunner)}",
+                    AttributesDefinition = "SupportsErrors=yes; SupportsInformationals=yes; SupportsWarnings=yes; KeyPath=yes"
+                });
+            }
             var targetBinFolder = new Dir(new Id("BIN"), "bin",
                 new WixSharp.File(_agentBinaries.Agent, agentService),
                 // Temporary binary for extracting the embedded Python - will be deleted


### PR DESCRIPTION
### What does this PR do?
This PR adds the Private Action Runner (PAR) binary and Windows service to the MSI installer:

- includes the binary `privateactionrunner.exe` in the MSI payload under `bin\agent\`
- registers `datadog-private-action-runner `as a Windows service (demand-start, depends on datadogagent)
- registers an Event Log source for the service
- wires PAR into `ConfigureServiceUsers` (`ddagentuser` credentials) and `ConfigureServicePermissions (ACLs)`
- skips PAR in Windows FIPS builds (matching omnibus behavior)

### Motivation
This change is part of the Private Action Runner integration with Agent on Windows.

### Describe how you validated your changes
<details>
 <summary> 1. Clean up old installations and bianaries + reboot </summary>

```
1) Stop PAR if there's one
sc.exe stop "datadog-private-action-runner"
sc.exe delete "datadog-private-action-runner"

2) Uninstall agent
$dd = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" |
  Where-Object { $_.DisplayName -eq "Datadog Agent" } |
  Select-Object -First 1
$dd.PSChildName  # this is the ProductCode GUID
msiexec /x $dd.PSChildName /qn /l*vx C:\tmp\ddagent-uninstall.log

3) Clean build dirs to ensure new WixSetup sources are used
Remove-Item -Recurse -Force C:\dev\msi\DatadogAgentInstaller\src
Remove-Item -Recurse -Force C:\dev\msi\DatadogAgentInstaller\output

4) Reboot vm
Restart-Computer -Force
```
</details>

<details>
<summary> 2. Test addition of PAR binary </summary>

```
1) Build PAR + MSI:
dda inv -- -e privateactionrunner.build
Copy-Item .\bin\privateactionrunner\privateactionrunner.exe C:\opt\datadog-agent\bin\agent\
Get-ChildItem C:\opt\datadog-agent\bin\agent\*.exe |
  Sort-Object LastWriteTime -Descending | Select-Object -First 1
dda inv -- -e msi.build

2) Get the path for the newly built image:
Get-ChildItem C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\*.msi |
  Sort-Object LastWriteTime -Descending | Select-Object -First 1
# this returns something like
C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\datadog-agent-7.77.0-devel.git.582.17de3b0-1-x86_64.msi

3) Admin-extract the MSI to a fresh folder
$msi  = "C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\datadog-agent-7.77.0-devel.git.582.17de3b0-1-x86_64.msi"
$root = "C:\tmp\dd-msi-$(Get-Date -Format yyyyMMdd-HHmmss)"
New-Item -ItemType Directory -Path $root -Force | Out-Null

$proc = Start-Process msiexec -Wait -PassThru -ArgumentList "/a `"$msi`" /qn TARGETDIR=`"$root`" /l*vx C:\tmp\msi-admin-install.log"
$proc.ExitCode  # should be 0

4) Compare payload hash to the staged build binary
$payload = "$root\ProgramFiles64Folder\Datadog\Datadog Agent\bin\agent\privateactionrunner.exe"
Get-Item $payload
$staged = "C:\opt\datadog-agent\bin\agent\privateactionrunner.exe"
Get-FileHash $payload
Get-FileHash $staged
```
</details>

<details>
<summary>  3. Test PAR Service Registration </summary>

```
1) Confirm WXS contains ServiceInstall for PAR
Select-String -Path C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\*.wxs `
  -Pattern "ServiceInstall.*datadog-private-action-runner" -Context 2,2

2) Install the MSI:
$msi = "C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\datadog-agent-7.77.0-devel.git.582.17de3b0-1-x86_64.msi"
$log = "C:\tmp\ddagent-install.log"
New-Item -ItemType Directory -Path C:\tmp -Force | Out-Null
$proc = Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$msi`" /qn /l*vx `"$log`""
$proc.ExitCode  # should be 0

3) Verify PAR is registered:
sc.exe query "datadog-private-action-runner"
sc.exe qc "datadog-private-action-runner"

4) Verify Event Log source exists
reg query "HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\datadog-private-action-runner"
```
</details>

<details>
<summary>  4. Test ServiceConfig and ACL </summary>

```
1. Break the PAR service config
sc.exe stop "datadog-private-action-runner"
sc.exe config "datadog-private-action-runner" obj= LocalSystem
sc.exe qc "datadog-private-action-runner"

2. Run MSI reinstall to repair SERVICE_START_NAME (forces ConfigureServices)
Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$($msi.FullName)`" /qn REINSTALL=ALL REINSTALLMODE=amus /l*vx C:\tmp\ddagent-repair.log"
sc.exe qc "datadog-private-action-runner" # should be .\ddagentuser again
```
</details>


### Additional Notes
