### PR TITLE
[tagger/tagstore] Remove stale LookupHashedWithEntityStr

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -204,7 +204,7 @@ func (t *localTagger) getTags(entityID types.EntityID, cardinality types.TagCard
 		return tagset.HashedTags{}, errors.New("empty entity ID")
 	}
 
-	cachedTags, err := t.tagStore.LookupHashedWithEntityStr(entityID, cardinality)
+	cachedTags, err := t.tagStore.LookupHashed(entityID, cardinality)
 	if err != nil {
 		t.telemetryStore.QueriesByCardinality(cardinality).EmptyTags.Inc()
 		return tagset.HashedTags{}, err

--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -248,23 +248,8 @@ func (s *TagStore) Prune() {
 }
 
 // LookupHashed gets tags from the store and returns them as a HashedTags instance.
-func (s *TagStore) LookupHashed(entityID types.EntityID, cardinality types.TagCardinality) tagset.HashedTags {
-	s.RLock()
-	defer s.RUnlock()
-	storedTags, present := s.store.Get(entityID)
-
-	if !present {
-		return tagset.HashedTags{}
-	}
-	return storedTags.getHashedTags(cardinality)
-}
-
-// LookupHashedWithEntityStr is the same as LookupHashed but takes a string as input.
-// This function is needed only for performance reasons. It functions like
-// LookupHashed, but accepts a string instead of an EntityID. This reduces the
-// allocations that occur when an EntityID is passed as a parameter.
 // Returns ErrNotFound if the entity is not present in the store.
-func (s *TagStore) LookupHashedWithEntityStr(entityID types.EntityID, cardinality types.TagCardinality) (tagset.HashedTags, error) {
+func (s *TagStore) LookupHashed(entityID types.EntityID, cardinality types.TagCardinality) (tagset.HashedTags, error) {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -278,7 +263,8 @@ func (s *TagStore) LookupHashedWithEntityStr(entityID types.EntityID, cardinalit
 
 // Lookup gets tags from the store and returns them concatenated in a string slice.
 func (s *TagStore) Lookup(entityID types.EntityID, cardinality types.TagCardinality) []string {
-	return s.LookupHashed(entityID, cardinality).Get()
+	tags, _ := s.LookupHashed(entityID, cardinality)
+	return tags.Get()
 }
 
 // LookupStandard returns the standard tags recorded for a given entity

--- a/comp/core/tagger/tagstore/tagstore_test.go
+++ b/comp/core/tagger/tagstore/tagstore_test.go
@@ -96,7 +96,7 @@ func (s *StoreTestSuite) TestLookup() {
 	assert.Nil(s.T(), tagsNone)
 }
 
-func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
+func (s *StoreTestSuite) TestLookupHashed() {
 	entityID := types.NewEntityID(types.ContainerID, "test")
 	s.tagstore.ProcessTagInfo([]*types.TagInfo{
 		{
@@ -117,13 +117,13 @@ func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
 		},
 	})
 
-	tagsLow, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.LowCardinality)
+	tagsLow, err := s.tagstore.LookupHashed(entityID, types.LowCardinality)
 	assert.NoError(s.T(), err)
-	tagsOrch, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.OrchestratorCardinality)
+	tagsOrch, err := s.tagstore.LookupHashed(entityID, types.OrchestratorCardinality)
 	assert.NoError(s.T(), err)
-	tagsHigh, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.HighCardinality)
+	tagsHigh, err := s.tagstore.LookupHashed(entityID, types.HighCardinality)
 	assert.NoError(s.T(), err)
-	tagsNone, err := s.tagstore.LookupHashedWithEntityStr(entityID, types.NoneCardinality)
+	tagsNone, err := s.tagstore.LookupHashed(entityID, types.NoneCardinality)
 	assert.NoError(s.T(), err)
 
 	assert.ElementsMatch(s.T(), tagsLow.Get(), []string{"low1", "low2"})
@@ -133,7 +133,7 @@ func (s *StoreTestSuite) TestLookupHashedWithEntityStr() {
 
 	// Test entity not found
 	nonExistentEntityID := types.NewEntityID(types.ContainerID, "non_existent")
-	_, err = s.tagstore.LookupHashedWithEntityStr(nonExistentEntityID, types.LowCardinality)
+	_, err = s.tagstore.LookupHashed(nonExistentEntityID, types.LowCardinality)
 	assert.Error(s.T(), err)
 	assert.Equal(s.T(), ErrNotFound, err)
 }


### PR DESCRIPTION
### What does this PR do?

This PR is a cleanup in the tagger code.

The `LookupHashedWithEntityStr` function was added to avoid allocations by taking a `string` instead of an `EntityID`. A later refactor changed the parameter to `EntityID`, making it identical to the other `LookupHashed` function, except it also returns an error. The name and comment were never updated.

The code has changed and the original optimization can no longer be applied.

This PR consolidates the two functions because we no longer need two separate ones.

### Describe how you validated your changes

CI
