### PR TITLE
[PROF-13807] added devtest image publish job

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -106,6 +106,8 @@ cws_instrumentation_dev_branch*        @DataDog/agent-security
 dev_branch*                            @Datadog/agent-delivery
 dev_master*                            @Datadog/agent-delivery
 dev_nightly*                           @Datadog/agent-delivery
+dev_branch-host-profiler-standalone    @DataDog/profiling-full-host
+dev_deploy-host-profiler-devtest       @DataDog/profiling-full-host
 qa_agent*                              @DataDog/agent-devx
 qa_ot_agent*                           @DataDog/agent-devx
 qa_cws_instrumentation*                @DataDog/agent-devx
@@ -121,6 +123,7 @@ internal_kubernetes_deploy*            @Datadog/agent-delivery
 
 # Deploy packages
 deploy_agent*                          @DataDog/agent-delivery
+deploy_host_profiler_to_reliability_env_*  @DataDog/profiling-full-host
 deploy_installer*                      @DataDog/agent-delivery
 deploy_ddot_oci*                       @DataDog/agent-delivery
 deploy_packages*                       @DataDog/agent-delivery

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -231,28 +231,48 @@ dev_nightly-host-profiler-standalone:
     IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
     IMG_DESTINATIONS: ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA},ddot-ebpf-dev:nightly-${CI_COMMIT_REF_SLUG},ddot-ebpf-dev:nightly-latest
 
-dev_branch-host-profiler-standalone:
+.publish_host_profiler_base:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules:
-    - !reference [.manual]
   needs:
     - docker_build_host_profiler_standalone_amd64
     - docker_build_host_profiler_standalone_arm64
+  before_script:
+    - |
+      if [ "${DEVTEST:-}" = "1" ]; then
+        export IMG_DESTINATIONS="ddot-ebpf-dev:devtest-latest"
+      else
+        export IMG_DESTINATIONS="ddot-ebpf-dev:${CI_COMMIT_REF_SLUG}"
+      fi
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-    IMG_DESTINATIONS: ddot-ebpf-dev:${CI_COMMIT_REF_SLUG}
 
-dev_devtest-host-profiler-standalone:
-  extends: .docker_publish_job_definition
+dev_branch-host-profiler-standalone:
+  extends: .publish_host_profiler_base
+  rules:
+    - when: manual
+      allow_failure: true
+
+dev_deploy-host-profiler-devtest:
+  extends: .publish_host_profiler_base
+  rules:
+    - when: manual
+      allow_failure: true
+  variables:
+    DEVTEST: "1"
+
+dev_branch-host-profiler-trigger_relenv:
   stage: dev_container_deploy
   rules:
-    - !reference [.manual]
+    - when: on_success
   needs:
-    - docker_build_host_profiler_standalone_amd64
-    - docker_build_host_profiler_standalone_arm64
+    - dev_deploy-host-profiler-devtest
+  trigger:
+    project: DataDog/apm-reliability/datadog-reliability-env
+    branch: theomagellan/add-host-profiler
   variables:
-    IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
-    IMG_DESTINATIONS: ddot-ebpf-dev:devtest-latest
+    UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: ddot-ebpf-dev
+    UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -235,8 +235,10 @@ dev_nightly-host-profiler-standalone:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   needs:
-    - docker_build_host_profiler_standalone_amd64
-    - docker_build_host_profiler_standalone_arm64
+    - job: docker_build_host_profiler_standalone_amd64
+      optional: true
+    - job: docker_build_host_profiler_standalone_arm64
+      optional: true
   before_script:
     - |
       if [ "${DEVTEST:-}" = "1" ]; then

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -243,3 +243,16 @@ dev_branch-host-profiler-standalone:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
     IMG_DESTINATIONS: ddot-ebpf-dev:${CI_COMMIT_REF_SLUG}
+
+dev_devtest-host-profiler-standalone:
+  extends: .docker_publish_job_definition
+  stage: dev_container_deploy
+  rules:
+    - !reference [.manual]
+  needs:
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
+  variables:
+    IMG_REGISTRIES: dev
+    IMG_SOURCES: ${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_DDOT_EBPF}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64
+    IMG_DESTINATIONS: ddot-ebpf-dev:devtest-latest

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -262,17 +262,30 @@ dev_deploy-host-profiler-devtest:
   variables:
     DEVTEST: "1"
 
