### PR TITLE
[AGENTRUN-1039] Do not recreate the logger when changing log level

### DIFF
--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -40,7 +40,7 @@ func New(t testing.TB) log.Component {
 	t.Cleanup(func() {
 		// stop using the logger to avoid a race condition
 		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugStr)
-		iface.Flush()
+		iface.Close()
 	})
 
 	// install the logger into pkg/util/log

--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -39,12 +39,12 @@ func New(t testing.TB) log.Component {
 
 	t.Cleanup(func() {
 		// stop using the logger to avoid a race condition
-		pkglog.ChangeLogLevel(pkglog.Default(), pkglog.DebugLvl)
+		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugStr)
 		iface.Flush()
 	})
 
 	// install the logger into pkg/util/log
-	pkglog.ChangeLogLevel(iface, pkglog.DebugLvl)
+	pkglog.SetupLogger(iface, pkglog.DebugStr)
 
 	return pkglog.NewWrapper(2)
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -106,7 +106,7 @@ func TestLogBuffer(t *testing.T) {
 	w.Flush()
 
 	// Trace will not be logged, Error and Critical will directly be logged to Stderr
-	assert.Equal(t, strings.Count(b.String(), "foo"), 5)
+	assert.Equal(t, 5, strings.Count(b.String(), "foo"), b.String())
 }
 func TestLogBufferWithContext(t *testing.T) {
 	// reset buffer state
@@ -613,9 +613,9 @@ func TestChangeLogLevel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("change log level to "+tc.String(), func(t *testing.T) {
 			levelVar := new(slog.LevelVar)
-			levelVar.Set(slog.LevelInfo)
+			levelVar.Set(slog.LevelDebug)
 
-			SetupLoggerWithLevelVar(Default(), DebugStr, levelVar)
+			SetupLoggerWithLevelVar(Default(), levelVar)
 
 			err := ChangeLogLevel(tc)
 			assert.NoError(t, err)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"log/slog"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -611,23 +612,18 @@ func TestChangeLogLevel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("change log level to "+tc.String(), func(t *testing.T) {
-			var b bytes.Buffer
-			w := bufio.NewWriter(&b)
+			levelVar := new(slog.LevelVar)
+			levelVar.Set(slog.LevelInfo)
 
-			l, _ := LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, DebugLvl)
+			SetupLoggerWithLevelVar(Default(), DebugStr, levelVar)
 
-			SetupLogger(Default(), DebugStr)
-
-			err := ChangeLogLevel(l, tc)
+			err := ChangeLogLevel(tc)
 			assert.NoError(t, err)
 
 			// log level should have been updated
 			level, err := GetLogLevel()
 			require.NoError(t, err)
 			assert.Equal(t, tc, level)
-
-			// inner logger should have been replaced
-			assert.Equal(t, l, logger.Load().inner)
 		})
 	}
 }

--- a/pkg/util/log/setup/internal/seelog/seelog_config.go
+++ b/pkg/util/log/setup/internal/seelog/seelog_config.go
@@ -43,14 +43,14 @@ type Config struct {
 	commonFormatter func(ctx context.Context, r stdslog.Record) string
 }
 
