### PR TITLE
Fix an edge case in openssl patching

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -67,6 +67,10 @@ FIX_OPENSSL_PATHS = """
 
     # === OPENSSLDIR paths ===
     # OPENSSLDIR display string: /ssl"
+    if [ $$(echo $${SANDBOX} | wc -c) -lt $$(echo $${TARGET} | wc -c) ]; then
+        echo "The new path placeholder is larger than the target it should replace replace ($${SANDBOX})";
+        exit 1;
+    fi
     OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
     # OPENSSLDIR internal path (bare, no quote) - used for actual config lookup

--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -148,6 +148,12 @@ configure_make(
         },
         "//conditions:default": {},
     }),
+    install_prefix = select({
+        "@platforms//os:windows": "",
+        # Provide a long value to ensure we end up with a path to openssl in the sandbox that
+        # is longer than the placeholder we will replace it with as part of the postfix script
+        "//conditions:default": "placeholder" + '_' * 50,
+    }),
     lib_source = ":all_srcs",
     out_include_dir = "include",
     out_interface_libs = select({

--- a/deps/openssl/fix_openssl_paths.sh
+++ b/deps/openssl/fix_openssl_paths.sh
@@ -51,13 +51,13 @@ for lib in "$@"; do
 
     # Resolve symlinks to get the actual file
     REAL_LIB=$(perl -e 'use Cwd "abs_path"; print abs_path($ARGV[0])' "$lib")
-    
+
     echo "Patching: $REAL_LIB"
-    
+
     PLACEHOLDER="$PLACEHOLDER" DESTDIR="$DESTDIR" perl -0777 -pi -e '
         my $placeholder = $ENV{PLACEHOLDER};
         my $destdir = $ENV{DESTDIR};
-        
+
         # All suffixes to replace (order matters - longer suffixes first to avoid partial matches)
         # OpenSSL stores paths in two forms:
         #   1. Display strings for `openssl version -a` ending with " (e.g., MODULESDIR: "/path")
@@ -66,7 +66,7 @@ for lib in "$@"; do
         my @suffixes = (
             # Longer paths first to avoid partial matches
             "/ssl/private",
-            "/ssl/cert.pem", 
+            "/ssl/cert.pem",
             "/ssl/certs",
             # Display strings (with trailing quote)
             "/lib/engines-3\"",
@@ -77,7 +77,7 @@ for lib in "$@"; do
             "/lib/ossl-modules",
             "/ssl",
         );
-        
+
         for my $suffix (@suffixes) {
             my $old_path = $placeholder . $suffix;
             my $new_path = $destdir . $suffix;


### PR DESCRIPTION
### What does this PR do?

Add a safety check before patching the path in OpenSSL's binaries & extend the lenght of the sandbox path to account for shorter than expected values

### Motivation

If the sandbox path is shorted than our placeholder, we end up butchering the binaries, leaving them unusable

### Describe how you validated your changes

Tested locally since the issue wasn't present in the CI

### Additional Notes
