### PR TITLE
[PROF-13652] Attach profiler's logger to OTel configured one when possible in standalone mode

### DIFF
--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -50,16 +50,3 @@ service:
       # infraattributes/default is automatically removed when the Agent Core is not available
       processors: [cumulativetodelta, infraattributes/default]
       exporters: [otlphttp/metrics]
-  telemetry:
-    logs:
-      level: info
-      encoding: console
-      output_paths:
-        - stderr
-      error_output_paths:
-        - stderr
-      sampling:
-        enabled: true
-        initial: 10
-        thereafter: 100
-        tick: 10s

--- a/cmd/host-profiler/dist/host-profiler-config.yaml
+++ b/cmd/host-profiler/dist/host-profiler-config.yaml
@@ -50,3 +50,16 @@ service:
       # infraattributes/default is automatically removed when the Agent Core is not available
       processors: [cumulativetodelta, infraattributes/default]
       exporters: [otlphttp/metrics]
+  telemetry:
+    logs:
+      level: info
+      encoding: console
+      output_paths:
+        - stderr
+      error_output_paths:
+        - stderr
+      sampling:
+        enabled: true
+        initial: 10
+        thereafter: 100
+        tick: 10s

--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
-	"go.uber.org/zap"
 )
 
 // Params contains the parameters for the collector component.
@@ -93,8 +92,6 @@ func (c *collectorImpl) Run() error {
 }
 
 func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.CollectorSettings, error) {
-	zapCore := extraFactories.GetZapCore()
-
 	return otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{
 			Command:     filepath.Base(os.Args[0]),
@@ -110,9 +107,6 @@ func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.Co
 					fileprovider.NewFactory(),
 				},
 				ConverterFactories: extraFactories.GetConverters(),
-				ProviderSettings: confmap.ProviderSettings{
-					Logger: zap.New(zapCore),
-				},
 			},
 		},
 		LoggingOptions: extraFactories.GetLoggingOptions(),

--- a/comp/host-profiler/collector/impl/collector.go
+++ b/comp/host-profiler/collector/impl/collector.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // Params contains the parameters for the collector component.
@@ -95,14 +94,6 @@ func (c *collectorImpl) Run() error {
 
 func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.CollectorSettings, error) {
 	zapCore := extraFactories.GetZapCore()
-	extraFactories.SetupSlogDefault(zapCore)
-
-	// Replace default core to use Agent logger
-	options := []zap.Option{
-		zap.WrapCore(func(zapcore.Core) zapcore.Core {
-			return zapCore
-		}),
-	}
 
 	return otelcol.CollectorSettings{
 		BuildInfo: component.BuildInfo{
@@ -124,7 +115,7 @@ func newCollectorSettings(uri string, extraFactories ExtraFactories) (otelcol.Co
 				},
 			},
 		},
-		LoggingOptions: options,
+		LoggingOptions: extraFactories.GetLoggingOptions(),
 	}, nil
 }
 

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -541,7 +542,7 @@ func TestConverterWithoutAgent(t *testing.T) {
 		},
 	}
 
-	runSuccessTests(t, &converterWithoutAgent{}, tests)
+	runSuccessTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)
 }
 
 func TestConverterWithoutAgentErrors(t *testing.T) {
@@ -598,5 +599,5 @@ func TestConverterWithoutAgentErrors(t *testing.T) {
 		},
 	}
 
-	runErrorTests(t, &converterWithoutAgent{}, tests)
+	runErrorTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)
 }

--- a/comp/host-profiler/collector/impl/converters/converter_with_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_with_agent.go
@@ -11,11 +11,11 @@ package converters
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"go.opentelemetry.io/collector/confmap"
 )
 
