### PR TITLE
[autoscaling] Enforce vertical constraints in vertical controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.76.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/version v0.76.0-rc.4
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671
+	github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6
 	github.com/DataDog/datadog-traceroute v1.0.8
 	github.com/DataDog/ebpf-manager v0.7.15
 	github.com/DataDog/go-sqllexer v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671 h1:AOZwJBuJZVyeBRcYi/AavxWozk6+mXZNs2SJJEEVp0U=
-github.com/DataDog/datadog-operator/api v0.0.0-20260130110400-4fcb91d49671/go.mod h1:qrisxX+IMicFX01uVrzmPWTxhSQrrmyb6fUTQdjQdN8=
+github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6 h1:UXO2N0ElAkDMRwMSX1aurYLCRbr1rYtT2ta/f7O9Hdg=
+github.com/DataDog/datadog-operator/api v0.0.0-20260218132256-6fb0dc76eec6/go.mod h1:lejC6AK61CXsAj6kfQI8/ByZly9xvsdBNODJfC+EutQ=
 github.com/DataDog/datadog-traceroute v1.0.8 h1:VZkBnNt5OFmusPALd/d4sNEPJ75lmTZxIihx7ZZYBHM=
 github.com/DataDog/datadog-traceroute v1.0.8/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=

--- a/pkg/clusteragent/autoscaling/errors.go
+++ b/pkg/clusteragent/autoscaling/errors.go
@@ -42,6 +42,12 @@ const (
 	ConditionReasonUnsupportedTargetKind ConditionReasonType = "UnsupportedTargetKind"
 	// ConditionReasonRolloutFailed indicates a failure when triggering a vertical rollout on the target.
 	ConditionReasonRolloutFailed ConditionReasonType = "RolloutFailed"
+	// ConditionReasonLimitedByConstraint indicates the recommendation was clamped by configured constraints
+	// (e.g. min/max replicas for horizontal, minAllowed/maxAllowed for vertical).
+	ConditionReasonLimitedByConstraint ConditionReasonType = "LimitedByConstraint"
+	// ConditionReasonLimitedByScalingBehavior indicates scaling was limited by behavior settings
+	// (e.g. stabilization window, scaling rules).
+	ConditionReasonLimitedByScalingBehavior ConditionReasonType = "LimitedByScalingBehavior"
 )
 
 // ConditionReason is an interface that errors can implement to provide

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -15,6 +15,7 @@ import (
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +73,7 @@ type Controller struct {
 	limitHeap *limitHeap
 
 	podWatcher           PodWatcher
+	scaler               scaler
 	horizontalController *horizontalController
 	verticalController   *verticalController
 
@@ -123,9 +125,10 @@ func NewController(
 	})
 	c.store = store
 	c.podWatcher = podWatcher
+	c.scaler = newScaler(restMapper, scaleClient)
 
 	// TODO: Ensure that controllers do not take action before the podwatcher is synced
-	c.horizontalController = newHorizontalReconciler(c.clock, eventRecorder, restMapper, scaleClient)
+	c.horizontalController = newHorizontalReconciler(c.clock, eventRecorder, c.scaler)
 	c.verticalController = newVerticalController(c.clock, eventRecorder, dynamicClient, c.podWatcher)
 
 	return c, nil
@@ -322,18 +325,25 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 	// Reaching this point, we had no errors in processing, clearing up global error
 	podAutoscalerInternal.SetError(nil)
 
+	// Helper functions for non-retryable errors, clear state to avoid misleading status.
+	handleNonRetryableError := func(err error) (autoscaling.ProcessResult, error) {
+		podAutoscalerInternal.SetError(err)
+		podAutoscalerInternal.ClearCurrentReplicas()
+		podAutoscalerInternal.ClearHorizontalState()
+		podAutoscalerInternal.ClearVerticalState()
+		return autoscaling.NoRequeue, c.updateAutoscalerStatusAndUnlock(ctx, key, ns, name, nil, podAutoscalerInternal, podAutoscaler)
+	}
+
 	// Validate autoscaler requirements
 	validationErr := c.validateAutoscaler(podAutoscalerInternal)
 	if validationErr != nil {
-		podAutoscalerInternal.SetError(validationErr)
-		return autoscaling.NoRequeue, c.updateAutoscalerStatusAndUnlock(ctx, key, ns, name, validationErr, podAutoscalerInternal, podAutoscaler)
+		return handleNonRetryableError(validationErr)
 	}
 
 	// Get autoscaler target
 	targetGVK, targetErr := podAutoscalerInternal.TargetGVK()
 	if targetErr != nil {
-		podAutoscalerInternal.SetError(targetErr)
-		return autoscaling.NoRequeue, c.updateAutoscalerStatusAndUnlock(ctx, key, ns, name, targetErr, podAutoscalerInternal, podAutoscaler)
+		return handleNonRetryableError(targetErr)
 	}
 	target := NamespacedPodOwner{
 		Namespace: podAutoscalerInternal.Namespace(),
@@ -341,8 +351,16 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 		Kind:      targetGVK.Kind,
 	}
 
+	// Check if target exists through Scale subresource
+	scale, gr, getScaleErr := c.scaler.get(ctx, target.Namespace, target.Name, targetGVK)
+	if getScaleErr != nil && k8serrors.IsNotFound(getScaleErr) {
+		notFoundErr := autoscaling.NewConditionError(autoscaling.ConditionReasonTargetNotFound,
+			fmt.Errorf("target %s %s/%s not found", targetGVK.Kind, target.Namespace, target.Name))
+		return handleNonRetryableError(notFoundErr)
+	}
+
 	// Now that everything is synced, we can perform the actual processing
-	result, scalingErr := c.handleScaling(ctx, podAutoscaler, &podAutoscalerInternal, targetGVK, target)
+	result, scalingErr := c.handleScaling(ctx, podAutoscaler, &podAutoscalerInternal, targetGVK, target, scale, gr, getScaleErr)
 
 	// Update current replicas
 	pods := c.podWatcher.GetPodsForOwner(target)
@@ -353,7 +371,7 @@ func (c *Controller) syncPodAutoscaler(ctx context.Context, key, ns, name string
 	return result, c.updateAutoscalerStatusAndUnlock(ctx, key, ns, name, scalingErr, podAutoscalerInternal, podAutoscaler)
 }
 
-func (c *Controller) handleScaling(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, podAutoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, target NamespacedPodOwner) (autoscaling.ProcessResult, error) {
+func (c *Controller) handleScaling(ctx context.Context, podAutoscaler *datadoghq.DatadogPodAutoscaler, podAutoscalerInternal *model.PodAutoscalerInternal, targetGVK schema.GroupVersionKind, target NamespacedPodOwner, scale *autoscalingv1.Scale, gr schema.GroupResource, scaleErr error) (autoscaling.ProcessResult, error) {
 	currentTime := c.clock.Now()
 
 	// Update the scaling values based on the staleness of recommendations
@@ -363,7 +381,7 @@ func (c *Controller) handleScaling(ctx context.Context, podAutoscaler *datadoghq
 
 	// TODO: While horizontal scaling is in progress we should not start vertical scaling
 	// While vertical scaling is in progress we should only allow horizontal scale up
-	horizontalRes, err := c.horizontalController.sync(ctx, podAutoscaler, podAutoscalerInternal)
+	horizontalRes, err := c.horizontalController.sync(ctx, podAutoscaler, podAutoscalerInternal, scale, gr, scaleErr)
 	if err != nil {
 		return horizontalRes, err
 	}
@@ -490,36 +508,9 @@ func (c *Controller) validateAutoscaler(podAutoscalerInternal model.PodAutoscale
 	if podAutoscalerInternal.Namespace() == clusterAgentNs && podAutoscalerInternal.Spec().TargetRef.Name == resourceName {
 		return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidTarget, "Autoscaling target cannot be set to the cluster agent")
 	}
-	if err := validateAutoscalerObjectives(podAutoscalerInternal.Spec()); err != nil {
+
+	if err := model.ValidateAutoscalerSpec(podAutoscalerInternal.Spec()); err != nil {
 		return err
-	}
-	return nil
-}
-
-func validateAutoscalerObjectives(spec *datadoghq.DatadogPodAutoscalerSpec) error {
-	if spec.Fallback != nil && len(spec.Fallback.Horizontal.Objectives) > 0 {
-		for _, objective := range spec.Fallback.Horizontal.Objectives {
-			if objective.Type == datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType {
-				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "Autoscaler fallback cannot be based on custom query objective")
-			}
-		}
-	}
-
-	for _, objective := range spec.Objectives {
-		switch objective.Type {
-		case datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType:
-			if objective.CustomQuery == nil {
-				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "Autoscaler objective type is custom query but customQueryObjective is nil")
-			}
-		case datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType:
-			if objective.PodResource == nil {
-				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "autoscaler objective type is %s but podResource is nil", objective.Type)
-			}
-		case datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType:
-			if objective.ContainerResource == nil {
-				return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "autoscaler objective type is %s but containerResource is nil", objective.Type)
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -71,7 +71,8 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 					return nil, err
 				}
 
-				// Patching horizontal controller scaler to use the fake scaler
+				// Patching controller and horizontal controller scaler to use the fake scaler
+				c.scaler = scaler
 				c.horizontalController.scaler = scaler
 				return c.Controller, err
 			},
@@ -202,6 +203,7 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
@@ -270,6 +272,7 @@ func TestLeaderCreateDeleteRemoteDefaultedSpec(t *testing.T) {
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
@@ -417,6 +420,7 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+						condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 						condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 						condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 					},
@@ -543,6 +547,7 @@ func TestPodAutoscalerClearStatusOnScalingModeChange(t *testing.T) {
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionFalse, "", "no data available", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionTrue, "", "", testTime),
 			},
@@ -595,6 +600,7 @@ func TestPodAutoscalerClearStatusOnScalingModeChange(t *testing.T) {
 		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionTrue, "", "", testTime),
 		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+		condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 		condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionTrue, "", "", testTime),
 		condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 	}
