### PR TITLE
[ABLD-317] Remove redundant `go:build` directive from `buffer_test.go`

### DIFF
--- a/pkg/trace/containertags/buffer_test.go
+++ b/pkg/trace/containertags/buffer_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build go1.25
-
 // Package containertagsbuffer contains the logic to buffer payloads for container tags
 // enrichment
 package containertagsbuffer


### PR DESCRIPTION
### What does this PR do?
Remove the `//go:build go1.25` directive from `pkg/trace/containertags/buffer_test.go`.

### Motivation
- only remaining directive denoting a Go version,
- became redundant because `go.work` now prescribes Go SDK 1.25.7 at the workspace level,
- one less tag to consider in the ongoing build migration to `bazel`.