### PR TITLE
Also enable ADMS config on Windows CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,7 @@ common:cache --remote_retries=1
 common:cache --remote_timeout=60
 
 # CI config ------------------------------------------------------------------------------------------------------------
+common:ci --config=adms
 common:ci --config=cache
 
 # For Rust targets, enable clippy and rustfmt checks during the build

--- a/tools/bazel
+++ b/tools/bazel
@@ -17,7 +17,6 @@ if [ -n "${CI:-}" ]; then
   # Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` also honor them
   cat >"$(dirname "$(dirname "$0")")/user.bazelrc" <<EOF
 common --config=ci
-common --config=adms
 EOF
 fi
 


### PR DESCRIPTION
### What does this PR do?
Move ADMS configuration from `tools/bazel` to the CI config section in `.bazelrc`, enabling ADMS for Windows CI builds.

### Motivation
Mitigate HTTP 502s [like](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1430682294:
):
```
WARNING: Download from https://github.com/bazel-contrib/supply-chain/archive/refs/tags/tools-0.0.1.tar.gz failed: class java.io.IOException GET returned 502 Bad Gateway or Proxy Error
[...]
WARNING: Target pattern parsing failed.
ERROR: Skipping '//packages/install_dir:install': no such package '@@supply_chain_tools+//gather_metadata': java.io.IOException: Error downloading [https://github.com/bazel-contrib/supply-chain/archive/refs/tags/tools-0.0.1.tar.gz] to C:/bzl/bazel/bv4fleb2/external/supply_chain_tools+/temp8864412009022687999/tools-0.0.1.tar.gz: GET returned 502 Bad Gateway or Proxy Error
ERROR: no such package '@@supply_chain_tools+//gather_metadata': java.io.IOException: Error downloading [https://github.com/bazel-contrib/supply-chain/archive/refs/tags/tools-0.0.1.tar.gz] to C:/bzl/bazel/bv4fleb2/external/supply_chain_tools+/temp8864412009022687999/tools-0.0.1.tar.gz: GET returned 502 Bad Gateway or Proxy Error
INFO: Elapsed time: 27.856s
INFO: 0 processes.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
```

### Describe how you validated your changes
To make sure downloads work through ADMS, I even gave a try after `bazel clean`s and **without remote caching** at all, see temp. commit 67094a2dcecf427191b3894b42b5c885c9dcaead on pipeline [96886185](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/96886185).