@@ -694,6 +700,7 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
@@ -774,6 +781,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+			condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 			condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 			condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 		},
@@ -836,6 +844,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
 				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
 			},
@@ -921,124 +930,6 @@ func TestIsTimestampStale(t *testing.T) {
 	assert.False(t, isTimestampStale(currentTime, receivedTime, staleTimestampThreshold))
 	receivedTime = currentTime.Add(-1 * time.Minute * 3)
 	assert.True(t, isTimestampStale(currentTime, receivedTime, staleTimestampThreshold))
-}
-
-func TestValidateAutoscalerObjectives(t *testing.T) {
-	tests := map[string]struct {
-		spec    datadoghq.DatadogPodAutoscalerSpec
-		wantErr string
-	}{
-		"fallback objective custom query not allowed": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Fallback: &datadoghq.DatadogFallbackPolicy{
-					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-							{Type: datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType},
-						},
-					},
-				},
-			},
-			wantErr: "Autoscaler fallback cannot be based on custom query objective",
-		},
-		"fallback objective cpu allowed": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Fallback: &datadoghq.DatadogFallbackPolicy{
-					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
-						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-							{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType},
-						},
-					},
-				},
-			},
-			wantErr: "",
-		},
-		"custom query objective missing payload": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type: datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
-					},
-				},
-			},
-			wantErr: "Autoscaler objective type is custom query but customQueryObjective is nil",
-		},
-		"custom query objective with pod resource also set": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type:              datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
-						CustomQuery:       &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
-						PodResource:       &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
-						ContainerResource: nil,
-					},
-				},
-			},
-		},
-		"pod resource type without resource": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
-					},
-				},
-			},
-			wantErr: "autoscaler objective type is PodResource but podResource is nil",
-		},
-		"container resource type without resource": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
-					},
-				},
-			},
-			wantErr: "autoscaler objective type is ContainerResource but containerResource is nil",
-		},
-		"pod resource type with custom query also set": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
-						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
-						CustomQuery: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
-					},
-				},
-			},
-		},
-		"container resource type with custom query also set": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type:              datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
-						ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{},
-						CustomQuery:       &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
-					},
-				},
-			},
-		},
-		"valid pod resource objective": {
-			spec: datadoghq.DatadogPodAutoscalerSpec{
-				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
-					{
-						Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
-						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
-					},
-				},
-			},
-			wantErr: "",
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			err := validateAutoscalerObjectives(&tt.spec)
-			if tt.wantErr == "" {
-				assert.NoError(t, err)
-				return
-			}
-			assert.EqualError(t, err, tt.wantErr)
-		})
-	}
 }
 
 func TestGetActiveScalingSources(t *testing.T) {
@@ -1241,6 +1132,142 @@ func TestGetActiveScalingSources(t *testing.T) {
 			assert.Equal(t, tt.wantVerticalSource, verticalSource)
 		})
 	}
