### PR TITLE
Put CWS tests back in separate jobs

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -663,11 +663,16 @@ new-e2e-cws:
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
-    EXTRA_PARAMS: --skip "Windows"
     # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
   # Temporary, remove once we made sure the recent changes have no impact on the stability of these tests
   # NOTE: Do not remove this from e2e fips pipeline before remote config is available with fips, you can re-enable on fips pipeline when this test does not rely on remote-configuration
+  parallel:
+    matrix:
+      - EXTRA_PARAMS: --run TestAgentSuiteEC2
+      - EXTRA_PARAMS: --run TestAgentSuiteGCP
+      - EXTRA_PARAMS: --run TestECSFargate
+      - EXTRA_PARAMS: --run TestKindSuite
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
@@ -682,8 +687,7 @@ new-e2e-cws-windows:
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
-    EXTRA_PARAMS: --run "Windows"
-    # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
+    EXTRA_PARAMS: --run TestAgentWindowsSuite    # Temporarily disable the test on FIPS pipeline, as remote-configuration is not available with FIPS Agent yet
     # ON_NIGHTLY_FIPS: "true"
   # Temporary, remove once we made sure the recent changes have no impact on the stability of these tests
   # NOTE: Do not remove this from e2e fips pipeline before remote config is available with fips, you can re-enable on fips pipeline when this test does not rely on remote-configuration


### PR DESCRIPTION
### What does this PR do?

Put back CWS test in a matrix with dedicated job for each test

### Motivation

Fix an oversight of: https://github.com/DataDog/datadog-agent/pull/46243/changes#diff-0f0118d3382b0f70f204bec29be2a0f840e10256cf4f8e1cf27566735dcfaac3L605

### Describe how you validated your changes

### Additional Notes
