### PR TITLE
[AGENTCFG-635] Adding an enable-tee option

### DIFF
--- a/pkg/config/create/new.go
+++ b/pkg/config/create/new.go
@@ -22,7 +22,8 @@ import (
 //
 // Possible values for DD_CONF_NODETREEMODEL:
 //   - "enable":          Use the nodetreemodel for the config, instead of viper
-//   - "tee":             Construct both viper and nodetreemodel. Write to both, only read from viper
+//   - "tee":             Construct both viper and nodetreemodel. Write to both, only read from viper (base=viper, compare=nodetreemodel)
+//   - "enable-tee":      Same as tee but with base=nodetreemodel and compare=viper (read from nodetreemodel, log diffs vs viper)
 //   - "<Agent version>": enable NTM if the Agent has a version equal or higher than the given version. This acts has a
 //     minimum version for whitch to enable NTM, useful when using the same configuration across
 //     different agent versions.
@@ -41,6 +42,10 @@ func NewConfig(name string, configLib string) model.BuildableConfig {
 		viperImpl := viperconfig.NewViperConfig(name, "DD", strings.NewReplacer(".", "_"))         // nolint: forbidigo // legit use case
 		nodetreeImpl := nodetreemodel.NewNodeTreeConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 		return teeconfig.NewTeeConfig(viperImpl, nodetreeImpl)
+	} else if lib == "enable-tee" {
+		viperImpl := viperconfig.NewViperConfig(name, "DD", strings.NewReplacer(".", "_"))         // nolint: forbidigo // legit use case
+		nodetreeImpl := nodetreemodel.NewNodeTreeConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+		return teeconfig.NewTeeConfig(nodetreeImpl, viperImpl)
 	} else if lib != "" {
 		// If the Agent is at or above the minimum version specified we enabled NTM
 		agentVersion, err := version.Agent()

--- a/pkg/config/create/new_test.go
+++ b/pkg/config/create/new_test.go
@@ -30,6 +30,9 @@ func TestCreateFromParms(t *testing.T) {
 	m = NewConfig("test", "tee")
 	assert.Equal(t, "tee", m.GetLibType())
 
+	m = NewConfig("test", "enable-tee")
+	assert.Equal(t, "tee", m.GetLibType())
+
 	m = NewConfig("test", "something invalid")
 	assert.Equal(t, "viper", m.GetLibType())
 
@@ -74,6 +77,10 @@ func TestCreateFromEnv(t *testing.T) {
 	assert.Equal(t, "nodetreemodel", m.GetLibType())
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "tee")
+	m = NewConfig("test", "")
+	assert.Equal(t, "tee", m.GetLibType())
+
+	t.Setenv("DD_CONF_NODETREEMODEL", "enable-tee")
 	m = NewConfig("test", "")
 	assert.Equal(t, "tee", m.GetLibType())
 


### PR DESCRIPTION
### What does this PR do?
We want a config option which will use nodetreemodel as the base, and viper as the comparison.

### Motivation

### Describe how you validated your changes

Added a unit test case, and validated that `DD_CONF_NODETREEMODEL=enable-tee dda inv test --targets=./pkg/config/create` passes.

### Additional Notes