+}
+
+// TestVerticalConstraintsIdempotent is an end-to-end controller test verifying that when
+// vertical constraints clamp a recommendation, the second reconcile does NOT produce
+// a different status. If it did, updatePodAutoscalerStatus would call UpdateStatus on
+// every sync, causing an infinite reconcile loop.
+func TestVerticalConstraintsIdempotent(t *testing.T) {
+	testTime := time.Now()
+	f := newFixture(t, testTime)
+
+	// Original (unconstrained) recommendation: CPU request=50m, limit=80m.
+	// Constraint: MinAllowed CPU=200m → after clamping: request=200m, limit raised to 200m.
+	constraints := &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{
+				Name:       "app",
+				MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			},
+		},
+	}
+
+	constrainedResources := []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+		{
+			Name:     "app",
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+		},
+	}
+	constrainedHash, err := autoscaling.ObjectHash(constrainedResources)
+	require.NoError(t, err)
+
+	dpaSpec := datadoghq.DatadogPodAutoscalerSpec{
+		TargetRef: autoscalingv2.CrossVersionObjectReference{
+			Kind:       "Deployment",
+			Name:       "app-0",
+			APIVersion: "apps/v1",
+		},
+		Owner:       datadoghqcommon.DatadogPodAutoscalerLocalOwner,
+		Constraints: constraints,
+	}
+
+	dpa, dpaTyped := newFakePodAutoscaler("default", "dpa-0", 1, testTime, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
+
+	dpaInternal := model.FakePodAutoscalerInternal{
+		Namespace:         "default",
+		Name:              "dpa-0",
+		Generation:        1,
+		CreationTimestamp: testTime,
+		Spec:              &dpaSpec,
+		MainScalingValues: model.ScalingValues{
+			Vertical: &model.VerticalScalingValues{
+				Source:        datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+				Timestamp:     testTime,
+				ResourcesHash: "original-hash",
+				ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+					{
+						Name:     "app",
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("80m")},
+					},
+				},
+			},
+		},
+	}
+	f.store.Set("default/dpa-0", dpaInternal.Build(), controllerID)
+
+	// Pods already on the constrained hash (steady state after first patch).
+	f.podWatcher.mockGetPodsForOwner(NamespacedPodOwner{
+		Namespace: "default",
+		Kind:      "Deployment",
+		Name:      "app-0",
+	}, []*workloadmeta.KubernetesPod{
+		{
+			EntityMeta: workloadmeta.EntityMeta{
+				Name: "pod-1", Namespace: "default",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: constrainedHash},
+			},
+			Owners: []workloadmeta.KubernetesPodOwner{{Kind: "ReplicaSet", Name: "app-0-rs1", ID: "app-0-rs1"}},
+		},
+	})
+
+	// Horizontal controller needs the scaler mock even if there are no horizontal recs.
+	f.scaler.On("get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		&autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 1}, Status: autoscalingv1.ScaleStatus{Replicas: 1}},
+		schema.GroupResource{}, nil,
+	).Maybe()
+
+	cpuReqSum, memReqSum := (&model.VerticalScalingValues{ContainerResources: constrainedResources}).SumCPUMemoryRequests()
+
+	// First sync: status goes from empty to populated → UpdateStatus expected.
+	f.InformerObjects = []*unstructured.Unstructured{dpa}
+	f.Objects = []runtime.Object{dpaTyped}
+
+	expectedDPA := &datadoghq.DatadogPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{Kind: "DatadogPodAutoscaler", APIVersion: "datadoghq.com/v1alpha2"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dpa-0", Namespace: "default",
+			Generation: 1, UID: dpa.GetUID(), CreationTimestamp: metav1.NewTime(testTime),
+		},
+		Spec: datadoghq.DatadogPodAutoscalerSpec{},
+		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+			CurrentReplicas: pointer.Ptr[int32](1),
+			Vertical: &datadoghqcommon.DatadogPodAutoscalerVerticalStatus{
+				Target: &datadoghqcommon.DatadogPodAutoscalerVerticalTargetStatus{
+					Source:           datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					GeneratedAt:      metav1.NewTime(testTime),
+					Version:          constrainedHash,
+					DesiredResources: constrainedResources,
+					PodCPURequest:    cpuReqSum,
+					PodMemoryRequest: memReqSum,
+					Scaled:           pointer.Ptr[int32](1),
+				},
+			},
+			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
+				condition(datadoghqcommon.DatadogPodAutoscalerErrorCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerActiveCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, corev1.ConditionTrue, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, corev1.ConditionFalse, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, corev1.ConditionTrue, "LimitedByConstraint", "recommendation clamped to min/max bounds for containers: app", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, corev1.ConditionUnknown, "", "", testTime),
+				condition(datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, corev1.ConditionUnknown, "", "", testTime),
+			},
+		},
+	}
+	f.ExpectUpdateStatusAction(mustUnstructured(t, expectedDPA))
+	f.RunControllerSync(true, "default/dpa-0")
+
+	// Second sync: feed back the status from the first sync into the DPA object.
+	// The controller must see no status diff → no UpdateStatus call → no spurious reconcile.
+	dpaTyped.Status = expectedDPA.Status
+	f.InformerObjects = []*unstructured.Unstructured{mustUnstructured(t, dpaTyped)}
+	f.Objects = []runtime.Object{dpaTyped}
+	f.Actions = nil // expect zero actions
+
+	f.RunControllerSync(true, "default/dpa-0")
 }
 
 func mustUnstructured(t *testing.T, structIn any) *unstructured.Unstructured {

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -9,11 +9,16 @@ package workload
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -250,4 +255,171 @@ func hasLimitIncrease(
 	}
 
 	return false
+}
+
+// applyVerticalConstraints applies the container constraints from the PodAutoscaler spec to the recommendations
+func applyVerticalConstraints(verticalRecs *model.VerticalScalingValues, constraints *datadoghqcommon.DatadogPodAutoscalerConstraints) (limitErr, err error) {
+	if constraints == nil || len(constraints.Containers) == 0 || verticalRecs == nil {
+		return nil, nil
+	}
+
+	// Build constraint lookup and validate uniqueness
+	constraintsByName := make(map[string]*datadoghqcommon.DatadogPodAutoscalerContainerConstraints, len(constraints.Containers))
+	var wildcardConstraint *datadoghqcommon.DatadogPodAutoscalerContainerConstraints
+	for i := range constraints.Containers {
+		c := &constraints.Containers[i]
+		if c.Name == "*" {
+			if wildcardConstraint != nil {
+				return nil, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "duplicate wildcard (*) constraint in containers list")
+			}
+			wildcardConstraint = c
+		} else {
+			if _, exists := constraintsByName[c.Name]; exists {
+				return nil, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec, "duplicate constraint for container %q", c.Name)
+			}
+			constraintsByName[c.Name] = c
+		}
+	}
+
+	modified := false
+	var clampedContainers []string
+	kept := make([]datadoghqcommon.DatadogPodAutoscalerContainerResources, 0, len(verticalRecs.ContainerResources))
+
+	for _, cr := range verticalRecs.ContainerResources {
+		// Resolve constraint: specific name > wildcard > none
+		constraint, found := constraintsByName[cr.Name]
+		if !found {
+			constraint = wildcardConstraint
+		}
+		if constraint == nil {
+			kept = append(kept, cr)
+			continue
+		}
+
+		// Enabled=false: drop this container's recommendations entirely
+		if constraint.Enabled != nil && !*constraint.Enabled {
+			modified = true
+			continue
+		}
+
+		// Resolve which resources are controlled.
+		// nil defaults to [cpu, memory]; empty list is equivalent to Enabled=false.
+		controlled := constraint.ControlledResources
+		if controlled == nil {
+			controlled = []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory}
+		}
+		if len(controlled) == 0 {
+			modified = true
+			continue
+		}
+
+		// Remove resources not in the controlled list from requests and limits
+		for name := range cr.Requests {
+			if !slices.Contains(controlled, name) {
+				delete(cr.Requests, name)
+				modified = true
+			}
+		}
+		for name := range cr.Limits {
+			if !slices.Contains(controlled, name) {
+				delete(cr.Limits, name)
+				modified = true
+			}
+		}
+
+		// ControlledValues=RequestsOnly: strip all limits
+		if constraint.ControlledValues != nil && *constraint.ControlledValues == datadoghqcommon.DatadogPodAutoscalerContainerControlledValuesRequestsOnly {
+			if len(cr.Limits) > 0 {
+				cr.Limits = nil
+				modified = true
+			}
+		}
+
+		// Resolve min/max bounds for clamping.
+		// New top-level MinAllowed/MaxAllowed apply to both requests and limits.
+		// Deprecated Requests.MinAllowed/MaxAllowed apply to requests only.
+		reqMin, reqMax, limMin, limMax := resolveMinMaxBounds(constraint)
+
+		// Clamp existing requests and limits to their respective bounds.
+		// Track which containers were clamped for the VerticalScalingLimited condition.
+		requestsClamped := clampResourceList(cr.Requests, reqMin, reqMax)
+		limitsClamped := clampResourceList(cr.Limits, limMin, limMax)
+		if requestsClamped || limitsClamped {
+			clampedContainers = append(clampedContainers, cr.Name)
+			modified = true
+		}
+
+		// Maintain invariant: limits >= requests for all resources where both exist
+		for resourceName, reqQty := range cr.Requests {
+			if limQty, hasLimit := cr.Limits[resourceName]; hasLimit && limQty.Cmp(reqQty) < 0 {
+				cr.Limits[resourceName] = reqQty.DeepCopy()
+				modified = true
+			}
+		}
+
+		kept = append(kept, cr)
+	}
+
+	verticalRecs.ContainerResources = kept
+
+	if modified {
+		newHash, hashErr := autoscaling.ObjectHash(verticalRecs.ContainerResources)
+		if hashErr != nil {
+			return nil, autoscaling.NewConditionError(autoscaling.ConditionReasonRecommendationError,
+				fmt.Errorf("failed to recompute resources hash after applying constraints: %w", hashErr))
+		}
+		verticalRecs.ResourcesHash = newHash
+	}
+
+	if len(clampedContainers) > 0 {
+		limitErr = autoscaling.NewConditionErrorf(autoscaling.ConditionReasonLimitedByConstraint,
+			"recommendation clamped to min/max bounds for containers: %s", strings.Join(clampedContainers, ", "))
+	}
+
+	return limitErr, nil
+}
+
+// resolveMinMaxBounds returns the effective min/max bounds for requests and limits.
+// New top-level MinAllowed/MaxAllowed apply to both; deprecated Requests field applies to requests only.
+func resolveMinMaxBounds(c *datadoghqcommon.DatadogPodAutoscalerContainerConstraints) (reqMin, reqMax, limMin, limMax corev1.ResourceList) {
+	if len(c.MinAllowed) > 0 {
+		reqMin = c.MinAllowed
+		limMin = c.MinAllowed
+	} else if c.Requests != nil {
+		reqMin = c.Requests.MinAllowed
+	}
+
+	if len(c.MaxAllowed) > 0 {
+		reqMax = c.MaxAllowed
+		limMax = c.MaxAllowed
+	} else if c.Requests != nil {
+		reqMax = c.Requests.MaxAllowed
+	}
+
+	return
+}
+
+// clampResourceList clamps each resource quantity in the list to [min, max].
+// Returns true if any values were modified.
+func clampResourceList(rl corev1.ResourceList, minAllowed, maxAllowed corev1.ResourceList) bool {
+	if rl == nil {
+		return false
+	}
+	modified := false
+	for name, qty := range rl {
+		clamped := false
+		if minQty, ok := minAllowed[name]; ok && qty.Cmp(minQty) < 0 {
+			qty = minQty.DeepCopy()
+			clamped = true
+		}
+		if maxQty, ok := maxAllowed[name]; ok && qty.Cmp(maxQty) > 0 {
+			qty = maxQty.DeepCopy()
+			clamped = true
+		}
+		if clamped {
+			rl[name] = qty
+			modified = true
+		}
+	}
+	return modified
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
@@ -12,114 +12,102 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 )
 
