### PR TITLE
Fix panics in NDM E2E tests

### DIFF
--- a/test/new-e2e/tests/ndm/snmp/snmp_vm_test.go
+++ b/test/new-e2e/tests/ndm/snmp/snmp_vm_test.go
@@ -64,6 +64,7 @@ func (v *snmpVMSuite) TestAPIKeyRefresh() {
 
 	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
 		ndmPayload := checkLastNDMPayload(c, fakeIntake, "default")
+		require.NotEmpty(c, ndmPayload.Devices)
 		checkCiscoNexusDeviceMetadata(c, ndmPayload.Devices[0])
 	}, 6*time.Minute, 10*time.Second)
 
@@ -109,6 +110,7 @@ secret_backend_arguments:
 
 	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
 		ndmPayload := checkLastNDMPayload(c, fakeIntake, "default")
+		require.NotEmpty(c, ndmPayload.Devices)
 		checkCiscoNexusDeviceMetadata(c, ndmPayload.Devices[0])
 	}, 6*time.Minute, 10*time.Second)
 
@@ -130,6 +132,7 @@ secret_backend_arguments:
 
 	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
 		ndmPayload := checkLastNDMPayload(c, fakeIntake, "default")
+		require.NotEmpty(c, ndmPayload.Devices)
 		checkCiscoNexusDeviceMetadata(c, ndmPayload.Devices[0])
 	}, 6*time.Minute, 10*time.Second)
 }


### PR DESCRIPTION
### What does this PR do?

Checks array length before accessing it to not panic in NDM E2E tests

### Motivation

### Describe how you validated your changes

### Additional Notes
