### PR TITLE
[APMLP-747] Add `bucket` label to `image_resolution_attempts` COAT telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -458,6 +458,7 @@ var defaultProfiles = `
           aggregate_tags:
             - repository
             - tag
+            - bucket
             - outcome
     schedule:
       start_after: 30

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -115,6 +115,6 @@ var (
 
 	// Image resolution tracking for gradual rollout monitoring
 	ImageResolutionAttempts = telemetry.NewCounterWithOpts("admission_webhooks", "image_resolution_attempts",
-		[]string{"repository", "tag", "outcome"}, "Number of image resolution attempts by repository, tag, and resolution outcome",
+		[]string{"repository", "tag", "bucket", "outcome"}, "Number of image resolution attempts by repository, tag, bucket, and resolution outcome",
 		telemetry.Options{})
 )

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
@@ -39,7 +39,7 @@ func NewNoOpResolver() Resolver {
 // ResolveImage returns the original image reference.
 func (r *noOpResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
 	log.Debugf("Cannot resolve %s/%s:%s without remote config", registry, repository, tag)
-	metrics.ImageResolutionAttempts.Inc(repository, tag, tag)
+	metrics.ImageResolutionAttempts.Inc(repository, tag, "-", tag)
 	return nil, false
 }
 
@@ -65,20 +65,19 @@ func (r *bucketTagResolver) createBucketTag(tag string) string {
 }
 
 func (r *bucketTagResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
-	var result = tag
-	var resolvedTag = tag
+	normalizedTag := strings.TrimPrefix(tag, "v")
+	var result = normalizedTag
 	defer func() {
-		metrics.ImageResolutionAttempts.Inc(repository, resolvedTag, result)
+		metrics.ImageResolutionAttempts.Inc(repository, normalizedTag, r.bucketID, result)
 	}()
 	if !isDatadoghqRegistry(registry, r.datadoghqRegistries) {
 		log.Debugf("%s is not a Datadoghq registry, not opting into gradual rollout", registry)
 		return nil, false
 	}
 
-	bucketTag := r.createBucketTag(tag)
+	bucketTag := r.createBucketTag(normalizedTag)
 
 	digest, err := r.cache.get(registry, repository, bucketTag)
-	resolvedTag = bucketTag
 	if err != nil {
 		log.Debugf("Failed to resolve %s/%s:%s for gradual rollout - %v", registry, repository, bucketTag, err)
 		return nil, false

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
@@ -37,7 +37,7 @@ func NewNoOpResolver() Resolver {
 }
 
 // ResolveImage returns the original image reference.
-func (r *noOpResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
+func (r *noOpResolver) Resolve(_ string, repository string, tag string) (*ResolvedImage, bool) {
 	metrics.ImageResolutionAttempts.Inc(repository, tag, "-", tag)
 	return nil, false
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/imageresolver/resolver.go
@@ -38,7 +38,6 @@ func NewNoOpResolver() Resolver {
 
 // ResolveImage returns the original image reference.
 func (r *noOpResolver) Resolve(registry string, repository string, tag string) (*ResolvedImage, bool) {
-	log.Debugf("Cannot resolve %s/%s:%s without remote config", registry, repository, tag)
 	metrics.ImageResolutionAttempts.Inc(repository, tag, "-", tag)
 	return nil, false
 }

--- a/releasenotes/notes/add-bucket-label-image-resolution-attempts-b8ff9092dca2caed.yaml
+++ b/releasenotes/notes/add-bucket-label-image-resolution-attempts-b8ff9092dca2caed.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``bucket`` label to ``image_resolution_attempts`` telemetry to track gradual rollout progress.


### PR DESCRIPTION
### What does this PR do?
Adds a new label `bucket` to the existing `image_resolution_attempts` COAT telemetry to track the customer-provided version separately from the gradual rollout bucket. 

Also normalizes the `tag` value being emitted for improved cardinality.

### Motivation
Currently, we would store something like `{repo: dd-lib-python-init, tag: 4-gr5, outcome: sha256:...}` for a customer specifying major version 4 who is in gradual rollout bucket 5. This is fine, but makes it harder to visualize in our dashboards if all we care about is which major versions customers are configuring, or if we just want to see bucket distribution for a given major version. Now it could be stored as `{repo: dd-lib-python-init, tag: 4, bucket: 5, outcome: sha256:...}`. This ergonomic improvement will make it simpler to query for only the relevant labels, without any regex filtering.

Also adding in a small cardinality improvement, by only passing in normalized tags for the `tag` value. So now there will be no distinguisher between `v4` and `4`, they will both be emitted as `4`. This normalization reduces the number of unique values for the tag label by consolidating previously distinct representations of the same user intent into a single value.

### Describe how you validated your changes
Local E2E testing with `injector-dev` to validate that the correct metric is being emitted to the COAT telemetry org.

### Additional Notes