-func TestHasLimitIncrease_CPUIncrease(t *testing.T) {
-	// Pod with current CPU limit of 500m (50% in workloadmeta format)
-	cpuLimit := float64(50)
+func TestHasLimitIncrease_Detected(t *testing.T) {
+	cpuLimit1 := float64(50) // 500m
+	memLimit1 := uint64(512 * 1024 * 1024)
+	cpuLimit2 := float64(100) // 1000m
+
 	pods := []*workloadmeta.KubernetesPod{
 		{
 			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
+				Name: "pod-1", Namespace: "default",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
 			},
 			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit: &cpuLimit,
-					},
-				},
+				{Name: "container-1", Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit1, MemoryLimit: &memLimit1}},
+			},
+		},
+		{
+			// Pod already on current recommendation - must be skipped
+			EntityMeta: workloadmeta.EntityMeta{
+				Name: "pod-2", Namespace: "default",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "new-rec"},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{Name: "container-1", Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit2}},
 			},
 		},
 	}
 
-	// Recommendation with higher CPU limit (800m)
+	// Higher CPU limit + removed memory limit (no memory in Limits = unlimited)
 	recommendation := &model.VerticalScalingValues{
 		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
+				Name:     "container-1",
+				Limits:   corev1.ResourceList{"cpu": resource.MustParse("800m")},
+				Requests: corev1.ResourceList{"cpu": resource.MustParse("250m"), "memory": resource.MustParse("256Mi")},
+				// No memory in Limits -> pod-1's memory limit is being removed (= increase)
 			},
 		},
 	}
 
-	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
+	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec"))
 }
 
-func TestHasLimitIncrease_MemoryIncrease(t *testing.T) {
-	// Pod with current memory limit of 512Mi
-	memLimit := uint64(512 * 1024 * 1024)
+func TestHasLimitIncrease_NotDetected(t *testing.T) {
+	cpuLimit1 := float64(50)
+	cpuLimit2 := float64(100) // 1000m
+	memLimit2 := uint64(1024 * 1024 * 1024)
+	cpuLimit3 := float64(100) // 1000m
+	memLimit3 := uint64(1024 * 1024 * 1024)
+
 	pods := []*workloadmeta.KubernetesPod{
 		{
+			// No recommendation annotation -> skipped
 			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
+				Name: "pod-1", Namespace: "default",
+				Annotations: map[string]string{},
 			},
 			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						MemoryLimit: &memLimit,
-					},
-				},
+				{Name: "container-1", Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit1}},
 			},
 		},
-	}
-
-	// Recommendation with higher memory limit (1Gi)
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"memory": resource.MustParse("1Gi")},
-			},
-		},
-	}
-
-	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
-}
-
-func TestHasLimitIncrease_NoIncrease(t *testing.T) {
-	// Pod with current CPU limit of 1000m (100%)
-	cpuLimit := float64(100)
-	memLimit := uint64(1024 * 1024 * 1024) // 1Gi
-	pods := []*workloadmeta.KubernetesPod{
 		{
+			// Already on current recommendation -> skipped
 			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
+				Name: "pod-2", Namespace: "default",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "current-rec"},
 			},
 			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit:    &cpuLimit,
-						MemoryLimit: &memLimit,
-					},
-				},
+				{Name: "container-1", Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit2, MemoryLimit: &memLimit2}},
+			},
+		},
+		{
+			// Old recommendation, but limits are higher than the new recommendation
+			EntityMeta: workloadmeta.EntityMeta{
+				Name: "pod-3", Namespace: "default",
+				Annotations: map[string]string{model.RecommendationIDAnnotation: "old-rec"},
+			},
+			Containers: []workloadmeta.OrchestratorContainer{
+				{Name: "container-1", Resources: workloadmeta.ContainerResources{CPULimit: &cpuLimit3, MemoryLimit: &memLimit3}},
 			},
 		},
 	}
 
