### PR TITLE
[ABLD-317] Conservatively extend `inv tidy` scope to `bazel`

### DIFF
--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -50,6 +50,6 @@ bazel:run-gazelle:
 bazel:run-go-mod-tidy:
   extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
-    - bazel run //:go mod tidy -- -diff
+    - bazel run //:go_mod_tidy_all -- -diff
   variables:
-    FIX_COMMAND: "bazel run //:go mod tidy"
+    FIX_COMMAND: "bazel run //:go_mod_tidy_all"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,6 +32,12 @@ alias(
     actual = "@rules_go//go",
 )
 
+# bazel run //:go_mod_tidy_all -- -x
+alias(
+    name = "go_mod_tidy_all",
+    actual = "//bazel/tools:go_mod_tidy_all",
+)
+
 run_binary(
     name = "gen_go_work",
     srcs = [

--- a/bazel/tools/BUILD.bazel
+++ b/bazel/tools/BUILD.bazel
@@ -5,6 +5,15 @@ load("@rules_python//python:py_binary.bzl", "py_binary")
 check_bazel_version()
 
 py_binary(
+    name = "go_mod_tidy_all",
+    srcs = ["go_mod_tidy_all.py"],
+    args = ["$(rlocationpath @rules_go//go)"],
+    data = ["@rules_go//go"],
+    visibility = ["//:__pkg__"],
+    deps = ["@rules_python//python/runfiles"],
+)
+
+py_binary(
     name = "generate_module_bazel",
     srcs = ["generate_module_bazel.py"],
     visibility = ["//deps:__subpackages__"],

--- a/bazel/tools/go_mod_tidy_all.py
+++ b/bazel/tools/go_mod_tidy_all.py
@@ -1,0 +1,40 @@
+"""Run `go mod tidy` concurrently across all modules in the workspace.
+
+Processes ~180 go.mod files in ~4 seconds (with a warm Go module cache) using `asyncio`, while reproducing the default
+`ThreadPoolExecutor._max_workers` heuristic (still a private API as of Python 3.12).
+"""
+
+import asyncio
+import os
+import sys
+from subprocess import PIPE, CalledProcessError
+
+from python.runfiles import runfiles
+
+
+async def _exec(go, *args, **kwargs):
+    proc = await asyncio.create_subprocess_exec(go, *args, **kwargs)
+    stdout, _ = await proc.communicate()
+    if proc.returncode == 0:
+        return stdout
+    raise CalledProcessError(proc.returncode, " ".join(("go", *args)))
+
+
+async def _tidy(max_workers, go, mod_path, args):
+    async with max_workers, asyncio.timeout(30):
+        await _exec(go, "mod", "tidy", "-C", mod_path, *args)
+
+
+async def main(go, args):
+    mod_paths = await _exec(go, "list", "-f", "{{.Dir}}", "-m", stdout=PIPE)
+    max_workers = asyncio.Semaphore((os.cpu_count() or 1) + 4)  # TODO(regis): cpu_count -> Py 3.13's process_cpu_count
+    async with asyncio.TaskGroup() as tg:
+        for mod_path in mod_paths.decode().splitlines():
+            tg.create_task(_tidy(max_workers, go, mod_path, args))
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main(runfiles.Create().Rlocation(sys.argv[1]), sys.argv[2:]))
+    except* Exception as eg:
+        sys.exit("\n".join(str(e) for e in eg.exceptions))

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import shlex
 import shutil
 import subprocess
 import sys
 
-from tasks.libs.common.utils import get_repo_root
+from tasks.libs.common.color import color_message
+
+
+def bazel_not_found_message(color: str) -> str:
+    return color_message("Please run `inv install-tools` for `bazel` support!", color)
 
 
 def bazel(*args: str, capture_output: bool = False) -> None | str:
     """Execute a bazel command. Returns the captured standard output as string if capture_output=True."""
 
-    cmd = shutil.which("bazel") or sys.exit((get_repo_root() / "tools" / "bazelisk.md").read_text())
+    cmd = shutil.which("bazel") or sys.exit(bazel_not_found_message("red"))
+    print(color_message(shlex.join(("bazel", *args)), "bold"), file=sys.stderr)
     return (subprocess.check_output if capture_output else subprocess.check_call)((cmd, *args), text=True)

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -19,7 +19,7 @@ class TestBazel(unittest.TestCase):
     def test_bazel_not_found(self):
         with self.assertRaises(SystemExit) as cm:
             bazel("info")
-        self.assertIn("❌ ERROR: `bazelisk` is required to build this project", cm.exception.code)
+        self.assertIn("Please run `inv install-tools` for `bazel` support!", cm.exception.code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
So far, `[dda] inv [go.]tidy` only covers Go project files (`go.mod`, `go.sum`).
As Go modules are progressively `bazel`ified, impacted Bazel files must be kept in-sync too:
- `deps/go.MODULE.bazel` (`use_repo` declarations),
- `**/BUILD.bazel` files (`gazelle`-managed).

To minimize disruptions, the intent is to keep `inv tidy` as the single entry point for developers: run it, and every Go **and** Bazel project file stays in sync.

### What does this PR do?
When `bazel` is available, the pipeline is:
1. `go work sync`, `bazel`ified:
    `go.work + **/go.mod -> **/go.mod`
2. recursive `go mod tidy`, `bazel`ified:
    `**/*.go + **/go.mod -> **/go.mod, **/go.sum`
3. `bazel mod tidy`, new:
    `go.work + **/go.mod -> deps/go.MODULE.bazel`
4. `bazel run //:gazelle`, new:
    `deps/go.MODULE.bazel + /BUILD.bazel + **/*.go + **/go.mod -> **/BUILD.bazel`

Some scenarios are still run without `bazel` (e.g., OTEL build images), in which case the pipeline then falls back to the original Go-only behavior and simply warns the developer, buying everyone some time to install `bazelisk` way ahead it becomes a hard requirement.

### Additional Notes
In the pipeline, step 3 precedes step 4 because gazelle needs exhaustive `use_repo` declarations to resolve external repositories.

Since `go work tidy` does not exist (yet?) and to honor/improve the original parallelization and speed of recursive `go mod tidy`s throughout the workspace, the new `go_mod_tidy_all` target takes it over, which can be run in isolation:
```sh
bazel run //go_mod_tidy_all
# also accepts same arguments as `go mod tidy`:
bazel run //go_mod_tidy_all -- -x
```
(takes about 4 seconds with a warm module cache)