### PR TITLE
[CNM-4667] Fix several flaky TestTracerSuite tests.

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1973,11 +1973,17 @@ func (s *TracerSuite) TestShortWrite() {
 	toSend := sndBufSize / 2
 	for i := 0; i < 100; i++ {
 		written, err = unix.Write(sk, genPayload(toSend))
+		if errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK) {
+			// Short write, send buffer is completely full
+			done = true
+			break
+		}
 		require.NoError(t, err)
 		require.Greater(t, written, 0)
 		sent += uint64(written)
 		t.Logf("sent: %v", sent)
 		if written < toSend {
+			// Short write, partial write
 			done = true
 			break
 		}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1937,7 +1937,8 @@ func (s *TracerSuite) TestShortWrite() {
 
 	sk, err := unix.Socket(syscall.AF_INET, syscall.SOCK_STREAM|syscall.SOCK_NONBLOCK, 0)
 	require.NoError(t, err)
-	defer syscall.Close(sk)
+	f := os.NewFile(uintptr(sk), "")
+	t.Cleanup(func() { f.Close() })
 
 	err = unix.SetsockoptInt(sk, syscall.SOL_SOCKET, syscall.SO_SNDBUF, 5000)
 	require.NoError(t, err)
@@ -1991,14 +1992,12 @@ func (s *TracerSuite) TestShortWrite() {
 
 	require.True(t, done)
 
-	f := os.NewFile(uintptr(sk), "")
 	c, err := net.FileConn(f)
 	require.NoError(t, err)
 	t.Cleanup(func() { c.Close() })
 
 	unix.Shutdown(sk, unix.SHUT_WR)
 	close(read)
-	unix.Close(sk)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conns, cleanup := getConnections(collect, tr)


### PR DESCRIPTION
### What does this PR do?

Fixes several flaky eBPFless tests in `TestTracerSuite`.

1. **`TestTracerSuite/eBPFless/TestShortWrite` — "couldn't find connection used by short write"**
   * (Real bug.)  Fixes `updateTCPStats()` so it no longer overcounts `SentBytes` when the kernel retransmits TCP segments that partially overlap with previously-counted data. We now only add the new bytes beyond the sequence high‑water mark.

2. **`TestTracerSuite/eBPFless/TestShortWrite` — "resource temporarily unavailable"**
   * (Test-only bug.)  Fixes the `TestShortWrite` write loop to correctly handle the case where the send buffer is completely full and a write returns zero bytes with `resource temporarily unavailable`.

3. **`TestTracerSuite/eBPFless/TestTCPRTT` — "write: bad file descriptor"**
   * (Test-only bug.)  Fixes an fd lifecycle issue in `TestShortWrite`: The original TestShortWrite had a triple-close on the socket fd (defer syscall.Close, explicit unix.Close, and the os.NewFile GC finalizer). After the first close, the kernel could reuse the fd number, so later closes would clobber unrelated fds in other tests. Fixed by consolidating ownership into a single t.Cleanup that does f.Close().

### Motivation

`pkg/network/tracer.TestTracerSuite` has many flaky test failures in CI. 

### Describe how you validated your changes

1. `TestShortWrite` connection‑not‑found

```
# Reproduced by running the following on a vagrant VM.
# Validated after the fix was applied that this failure no longer occurred.

sudo go test -v -count 1000 -failfast -tags linux_bpf,test ./pkg/network/tracer -run 'TestTracerSuite/eBPFless/TestShortWrite'

=== RUN   TestTracerSuite/eBPFless/TestShortWrite
1771024760834621303 [Warn] not starting resolv.conf container store, because it depends on process event monitoring which is disabled
    tracer_linux_test.go:1979: sent: 5000
    tracer_linux_test.go:1979: sent: 10000
    tracer_linux_test.go:1979: sent: 15000
    tracer_linux_test.go:1979: sent: 20000
    tracer_linux_test.go:1979: sent: 25000
    tracer_linux_test.go:1979: sent: 30000
    tracer_linux_test.go:1979: sent: 35000
    tracer_linux_test.go:1979: sent: 40000
    tracer_linux_test.go:1979: sent: 42741
    tracer_linux_test.go:1997:
        	Error Trace:	/git/datadog-agent/pkg/network/tracer/tracer_linux_test.go:2001
        	            				/root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.7.linux-arm64/src/runtime/asm_arm64.s:1268
        	Error:      	Should be true
    tracer_linux_test.go:1997:
        	Error Trace:	/git/datadog-agent/pkg/network/tracer/tracer_linux_test.go:1997
        	Error:      	Condition never satisfied
        	Test:       	TestTracerSuite/eBPFless/TestShortWrite
        	Messages:   	couldn't find connection used by short write
--- FAIL: TestTracerSuite (10.16s)
    --- FAIL: TestTracerSuite/eBPFless (10.16s)
        --- FAIL: TestTracerSuite/eBPFless/TestShortWrite (10.16s)
```

2. `TestShortWrite` resource temporarily unavailable

```
# Reproduced by running the following on a vagrant VM (with fix for #1)
# Validated after the fix was applied that this failure no longer occurred.

sudo go test -v -count 1000 -failfast -tags linux_bpf,test ./pkg/network/tracer -run 'TestTracerSuite/eBPFless/TestShortWrite'

=== RUN   TestTracerSuite/eBPFless/TestShortWrite
1771025049854166657 [Warn] not starting resolv.conf container store, because it depends on process event monitoring which is disabled
    tracer_linux_test.go:1981: sent: 5000
    tracer_linux_test.go:1981: sent: 10000
    tracer_linux_test.go:1981: sent: 15000
    tracer_linux_test.go:1978:
        	Error Trace:	/git/datadog-agent/pkg/network/tracer/tracer_linux_test.go:1978
        	Error:      	Received unexpected error:
        	            	resource temporarily unavailable
        	Test:       	TestTracerSuite/eBPFless/TestShortWrite
--- FAIL: TestTracerSuite (1.22s)
    --- FAIL: TestTracerSuite/eBPFless (1.22s)
        --- FAIL: TestTracerSuite/eBPFless/TestShortWrite (1.21s)

```

3. `TestTCPRTT` write: bad file descriptor

```
# Reproduced by running the following on a vagrant VM (with fixes for #1 and #2)
# Validated after the fix was applied that this failure no longer occurred.

sudo go test -v -count 100 -failfast -tags linux_bpf,test ./pkg/network/tracer -run 'TestTracerSuite/eBPFless/(TestShortWrite|TestTCPRTT)'

=== RUN   TestTracerSuite/eBPFless/TestTCPRTT
1771024042054119651 [Warn] not starting resolv.conf container store, because it depends on process event monitoring which is disabled
    tracer_linux_test.go:316:
        	Error Trace:	/git/datadog-agent/pkg/network/tracer/tracer_linux_test.go:316
        	Error:      	Received unexpected error:
        	            	write tcp 127.0.0.1:44304->127.0.0.1:43449: write: bad file descriptor
        	Test:       	TestTracerSuite/eBPFless/TestTCPRTT
--- FAIL: TestTracerSuite (1.30s)
    --- FAIL: TestTracerSuite/eBPFless (1.30s)
        --- PASS: TestTracerSuite/eBPFless/TestShortWrite (0.15s)
        --- FAIL: TestTracerSuite/eBPFless/TestTCPRTT (1.16s)
```