-	// Recommendation with lower limits
+	// Recommendation with lower limits than pod-3
 	recommendation := &model.VerticalScalingValues{
 		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 			{
@@ -129,214 +117,7 @@ func TestHasLimitIncrease_NoIncrease(t *testing.T) {
 		},
 	}
 
-	assert.False(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
-}
-
-func TestHasLimitIncrease_NoPatchedPods(t *testing.T) {
-	// Pods without RecommendationIDAnnotation should be ignored
-	cpuLimit := float64(50)
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:        "pod-1",
-				Namespace:   "default",
-				Annotations: map[string]string{}, // No RecommendationIDAnnotation
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit: &cpuLimit,
-					},
-				},
-			},
-		},
-	}
-
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
-			},
-		},
-	}
-
-	// Should return false since there are no patched pods to compare with
-	assert.False(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
-}
-
-func TestHasLimitIncrease_SkipsPodsWithCurrentRecommendation(t *testing.T) {
-	// Pod-1 has old recommendation with low limit - should be checked
-	// Pod-2 has current recommendation - should be skipped
-	cpuLimit1 := float64(50)  // 500m
-	cpuLimit2 := float64(100) // 1000m
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit: &cpuLimit1,
-					},
-				},
-			},
-		},
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-2",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "new-rec-456", // Already on current recommendation
-				},
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit: &cpuLimit2,
-					},
-				},
-			},
-		},
-	}
-
-	// Recommendation with 700m - higher than pod-1's 500m limit
-	// Pod-2 is skipped because it already has current recommendation
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"cpu": resource.MustParse("700m")},
-			},
-		},
-	}
-
-	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
-}
-
-func TestHasLimitIncrease_AllPodsOnCurrentRecommendation(t *testing.T) {
-	// All pods already have current recommendation - should return false
-	cpuLimit := float64(50) // 500m
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "current-rec",
-				},
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit: &cpuLimit,
-					},
-				},
-			},
-		},
-	}
-
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"cpu": resource.MustParse("800m")},
-			},
-		},
-	}
-
-	// Should return false since all pods are already on current recommendation
 	assert.False(t, hasLimitIncrease(recommendation, pods, "current-rec"))
-}
-
-func TestHasLimitIncrease_LimitRemovedIsIncrease(t *testing.T) {
-	// Pod has a limit, but recommendation removes it (no limit = unlimited)
-	// This should be treated as an increase
-	cpuLimit := float64(50) // 500m
-	memLimit := uint64(512 * 1024 * 1024)
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit:    &cpuLimit,
-						MemoryLimit: &memLimit,
-					},
-				},
-			},
-		},
-	}
-
-	// Recommendation with only requests, no limits
-	// This means limits are being removed (unlimited)
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:     "container-1",
-				Requests: corev1.ResourceList{"cpu": resource.MustParse("250m"), "memory": resource.MustParse("256Mi")},
-				// No Limits specified - this removes the limit
-			},
-		},
-	}
-
-	// Should return true since removing a limit is effectively increasing it to unlimited
-	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
-}
-
-func TestHasLimitIncrease_OnlyCPULimitRemoved(t *testing.T) {
-	// Pod has CPU limit, recommendation removes only CPU limit but keeps memory limit
-	cpuLimit := float64(50) // 500m
-	memLimit := uint64(512 * 1024 * 1024)
-	pods := []*workloadmeta.KubernetesPod{
-		{
-			EntityMeta: workloadmeta.EntityMeta{
-				Name:      "pod-1",
-				Namespace: "default",
-				Annotations: map[string]string{
-					model.RecommendationIDAnnotation: "old-rec-123",
-				},
-			},
-			Containers: []workloadmeta.OrchestratorContainer{
-				{
-					Name: "container-1",
-					Resources: workloadmeta.ContainerResources{
-						CPULimit:    &cpuLimit,
-						MemoryLimit: &memLimit,
-					},
-				},
-			},
-		},
-	}
-
-	// Recommendation keeps memory limit but removes CPU limit
-	recommendation := &model.VerticalScalingValues{
-		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
-			{
-				Name:   "container-1",
-				Limits: corev1.ResourceList{"memory": resource.MustParse("512Mi")}, // Only memory, no CPU limit
-			},
-		},
-	}
-
-	// Should return true since CPU limit is being removed
-	assert.True(t, hasLimitIncrease(recommendation, pods, "new-rec-456"))
 }
 
 // Tests for shouldTriggerRollout
@@ -590,4 +371,254 @@ func TestShouldTriggerRollout_FirstTriggerNoLastAction(t *testing.T) {
 	)
 
 	assert.Equal(t, rolloutDecisionTrigger, decision)
