### PR TITLE
[CWS] fix intermediate variable breaking inherited variables

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -1109,16 +1109,28 @@ func (v *ScopedVariables) NewSECLVariable(name string, value any, scopeName stri
 		v.varsLock.RLock()
 		defer v.varsLock.RUnlock()
 		vars := v.vars[key]
-		if (vars == nil || vars[name] == nil) && opts.Inherited && !noFollowInheritance {
+		if vars != nil && vars[name] != nil {
+			return vars[name]
+		}
+
+		if opts.Inherited && !noFollowInheritance {
 			var ok bool
-			scope, ok = scope.ParentScope()
-			for vars == nil && ok {
-				key := scope.Hash()
-				vars = v.vars[key]
+
+			for {
 				scope, ok = scope.ParentScope()
+				if !ok {
+					break
+				}
+
+				key = scope.Hash()
+				vars = v.vars[key]
+				if vars != nil && vars[name] != nil {
+					return vars[name]
+				}
 			}
 		}
-		return vars[name]
+
+		return nil
 	}
 
 	setVariable := func(ctx *Context, value any) error {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1175,6 +1175,19 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 					},
 				},
 			},
+			{
+				ID:         "variable_noise",
+				Expression: `open.file.path == "/tmp/noise"`,
+				Actions: []*ActionDefinition{
+					{
+						Set: &SetDefinition{
+							Name:  "noise",
+							Value: "noise",
+							Scope: "process",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -1237,6 +1250,12 @@ func TestActionSetVariableInheritedFilter(t *testing.T) {
 	correlationKeyFromFirstRule := correlationKeyValue.(string)
 
 	pce2 := newFakeProcessCacheEntry(2, pce1)
+
+	// trigger the variable_noise rule
+	eventNoise := fakeOpenEvent("/tmp/noise", pce2)
+	if !rs.Evaluate(eventNoise) {
+		t.Errorf("Expected event to match rule")
+	}
 
 	// trigger the first rule again, and make sure nothing changes
 	event2 := fakeOpenEvent("/tmp/first", pce2)


### PR DESCRIPTION
### What does this PR do?

Return the inherited value if the ancestor has the value and not only if the ancestor has variables. It avoids having intermediate variables stopping the inherited variable from being resolved.

### Motivation

### Describe how you validated your changes

### Additional Notes