@@ -39,7 +39,7 @@ func newConfigManager(config config.Component) configManager {
 	if profilingDDURL != "" {
 		usedSite = configutils.ExtractSiteFromURL(profilingDDURL)
 		if usedSite == "" {
-			log.Warnf("Could not extract site from apm_config.profiling_dd_url %s, skipping endpoint", profilingDDURL)
+			slog.Warn("could not extract site from apm_config.profiling_dd_url, skipping endpoint", "url", profilingDDURL)
 		}
 		usedURL = profilingDDURL
 	} else if ddSite != "" {
@@ -51,7 +51,7 @@ func newConfigManager(config config.Component) configManager {
 	for endpointURL, keys := range profilingAdditionalEndpoints {
 		site := configutils.ExtractSiteFromURL(endpointURL)
 		if site == "" {
-			log.Warnf("Could not extract site from URL %s, skipping endpoint", endpointURL)
+			slog.Warn("could not extract site from URL, skipping endpoint", "url", endpointURL)
 			continue
 		}
 		endpoints = append(endpoints, endpoint{
@@ -60,17 +60,17 @@ func newConfigManager(config config.Component) configManager {
 			apiKeys: keys,
 		})
 	}
-	log.Infof("Main site inferred from core configuration is %s", usedSite)
+	slog.Info("main site inferred from core configuration", "site", usedSite)
 
 	// Add main endpoint if we have a valid site
 	if usedSite == "" {
-		log.Warn("Could not determine site from core configuration, no default endpoint will be configured")
+		slog.Warn("could not determine site from core configuration, no default endpoint will be configured")
 	} else {
 		endpoints = append(endpoints, endpoint{site: usedSite, url: usedURL, apiKeys: []string{apiKey}})
 	}
 
 	if len(endpoints) == 0 {
-		log.Warn("No valid endpoints in core agent configured for inference")
+		slog.Warn("no valid endpoints in core agent configured for inference")
 	}
 
 	return configManager{config: config, endpoints: endpoints}
@@ -204,7 +204,7 @@ func (c *converterWithAgent) checkHostProfilerReceiverConfig(hostProfiler confMa
 
 	// If symbol_endpoints is missing, wrong type, or empty, infer from agent config
 	if !ok || len(endpoints) == 0 {
-		log.Info("Symbol uploader enabled but endpoints not configured, inferring from agent config")
+		slog.Info("symbol uploader enabled but endpoints not configured, inferring from agent config")
 		if err := c.inferHostProfilerEndpointConfig(hostProfiler); err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ func (c *converterWithAgent) ensureOtlpHTTPExporterConfig(conf confMap, exporter
 	}
 
 	if !hasOtlpHTTP {
-		log.Info("No otlphttp exporter configured, inferring from agent config")
+		slog.Info("no otlphttp exporter configured, inferring from agent config")
 		if err := c.inferOtlpHTTPConfig(conf); err != nil {
 			return err
 		}
@@ -346,7 +346,7 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 				return nil, err
 			}
 			if !ddDefaultValue {
-				log.Warn("allow_hostname_override is required but is disabled by user configuration; preserving user value.")
+				slog.Warn("allow_hostname_override is required but is disabled by user configuration; preserving user value.")
 			}
 			foundInfraattributes = true
 		}
@@ -357,7 +357,7 @@ func (c *converterWithAgent) fixProcessorsPipeline(conf confMap, processorNames 
 		if err := Set(processors, defaultInfraAttributesName+"::"+fieldAllowHostnameOverride, true); err != nil {
 			return nil, err
 		}
-		log.Warn("Added minimal infraattributes processor to user configuration")
+		slog.Warn("added minimal infraattributes processor to user configuration")
 		processorNames = append(processorNames, defaultInfraAttributesName)
 	}
 

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -243,7 +243,7 @@ func (c *converterWithoutAgent) ensureResourceDetectionConfig(resourceDetection 
 		return err
 	}
 	if !ddDefaultValue {
-		standaloneLogger.Warn("host.arch is required but is disabled by user configuration; preserving user value. Profiles for compiled languages will be missing symbols.")
+		slog.Warn("host.arch is required but is disabled by user configuration; preserving user value. Profiles for compiled languages will be missing symbols.")
 	}
 
 	// Only set these defaults if we added the system detector

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -13,8 +13,8 @@ package converters
 
 import (
 	"fmt"
-	"reflect"
 	"log/slog"
+	"reflect"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -8,12 +8,17 @@
 package converters
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func loadTestData(t *testing.T, filename string) confMap {
@@ -29,6 +34,11 @@ func loadTestData(t *testing.T, filename string) confMap {
 	require.NoError(t, err, "failed to convert to confmap from: %s", filename)
 
 	return conf.ToStringMap()
+}
+
+func newObserverLogger(level zapcore.Level) (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(level)
+	return zap.New(core), logs
 }
 
 func TestGetBasicTypes(t *testing.T) {
@@ -286,4 +296,60 @@ func TestEnsureErrorWhenIntermediateNotMap(t *testing.T) {
 	_, err := Ensure[bool](cm, "processors::batch::enabled")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "processors")
+}
+
+func TestConverterWithoutAgentLogsViaOTelLogger(t *testing.T) {
+	logger, logs := newObserverLogger(zap.WarnLevel)
+
+	conv := newConverterWithoutAgent(confmap.ConverterSettings{Logger: logger})
+	conf := confmap.NewFromStringMap(loadTestData(t, "no_agent/symbol-up-disabled/in.yaml"))
+
+	err := conv.Convert(context.Background(), conf)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, logs.Len(), 1, "expected at least one log from the converter")
+
+	const expectedMsg = "Added minimal resourcedetection processor to user configuration"
+	found := false
+	for _, entry := range logs.All() {
+		if entry.Level == zap.WarnLevel && entry.Message == expectedMsg {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected warning about adding resourcedetection processor, got: %v", logs.All())
+}
+
+func TestSetLoggerOverridesSlog(t *testing.T) {
+	logger, logs := newObserverLogger(zap.DebugLevel)
+
+	SetLogger(logger)
+	t.Cleanup(func() {
+		SetLogger(zap.NewNop())
+	})
+
+	cm := confMap{}
+	Get[string](cm, "nonexistent::path")
+
+	require.GreaterOrEqual(t, logs.Len(), 1, "expected slog to use the overridden logger")
+	assert.Contains(t, logs.All()[0].Message, "non-existent intermediate map")
+}
+
+func TestConverterWithoutAgentLogsHostArchWarning(t *testing.T) {
+	logger, logs := newObserverLogger(zap.DebugLevel)
+
+	conv := newConverterWithoutAgent(confmap.ConverterSettings{Logger: logger})
+	conf := confmap.NewFromStringMap(loadTestData(t, "no_agent/preserve-host-arch/in.yaml"))
+
+	err := conv.Convert(context.Background(), conf)
+	require.NoError(t, err)
+
+	const expectedMsg = "host.arch is required but is disabled by user configuration and will break symbolication; preserving user value"
+	found := false
+	for _, entry := range logs.All() {
+		if entry.Message == expectedMsg {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected warning about host.arch being disabled, got logs: %v", logs.All())
 }

--- a/comp/host-profiler/collector/impl/converters/converters_test.go
+++ b/comp/host-profiler/collector/impl/converters/converters_test.go
@@ -319,21 +319,6 @@ func TestConverterWithoutAgentLogsViaOTelLogger(t *testing.T) {
 	assert.True(t, found, "expected warning about adding resourcedetection processor, got: %v", logs.All())
 }
 
-func TestSetLoggerOverridesSlog(t *testing.T) {
-	logger, logs := newObserverLogger(zap.DebugLevel)
-
-	SetLogger(logger)
-	t.Cleanup(func() {
-		SetLogger(zap.NewNop())
-	})
-
-	cm := confMap{}
-	Get[string](cm, "nonexistent::path")
-
-	require.GreaterOrEqual(t, logs.Len(), 1, "expected slog to use the overridden logger")
-	assert.Contains(t, logs.All()[0].Message, "non-existent intermediate map")
-}
-
 func TestConverterWithoutAgentLogsHostArchWarning(t *testing.T) {
 	logger, logs := newObserverLogger(zap.DebugLevel)
 
@@ -343,7 +328,7 @@ func TestConverterWithoutAgentLogsHostArchWarning(t *testing.T) {
 	err := conv.Convert(context.Background(), conf)
 	require.NoError(t, err)
 
-	const expectedMsg = "host.arch is required but is disabled by user configuration and will break symbolication; preserving user value"
+	const expectedMsg = "host.arch is required but is disabled by user configuration; preserving user value. Profiles for compiled languages will be missing symbols."
 	found := false
 	for _, entry := range logs.All() {
 		if entry.Message == expectedMsg {

--- a/comp/host-profiler/flare/impl/flare.go
+++ b/comp/host-profiler/flare/impl/flare.go
@@ -9,11 +9,11 @@ package flareimpl
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	flaretypes "github.com/DataDog/datadog-agent/comp/core/flare/types"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	"github.com/DataDog/datadog-agent/comp/host-profiler/collector/impl/extensions/hpflareextension"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Can be overridden for tests
@@ -47,7 +47,7 @@ func (c *flareImpl) fillFlare(fb flaretypes.FlareBuilder) error {
 	responseBytes, err := c.requestOtelConfigInfo()
 	if err != nil {
 		msg := fmt.Sprintf("did not get host-profiler configuration: %v", err)
-		log.Error(msg)
+		slog.Error(msg)
 		fb.AddFile("host-profiler/host-profiler.log", []byte(msg))
 
 		return nil
@@ -56,7 +56,7 @@ func (c *flareImpl) fillFlare(fb flaretypes.FlareBuilder) error {
 	var responseInfo hpflareextension.Response
 	if err := json.Unmarshal(responseBytes, &responseInfo); err != nil {
 		msg := fmt.Sprintf("could not read sources from host-profiler response: %s, error: %v", responseBytes, err)
-		log.Error(msg)
+		slog.Error(msg)
 		fb.AddFile("host-profiler/host-profiler.log", []byte(msg))
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?
https://datadoghq.atlassian.net/browse/PROF-13652

In standalone mode, the host profiler was using a hardcoded logger core (`zapAgent.NewZapCoreWithDepth`) that was force-injected into the OTel collector via `LoggingOptions` and `ProviderSettings`. This overrode any logger configuration the user set in `host-profiler-config.yaml` under `service.telemetry.logs`.

This PR removes the hardcoded standalone logger and instead relies on the logger that the upstream OTel collector creates from the user's configuration file.

#### Changes

`otel_col_factories.go` - Simplified the ExtraFactories interface:
- Removed `GetZapCore()` and `SetupSlogDefault()` methods, replaced by a single `GetLoggingOptions()` that returns `[]zap.Option`.
- In bundled mode (`extraFactoriesWithAgentCore`), `GetLoggingOptions()` returns a `zap.WrapCore` that redirects the OTel collector's logger to the Agent's logger - same behavior as before.
- In standalone mode (`extraFactoriesWithoutAgentCore`), `GetLoggingOptions()` returns an empty slice - no override, letting the OTel collector build its logger entirely from the YAML config.

`collector.go` - Removed all manual logger setup from `newCollectorSettings`:
- No more `GetZapCore()` / `SetupSlogDefault()` calls.
- No more hardcoded `ProviderSettings.Logger` as it is override (https://github.com/open-telemetry/opentelemetry-collector/blob/main/otelcol/collector.go#L128). 

`converter_without_agent.go` - Replaced the standaloneLogger with slog:
- `newConverterWithoutAgent` now calls `slog.SetDefault()` using OTel collector's logger.

`converters.go` - Replaced `pkg/util/log` (the Agent's logger) with `log/slog` in shared utility functions (`Get`, `Set`, `ensureKeyStringValue`):
- In standalone mode we configure the `slog` logger before any call to converter.
- In bundle mode, we rely on the fact that slog is setup by the agent. This is the same behavior as before:
```
func (e extraFactoriesWithAgentCore) SetupSlogDefault(_ zapcore.Core) {
	// In Bundled mode, the Agent logger takes care of setting up global logging
}
```

`host-profiler-config.yaml` - Added a default service.telemetry.logs section

#### Handle crash-safe buffering

The upstream OTel collector already handles this. In https://github.com/open-telemetry/opentelemetry-collector/blob/main/otelcol/collector.go, the collector creates a bufferedCore that captures all log entries emitted before the configuration is parsed. Once `setupConfigurationComponents` builds the real logger from the YAML config, the buffered logs are replayed through it. If `setupConfigurationComponents` fails, the collector creates a fallback stderr logger and replays the buffered logs through that instead.

This works for us because:
- The `ConverterSettings.Logger` passed to our converters is backed by this same bufferedCore - it is created early in `NewCollector`, before any config parsing.
- Our `newConverterWithoutAgent` is invoked during config resolution (inside `configProvider.Get`), which is part of `setupConfigurationComponents`. At that point, the buffered core is active and captures everything.
- It seems we have no logging needs before the converter is constructed
- After `setupConfigurationComponents` completes, the real logger replaces the buffered core and all captured logs are replayed with the correct configuration.

### Motivation

Allow users to configure the standalone host profiler's logging behavior through the standard `OTel service.telemetry.logs` configuration. Previously these settings were silently ignored.

### Describe how you validated your changes

- Unit tests: Added `TestConverterWithoutAgentLogsViaOTelLogger `and `TestConverterWithoutAgentLogsHostArchWarning` that verify log messages from the converter using a zap observer set instead of OTel's logger.
- Manual testing: Ran the standalone host profiler with various service.telemetry.logs configurations (different levels, encoding) and confirmed the logs reflected the configured settings.

Few configs in order to run tests:
```
telemetry:
    logs:
      level: info
      encoding: console
      output_paths:
        - stderr
      error_output_paths:
        - stderr
      sampling:
        enabled: true
        initial: 10
        thereafter: 100
        tick: 10s
```

```
telemetry:
    logs:
      level: debug
      encoding: json
      output_paths:
        - stderr
        - host-profiler.log
      error_output_paths:
        - stderr
        - host-profiler-err.log
      initial_fields:
        service: my-test-is-great
      sampling:
        enabled: true
        initial: 10
        thereafter: 100
        tick: 10s
```

### Additional Notes
