### PR TITLE
[workloadmeta] Add telemetry for pending events

### DIFF
--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -50,6 +50,7 @@ func (w *workloadmeta) start(ctx context.Context) {
 			case <-health.C:
 
 			case evs := <-w.eventCh:
+				telemetry.PendingEventBundles.Dec()
 				w.handleEvents(evs)
 
 			case <-ctx.Done():
@@ -508,6 +509,7 @@ func (w *workloadmeta) ListGPUs() []*wmdef.GPU {
 // Notify implements Store#Notify
 func (w *workloadmeta) Notify(events []wmdef.CollectorEvent) {
 	if len(events) > 0 {
+		telemetry.PendingEventBundles.Inc()
 		w.eventCh <- events
 	}
 }

--- a/comp/core/workloadmeta/telemetry/telemetry.go
+++ b/comp/core/workloadmeta/telemetry/telemetry.go
@@ -98,4 +98,14 @@ var (
 		"Number of errors on the remote workloadmeta server while streaming events",
 		commonOpts,
 	)
+
+	// PendingEventBundles tracks the current number of event bundles pending to
+	// be handled by workloadmeta.
+	PendingEventBundles = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"pending_event_bundles",
+		[]string{},
+		"Number of event bundles pending to be handled by workloadmeta",
+		commonOpts,
+	)
 )

--- a/releasenotes/notes/wmeta-eventch-telemetry-889d435679cf1255.yaml
+++ b/releasenotes/notes/wmeta-eventch-telemetry-889d435679cf1255.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a telemetry metric to track pending events in workloadmeta:
+    "workloadmeta.pending_event_bundles".


### PR DESCRIPTION
### What does this PR do?

Adds a new telemetry metric (`workloadmeta.pending_event_bundles`) in workloadmeta that tracks the number of pending event bundles to be processed. When the channel is full, collectors block. This metric helps detect that situation.


### Describe how you validated your changes

Tested in a kind cluster to check that the new telemetry metric is reported.