+}
+
+// Tests for applyVerticalConstraints
+
+func TestApplyVerticalConstraints_NoModification(t *testing.T) {
+	vertical := &model.VerticalScalingValues{
+		ResourcesHash: "original-hash",
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:     "app",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("512Mi")},
+			},
+		},
+	}
+
+	// Nil constraints
+	limitErr, err := applyVerticalConstraints(vertical, nil)
+	assert.NoError(t, err)
+	assert.NoError(t, limitErr)
+
+	// Empty container list
+	limitErr, err = applyVerticalConstraints(vertical, &datadoghqcommon.DatadogPodAutoscalerConstraints{})
+	assert.NoError(t, err)
+	assert.NoError(t, limitErr)
+
+	// No matching constraint name
+	limitErr, err = applyVerticalConstraints(vertical, &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{Name: "other-container", MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, limitErr)
+
+	// Values within bounds (new top-level MinAllowed/MaxAllowed)
+	limitErr, err = applyVerticalConstraints(vertical, &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{
+				Name:       "app",
+				MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+				MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("1Gi")},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, limitErr)
+
+	// Hash unchanged through all scenarios
+	assert.Equal(t, "original-hash", vertical.ResourcesHash)
+}
+
+func TestApplyVerticalConstraints_AllFeatures(t *testing.T) {
+	// A comprehensive test with 5 containers exercising every constraint feature:
+	//
+	// "app" (specific constraint, new MinAllowed/MaxAllowed applying to BOTH requests and limits):
+	//   - CPU request  50m  -> clamped UP to min 100m
+	//   - CPU limit   80m   -> clamped UP to min 100m (new fields apply to limits too)
+	//   - Mem request  8Gi  -> clamped DOWN to max 4Gi
+	//   - Mem limit   16Gi  -> clamped DOWN to max 4Gi (new fields apply to limits too)
+	//
+	// "sidecar" (wildcard, ControlledValues=RequestsOnly):
+	//   - Limits stripped entirely
+	//   - CPU request 10m -> clamped UP to wildcard min 50m
+	//   - Memory request absent -> added from wildcard minAllowed 64Mi
+	//
+	// "disabled" (Enabled=false):
+	//   - Entire container removed from recommendations
+	//
+	// "filtered" (ControlledResources=[cpu] only):
+	//   - Memory removed from both requests and limits (not controlled)
+	//   - CPU stays, ephemeral-storage removed
+	//
+	// "empty-controlled" (ControlledResources=[] empty list):
+	//   - Entire container removed (equivalent to Enabled=false)
+	//
+	// "limit-bump" (specific constraint, MinAllowed pushes request above existing limit):
+	//   - CPU request 50m, limit 80m
+	//   - MinAllowed CPU 200m -> request clamped to 200m, limit (80m) < request (200m) -> raised to 200m
+
+	vertical := &model.VerticalScalingValues{
+		ResourcesHash: "original-hash",
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{
+				Name:     "app",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("8Gi")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("80m"), corev1.ResourceMemory: resource.MustParse("16Gi")},
+			},
+			{
+				Name:     "sidecar",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("10m")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			},
+			{
+				Name:     "disabled",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			},
+			{
+				Name: "filtered",
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("200m"),
+					corev1.ResourceMemory:           resource.MustParse("128Mi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+			},
+			{
+				Name:     "empty-controlled",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			},
+			{
+				Name:     "limit-bump",
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("80m")},
+			},
+		},
+	}
+
+	constraints := &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{
+				// Wildcard: applies to "sidecar" (no specific constraint)
+				Name: "*",
+				MinAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("50m"),
+					corev1.ResourceMemory: resource.MustParse("64Mi"),
+				},
+				ControlledValues: pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerContainerControlledValuesRequestsOnly),
+			},
+			{
+				// Specific for "app": new top-level MinAllowed/MaxAllowed (apply to both requests and limits)
+				Name:       "app",
+				MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+				MaxAllowed: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("4Gi")},
+			},
+			{
+				Name:    "disabled",
+				Enabled: pointer.Ptr(false),
+			},
+			{
+				Name:                "filtered",
+				ControlledResources: []corev1.ResourceName{corev1.ResourceCPU},
+			},
+			{
+				Name:                "empty-controlled",
+				ControlledResources: []corev1.ResourceName{}, // empty = disabled
+			},
+			{
+				Name:       "limit-bump",
+				MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			},
+		},
+	}
+
+	limitErr, err := applyVerticalConstraints(vertical, constraints)
+	require.NoError(t, err)
+
+	// "disabled" and "empty-controlled" should be removed -> 4 containers left
+	require.Len(t, vertical.ContainerResources, 4)
+
+	// --- "app" (index 0): specific constraint, min/max applied to BOTH requests and limits ---
+	app := vertical.ContainerResources[0]
+	assert.Equal(t, "app", app.Name)
+	assert.True(t, app.Requests[corev1.ResourceCPU].Equal(resource.MustParse("100m")))   // 50m -> min 100m
+	assert.True(t, app.Requests[corev1.ResourceMemory].Equal(resource.MustParse("4Gi"))) // 8Gi -> max 4Gi
+	assert.True(t, app.Limits[corev1.ResourceCPU].Equal(resource.MustParse("100m")))     // 80m -> min 100m (limits clamped too)
+	assert.True(t, app.Limits[corev1.ResourceMemory].Equal(resource.MustParse("4Gi")))   // 16Gi -> max 4Gi (limits clamped too)
+
+	// --- "sidecar" (index 1): wildcard, RequestsOnly + min clamping ---
+	sidecar := vertical.ContainerResources[1]
+	assert.Equal(t, "sidecar", sidecar.Name)
+	assert.True(t, sidecar.Requests[corev1.ResourceCPU].Equal(resource.MustParse("50m"))) // 10m -> min 50m
+	_, hasSidecarMem := sidecar.Requests[corev1.ResourceMemory]
+	assert.False(t, hasSidecarMem, "memory not in recommendation -> should not be injected")
+	assert.Nil(t, sidecar.Limits, "limits should be stripped by RequestsOnly")
+
+	// --- "filtered" (index 2): ControlledResources=[cpu] only ---
+	filtered := vertical.ContainerResources[2]
+	assert.Equal(t, "filtered", filtered.Name)
+	assert.True(t, filtered.Requests[corev1.ResourceCPU].Equal(resource.MustParse("200m"))) // unchanged
+	_, hasMemReq := filtered.Requests[corev1.ResourceMemory]
+	_, hasEphReq := filtered.Requests[corev1.ResourceEphemeralStorage]
+	assert.False(t, hasMemReq, "memory should be removed (not controlled)")
+	assert.False(t, hasEphReq, "ephemeral-storage should be removed (not controlled)")
+	assert.True(t, filtered.Limits[corev1.ResourceCPU].Equal(resource.MustParse("500m"))) // unchanged
+	_, hasMemLim := filtered.Limits[corev1.ResourceMemory]
+	assert.False(t, hasMemLim, "memory limit should be removed (not controlled)")
+
+	// --- "limit-bump" (index 3): MinAllowed pushes request above limit, limit raised to match ---
+	limitBump := vertical.ContainerResources[3]
+	assert.Equal(t, "limit-bump", limitBump.Name)
+	assert.True(t, limitBump.Requests[corev1.ResourceCPU].Equal(resource.MustParse("200m")), "request clamped up to min")
+	assert.True(t, limitBump.Limits[corev1.ResourceCPU].Equal(resource.MustParse("200m")), "limit raised to match request")
+
+	// --- Limit reason: "app", "sidecar", "limit-bump" were clamped; "filtered" was not ---
+	require.Error(t, limitErr)
+	var condErr autoscaling.ConditionReason
+	require.ErrorAs(t, limitErr, &condErr)
+	assert.Equal(t, autoscaling.ConditionReasonLimitedByConstraint, condErr.Reason())
+	assert.Contains(t, limitErr.Error(), "app")
+	assert.Contains(t, limitErr.Error(), "sidecar")
+	assert.Contains(t, limitErr.Error(), "limit-bump")
+	assert.NotContains(t, limitErr.Error(), "filtered")
+
+	// --- Hash should be recomputed and valid ---
+	assert.NotEqual(t, "original-hash", vertical.ResourcesHash)
+	expectedHash, err := autoscaling.ObjectHash(vertical.ContainerResources)
+	require.NoError(t, err)
+	assert.Equal(t, expectedHash, vertical.ResourcesHash)
+}
+
+func TestApplyVerticalConstraints_ValidationErrors(t *testing.T) {
+	vertical := &model.VerticalScalingValues{
+		ResourcesHash: "original-hash",
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{Name: "app", Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")}},
+		},
+	}
+
+	// Duplicate container name
+	_, err := applyVerticalConstraints(vertical, &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{Name: "app", MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}},
+			{Name: "app", MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}},
+		},
+	})
+	require.Error(t, err)
+	var condErr autoscaling.ConditionReason
+	require.ErrorAs(t, err, &condErr)
+	assert.Equal(t, autoscaling.ConditionReasonInvalidSpec, condErr.Reason())
+	assert.Contains(t, err.Error(), "duplicate constraint for container")
+
+	// Duplicate wildcard
+	_, err = applyVerticalConstraints(vertical, &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+			{Name: "*", MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m")}},
+			{Name: "*", MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}},
+		},
+	})
+	require.Error(t, err)
+	require.ErrorAs(t, err, &condErr)
+	assert.Equal(t, autoscaling.ConditionReasonInvalidSpec, condErr.Reason())
+	assert.Contains(t, err.Error(), "duplicate wildcard")
+
+	// Vertical values should be untouched
+	assert.Equal(t, "original-hash", vertical.ResourcesHash)
 }

--- a/pkg/clusteragent/autoscaling/workload/dump_test.go
+++ b/pkg/clusteragent/autoscaling/workload/dump_test.go
@@ -248,7 +248,7 @@ func createFakePodAutoscaler(testTime time.Time) model.FakePodAutoscalerInternal
 			},
 			Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 				MinReplicas: pointer.Ptr(int32(1)),