-dev_branch-host-profiler-trigger_relenv:
+.trigger_relenv_base:
   stage: dev_container_deploy
-  rules:
-    - when: on_success
-  needs:
-    - dev_deploy-host-profiler-devtest
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
-    branch: theomagellan/add-host-profiler
   variables:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: ddot-ebpf-dev
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
+
+deploy_host_profiler_to_reliability_env_nightly:
+  extends: .trigger_relenv_base
+  rules:
+    - !reference [.on_deploy_nightly_repo_branch]
+  needs:
+    - dev_nightly-host-profiler-standalone
+  trigger:
+    branch: master
+
+deploy_host_profiler_to_reliability_env_devtest:
+  extends: .trigger_relenv_base
+  rules:
+    - when: on_success
+  needs:
+    - dev_deploy-host-profiler-devtest
+  trigger:
+    branch: theomagellan/add-host-profiler

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -267,6 +267,7 @@ dev_deploy-host-profiler-devtest:
 .trigger_relenv_base:
   stage: dev_container_deploy
   trigger:
+    branch: master
     project: DataDog/apm-reliability/datadog-reliability-env
   variables:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
@@ -280,8 +281,6 @@ deploy_host_profiler_to_reliability_env_nightly:
     - !reference [.on_deploy_nightly_repo_branch]
   needs:
     - dev_nightly-host-profiler-standalone
-  trigger:
-    branch: master
 
 deploy_host_profiler_to_reliability_env_devtest:
   extends: .trigger_relenv_base
@@ -290,5 +289,3 @@ deploy_host_profiler_to_reliability_env_devtest:
     - when: on_success
   needs:
     - dev_deploy-host-profiler-devtest
-  trigger:
-    branch: master

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -290,4 +290,4 @@ deploy_host_profiler_to_reliability_env_devtest:
   needs:
     - dev_deploy-host-profiler-devtest
   trigger:
-    branch: theomagellan/add-host-profiler
+    branch: master

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -235,10 +235,8 @@ dev_nightly-host-profiler-standalone:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
   needs:
-    - job: docker_build_host_profiler_standalone_amd64
-      optional: true
-    - job: docker_build_host_profiler_standalone_arm64
-      optional: true
+    - docker_build_host_profiler_standalone_amd64
+    - docker_build_host_profiler_standalone_arm64
   before_script:
     - |
       if [ "${DEVTEST:-}" = "1" ]; then
@@ -253,12 +251,14 @@ dev_nightly-host-profiler-standalone:
 dev_branch-host-profiler-standalone:
   extends: .publish_host_profiler_base
   rules:
+    - !reference [.except_mergequeue]
     - when: manual
       allow_failure: true
 
 dev_deploy-host-profiler-devtest:
   extends: .publish_host_profiler_base
   rules:
+    - !reference [.except_mergequeue]
     - when: manual
       allow_failure: true
   variables:
@@ -286,6 +286,7 @@ deploy_host_profiler_to_reliability_env_nightly:
 deploy_host_profiler_to_reliability_env_devtest:
   extends: .trigger_relenv_base
   rules:
+    - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - dev_deploy-host-profiler-devtest


### PR DESCRIPTION
### What does this PR do?
Adds CI/CD pipeline jobs for the host profiler standalone image to automate publishing and deployment to the reliability environment (datadog-reliability-env).
  Specifically:
  - Refactors the existing publish jobs into a shared .publish_host_profiler_base template to reduce duplication
  - Adds a `dev_deploy-host-profiler-devtest` job for manually publishing a devtest-latest tagged image
  - Adds two deployment trigger jobs: one for nightly builds and one for devtest, both triggering the `datadog-reliability-env` downstream pipeline
  - Adds JOBOWNERS entries for @DataDog/profiling-full-host covering the new jobs
### Motivation
The host profiler standalone image previously had no automated path to the reliability environment. This PR wires up the publish and deploy stages so that
  nightly images and devtest images can automatically trigger environment deployments, enabling end-to-end validation of the host profiler.

In tandem with https://github.com/DataDog/datadog-reliability-env/pull/1221