### PR TITLE
Remove codeowners for internal/tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -867,9 +867,6 @@
 /**/go.sum                              # do not notify anyone
 
 # Add here modules that need explicit review from the team owning them
-/internal/tools/**/go.mod                @DataDog/agent-devx
-/internal/tools/**/go.sum                @DataDog/agent-devx
-
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 


### PR DESCRIPTION
### What does this PR do?
Remove codeowners for internal/tools go.mod files.

### Motivation
Ease dependency and tool updates.

### Describe how you validated your changes
CI

### Additional Notes
Alternative to https://github.com/DataDog/datadog-agent/pull/46552, since the devx teams doesn't really care about reviewing tools update.