-				MaxReplicas: int32(10),
+				MaxReplicas: pointer.Ptr(int32(10)),
 				Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
 					{
 						Name:    "app",

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client.go
@@ -165,11 +165,12 @@ func (r *recommenderClient) buildWorkloadRecommendationRequest(clusterName strin
 	}
 
 	if dpa.Spec().Constraints != nil {
-		req.Constraints = &kubeAutoscaling.WorkloadRecommendationConstraints{
-			MaxReplicas: dpa.Spec().Constraints.MaxReplicas,
-		}
+		req.Constraints = &kubeAutoscaling.WorkloadRecommendationConstraints{}
 		if dpa.Spec().Constraints.MinReplicas != nil {
 			req.Constraints.MinReplicas = *dpa.Spec().Constraints.MinReplicas
+		}
+		if dpa.Spec().Constraints.MaxReplicas != nil {
+			req.Constraints.MaxReplicas = *dpa.Spec().Constraints.MaxReplicas
 		}
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client_build_request_test.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client_build_request_test.go
@@ -64,7 +64,7 @@ func TestBuildWorkloadRecommendationRequest_Table(t *testing.T) {
 							},
 						},
 					},
-					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{MinReplicas: pointer.Ptr[int32](2), MaxReplicas: 4},
+					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{MinReplicas: pointer.Ptr[int32](2), MaxReplicas: pointer.Ptr[int32](4)},
 				},
 				CurrentReplicas: pointer.Ptr[int32](3),
 				ScalingValues:   model.ScalingValues{Horizontal: &model.HorizontalScalingValues{Replicas: 3}},

--- a/pkg/clusteragent/autoscaling/workload/external/recommender_client_test.go
+++ b/pkg/clusteragent/autoscaling/workload/external/recommender_client_test.go
@@ -81,7 +81,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 						MinReplicas: pointer.Ptr[int32](2),
-						MaxReplicas: 4,
+						MaxReplicas: pointer.Ptr[int32](4),
 					},
 				},
 				CurrentReplicas: pointer.Ptr[int32](3),
@@ -236,7 +236,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 						MinReplicas: pointer.Ptr[int32](2),
-						MaxReplicas: 4,
+						MaxReplicas: pointer.Ptr[int32](4),
 					},
 				},
 			},
