### PR TITLE
chore(static_quality_gates): add Container Platform team as reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -836,7 +836,7 @@
 /test/new-e2e/examples/ecs_test.go           @DataDog/ecs-experiences
 /test/otel/                                   @DataDog/opentelemetry-agent
 /test/static/                                 @DataDog/agent-build
-/test/static/static_quality_gates.yml        @DataDog/agent-build @cmourot @dd-ddamien
+/test/static/static_quality_gates.yml        @DataDog/agent-build @DataDog/container-platform @cmourot @dd-ddamien
 /test/benchmarks/apm_scripts/                 @DataDog/agent-apm
 /test/regression/                             @DataDog/single-machine-performance
 /test/regression/cases/docker_containers*     @DataDog/single-machine-performance @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?

Adds the @DataDog/container-platform team as reviewers for the Static Quality Gate to target the Datadog Cluster Agent.

### Motivation

The Container Platform team owns the Cluster Agent.

### Describe how you validated your changes

This CODEOWNERS file is valid.

### Additional Notes
N/A
