### PR TITLE
Remove last exclusion from `bazel` tests in CI

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -7,12 +7,12 @@
 bazel:test:linux-amd64:
   extends: [ .bazel:test, .bazel:runner:linux-amd64 ]
   script:
-    - bazel test //... -- -//pkg/discovery/module/rust:dd_discovery_test
+    - bazel test //...
 
 bazel:test:linux-arm64:
   extends: [ .bazel:test, .bazel:runner:linux-arm64 ]
   script:
-    - bazel test //... -- -//pkg/discovery/module/rust:dd_discovery_test
+    - bazel test //...
 
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:runner:macos-amd64 ]


### PR DESCRIPTION
### What does this PR do?
Remove the last exclusion from `bazel test //...` on Linux:
- `-//pkg/discovery/module/rust:dd_discovery_test`

### Motivation
Secure the progress made by:
- #46547,
- #46580.

### Additional Notes
This completes #46518.