@@ -266,7 +266,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 						MinReplicas: pointer.Ptr[int32](2),
-						MaxReplicas: 4,
+						MaxReplicas: pointer.Ptr[int32](4),
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{
@@ -299,7 +299,7 @@ func TestRecommenderClient_GetReplicaRecommendation(t *testing.T) {
 					},
 					Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 						MinReplicas: pointer.Ptr[int32](2),
-						MaxReplicas: 4,
+						MaxReplicas: pointer.Ptr[int32](4),
 					},
 				},
 				CustomRecommenderConfiguration: &model.RecommenderConfiguration{

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_string.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_string.go
@@ -160,7 +160,9 @@ func formatConstraints(constraints *datadoghqcommon.DatadogPodAutoscalerConstrai
 	if constraints.MinReplicas != nil {
 		_, _ = fmt.Fprintln(&sb, "Min Replicas:", *constraints.MinReplicas)
 	}
-	_, _ = fmt.Fprintln(&sb, "Max Replicas:", constraints.MaxReplicas)
+	if constraints.MaxReplicas != nil {
+		_, _ = fmt.Fprintln(&sb, "Max Replicas:", *constraints.MaxReplicas)
+	}
 
 	for _, container := range constraints.Containers {
 		_, _ = fmt.Fprintln(&sb, "Container:", container.Name)

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test.go
@@ -18,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
@@ -444,6 +446,7 @@ func TestUpdateFromStatus(t *testing.T) {
 			{Type: datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, Status: corev1.ConditionTrue, Reason: limitReason},
 			{Type: datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, Status: corev1.ConditionFalse, Reason: "vRecErr"},
 			{Type: datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, Status: corev1.ConditionFalse, Reason: "vApplyErr"},
+			{Type: datadoghqcommon.DatadogPodAutoscalerVerticalScalingLimitedCondition, Status: corev1.ConditionTrue, Reason: "LimitedByConstraint", Message: "clamped for containers: app"},
 		},
 	}
 
@@ -485,6 +488,7 @@ func TestUpdateFromStatus(t *testing.T) {
 		HorizontalLastActionError: errors.New("hScaleErr"),
 		VerticalLastAction:        status.Vertical.LastAction,
 		VerticalLastActionError:   errors.New("vApplyErr"),
+		VerticalLastLimitReason:   autoscaling.NewConditionError(autoscaling.ConditionReasonLimitedByConstraint, errors.New("clamped for containers: app")),
 		CurrentReplicas:           &currentReplicas,
 		Error:                     errors.New("globalErr"),
 	}

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -42,6 +42,7 @@ type FakePodAutoscalerInternal struct {
 	HorizontalRecommendationsRetention time.Duration
 	VerticalLastAction                 *datadoghqcommon.DatadogPodAutoscalerVerticalAction
 	VerticalLastActionError            error
+	VerticalLastLimitReason            error
 	CurrentReplicas                    *int32
 	ScaledReplicas                     *int32
 	Error                              error
@@ -70,6 +71,7 @@ func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 		horizontalRecommendationsRetention: f.HorizontalRecommendationsRetention,
 		verticalLastAction:                 f.VerticalLastAction,
 		verticalLastActionError:            f.VerticalLastActionError,
+		verticalLastLimitReason:            f.VerticalLastLimitReason,
 		currentReplicas:                    f.CurrentReplicas,
 		scaledReplicas:                     f.ScaledReplicas,
 		error:                              f.Error,

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_validation.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_validation.go
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package model
+
+import (
+	"fmt"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
+)
+
+// ValidateAutoscalerSpec validates the spec of a DatadogPodAutoscaler.
+func ValidateAutoscalerSpec(spec *datadoghq.DatadogPodAutoscalerSpec) error {
+	if err := validateConstraints(spec.Constraints); err != nil {
+		return err
+	}
+	if err := validateObjectives(spec.Objectives); err != nil {
+		return err
+	}
+	if err := validateFallback(spec.Fallback); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConstraints(constraints *datadoghqcommon.DatadogPodAutoscalerConstraints) error {
+	if constraints == nil {
+		return nil
+	}
+
+	if constraints.MinReplicas != nil && constraints.MaxReplicas != nil && *constraints.MaxReplicas < *constraints.MinReplicas {
+		return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+			"constraints.maxReplicas (%d) must be greater than or equal to constraints.minReplicas (%d)",
+			*constraints.MaxReplicas, *constraints.MinReplicas)
+	}
+
+	seen := make(map[string]struct{}, len(constraints.Containers))
+	for _, container := range constraints.Containers {
+		if _, exists := seen[container.Name]; exists {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"duplicate container name %q in constraints", container.Name)
+		}
+		seen[container.Name] = struct{}{}
+
+		if err := validateContainerConstraints(container); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateObjectives(objectives []datadoghqcommon.DatadogPodAutoscalerObjective) error {
+	for _, objective := range objectives {
+		if err := validateSingleObjective(objective); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateFallback(fallback *datadoghq.DatadogFallbackPolicy) error {
+	if fallback == nil {
+		return nil
+	}
+
+	for _, objective := range fallback.Horizontal.Objectives {
+		if objective.Type == datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"Autoscaler fallback cannot be based on custom query objective")
+		}
+		if err := validateSingleObjective(objective); err != nil {
+			return fmt.Errorf("fallback: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func validateContainerConstraints(container datadoghqcommon.DatadogPodAutoscalerContainerConstraints) error {
+	if err := validateResourceBounds(container.Name, container.MinAllowed, container.MaxAllowed); err != nil {
+		return err
+	}
+
+	if container.Requests != nil {
+		if err := validateResourceBounds(container.Name, container.Requests.MinAllowed, container.Requests.MaxAllowed); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateResourceBounds(containerName string, minAllowed, maxAllowed corev1.ResourceList) error {
+	for resource, minVal := range minAllowed {
+		maxVal, hasMax := maxAllowed[resource]
+		if hasMax && minVal.Cmp(maxVal) > 0 {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"container %q: minAllowed %s (%s) must be less than or equal to maxAllowed (%s)",
+				containerName, resource, minVal.String(), maxVal.String())
+		}
+	}
+	return nil
+}
+
+func validateSingleObjective(objective datadoghqcommon.DatadogPodAutoscalerObjective) error {
+	switch objective.Type {
+	case datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType:
+		if objective.CustomQuery == nil {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"Autoscaler objective type is custom query but customQueryObjective is nil")
+		}
+	case datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType:
+		if objective.PodResource == nil {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"autoscaler objective type is %s but podResource is nil", objective.Type)
+		}
+	case datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType:
+		if objective.ContainerResource == nil {
+			return autoscaling.NewConditionErrorf(autoscaling.ConditionReasonInvalidSpec,
+				"autoscaler objective type is %s but containerResource is nil", objective.Type)
+		}
+	}
+	return nil
+}

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_validation_test.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_validation_test.go
@@ -1,0 +1,335 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+func TestValidateAutoscalerSpec(t *testing.T) {
+	tests := map[string]struct {
+		spec    datadoghq.DatadogPodAutoscalerSpec
+		wantErr string
+	}{
+		// Objective type-to-payload checks
+		"custom query objective missing payload": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{Type: datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType},
+				},
+			},
+			wantErr: "Autoscaler objective type is custom query but customQueryObjective is nil",
+		},
+		"pod resource type without resource": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType},
+				},
+			},
+			wantErr: "autoscaler objective type is PodResource but podResource is nil",
+		},
+		"container resource type without resource": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType},
+				},
+			},
+			wantErr: "autoscaler objective type is ContainerResource but containerResource is nil",
+		},
+		"custom query objective with pod resource also set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{
+						Type:        datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType,
+						CustomQuery: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
+					},
+				},
+			},
+		},
+		"pod resource type with custom query also set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{
+						Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
+						CustomQuery: &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+					},
+				},
+			},
+		},
+		"container resource type with custom query also set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{
+						Type:              datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+						ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{},
+						CustomQuery:       &datadoghqcommon.DatadogPodAutoscalerCustomQueryObjective{},
+					},
+				},
+			},
+		},
+		"valid pod resource objective": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+					{
+						Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+						PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{},
+					},
+				},
+			},
+		},
+
+		// Fallback objective checks
+		"fallback objective custom query not allowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Fallback: &datadoghq.DatadogFallbackPolicy{
+					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+							{Type: datadoghqcommon.DatadogPodAutoscalerCustomQueryObjectiveType},
+						},
+					},
+				},
+			},
+			wantErr: "Autoscaler fallback cannot be based on custom query objective",
+		},
+		"fallback objective cpu allowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Fallback: &datadoghq.DatadogFallbackPolicy{
+					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+							{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+								ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{}},
+						},
+					},
+				},
+			},
+		},
+		"fallback objective pod resource type without resource": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Fallback: &datadoghq.DatadogFallbackPolicy{
+					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+							{Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType},
+						},
+					},
+				},
+			},
+			wantErr: "fallback: autoscaler objective type is PodResource but podResource is nil",
+		},
+		"fallback objective container resource type without resource": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Fallback: &datadoghq.DatadogFallbackPolicy{
+					Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{
+						Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+							{Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType},
+						},
+					},
+				},
+			},
+			wantErr: "fallback: autoscaler objective type is ContainerResource but containerResource is nil",
+		},
+
+		// Constraints: minReplicas / maxReplicas
+		"maxReplicas less than minReplicas": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					MinReplicas: pointer.Ptr[int32](5),
+					MaxReplicas: pointer.Ptr[int32](2),
+				},
+			},
+			wantErr: "constraints.maxReplicas (2) must be greater than or equal to constraints.minReplicas (5)",
+		},
+		"maxReplicas equals minReplicas": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					MinReplicas: pointer.Ptr[int32](3),
+					MaxReplicas: pointer.Ptr[int32](3),
+				},
+			},
+		},
+		"only minReplicas set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					MinReplicas: pointer.Ptr[int32](5),
+				},
+			},
+		},
+		"only maxReplicas set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					MaxReplicas: pointer.Ptr[int32](10),
+				},
+			},
+		},
+
+		// Constraints: duplicate container names
+		"duplicate container name in constraints": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{Name: "app"},
+						{Name: "sidecar"},
+						{Name: "app"},
+					},
+				},
+			},
+			wantErr: `duplicate container name "app" in constraints`,
+		},
+		"unique container names in constraints": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{Name: "app"},
+						{Name: "sidecar"},
+					},
+				},
+			},
+		},
+
+		// Constraints: minAllowed > maxAllowed (top-level)
+		"container cpu minAllowed greater than maxAllowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name:       "app",
+							MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+							MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						},
+					},
+				},
+			},
+			wantErr: `container "app": minAllowed cpu (500m) must be less than or equal to maxAllowed (100m)`,
+		},
+		"container memory minAllowed greater than maxAllowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name:       "app",
+							MinAllowed: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+							MaxAllowed: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+						},
+					},
+				},
+			},
+			wantErr: `container "app": minAllowed memory (1Gi) must be less than or equal to maxAllowed (256Mi)`,
+		},
+		"container minAllowed equals maxAllowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name:       "app",
+							MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+							MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+						},
+					},
+				},
+			},
+		},
+		"container only minAllowed set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name:       "app",
+							MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						},
+					},
+				},
+			},
+		},
+		"container only maxAllowed set": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name:       "app",
+							MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						},
+					},
+				},
+			},
+		},
+		"container cpu valid memory invalid": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name: "app",
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							MaxAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+			wantErr: `container "app": minAllowed memory (1Gi) must be less than or equal to maxAllowed (256Mi)`,
+		},
+
+		// Constraints: legacy Requests field
+		"legacy requests minAllowed greater than maxAllowed": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name: "app",
+							Requests: &datadoghqcommon.DatadogPodAutoscalerContainerResourceConstraints{
+								MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+								MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+							},
+						},
+					},
+				},
+			},
+			wantErr: `container "app": minAllowed cpu (500m) must be less than or equal to maxAllowed (100m)`,
+		},
+		"legacy requests valid bounds": {
+			spec: datadoghq.DatadogPodAutoscalerSpec{
+				Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
+					Containers: []datadoghqcommon.DatadogPodAutoscalerContainerConstraints{
+						{
+							Name: "app",
+							Requests: &datadoghqcommon.DatadogPodAutoscalerContainerResourceConstraints{
+								MinAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+								MaxAllowed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateAutoscalerSpec(&tt.spec)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Currently the vertical autoscaler controller does not enforce that Spec constraints are lived-applied. It relies on these requirements be already fulfilled by the values it receives.
However in some cases, it creates additional operational burden to _not_ have the controller enforce this.

Goal of this PR is to enforce all constraints in-cluster, including the new ones added recently in the CRD

### Motivation

### Describe how you validated your changes

Deploy a DPA, modify the `ContainerConstraints` (min/max, controlled resources, controlled dimensions), observe that a rollup is triggered immediately.

### Additional Notes
