### PR TITLE
[TEEP-4964] [AGENT-15614] fix(process-agent): Windows PID reuse metadata misattribution (PID+CreateTime validation)

### DIFF
--- a/releasenotes/notes/fix-windows-pid-reuse-53t214.yaml
+++ b/releasenotes/notes/fix-windows-pid-reuse-53t214.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Windows: Fixed a Process Agent issue where process metadata (for example executable
+    path, command line, and username) could be incorrectly reused after Windows PID
+    recycling. The agent now validates process identity with PID + creation time in
+    both Toolhelp and performance-counter probes, and refreshes cached metadata when
+    a PID is reused.


### PR DESCRIPTION
### What does this PR do?
- Updates `/Users/roberto.ahumada/tee-work/ghrepos/datadog-agent/pkg/process/procutil/process_windows.go` to validate cached processes by `CreateTime` before reusing metadata.
- Adds `getProcessCreateTime` and `getProcessCreateTimeFromHandle` helpers and reuses them in metadata collection.
- Updates `/Users/roberto.ahumada/tee-work/ghrepos/datadog-agent/pkg/process/procutil/process_windows_toolhelp.go` to store cached create time and refresh cached metadata when PID reuse is detected.
- Preserves existing behavior for stable (non-recycled) PIDs.

### Motivation
- A customer observed CPU attribution remaining on a previous process identity after Windows PID reuse.
- Root cause: cache keys effectively used PID-only identity, so recycled PIDs could inherit stale metadata between polling intervals.
- This change prevents CPU/memory stats from being paired with stale process identity fields.

### Describe how you validated your changes
- Ran `gofmt` on modified files.
- Ran Windows-targeted compile validation: `GOOS=windows GOARCH=amd64 go test -c ./pkg/process/procutil` (success).
- Performed code-path verification for both Windows probe modes (Toolhelp default path and perf-counter optional path).

### Additional Notes
- No config changes and no payload schema changes.
- Small runtime overhead from extra create-time checks on cached PIDs.
- I did not run runtime/integration tests on an actual Windows host in this environment.
- Added tests