### PR TITLE
Add Config Sync to Host Profiler

### DIFF
--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -32,7 +32,7 @@ func MakeRootCommand() *cobra.Command {
 	}
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to host-profiler configuration file")
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.CoreConfPath, "core-config", "", "", "Location to the Datadog Agent config file. If this value is not set, infra attribute processor and all features related to the Agent will not be enabled.")
-	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncOnInitTimeout, "sync-on-init-timeout", 0, "How long should config sync retry at initialization before failing.")
+	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncOnInitTimeout, "sync-on-init-timeout", 30*time.Second, "How long should config sync retry at initialization before failing.")
 	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncTimeout, "sync-to", 3*time.Second, "Timeout for config sync requests.")
 	for _, subCommandFactory := range hostProfilerSubcommands() {
 		subcommands := subCommandFactory(globalParamsGetter)

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -32,9 +32,8 @@ func MakeRootCommand() *cobra.Command {
 	}
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to host-profiler configuration file")
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.CoreConfPath, "core-config", "", "", "Location to the Datadog Agent config file. If this value is not set, infra attribute processor and all features related to the Agent will not be enabled.")
-	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncOnInitTimeout, "sync-delay", 0, "How long should config sync retry at initialization before failing.")
+	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncOnInitTimeout, "sync-on-init-timeout", 0, "How long should config sync retry at initialization before failing.")
 	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncTimeout, "sync-to", 3*time.Second, "Timeout for config sync requests.")
-
 	for _, subCommandFactory := range hostProfilerSubcommands() {
 		subcommands := subCommandFactory(globalParamsGetter)
 		for _, cmd := range subcommands {

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -9,6 +9,8 @@
 package command
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
@@ -30,6 +32,8 @@ func MakeRootCommand() *cobra.Command {
 	}
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to host-profiler configuration file")
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.CoreConfPath, "core-config", "", "", "Location to the Datadog Agent config file. If this value is not set, infra attribute processor and all features related to the Agent will not be enabled.")
+	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncOnInitTimeout, "sync-delay", 0, "How long should config sync retry at initialization before failing.")
+	hostProfiler.PersistentFlags().DurationVar(&globalParams.SyncTimeout, "sync-to", 3*time.Second, "Timeout for config sync requests.")
 
 	for _, subCommandFactory := range hostProfilerSubcommands() {
 		subcommands := subCommandFactory(globalParamsGetter)

--- a/cmd/host-profiler/globalparams/globalparams.go
+++ b/cmd/host-profiler/globalparams/globalparams.go
@@ -8,6 +8,8 @@
 // Package globalparams contains the global CLI parameters for the host profiler.
 package globalparams
 
+import "time"
+
 // GlobalParams contains the values of host profiler global Cobra flags.
 //
 // A pointer to this type is passed to SubcommandFactory's, but its contents
@@ -17,5 +19,7 @@ type GlobalParams struct {
 	ConfFilePath string
 
 	// CoreConfPath holds the path to the Datadog Agent config file.
-	CoreConfPath string
+	CoreConfPath      string
+	SyncOnInitTimeout time.Duration
+	SyncTimeout       time.Duration
 }

--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -10,7 +10,6 @@ package run
 
 import (
 	"context"
-	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -63,6 +62,7 @@ func MakeCommand(globalConfGetter func() *globalparams.GlobalParams) []*cobra.Co
 			return runHostProfilerCommand(context.Background(), params)
 		},
 	}
+
 	cmd.Flags().BoolVar(&params.GoRuntimeMetrics, "go-runtime-metrics", false, "Enable Go runtime metrics collection.")
 	return []*cobra.Command{cmd}
 }
@@ -85,7 +85,7 @@ func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
 		)
 		opts = append(opts, getRemoteTaggerOptions()...)
 		opts = append(opts, getTraceAgentOptions(ctx)...)
-		opts = append(opts, getConfigOptions()...)
+		opts = append(opts, getConfigOptions(cliParams.GlobalParams)...)
 	} else {
 		opts = append(opts, fx.Provide(collectorimpl.NewExtraFactoriesWithoutAgentCore))
 	}
@@ -104,10 +104,10 @@ func getRemoteTaggerOptions() []fx.Option {
 	}
 }
 
-func getConfigOptions() []fx.Option {
+func getConfigOptions(params *globalparams.GlobalParams) []fx.Option {
 	return []fx.Option{
 		secretsnoopfx.Module(),
-		configsyncimpl.Module(configsyncimpl.NewParams(30*time.Second, true, 0)),
+		configsyncimpl.Module(configsyncimpl.NewParams(params.SyncTimeout, true, params.SyncOnInitTimeout)),
 	}
 }
 

--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -10,6 +10,7 @@ package run
 
 import (
 	"context"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
@@ -18,10 +19,11 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/host-profiler/globalparams"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/remotehostnameimpl"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	remoteTaggerFx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -83,7 +85,7 @@ func runHostProfilerCommand(ctx context.Context, cliParams *cliParams) error {
 		)
 		opts = append(opts, getRemoteTaggerOptions()...)
 		opts = append(opts, getTraceAgentOptions(ctx)...)
-
+		opts = append(opts, getConfigOptions()...)
 	} else {
 		opts = append(opts, fx.Provide(collectorimpl.NewExtraFactoriesWithoutAgentCore))
 	}
@@ -98,8 +100,14 @@ func run(collector collector.Component) error {
 func getRemoteTaggerOptions() []fx.Option {
 	return []fx.Option{
 		ipcfx.ModuleReadOnly(),
-		secretfx.Module(),
 		remoteTaggerFx.Module(tagger.NewRemoteParams()),
+	}
+}
+
+func getConfigOptions() []fx.Option {
+	return []fx.Option{
+		secretsnoopfx.Module(),
+		configsyncimpl.Module(configsyncimpl.NewParams(30*time.Second, true, 0)),
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR forces the host-profiler to fetch API keys from core agent, preventing the need for secret resolution within the full host profiler.

### Motivation
OTAGENT-865

### Describe how you validated your changes

### Additional Notes
