### PR TITLE
Fix non-deterministic test in `dd_discovery`

### DIFF
--- a/pkg/discovery/module/rust/src/procfs/fd.rs
+++ b/pkg/discovery/module/rust/src/procfs/fd.rs
@@ -446,18 +446,19 @@ mod tests {
 
         #[test]
         fn returns_empty_when_fdinfo_not_accessible() {
+            let nonexistent_pid = i32::MAX;
             let candidates = vec![
                 FdPath {
-                    fd: "/proc/1234/fd/3".to_string(),
+                    fd: format!("/proc/{}/fd/3", nonexistent_pid),
                     path: PathBuf::from("/var/log/app.log"),
                 },
                 FdPath {
-                    fd: "/proc/1234/fd/5".to_string(),
+                    fd: format!("/proc/{}/fd/5", nonexistent_pid),
                     path: PathBuf::from("/var/log/app.log"),
                 },
             ];
 
-            let result = get_log_files(1234, &candidates);
+            let result = get_log_files(nonexistent_pid, &candidates);
             assert!(result.is_empty());
         }
 


### PR DESCRIPTION
### What does this PR do?
Fix the `returns_empty_when_fdinfo_not_accessible` test to use a guaranteed non-existent PID instead of `1234`.

### Motivation
Unblock:
- #46576.

The test would indeed sometimes fail in CI:
```
failures:
---- procfs::fd::tests::get_log_files::returns_empty_when_fdinfo_not_accessible stdout ----
thread 'procfs::fd::tests::get_log_files::returns_empty_when_fdinfo_not_accessible' (5788) panicked at pkg/discovery/module/rust/src/procfs/fd.rs:461:13:
assertion failed: result.is_empty()
```
([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1432568547#L2246))

PID 1234 might exist and be accessible with root permissions in the **container** used in CI, esp. if processes are spawned from the `root` user (lower PIDs).

### Describe how you validated your changes
Dry runs with the present change on top of a PR that enables it:
- https://gitlab.ddbuild.io/datadog/datadog-agent/builds/1432671737
- https://gitlab.ddbuild.io/datadog/datadog-agent/builds/1432671739

### Additional Notes
`i32::MAX` (2,147,483,647) is guaranteed to never be a valid PID in Linux:
- https://github.com/torvalds/linux/blob/master/include/linux/threads.h#L31
- https://github.com/torvalds/linux/blob/master/kernel/pid.c#L64

The test should now be more deterministic.