### PR TITLE
Rename TestRunTypeOnDemand to TestRunTypeTriggered

### DIFF
--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -112,8 +112,8 @@ const (
 	TestRunTypeScheduled TestRunType = "scheduled"
 	// TestRunTypeDynamic is a dynamic test run.
 	TestRunTypeDynamic TestRunType = "dynamic"
-	// TestRunTypeOnDemand is a on-demand test run.
-	TestRunTypeOnDemand TestRunType = "on-demand"
+	// TestRunTypeTriggered is a triggered test run.
+	TestRunTypeTriggered TestRunType = "triggered"
 )
 
 // SourceProduct defines the product that originated the path

--- a/pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path.go
+++ b/pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path.go
@@ -114,7 +114,7 @@ func (h *GetNetworkPathHandler) Run(
 
 	path.Namespace = inputs.Namespace
 	path.Origin = payload.PathOriginNetworkPathIntegration
-	path.TestRunType = payload.TestRunTypeOnDemand
+	path.TestRunType = payload.TestRunTypeTriggered
 	path.SourceProduct = payload.SourceProductNetworkPath
 	path.CollectorType = payload.CollectorTypeAgent
 	path.Source.Service = inputs.SourceService

--- a/pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path_test.go
+++ b/pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path_test.go
@@ -103,7 +103,7 @@ func TestGetNetworkPathHandlerRun(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "default", result.Namespace)
 	require.Equal(t, payload.PathOriginNetworkPathIntegration, result.Origin)
-	require.Equal(t, payload.TestRunTypeOnDemand, result.TestRunType)
+	require.Equal(t, payload.TestRunTypeTriggered, result.TestRunType)
 	require.Equal(t, payload.SourceProductNetworkPath, result.SourceProduct)
 	require.Equal(t, payload.CollectorTypeAgent, result.CollectorType)
 	require.Equal(t, "source-service", result.Source.Service)
@@ -245,7 +245,7 @@ func TestGetNetworkPathHandlerRunSendToBackend(t *testing.T) {
 	require.NoError(t, json.Unmarshal(forwarder.lastMessage.GetContent(), &sent))
 	require.Equal(t, "default", sent.Namespace)
 	require.Equal(t, payload.PathOriginNetworkPathIntegration, sent.Origin)
-	require.Equal(t, payload.TestRunTypeOnDemand, sent.TestRunType)
+	require.Equal(t, payload.TestRunTypeTriggered, sent.TestRunType)
 	require.Equal(t, payload.SourceProductNetworkPath, sent.SourceProduct)
 	require.Equal(t, payload.CollectorTypeAgent, sent.CollectorType)
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5b971e48-421f-446d-a2df-f03a0dbd9a68","source":"chat","resourceId":"a5a0cb4e-3c7b-46ab-8b35-567708e25301","workflowId":"e5ad2993-2380-4751-bcc5-75bc60a57040","codeChangeId":"e5ad2993-2380-4751-bcc5-75bc60a57040","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/a5a0cb4e-3c7b-46ab-8b35-567708e25301)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Renames the `TestRunTypeOnDemand` constant to `TestRunTypeTriggered` throughout the codebase to better reflect the nature of network path test runs triggered by the integration.

### Motivation

The naming convention needed to be updated to accurately describe triggered test runs. This change improves clarity and consistency in the codebase by using more descriptive terminology.

### Describe how you validated your changes

- Updated constant definition in `pkg/networkpath/payload/pathevent.go`
- Updated all references to use the new constant in `pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path.go`
- Updated all test assertions to use the new constant in `pkg/privateactionrunner/bundles/ddagent/networkpath/get_network_path_test.go`
- Tests continue to validate that the correct test run type is set on network path objects

### Additional Notes

This is a straightforward rename that updates both the constant name and its string value from `"on-demand"` to `"triggered"`, along with all associated usages and test cases.