### PR TITLE
Cluster Agent Generic Workload Patcher

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -542,7 +542,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("language_detection.enabled") && config.GetBool("cluster_agent.language_detection.patcher.enabled") {
-		if err = languagedetection.Start(mainCtx, wmeta, log, config); err != nil {
+		if err = languagedetection.Start(mainCtx, le.IsLeader, wmeta, log, config); err != nil {
 			log.Errorf("Cannot start language detection patcher: %v", err)
 		}
 	}

--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -10,64 +10,57 @@ package languagedetection
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/validation"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadpatcher "github.com/DataDog/datadog-agent/pkg/clusteragent/patcher"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 )
 
 const (
 	// subscriber is the workloadmeta subscriber name
 	subscriber    = "language_detection_patcher"
 	statusSuccess = "success"
-	statusRetry   = "retry"
 	statusError   = "error"
 	statusSkip    = "skip"
 )
 
 // LanguagePatcher defines an object that patches kubernetes resources with language annotations
 type languagePatcher struct {
-	ctx                   context.Context
-	cancel                context.CancelFunc
-	k8sClient             dynamic.Interface
-	store                 workloadmeta.Component
-	logger                log.Component
-	queue                 workqueue.TypedRateLimitingInterface[langUtil.NamespacedOwnerReference]
-	leaderElectionEnabled bool
+	ctx             context.Context
+	cancel          context.CancelFunc
+	k8sClient       dynamic.Interface
+	workloadPatcher *workloadpatcher.Patcher
+	store           workloadmeta.Component
+	logger          log.Component
+	queue           workqueue.TypedRateLimitingInterface[langUtil.NamespacedOwnerReference]
 }
 
 // NewLanguagePatcher initializes and returns a new patcher with a dynamic k8s client
-func newLanguagePatcher(ctx context.Context, store workloadmeta.Component, logger log.Component, datadogConfig config.Component, apiCl *apiserver.APIClient) *languagePatcher {
-
+func newLanguagePatcher(ctx context.Context, isLeader func() bool, store workloadmeta.Component, logger log.Component, datadogConfig config.Component, apiCl *apiserver.APIClient) *languagePatcher {
 	ctx, cancel := context.WithCancel(ctx)
-
 	k8sClient := apiCl.DynamicCl
 
 	return &languagePatcher{
-		ctx:                   ctx,
-		cancel:                cancel,
-		k8sClient:             k8sClient,
-		store:                 store,
-		logger:                logger,
-		leaderElectionEnabled: datadogConfig.GetBool("leader_election"),
+		ctx:             ctx,
+		cancel:          cancel,
+		k8sClient:       k8sClient,
+		workloadPatcher: workloadpatcher.NewPatcher(k8sClient, isLeader),
+		store:           store,
+		logger:          logger,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.NewTypedItemExponentialFailureRateLimiter[langUtil.NamespacedOwnerReference](
 				datadogConfig.GetDuration("cluster_agent.language_detection.patcher.base_backoff"),
@@ -87,7 +80,7 @@ var (
 )
 
 // Start initializes and starts the language detection patcher
-func Start(ctx context.Context, store workloadmeta.Component, logger log.Component, datadogConfig config.Component) error {
+func Start(ctx context.Context, isLeader func() bool, store workloadmeta.Component, logger log.Component, datadogConfig config.Component) error {
 
 	if patcher != nil {
 		return errors.New("can't start language detection patcher twice")
@@ -105,7 +98,7 @@ func Start(ctx context.Context, store workloadmeta.Component, logger log.Compone
 
 	languagePatcherOnce.Do(func() {
 		logger.Info("Starting language detection patcher")
-		patcher = newLanguagePatcher(ctx, store, logger, datadogConfig, apiCl)
+		patcher = newLanguagePatcher(ctx, isLeader, store, logger, datadogConfig, apiCl)
 		go patcher.run(ctx)
 	})
 
@@ -227,32 +220,8 @@ func (lp *languagePatcher) startProcessingPatchingRequests(ctx context.Context) 
 	}()
 }
 
-// isLeader checks if the current instance is the leader
-func (lp *languagePatcher) isLeader() bool {
-	if !lp.leaderElectionEnabled {
-		// If leader election is disabled, we're always the leader
-		return true
-	}
-
-	leaderEngine, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		lp.logger.Errorf("Failed to get leader engine: %v", err)
-		// If we can't determine leader status, don't patch to be safe
-		return false
-	}
-
-	return leaderEngine.IsLeader()
-}
-
 func (lp *languagePatcher) processOwner(ctx context.Context, owner langUtil.NamespacedOwnerReference) error {
 	lp.logger.Tracef("Processing %s: %s/%s", owner.Kind, owner.Namespace, owner.Name)
-
-	// Check if we're the leader before processing patches
-	if !lp.isLeader() {
-		lp.logger.Tracef("Skipping patch for %s: %s/%s - not leader", owner.Kind, owner.Namespace, owner.Name)
-		Patches.Inc(owner.Kind, owner.Name, owner.Namespace, statusSkip)
-		return nil
-	}
 
 	var err error
 
@@ -272,6 +241,7 @@ func (lp *languagePatcher) handleDeployment(ctx context.Context, owner langUtil.
 
 	if err != nil {
 		lp.logger.Info("Didn't find deployment in store, skipping")
+		Patches.Inc(owner.Kind, owner.Name, owner.Namespace, statusSkip)
 		// skip if not in store
 		return nil
 	}
@@ -334,29 +304,31 @@ func (lp *languagePatcher) patchOwner(ctx context.Context, namespacedOwnerRef *l
 		return err
 	}
 
-	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Serialize the patch data
-		patchData, err := json.Marshal(map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": annotationsPatch,
-			},
-		})
-		if err != nil {
-			return err
-		}
+	target := workloadpatcher.Target{
+		GVR:       ownerGVR,
+		Namespace: namespacedOwnerRef.Namespace,
+		Name:      namespacedOwnerRef.Name,
+	}
+	intent := workloadpatcher.NewPatchIntent(target).
+		With(workloadpatcher.SetMetadataAnnotations(annotationsPatch))
 
-		_, err = lp.k8sClient.Resource(ownerGVR).Namespace(namespacedOwnerRef.Namespace).Patch(ctx, namespacedOwnerRef.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
-		if err != nil {
-			Patches.Inc(namespacedOwnerRef.Kind, namespacedOwnerRef.Name, namespacedOwnerRef.Namespace, statusRetry)
-		}
-
-		return err
+	isPatched, patchErr := lp.workloadPatcher.Apply(ctx, intent, workloadpatcher.PatchOptions{
+		RetryOnConflict: true,
+		Caller:          "language_detection",
 	})
 
-	if retryErr != nil {
-		return retryErr
+	// Skip: not leader or empty patch request
+	if !isPatched && patchErr == nil {
+		Patches.Inc(namespacedOwnerRef.Kind, namespacedOwnerRef.Name, namespacedOwnerRef.Namespace, statusSkip)
+		return nil
 	}
 
+	// Error: leader failed to patch
+	if patchErr != nil {
+		return patchErr
+	}
+
+	// Success: resource is patched and no error
 	Patches.Inc(namespacedOwnerRef.Kind, namespacedOwnerRef.Name, namespacedOwnerRef.Namespace, statusSuccess)
 	return nil
 }

--- a/pkg/clusteragent/languagedetection/patcher.go
+++ b/pkg/clusteragent/languagedetection/patcher.go
@@ -17,7 +17,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -42,7 +41,6 @@ const (
 type languagePatcher struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
-	k8sClient       dynamic.Interface
 	workloadPatcher *workloadpatcher.Patcher
 	store           workloadmeta.Component
 	logger          log.Component
@@ -57,7 +55,6 @@ func newLanguagePatcher(ctx context.Context, isLeader func() bool, store workloa
 	return &languagePatcher{
 		ctx:             ctx,
 		cancel:          cancel,
-		k8sClient:       k8sClient,
 		workloadPatcher: workloadpatcher.NewPatcher(k8sClient, isLeader),
 		store:           store,
 		logger:          logger,

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -31,6 +31,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	workloadpatcher "github.com/DataDog/datadog-agent/pkg/clusteragent/patcher"
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
 	langUtil "github.com/DataDog/datadog-agent/pkg/languagedetection/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -45,12 +46,13 @@ func newMockLanguagePatcher(ctx context.Context, mockClient dynamic.Interface, m
 	ctx, cancel := context.WithCancel(ctx)
 
 	return languagePatcher{
-		ctx:       ctx,
-		cancel:    cancel,
-		k8sClient: mockClient,
-		store:     mockStore,
-		logger:    mockLogger,
-		queue: workqueue.NewTypedRateLimitingQueue[langUtil.NamespacedOwnerReference](
+		ctx:             ctx,
+		cancel:          cancel,
+		k8sClient:       mockClient,
+		workloadPatcher: workloadpatcher.NewPatcher(mockClient, nil),
+		store:           mockStore,
+		logger:          mockLogger,
+		queue: workqueue.NewTypedRateLimitingQueue(
 			workqueue.NewTypedItemExponentialFailureRateLimiter[langUtil.NamespacedOwnerReference](
 				1*time.Second,
 				4*time.Second,

--- a/pkg/clusteragent/languagedetection/patcher_test.go
+++ b/pkg/clusteragent/languagedetection/patcher_test.go
@@ -48,7 +48,6 @@ func newMockLanguagePatcher(ctx context.Context, mockClient dynamic.Interface, m
 	return languagePatcher{
 		ctx:             ctx,
 		cancel:          cancel,
-		k8sClient:       mockClient,
 		workloadPatcher: workloadpatcher.NewPatcher(mockClient, nil),
 		store:           mockStore,
 		logger:          mockLogger,
@@ -183,7 +182,7 @@ func TestRun(t *testing.T) {
 
 	checkDeploymentAnnotations := func() bool {
 		// Check the patch
-		got, err := lp.k8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		got, err := mockK8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -205,7 +204,7 @@ func TestRun(t *testing.T) {
 	// the first event has already been processed and its side-effect can be asserted instantly
 	assert.Truef(t, func() bool {
 		// Check the patch
-		got, err := lp.k8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), longContNameDeploymentName, metav1.GetOptions{})
+		got, err := mockK8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), longContNameDeploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -275,7 +274,7 @@ func TestRun(t *testing.T) {
 
 	checkDeploymentAnnotations = func() bool {
 		// Check the patch
-		got, err := lp.k8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		got, err := mockK8sClient.Resource(gvr).Namespace(ns).Get(context.TODO(), deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false
 		}

--- a/pkg/clusteragent/patcher/intent.go
+++ b/pkg/clusteragent/patcher/intent.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+import "encoding/json"
+
+// PatchIntent describes a set of mutations to apply to a single Kubernetes
+// resource. It combines a Target with one or more PatchOperations.
+//
+// Use NewPatchIntent to create one, chain With() calls to add operations,
+// then pass it to Patcher.Apply().
+type PatchIntent struct {
+	target     Target
+	operations []PatchOperation
+}
+
+// NewPatchIntent creates a PatchIntent for the given target.
+func NewPatchIntent(target Target) *PatchIntent {
+	return &PatchIntent{target: target}
+}
+
+// With appends an operation to the intent and returns the intent for chaining.
+func (p *PatchIntent) With(op PatchOperation) *PatchIntent {
+	p.operations = append(p.operations, op)
+	return p
+}
+
+// Target returns the target resource for this intent.
+func (p *PatchIntent) Target() Target {
+	return p.target
+}
+
+// Build constructs the final patch body by deep-merging all operations.
+// Returns the JSON-encoded patch bytes suitable for a Kubernetes Patch() call.
+// Returns nil if there are no operations.
+func (p *PatchIntent) Build() ([]byte, error) {
+	if len(p.operations) == 0 {
+		return nil, nil
+	}
+
+	merged := make(map[string]interface{})
+	for _, op := range p.operations {
+		fragment := op.build()
+		mergeMaps(merged, fragment)
+	}
+
+	return json.Marshal(merged)
+}
+
+// mergeMaps recursively merges src into dst. When both src and dst have a
+// map[string]interface{} at the same key, the maps are merged recursively.
+// Otherwise the src value overwrites the dst value.
+func mergeMaps(dst, src map[string]interface{}) {
+	for key, srcVal := range src {
+		dstVal, exists := dst[key]
+		if !exists {
+			dst[key] = srcVal
+			continue
+		}
+
+		// If both values are maps, merge recursively
+		dstMap, dstOk := dstVal.(map[string]interface{})
+		srcMap, srcOk := srcVal.(map[string]interface{})
+		if dstOk && srcOk {
+			mergeMaps(dstMap, srcMap)
+			continue
+		}
+
+		// Otherwise overwrite
+		dst[key] = srcVal
+	}
+}

--- a/pkg/clusteragent/patcher/intent_test.go
+++ b/pkg/clusteragent/patcher/intent_test.go
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatchIntentBuildEmpty(t *testing.T) {
+	intent := NewPatchIntent(DeploymentTarget("default", "test"))
+	data, err := intent.Build()
+	require.NoError(t, err)
+	assert.Nil(t, data, "empty intent should return nil patch data")
+}
+
+func TestPatchIntentBuildSingleOperation(t *testing.T) {
+	intent := NewPatchIntent(DeploymentTarget("default", "test")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"key": "value",
+		}))
+
+	data, err := intent.Build()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	metadata := result["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "value", annotations["key"])
+}
+
+func TestPatchIntentBuildMergesOperations(t *testing.T) {
+	intent := NewPatchIntent(DeploymentTarget("default", "test")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"meta-annot": "meta-value",
+		})).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"template-annot": "template-value",
+		})).
+		With(SetPodTemplateLabels(map[string]interface{}{
+			"app": "myapp",
+		}))
+
+	data, err := intent.Build()
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	// Check metadata.annotations
+	metadata := result["metadata"].(map[string]interface{})
+	metaAnnotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "meta-value", metaAnnotations["meta-annot"])
+
+	// Check spec.template.metadata.annotations
+	spec := result["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateMeta := template["metadata"].(map[string]interface{})
+	templateAnnotations := templateMeta["annotations"].(map[string]interface{})
+	assert.Equal(t, "template-value", templateAnnotations["template-annot"])
+
+	// Check spec.template.metadata.labels
+	templateLabels := templateMeta["labels"].(map[string]interface{})
+	assert.Equal(t, "myapp", templateLabels["app"])
+}
+
+func TestPatchIntentBuildMergesOperationsConflicts(t *testing.T) {
+	// Operations that set metadata annotations which should be merged
+	intent := NewPatchIntent(DeploymentTarget("default", "test")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"key1": "val1",
+		})).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"key2": "val2",
+		})).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"key1": "val3",
+		}))
+
+	data, err := intent.Build()
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	require.NoError(t, err)
+
+	metadata := result["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "val3", annotations["key1"])
+	assert.Equal(t, "val2", annotations["key2"])
+}
+
+func TestMergeMaps(t *testing.T) {
+	t.Run("simple merge", func(t *testing.T) {
+		dst := map[string]interface{}{"a": "1"}
+		src := map[string]interface{}{"b": "2"}
+		mergeMaps(dst, src)
+		assert.Equal(t, "1", dst["a"])
+		assert.Equal(t, "2", dst["b"])
+	})
+
+	t.Run("nested merge", func(t *testing.T) {
+		dst := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{"existing": "val"},
+			},
+		}
+		src := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{"new": "val2"},
+			},
+		}
+		mergeMaps(dst, src)
+
+		metadata := dst["metadata"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+		assert.Equal(t, "val", annotations["existing"])
+		assert.Equal(t, "val2", annotations["new"])
+	})
+
+	t.Run("overwrite non-map value", func(t *testing.T) {
+		dst := map[string]interface{}{"key": "old"}
+		src := map[string]interface{}{"key": "new"}
+		mergeMaps(dst, src)
+		assert.Equal(t, "new", dst["key"])
+	})
+
+	t.Run("nil values preserved", func(t *testing.T) {
+		dst := map[string]interface{}{}
+		src := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{"delete-me": nil},
+			},
+		}
+		mergeMaps(dst, src)
+		metadata := dst["metadata"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+		v, exists := annotations["delete-me"]
+		assert.True(t, exists)
+		assert.Nil(t, v)
+	})
+}

--- a/pkg/clusteragent/patcher/operations.go
+++ b/pkg/clusteragent/patcher/operations.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+// PatchOperation represents a single mutation to be included in a patch.
+// Operations are composable — multiple operations can be combined in a
+// PatchIntent and their results are deep-merged into a single patch body.
+type PatchOperation interface {
+	// build returns a nested map fragment that will be deep-merged into
+	// the final patch body. For example, setting a metadata annotation
+	// returns {"metadata": {"annotations": {"key": "value"}}}.
+	build() map[string]interface{}
+}
+
+// --- Metadata-level operations  ---
+
+// setMetadataAnnotations sets annotations on .metadata.annotations.
+// Values can be strings (set) or nil (delete).
+type setMetadataAnnotations struct {
+	annotations map[string]interface{}
+}
+
+// SetMetadataAnnotations creates an operation that sets (or deletes) annotations
+// on the resource's metadata. Pass nil values to delete annotations.
+func SetMetadataAnnotations(annotations map[string]interface{}) PatchOperation {
+	return &setMetadataAnnotations{annotations: annotations}
+}
+
+func (o *setMetadataAnnotations) build() map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": o.annotations,
+		},
+	}
+}
+
+// setMetadataLabels sets labels on .metadata.labels.
+type setMetadataLabels struct {
+	labels map[string]interface{}
+}
+
+// SetMetadataLabels creates an operation that sets (or deletes) labels
+// on the resource's metadata. Pass nil values to delete labels.
+func SetMetadataLabels(labels map[string]interface{}) PatchOperation {
+	return &setMetadataLabels{labels: labels}
+}
+
+func (o *setMetadataLabels) build() map[string]interface{} {
+	return map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": o.labels,
+		},
+	}
+}
+
+// --- Pod template operations (on pod controllers like Deployments, StatefulSets, Rollouts) ---
+
+// setPodTemplateAnnotations sets annotations on .spec.template.metadata.annotations.
+type setPodTemplateAnnotations struct {
+	annotations map[string]interface{}
+}
+
+// SetPodTemplateAnnotations creates an operation that sets annotations on
+// the pod template.
+func SetPodTemplateAnnotations(annotations map[string]interface{}) PatchOperation {
+	return &setPodTemplateAnnotations{annotations: annotations}
+}
+
+func (o *setPodTemplateAnnotations) build() map[string]interface{} {
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": o.annotations,
+				},
+			},
+		},
+	}
+}
+
+// setPodTemplateLabels sets labels on .spec.template.metadata.labels.
+type setPodTemplateLabels struct {
+	labels map[string]interface{}
+}
+
+// SetPodTemplateLabels creates an operation that sets labels on the pod
+// template.
+func SetPodTemplateLabels(labels map[string]interface{}) PatchOperation {
+	return &setPodTemplateLabels{labels: labels}
+}
+
+func (o *setPodTemplateLabels) build() map[string]interface{} {
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": o.labels,
+				},
+			},
+		},
+	}
+}
+
+// deletePodTemplateAnnotations removes annotations from .spec.template.metadata.annotations
+// by setting them to nil in a merge patch.
+type deletePodTemplateAnnotations struct {
+	keys []string
+}
+
+// DeletePodTemplateAnnotations creates an operation that removes the
+// specified annotations from the pod template.
+func DeletePodTemplateAnnotations(keys []string) PatchOperation {
+	return &deletePodTemplateAnnotations{keys: keys}
+}
+
+func (o *deletePodTemplateAnnotations) build() map[string]interface{} {
+	annots := make(map[string]interface{}, len(o.keys))
+	for _, k := range o.keys {
+		annots[k] = nil
+	}
+	return map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": annots,
+				},
+			},
+		},
+	}
+}