-// SlogLogger returns a slog logger
-func (c *Config) SlogLogger() (types.LoggerInterface, error) {
+// SlogLogger returns a slog logger and a level variable that can be used to change the log level dynamically
+func (c *Config) SlogLogger() (types.LoggerInterface, *stdslog.LevelVar, error) {
 	c.Lock()
 	defer c.Unlock()
 
 	if !c.consoleLoggingEnabled && c.logfile == "" && c.syslogURI == "" {
 		// seelog requires at least one output to be configured, we do the same
-		return nil, errors.New("no logging configuration provided")
+		return nil, nil, errors.New("no logging configuration provided")
 	}
 
 	// the logger:
@@ -70,7 +70,7 @@ func (c *Config) SlogLogger() (types.LoggerInterface, error) {
 	if c.logfile != "" {
 		fw, err := filewriter.NewRollingFileWriterSize(c.logfile, int64(c.maxsize), int(c.maxrolls), filewriter.RollingNameModePostfix)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		writers = append(writers, fw)
 		closeFuncs = append(closeFuncs, func() { fw.Close() })
@@ -90,7 +90,7 @@ func (c *Config) SlogLogger() (types.LoggerInterface, error) {
 	if c.syslogURI != "" {
 		syslogReceiver, err := syslog.NewReceiver(c.syslogURI)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		syslogFormatter := c.commonSyslogFormatter
 		if c.format == "json" {
@@ -107,9 +107,11 @@ func (c *Config) SlogLogger() (types.LoggerInterface, error) {
 
 	lvl, err := log.ValidateLogLevel(c.logLevel)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	levelHandler := handlers.NewLevel(types.ToSlogLevel(lvl), asyncHandler)
+	levelVar := new(stdslog.LevelVar)
+	levelVar.Set(types.ToSlogLevel(lvl))
+	levelHandler := handlers.NewLevel(levelVar, asyncHandler)
 
 	closeFunc := func() {
 		for _, closeFunc := range closeFuncs {
@@ -119,7 +121,7 @@ func (c *Config) SlogLogger() (types.LoggerInterface, error) {
 
 	logger := slog.NewWrapperWithCloseAndFlush(levelHandler, asyncHandler.Flush, closeFunc)
 
-	return logger, nil
+	return logger, levelVar, nil
 }
 
 // commonSyslogFormatter formats the syslog message in the common format

--- a/pkg/util/log/setup/log.go
+++ b/pkg/util/log/setup/log.go
@@ -37,13 +37,13 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 	if err != nil {
 		return err
 	}
-	loggerInterface, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+	loggerInterface, levelVar, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
 		return err
 	}
 	handler := loggerInterface.(*slog.Wrapper).Handler()
 	stdslog.SetDefault(stdslog.New(handler))
-	log.SetupLogger(loggerInterface, seelogLogLevel.String())
+	log.SetupLoggerWithLevelVar(loggerInterface, seelogLogLevel.String(), levelVar)
 
 	// Registering a callback in case of "log_level" update
 	cfg.OnUpdate(func(setting string, _ pkgconfigmodel.Source, oldValue, newValue any, _ uint64) {
@@ -57,14 +57,9 @@ func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, sys
 			log.Warnf("Unable to set new log level: %v", err)
 			return
 		}
-		loggerInterface, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
-		if err != nil {
-			return
+		if err := log.ChangeLogLevel(seelogLogLevel); err != nil {
+			log.Warnf("Unable to change log level: %v", err)
 		}
-		handler := loggerInterface.(*slog.Wrapper).Handler()
-		stdslog.SetDefault(stdslog.New(handler))
-		// We wire the new logger with the Datadog logic
-		log.ChangeLogLevel(loggerInterface, seelogLogLevel)
 	})
 	return nil
 }
@@ -77,7 +72,7 @@ func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonForm
 	// The JMX logger always logs at level "info", because JMXFetch does its
 	// own level filtering on and provides all messages to seelog at the info
 	// or error levels, via log.JMXInfo and log.JMXError.
-	logger, err := buildLogger(JMXLoggerName, log.InfoLvl, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+	logger, _, err := buildLogger(JMXLoggerName, log.InfoLvl, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -87,14 +82,14 @@ func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonForm
 // SetupDogstatsdLogger returns a logger with dogstatsd logger name and log level
 // if a non empty logFile is provided, it will also log to the file
 func SetupDogstatsdLogger(logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
-	logger, err := buildDogstatsdLogger(DogstatsDLoggerName, log.InfoLvl, logFile, cfg)
+	logger, _, err := buildDogstatsdLogger(DogstatsDLoggerName, log.InfoLvl, logFile, cfg)
 	if err != nil {
 		return nil, err
 	}
 	return logger, nil
 }
 
-func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
+func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
 	config := seelogCfg.NewSeelogConfig(string(loggerName), seelogLogLevel.String(), "common", false, nil, commonFormatter(loggerName, cfg))
 
 	// Configuring max roll for log file, if dogstatsd_log_file_max_rolls env var is not set (or set improperly ) within datadog.yaml then default value is 3
@@ -110,7 +105,7 @@ func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, lo
 	return generateLoggerInterface(config, cfg)
 }
 
-func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
+func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
 	formatID := "common"
 	if jsonFormat {
 		formatID = "json"
@@ -128,7 +123,7 @@ func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, sy
 }
 
 // generateLoggerInterface return a logger Interface from a log config
-func generateLoggerInterface(logConfig *seelogCfg.Config, _ pkgconfigmodel.Reader) (log.LoggerInterface, error) {
+func generateLoggerInterface(logConfig *seelogCfg.Config, _ pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
 	return logConfig.SlogLogger()
 }
 

--- a/pkg/util/log/setup/log.go
+++ b/pkg/util/log/setup/log.go
@@ -32,18 +32,18 @@ const (
 // if a non empty logFile is provided, it will also log to the file
 // a non empty syslogURI will enable syslog, and format them following RFC 5424 if specified
 // you can also specify to log to the console and in JSON format
-func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) error {
-	seelogLogLevel, err := log.ValidateLogLevel(logLevel)
+func SetupLogger(loggerName LoggerName, strLogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) error {
+	logLevel, err := log.ValidateLogLevel(strLogLevel)
 	if err != nil {
 		return err
 	}
-	loggerInterface, levelVar, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+	loggerInterface, levelVar, err := buildLogger(loggerName, logLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
 		return err
 	}
 	handler := loggerInterface.(*slog.Wrapper).Handler()
 	stdslog.SetDefault(stdslog.New(handler))
-	log.SetupLoggerWithLevelVar(loggerInterface, seelogLogLevel.String(), levelVar)
+	log.SetupLoggerWithLevelVar(loggerInterface, levelVar)
 
 	// Registering a callback in case of "log_level" update
 	cfg.OnUpdate(func(setting string, _ pkgconfigmodel.Source, oldValue, newValue any, _ uint64) {

--- a/pkg/util/log/setup/log_nix_test.go
+++ b/pkg/util/log/setup/log_nix_test.go
@@ -39,8 +39,9 @@ func TestGetSyslogURI(t *testing.T) {
 func TestSetupLoggingNowhere(t *testing.T) {
 	// setup logger so that it logs nowhere: i.e.  not to file, not to syslog, not to console
 	mockConfig := configmock.New(t)
-	loggerInterface, err := buildLogger("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
+	loggerInterface, levelVar, err := buildLogger("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
 
 	assert.Nil(t, loggerInterface)
+	assert.Nil(t, levelVar)
 	assert.NotNil(t, err)
 }

--- a/pkg/util/log/setup/log_test.go
+++ b/pkg/util/log/setup/log_test.go
@@ -21,10 +21,10 @@ func BenchmarkSlogParallel(b *testing.B) {
 	b.StopTimer()
 
 	cfg := initConfig(b)
-	logger, err := cfg.SlogLogger()
+	logger, levelVar, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-	log.SetupLogger(logger, "debug")
+	log.SetupLoggerWithLevelVar(logger, "debug", levelVar)
 
 	runLogParallel(b)
 }
@@ -49,10 +49,10 @@ func BenchmarkSlogLogger(b *testing.B) {
 	b.StopTimer()
 
 	cfg := initConfig(b)
-	logger, err := cfg.SlogLogger()
+	logger, levelVar, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-	log.SetupLogger(logger, "debug")
+	log.SetupLoggerWithLevelVar(logger, "debug", levelVar)
 
 	runLog(b)
 }

--- a/pkg/util/log/setup/log_test.go
+++ b/pkg/util/log/setup/log_test.go
@@ -6,6 +6,7 @@
 package logs
 
 import (
+	"log/slog"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -24,7 +25,9 @@ func BenchmarkSlogParallel(b *testing.B) {
 	logger, levelVar, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-	log.SetupLoggerWithLevelVar(logger, "debug", levelVar)
+
+	levelVar.Set(slog.LevelDebug)
+	log.SetupLoggerWithLevelVar(logger, levelVar)
 
 	runLogParallel(b)
 }
@@ -52,7 +55,9 @@ func BenchmarkSlogLogger(b *testing.B) {
 	logger, levelVar, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-	log.SetupLoggerWithLevelVar(logger, "debug", levelVar)
+
+	levelVar.Set(slog.LevelDebug)
+	log.SetupLoggerWithLevelVar(logger, levelVar)
 
 	runLog(b)
 }


### PR DESCRIPTION
### What does this PR do?
Do not recreate the logger when changing log level.

### Motivation
This is now possible since we transitioned to the new slog-based logger.
This is more efficient and less risky.

It will also allow simplifying the logger later on (no need to handle the logger changing at any time, it is only set at the beginning).

### Describe how you validated your changes
CI

### Additional Notes
