### PR TITLE
[ACTP] Add base script-config file to the cluster agent image

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -417,6 +417,8 @@ docker_build_agent7_fips_full_arm64:
     - mv -vf $CLUSTER_AGENT_BINARIES_DIR/datadog-cluster-agent $ARTIFACTS_BUILD_CONTEXT/
     - mv -vf $CWS_INSTRUMENTATION_BINARIES_DIR $ARTIFACTS_BUILD_CONTEXT/
     - mv -vf Dockerfiles/agent/nosys-seccomp $BUILD_CONTEXT/
+    - mkdir -p ${BUILD_CONTEXT}/private-action-runner
+    - cp -v pkg/privateactionrunner/autoconnections/conf/script-config.yaml ${BUILD_CONTEXT}/private-action-runner/
 
 docker_build_cluster_agent_amd64:
   extends: [.docker_build_amd64, .docker_build_cluster_agent]

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -54,6 +54,7 @@ COPY ./datadog-cluster.yaml /etc/datadog-agent/datadog-cluster.yaml
 COPY ./security-agent-policies/compliance/containers/cis-kubernetes*.yaml /etc/datadog-agent/compliance.d/
 COPY ./security-agent-policies/compliance/containers/*.rego /etc/datadog-agent/compliance.d/
 COPY ./install_info etc/datadog-agent/install_info
+COPY ./private-action-runner /etc/datadog-agent/private-action-runner
 COPY entrypoint.sh .
 COPY readsecret.sh readsecret_multiple_providers.sh ./
 

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -137,11 +137,16 @@ def image_build(ctx, arch=None, tag=AGENT_TAG, push=False):
     shutil.copy2(latest_file, exec_path)
     shutil.copy2(latest_cws_instrumentation_file, cws_instrumentation_exec_path)
     shutil.copytree("Dockerfiles/agent/nosys-seccomp", f"{build_context}/nosys-seccomp", dirs_exist_ok=True)
+    par_config_src = "pkg/privateactionrunner/autoconnections/conf/script-config.yaml"
+    par_config_dest = f"{build_context}/private-action-runner"
+    os.makedirs(par_config_dest, exist_ok=True)
+    shutil.copy2(par_config_src, par_config_dest)
     ctx.run(
         f"docker build -t {tag} --platform linux/{arch} {build_context} -f {dockerfile_path} --build-context artifacts={build_context}"
     )
     ctx.run(f"rm {exec_path}")
     ctx.run(f"rm -rf {cws_instrumentation_base}")
+    ctx.run(f"rm -rf {par_config_dest}")
 
     if push:
         ctx.run(f"docker push {tag}")


### PR DESCRIPTION
## Summary

  Include script-config.yaml in the cluster-agent Docker image.

## Motivation
PAR auto-enrollment requires script-config.yaml at /etc/datadog-agent/private-action-runner/script-config.yaml to register script runner connections. The file was added to Linux packages (#46021, #46212) and the main agent Docker image (#46232), but the cluster-agent Docker image was missed because it has a separate build pipeline that manually manages config files.

## Changes

- tasks/cluster_agent.py: Copy script-config.yaml into the Docker build context before the build, and clean it up after (same pattern as cws-instrumentation and nosys-seccomp).
- Dockerfiles/cluster-agent/Dockerfile: Add COPY for private-action-runner/ into /etc/datadog-agent/private-action-runner.