--- a/pkg/clusteragent/patcher/operations_test.go
+++ b/pkg/clusteragent/patcher/operations_test.go
@@ -70,7 +70,6 @@ func TestDeletePodTemplateAnnotations(t *testing.T) {
 	assert.Len(t, annotations, 2)
 }
 
-
 func TestSetMetadataLabels(t *testing.T) {
 	op := SetMetadataLabels(map[string]interface{}{
 		"label1": "val1",

--- a/pkg/clusteragent/patcher/operations_test.go
+++ b/pkg/clusteragent/patcher/operations_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetMetadataAnnotations(t *testing.T) {
+	op := SetMetadataAnnotations(map[string]interface{}{
+		"key1": "val1",
+		"key2": nil, // deletion
+	})
+
+	result := op.build()
+	metadata := result["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+
+	assert.Equal(t, "val1", annotations["key1"])
+	assert.Nil(t, annotations["key2"])
+}
+
+func TestSetPodTemplateAnnotations(t *testing.T) {
+	op := SetPodTemplateAnnotations(map[string]interface{}{
+		"annot1": "value1",
+	})
+
+	result := op.build()
+	spec := result["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	metadata := template["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+
+	assert.Equal(t, "value1", annotations["annot1"])
+}
+
+func TestSetPodTemplateLabels(t *testing.T) {
+	op := SetPodTemplateLabels(map[string]interface{}{
+		"app": "myapp",
+	})
+
+	result := op.build()
+	spec := result["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	metadata := template["metadata"].(map[string]interface{})
+	labels := metadata["labels"].(map[string]interface{})
+
+	assert.Equal(t, "myapp", labels["app"])
+}
+
+func TestDeletePodTemplateAnnotations(t *testing.T) {
+	op := DeletePodTemplateAnnotations([]string{"remove-me", "also-remove"})
+
+	result := op.build()
+	spec := result["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	metadata := template["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+
+	assert.Nil(t, annotations["remove-me"])
+	assert.Nil(t, annotations["also-remove"])
+	assert.Len(t, annotations, 2)
+}
+
+
+func TestSetMetadataLabels(t *testing.T) {
+	op := SetMetadataLabels(map[string]interface{}{
+		"label1": "val1",
+		"label2": nil,
+	})
+
+	result := op.build()
+	metadata := result["metadata"].(map[string]interface{})
+	labels := metadata["labels"].(map[string]interface{})
+
+	assert.Equal(t, "val1", labels["label1"])
+	assert.Nil(t, labels["label2"])
+}
+
+func TestEmptyOperations(t *testing.T) {
+	t.Run("empty metadata annotations", func(t *testing.T) {
+		op := SetMetadataAnnotations(map[string]interface{}{})
+		result := op.build()
+		metadata := result["metadata"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+		require.Empty(t, annotations)
+	})
+
+	t.Run("empty delete list", func(t *testing.T) {
+		op := DeletePodTemplateAnnotations([]string{})
+		result := op.build()
+		spec := result["spec"].(map[string]interface{})
+		template := spec["template"].(map[string]interface{})
+		metadata := template["metadata"].(map[string]interface{})
+		annotations := metadata["annotations"].(map[string]interface{})
+		require.Empty(t, annotations)
+	})
+}

--- a/pkg/clusteragent/patcher/patcher.go
+++ b/pkg/clusteragent/patcher/patcher.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PatchOptions controls how a patch is applied.
+type PatchOptions struct {
+	// PatchType is the Kubernetes patch type to use.
+	// Defaults to types.MergePatchType if zero-valued.
+	PatchType types.PatchType
+
+	// RetryOnConflict enables automatic retry with exponential backoff when
+	// the API server returns a 409 Conflict (optimistic concurrency failure).
+	RetryOnConflict bool
+
+	// DryRun validates the patch without persisting it.
+	DryRun bool
+
+	// Caller identifies the subsystem making the patch, used for logging
+	// (e.g. "language_detection", "rc_patcher", "vpa").
+	Caller string
+}
+
+// Patcher applies PatchIntents to Kubernetes resources via the dynamic client.
+// It optionally enforces leader election so patches are only applied by the
+// cluster agent leader.
+type Patcher struct {
+	client   dynamic.Interface
+	isLeader func() bool
+}
+
+// NewPatcher creates a Patcher with the given dynamic client and a
+// leader check function. If isLeader is non-nil, Apply will short-circuit
+// with (false, nil) when the current instance is not the leader.
+func NewPatcher(client dynamic.Interface, isLeader func() bool) *Patcher {
+	return &Patcher{client: client, isLeader: isLeader}
+}
+
+// Apply executes a PatchIntent against the Kubernetes API server.
+// It builds a patch from the intent's operations and applies it using the
+// patch type specified in opts.PatchType (defaults to MergePatchType).
+//
+// Returns:
+//   - true if the patch was applied (API call succeeded)
+//   - false if the intent had no operations, or if not the leader (no-op)
+//   - error if the patch could not be built or applied
+func (p *Patcher) Apply(ctx context.Context, intent *PatchIntent, opts PatchOptions) (bool, error) {
+	if p.isLeader != nil && !p.isLeader() {
+		log.Debugf("[patcher/%s] not leader, skipping patch for %s", opts.Caller, intent.Target())
+		return false, nil
+	}
+
+	patchData, err := intent.Build()
+	if err != nil {
+		return false, fmt.Errorf("failed to build patch: %w", err)
+	}
+	if patchData == nil {
+		log.Debugf("[patcher/%s] no operations for %s, skipping", opts.Caller, intent.Target())
+		return false, nil
+	}
+
+	patchType := opts.PatchType
+	if patchType == "" {
+		patchType = types.MergePatchType
+	}
+
+	target := intent.Target()
+	log.Debugf("[patcher/%s] applying patch to %v", opts.Caller, target)
+
+	applyFn := func() error {
+		patchOpts := metav1.PatchOptions{}
+		if opts.DryRun {
+			patchOpts.DryRun = []string{metav1.DryRunAll}
+		}
+
+		_, err := p.client.Resource(target.GVR).
+			Namespace(target.Namespace).
+			Patch(ctx, target.Name, patchType, patchData, patchOpts)
+		return err
+	}
+
+	if opts.RetryOnConflict {
+		err = retry.RetryOnConflict(retry.DefaultRetry, applyFn)
+	} else {
+		err = applyFn()
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("failed to patch %s: %w", target, err)
+	}
+
+	log.Debugf("[patcher/%s] successfully patched %s", opts.Caller, target)
+	return true, nil
+}

--- a/pkg/clusteragent/patcher/patcher_test.go
+++ b/pkg/clusteragent/patcher/patcher_test.go
@@ -1,0 +1,461 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package patcher
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newFakeClient creates a fake dynamic client with the apps/v1 and core/v1
+// resource schemes registered.
+func newFakeClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{
+			deploymentGVR:  "DeploymentList",
+			statefulSetGVR: "StatefulSetList",
+			podGVR:         "PodList",
+		},
+		objects...,
+	)
+}
+
+// newUnstructuredDeployment creates an unstructured Deployment for testing.
+func newUnstructuredDeployment(namespace, name string, metadataAnnotations, templateAnnotations map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{},
+					"spec":     map[string]interface{}{},
+				},
+			},
+		},
+	}
+	if metadataAnnotations != nil {
+		obj.Object["metadata"].(map[string]interface{})["annotations"] = metadataAnnotations
+	}
+	if templateAnnotations != nil {
+		obj.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["metadata"].(map[string]interface{})["annotations"] = templateAnnotations
+	}
+	return obj
+}
+
+// newUnstructuredPod creates an unstructured Pod for testing.
+func newUnstructuredPod(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{},
+		},
+	}
+}
+
+func TestPatcherApplyMetadataAnnotations(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"test-key": "test-value",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	// Verify the patch was applied by reading the resource back
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotations := result.GetAnnotations()
+	assert.Equal(t, "test-value", annotations["test-key"])
+}
+
+func TestPatcherApplyPodTemplateAnnotations(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"template-key": "template-value",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Navigate to spec.template.metadata.annotations
+	spec := result.Object["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	metadata := template["metadata"].(map[string]interface{})
+	annotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "template-value", annotations["template-key"])
+}
+
+func TestPatcherApplyPodAnnotations(t *testing.T) {
+	pod := newUnstructuredPod("default", "my-pod")
+	client := newFakeClient(pod)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(PodTarget("default", "my-pod")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"pod-key": "pod-value",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(podGVR).Namespace("default").Get(context.Background(), "my-pod", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotations := result.GetAnnotations()
+	assert.Equal(t, "pod-value", annotations["pod-key"])
+}
+
+func TestPatcherApplyEmptyIntent(t *testing.T) {
+	client := newFakeClient()
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy"))
+	// No operations added
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.False(t, applied, "empty intent should be a no-op")
+}
+
+func TestPatcherApplyNonExistentResource(t *testing.T) {
+	client := newFakeClient() // No objects
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "does-not-exist")).
+		With(SetMetadataAnnotations(map[string]interface{}{"k": "v"}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	assert.False(t, applied)
+	assert.Error(t, err)
+}
+
+func TestPatcherApplyMultipleOperations(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"rc.id":  "config-123",
+			"rc.rev": "42",
+		})).
+		With(SetPodTemplateLabels(map[string]interface{}{
+			"admission.datadoghq.com/enabled": "true",
+		})).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"java-lib.version": "v1.4.0",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Verify metadata annotations
+	annotations := result.GetAnnotations()
+	assert.Equal(t, "config-123", annotations["rc.id"])
+	assert.Equal(t, "42", annotations["rc.rev"])
+
+	// Verify template labels and annotations
+	spec := result.Object["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	metadata := template["metadata"].(map[string]interface{})
+
+	templateLabels := metadata["labels"].(map[string]interface{})
+	assert.Equal(t, "true", templateLabels["admission.datadoghq.com/enabled"])
+
+	templateAnnotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "v1.4.0", templateAnnotations["java-lib.version"])
+}
+
+func TestPatcherApplyDeleteAnnotations(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, map[string]interface{}{
+		"keep-me":   "value",
+		"remove-me": "old-value",
+	})
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(DeletePodTemplateAnnotations([]string{"remove-me", "other-remove-nonexistent"}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	rspec := result.Object["spec"].(map[string]interface{})
+	rtemplate := rspec["template"].(map[string]interface{})
+	rmetadata := rtemplate["metadata"].(map[string]interface{})
+	rAnnotations := rmetadata["annotations"].(map[string]interface{})
+
+	assert.Equal(t, "value", rAnnotations["keep-me"])
+	// With merge patch, nil should remove the key
+	_, exists := rAnnotations["remove-me"]
+	assert.False(t, exists, "deleted annotation should be removed")
+}
+
+func TestPatcherApplyPreservesExistingAnnotations(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", map[string]interface{}{
+		"existing-key": "existing-value",
+	}, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"new-key": "new-value",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotations := result.GetAnnotations()
+	assert.Equal(t, "existing-value", annotations["existing-key"], "existing annotation should be preserved")
+	assert.Equal(t, "new-value", annotations["new-key"], "new annotation should be added")
+}
+
+func TestPatcherApplyDryRun(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"dry-run-key": "dry-run-value",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test", DryRun: true, RetryOnConflict: true})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	// Verify a patch action was issued (the fake client doesn't enforce
+	// DryRun semantics, but we verify the patch was constructed)
+	actions := client.Actions()
+	require.NotEmpty(t, actions)
+	lastAction := actions[len(actions)-1]
+	patchAction, ok := lastAction.(k8stesting.PatchAction)
+	require.True(t, ok)
+	assert.NotEmpty(t, patchAction.GetPatch())
+}
+
+func TestPatcherApplyUsesCorrectPatchType(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{"k": "v"}))
+
+	_, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+
+	// Verify MergePatchType was used (default patch type)
+	actions := client.Actions()
+	require.NotEmpty(t, actions)
+	lastAction := actions[len(actions)-1]
+	patchAction, ok := lastAction.(k8stesting.PatchAction)
+	require.True(t, ok, "last action should be a patch")
+	assert.Equal(t, string(types.MergePatchType), string(patchAction.GetPatchType()))
+}
+
+func TestPatcherApplyBuildsCorrectJSON(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"rc.id": "cfg-1",
+		})).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"version": "v1",
+		}))
+
+	_, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+
+	actions := client.Actions()
+	patchAction := actions[len(actions)-1].(k8stesting.PatchAction)
+	patchBytes := patchAction.GetPatch()
+
+	var patchBody map[string]interface{}
+	err = json.Unmarshal(patchBytes, &patchBody)
+	require.NoError(t, err)
+
+	// Verify top-level metadata
+	metadata := patchBody["metadata"].(map[string]interface{})
+	metaAnnotations := metadata["annotations"].(map[string]interface{})
+	assert.Equal(t, "cfg-1", metaAnnotations["rc.id"])
+
+	// Verify template annotations
+	spec := patchBody["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateMeta := template["metadata"].(map[string]interface{})
+	templateAnnotations := templateMeta["annotations"].(map[string]interface{})
+	assert.Equal(t, "v1", templateAnnotations["version"])
+}
+
+func TestPatcherRespondsToLeadershipChange(t *testing.T) {
+	deploy := newUnstructuredDeployment("default", "my-deploy", nil, nil)
+	client := newFakeClient(deploy)
+
+	isLeader := false
+	p := NewPatcher(client, func() bool { return isLeader })
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{"k": "v"}))
+
+	// Not leader — should skip
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.False(t, applied)
+
+	// Become leader — should apply
+	isLeader = true
+	applied, err = p.Apply(context.Background(), intent, PatchOptions{Caller: "test"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+}
+
+// --- Scenario tests matching real use cases ---
+
+func TestScenarioRCPatcherEnable(t *testing.T) {
+	// Simulates the RC patcher enable flow
+	deploy := newUnstructuredDeployment("default", "my-java-service", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-java-service")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"admission.datadoghq.com/rc.id":  "config-abc",
+			"admission.datadoghq.com/rc.rev": "1674236639474287600",
+		})).
+		With(SetPodTemplateLabels(map[string]interface{}{
+			"admission.datadoghq.com/enabled": "true",
+		})).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"admission.datadoghq.com/java-lib.version":   "v1.4.0",
+			"admission.datadoghq.com/java-lib.config.v1": `{"service_name":"my-app"}`,
+			"admission.datadoghq.com/rc.id":              "config-abc",
+			"admission.datadoghq.com/rc.rev":             "1674236639474287600",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "rc_patcher"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+}
+
+func TestScenarioLanguageDetection(t *testing.T) {
+	// Simulates the language detection patcher flow
+	deploy := newUnstructuredDeployment("default", "my-deploy", map[string]interface{}{
+		"internal.dd.datadoghq.com/app.detected_langs":   "java",
+		"internal.dd.datadoghq.com/stale.detected_langs": "python",
+	}, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("default", "my-deploy")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"internal.dd.datadoghq.com/app.detected_langs":   "java,python",
+			"internal.dd.datadoghq.com/stale.detected_langs": nil, // remove stale
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{
+		Caller:          "language_detection",
+		RetryOnConflict: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, applied)
+
+	result, err := client.Resource(deploymentGVR).Namespace("default").Get(context.Background(), "my-deploy", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	annotations := result.GetAnnotations()
+	assert.Equal(t, "java,python", annotations["internal.dd.datadoghq.com/app.detected_langs"])
+	_, exists := annotations["internal.dd.datadoghq.com/stale.detected_langs"]
+	assert.False(t, exists, "stale annotation should be removed")
+}
+
+func TestScenarioVPARollout(t *testing.T) {
+	// Simulates the VPA vertical controller rollout trigger
+	deploy := newUnstructuredDeployment("ns1", "web-app", nil, nil)
+	client := newFakeClient(deploy)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(DeploymentTarget("ns1", "web-app")).
+		With(SetPodTemplateAnnotations(map[string]interface{}{
+			"autoscaling.datadoghq.com/rollout-timestamp": "2024-01-15T10:30:00Z",
+			"autoscaling.datadoghq.com/scaling-hash":      "abc123def",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "vpa"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+}
+
+func TestScenarioVPAPodPatcher(t *testing.T) {
+	// Simulates the VPA pod patcher annotation update
+	pod := newUnstructuredPod("ns1", "web-app-abc123")
+	client := newFakeClient(pod)
+	p := NewPatcher(client, nil)
+
+	intent := NewPatchIntent(PodTarget("ns1", "web-app-abc123")).
+		With(SetMetadataAnnotations(map[string]interface{}{
+			"autoscaling.datadoghq.com/recommendation-applied-event-generated": "true",
+		}))
+
+	applied, err := p.Apply(context.Background(), intent, PatchOptions{Caller: "pod_patcher"})
+	require.NoError(t, err)
+	assert.True(t, applied)
+}

--- a/pkg/clusteragent/patcher/target.go
+++ b/pkg/clusteragent/patcher/target.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package patcher provides a shared API for patching Kubernetes workload
+// resources (Deployments, StatefulSets, Pods, Argo Rollouts, etc.) from the
+// Cluster Agent. It unifies the patch construction, Kubernetes API interaction,
+// and leader-guard patterns used across language detection, remote config,
+// autoscaling, and other subsystems.
+package patcher
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Target identifies a Kubernetes resource to patch.
+type Target struct {
+	// GVR is the GroupVersionResource of the target.
+	GVR schema.GroupVersionResource
+	// Namespace of the target resource. Empty for cluster-scoped resources.
+	Namespace string
+	// Name of the target resource.
+	Name string
+}
+
+func (t Target) String() string {
+	return fmt.Sprintf("%s/%s/%s", t.GVR.Resource, t.Namespace, t.Name)
+}
+
+var (
+	deploymentGVR  = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	statefulSetGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	podGVR         = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	rolloutGVR     = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}
+)
+
+// DeploymentTarget creates a Target for a namespaced Deployment.
+func DeploymentTarget(namespace, name string) Target {
+	return Target{GVR: deploymentGVR, Namespace: namespace, Name: name}
+}
+
+// StatefulSetTarget creates a Target for a namespaced StatefulSet.
+func StatefulSetTarget(namespace, name string) Target {
+	return Target{GVR: statefulSetGVR, Namespace: namespace, Name: name}
+}
+
+// PodTarget creates a Target for a namespaced Pod.
+func PodTarget(namespace, name string) Target {
+	return Target{GVR: podGVR, Namespace: namespace, Name: name}
+}
+
+// RolloutTarget creates a Target for a namespaced Argo Rollout.
+func RolloutTarget(namespace, name string) Target {
+	return Target{GVR: rolloutGVR, Namespace: namespace, Name: name}
+}


### PR DESCRIPTION
### What does this PR do?

Establishes a shared interface for patching workloads within the Cluster Agent, wrapping the officially exposed k8s `.Patch` method

### Motivation

Establish best practices for patching and a common client for all cluster-agent use cases.

[CONTP-1252]

### Describe how you validated your changes

Unit Tests and CI

`pkg/clusteragent/patcher/patcher_test.go` use a fake k8s dynamic client and are exhaustive of all the different type of patch operations

### Additional Notes

This PR establishes a base implementation for a shared workload patcher in the cluster agent. This begins by migrating our own Language Detection component to use the new patcher interface. Below is a brief analysis of the main patching use cases in the Cluster Agent. Currently, we will **leave idempotency checks to the respective clients which have their own tracking methods**.

| | RC Patcher | Lang Detection | VPA Controller | Pod Patcher |
|-----------|-----------|----------------|----------------|-------------|
| **Trigger** | RC subscription | Workloadmeta event | CRD reconciler | Pod observation |
| **Target** | Deployment only | Deployment only | Deploy/SS/Rollout | Pods |
| **Patch location** | Pod template (triggers rollout) | Metadata annotations (no rollout) | Pod template (triggers rollout) | Pod spec + annotations |
| **Patch type** | StrategicMergePatch | MergePatch | MergePatch | StrategicMergePatch |
| **K8s client** | Typed | Dynamic | Dynamic | Dynamic |
| **Queue model** | Channel | RateLimitingQueue | Reconciler | Channel |
| **Idempotency** | Revision check | Diff-based | Hash-based | Annotation check |