### PR TITLE
[ACTP] introduce dd-scriptuser for powershell

### DIFF
--- a/pkg/privateactionrunner/bundles/script/helper.go
+++ b/pkg/privateactionrunner/bundles/script/helper.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-//go:build !local
+//go:build !local && !windows
 
 package com_datadoghq_script
 

--- a/pkg/privateactionrunner/bundles/script/helper_windows.go
+++ b/pkg/privateactionrunner/bundles/script/helper_windows.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows && !local
+
+package com_datadoghq_script
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// ScriptUserName is the low-privilege local account under which all
+// PowerShell scripts are executed (mirrors Linux dd-scriptuser).
+var ScriptUserName = "dd-scriptuser"
+
+const (
+	passwordLSAKey             = "L$datadog_scriptuser_password" // LSA key for the script user password
+	logon32LogonBatch          = 4                               // LOGON32_LOGON_BATCH
+	logon32ProviderDefault     = 0                               // LOGON32_PROVIDER_DEFAULT
+	policyGetPrivateInformation = 0x00000004                     // LSA read-private-data access mask
+)
+
+var (
+	modadvapi32                = windows.NewLazySystemDLL("advapi32.dll")
+	procLogonUserW             = modadvapi32.NewProc("LogonUserW")
+	procLsaOpenPolicy          = modadvapi32.NewProc("LsaOpenPolicy")
+	procLsaRetrievePrivateData = modadvapi32.NewProc("LsaRetrievePrivateData")
+	procLsaClose               = modadvapi32.NewProc("LsaClose")
+	procLsaFreeMemory          = modadvapi32.NewProc("LsaFreeMemory")
+)
+
+type lsaUnicodeString struct {
+	Length        uint16
+	MaximumLength uint16
+	Buffer        *uint16
+}
+
+type lsaObjectAttributes struct {
+	Length                   uint32
+	RootDirectory            uintptr
+	ObjectName               uintptr
+	Attributes               uint32
+	SecurityDescriptor       uintptr
+	SecurityQualityOfService uintptr
+}
+
+// logonScriptUser obtains a user token for dd-scriptuser by reading the
+// password from LSA. The caller must close the returned token.
+func logonScriptUser() (syscall.Token, error) {
+	password, err := retrieveScriptUserPassword()
+	if err != nil {
+		return 0, fmt.Errorf("failed to retrieve script user password from LSA: %w", err)
+	}
+
+	token, err := logonUser(ScriptUserName, ".", password, logon32LogonBatch, logon32ProviderDefault)
+	if err != nil {
+		return 0, fmt.Errorf("LogonUser failed for %s: %w", ScriptUserName, err)
+	}
+
+	return token, nil
+}
+
+// logonUser wraps LogonUserW to authenticate a local user and return a token.
+func logonUser(username, domain, password string, logonType, logonProvider uint32) (syscall.Token, error) {
+	usernameP, err := windows.UTF16PtrFromString(username)
+	if err != nil {
+		return 0, err
+	}
+	domainP, err := windows.UTF16PtrFromString(domain)
+	if err != nil {
+		return 0, err
+	}
+	passwordP, err := windows.UTF16PtrFromString(password)
+	if err != nil {
+		return 0, err
+	}
+
+	var token syscall.Token
+	r1, _, lastErr := procLogonUserW.Call(
+		uintptr(unsafe.Pointer(usernameP)),
+		uintptr(unsafe.Pointer(domainP)),
+		uintptr(unsafe.Pointer(passwordP)),
+		uintptr(logonType),
+		uintptr(logonProvider),
+		uintptr(unsafe.Pointer(&token)),
+	)
+	if r1 == 0 {
+		return 0, lastErr
+	}
+	return token, nil
+}
+
+// retrieveScriptUserPassword reads the script user password from LSA private data.
+func retrieveScriptUserPassword() (string, error) {
+	var policyHandle uintptr
+	var objAttrs lsaObjectAttributes
+	objAttrs.Length = uint32(unsafe.Sizeof(objAttrs))
+
+	status, _, _ := procLsaOpenPolicy.Call(
+		0,
+		uintptr(unsafe.Pointer(&objAttrs)),
+		policyGetPrivateInformation,
+		uintptr(unsafe.Pointer(&policyHandle)),
+	)
+	if status != 0 {
+		return "", fmt.Errorf("LsaOpenPolicy failed with NTSTATUS: 0x%08X", status)
+	}
+	defer procLsaClose.Call(policyHandle) //nolint:errcheck
+
+	keyUTF16, err := windows.UTF16FromString(passwordLSAKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert LSA key to UTF-16: %w", err)
+	}
+	keyStr := lsaUnicodeString{
+		Length:        uint16((len(keyUTF16) - 1) * 2),
+		MaximumLength: uint16(len(keyUTF16) * 2),
+		Buffer:        &keyUTF16[0],
+	}
+
+	var privateData *lsaUnicodeString
+	status, _, _ = procLsaRetrievePrivateData.Call(
+		policyHandle,
+		uintptr(unsafe.Pointer(&keyStr)),
+		uintptr(unsafe.Pointer(&privateData)),
+	)
+	if status != 0 {
+		return "", fmt.Errorf("LsaRetrievePrivateData failed with NTSTATUS: 0x%08X — ensure %s account was provisioned during installation", status, ScriptUserName)
+	}
+	if privateData != nil {
+		defer procLsaFreeMemory.Call(uintptr(unsafe.Pointer(privateData))) //nolint:errcheck
+	}
+
+	if privateData == nil || privateData.Buffer == nil || privateData.Length == 0 {
+		return "", fmt.Errorf("script user password not found in LSA (key: %s) — run the provisioning script to create the %s account", passwordLSAKey, ScriptUserName)
+	}
+
+	charCount := int(privateData.Length / 2)
+	buf := unsafe.Slice(privateData.Buffer, charCount)
+	password := windows.UTF16ToString(buf)
+	return password, nil
+}
+
+// requiredWindowsEnvVars must always be passed for PowerShell to function.
+var requiredWindowsEnvVars = []string{
+	"SYSTEMROOT",
+	"COMSPEC",
+	"PATHEXT",
+	"WINDIR",
+	"TEMP",
+	"TMP",
+}
+
+// buildAllowedEnv returns only the required + explicitly allowed env vars.
+func buildAllowedEnv(envVarNames []string) []string {
+	allowed := make(map[string]bool)
+	for _, name := range requiredWindowsEnvVars {
+		allowed[strings.ToUpper(name)] = true
+	}
+	for _, name := range envVarNames {
+		allowed[strings.ToUpper(name)] = true
+	}
+
+	var env []string
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.ToUpper(parts[0])
+		if allowed[name] {
+			env = append(env, e)
+		}
+	}
+
+	return env
+}
+
+// NewShellScriptCommand is not supported on Windows.
+func NewShellScriptCommand(_ context.Context, _ string, _ []string) (*exec.Cmd, error) {
+	return nil, errors.New("shell script execution is not supported on Windows; use runPredefinedPowershellScript")
+}
+
+// NewPredefinedScriptCommand is not supported on Windows.
+func NewPredefinedScriptCommand(_ context.Context, _ []string, _ []string) (*exec.Cmd, error) {
+	return nil, errors.New("predefined script execution via shell is not supported on Windows; use runPredefinedPowershellScript")
+}
+

--- a/pkg/privateactionrunner/bundles/script/setup_scriptuser.ps1
+++ b/pkg/privateactionrunner/bundles/script/setup_scriptuser.ps1
@@ -1,0 +1,204 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2025-present Datadog, Inc.
+
+<#
+.SYNOPSIS
+    Provisions the dd-scriptuser local account for the Private Action Runner.
+.DESCRIPTION
+    Creates a low-privilege local user (dd-scriptuser) used by the PAR to
+    execute PowerShell scripts. Stores the password in LSA private data,
+    grants "Log on as a batch job", and denies interactive logon.
+    Idempotent: safe to run multiple times.
+.NOTES
+    Must be run as Administrator. Requires PowerShell 5.1+.
+#>
+
+#Requires -RunAsAdministrator
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ScriptUserName = "dd-scriptuser"
+$LSAKey = "L`$datadog_scriptuser_password"
+$PasswordLength = 64
+
+function New-RandomPassword {
+    param([int]$Length = 64)
+    $bytes = New-Object byte[] $Length
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    $rng.GetBytes($bytes)
+    return [Convert]::ToBase64String($bytes).Substring(0, $Length)
+}
+
+function Set-LsaPrivateData {
+    param(
+        [string]$Key,
+        [string]$Value
+    )
+
+    Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public class LsaHelper {
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LSA_UNICODE_STRING {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LSA_OBJECT_ATTRIBUTES {
+        public uint Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;
+        public uint Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern uint LsaOpenPolicy(
+        IntPtr SystemName,
+        ref LSA_OBJECT_ATTRIBUTES ObjectAttributes,
+        uint DesiredAccess,
+        out IntPtr PolicyHandle);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern uint LsaStorePrivateData(
+        IntPtr PolicyHandle,
+        ref LSA_UNICODE_STRING KeyName,
+        ref LSA_UNICODE_STRING PrivateData);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    public static extern uint LsaClose(IntPtr PolicyHandle);
+
+    [DllImport("advapi32.dll")]
+    public static extern int LsaNtStatusToWinError(uint Status);
+
+    public static LSA_UNICODE_STRING ToLsaString(string s) {
+        var lsa = new LSA_UNICODE_STRING();
+        lsa.Buffer = Marshal.StringToHGlobalUni(s);
+        lsa.Length = (ushort)(s.Length * 2);
+        lsa.MaximumLength = (ushort)((s.Length + 1) * 2);
+        return lsa;
+    }
+
+    public static void StorePrivateData(string key, string value) {
+        var objAttrs = new LSA_OBJECT_ATTRIBUTES();
+        objAttrs.Length = (uint)Marshal.SizeOf(objAttrs);
+
+        IntPtr policyHandle;
+        // POLICY_CREATE_SECRET = 0x00000020
+        uint result = LsaOpenPolicy(IntPtr.Zero, ref objAttrs, 0x00000020, out policyHandle);
+        if (result != 0) {
+            throw new Exception("LsaOpenPolicy failed: Win32 error " + LsaNtStatusToWinError(result));
+        }
+        try {
+            var keyStr = ToLsaString(key);
+            var valueStr = ToLsaString(value);
+            try {
+                result = LsaStorePrivateData(policyHandle, ref keyStr, ref valueStr);
+                if (result != 0) {
+                    throw new Exception("LsaStorePrivateData failed: Win32 error " + LsaNtStatusToWinError(result));
+                }
+            } finally {
+                Marshal.FreeHGlobal(keyStr.Buffer);
+                Marshal.FreeHGlobal(valueStr.Buffer);
+            }
+        } finally {
+            LsaClose(policyHandle);
+        }
+    }
+}
+"@ -Language CSharp
+
+    [LsaHelper]::StorePrivateData($Key, $Value)
+}
+
+function Grant-UserRight {
+    param(
+        [string]$UserName,
+        [string]$Right
+    )
+    $tempDir = Join-Path $env:TEMP "par-setup-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    try {
+        $cfgFile = Join-Path $tempDir "secpol.cfg"
+        $dbFile = Join-Path $tempDir "secpol.sdb"
+        secedit /export /cfg $cfgFile /quiet
+        $content = Get-Content $cfgFile -Raw
+        $account = New-Object System.Security.Principal.NTAccount($UserName)
+        $sid = $account.Translate([System.Security.Principal.SecurityIdentifier]).Value
+
+        if ($content -match "(?m)^$Right\s*=\s*(.*)$") {
+            $existing = $Matches[1]
+            if ($existing -notmatch $sid) {
+                $content = $content -replace "(?m)^$Right\s*=\s*(.*)$", "$Right = $existing,*$sid"
+            }
+        } else {
+            $content = $content -replace "(?m)^\[Privilege Rights\]", "[Privilege Rights]`n$Right = *$sid"
+        }
+
+        Set-Content -Path $cfgFile -Value $content
+        secedit /configure /db $dbFile /cfg $cfgFile /quiet
+    } finally {
+        Remove-Item -Recurse -Force $tempDir -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "=== Datadog PAR - Script User Provisioning ===" -ForegroundColor Cyan
+Write-Host ""
+
+Write-Host "[1/5] Generating password..." -ForegroundColor Yellow
+$password = New-RandomPassword -Length $PasswordLength
+$securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+
+$existingUser = Get-LocalUser -Name $ScriptUserName -ErrorAction SilentlyContinue
+if ($existingUser) {
+    Write-Host "[2/5] User '$ScriptUserName' exists, updating password..." -ForegroundColor Yellow
+    Set-LocalUser -Name $ScriptUserName -Password $securePassword -PasswordNeverExpires $true
+} else {
+    Write-Host "[2/5] Creating local user '$ScriptUserName'..." -ForegroundColor Yellow
+    New-LocalUser -Name $ScriptUserName `
+        -Password $securePassword `
+        -FullName "Datadog Script User" `
+        -Description "Low-privilege account for PAR script execution" `
+        -PasswordNeverExpires `
+        -UserMayNotChangePassword `
+        -AccountNeverExpires
+}
+
+$adminGroup = Get-LocalGroupMember -Group "Administrators" -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -like "*\$ScriptUserName" }
+if ($adminGroup) {
+    Write-Host "       Removing '$ScriptUserName' from Administrators group..." -ForegroundColor Yellow
+    Remove-LocalGroupMember -Group "Administrators" -Member $ScriptUserName
+}
+
+Write-Host "[3/5] Storing password in LSA (key: $LSAKey)..." -ForegroundColor Yellow
+Set-LsaPrivateData -Key $LSAKey -Value $password
+
+Write-Host "[4/5] Granting SeBatchLogonRight..." -ForegroundColor Yellow
+Grant-UserRight -UserName $ScriptUserName -Right "SeBatchLogonRight"
+
+Write-Host "[5/5] Denying SeDenyInteractiveLogonRight..." -ForegroundColor Yellow
+Grant-UserRight -UserName $ScriptUserName -Right "SeDenyInteractiveLogonRight"
+
+$password = $null
+$securePassword = $null
+[System.GC]::Collect()
+
+Write-Host ""
+Write-Host "=== Provisioning complete ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "The '$ScriptUserName' account is ready." -ForegroundColor Green
+Write-Host ""
+Write-Host "To grant permissions (analogous to sudoers):" -ForegroundColor Cyan
+Write-Host "  - Service control:  sc sdset <svcname> <SDDL with $ScriptUserName ACE>" -ForegroundColor White
+Write-Host "  - Folder access:    icacls C:\Path /grant ${ScriptUserName}:(OI)(CI)M" -ForegroundColor White
+Write-Host "  - Registry access:  Set-Acl on specific registry paths" -ForegroundColor White
+

--- a/pkg/privateactionrunner/bundles/script/test_connection.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection.go
@@ -8,8 +8,6 @@ package com_datadoghq_script
 import (
 	"context"
 	"fmt"
-	"os/user"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
@@ -83,30 +81,4 @@ func (h *TestConnectionHandler) Run(
 	}, nil
 }
 
-func (h *TestConnectionHandler) validateScriptUser() (string, []string) {
-	var errors []string
-	var info strings.Builder
-
-	scriptUserInfo, err := user.Lookup(ScriptUserName)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Script user '%s' not found: %v", ScriptUserName, err))
-	} else {
-		info.WriteString(fmt.Sprintf("Script user '%s' found (UID: %s, GID: %s)\n",
-			scriptUserInfo.Username, scriptUserInfo.Uid, scriptUserInfo.Gid))
-	}
-
-	// Check if the current user can run command
-	cmd, err := NewPredefinedScriptCommand(context.Background(), []string{"echo", "test"}, nil)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Failed to build test command: %v", err))
-		return info.String(), errors
-	}
-	_, err = cmd.CombinedOutput()
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("Failed to check if the current user can use the script user: %v", err))
-	} else {
-		info.WriteString("Current user can use the script user.\n")
-	}
-
-	return info.String(), errors
-}
+// validateScriptUser is in test_connection_unix.go / test_connection_windows.go

--- a/pkg/privateactionrunner/bundles/script/test_connection_unix.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection_unix.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !windows
+
+package com_datadoghq_script
+
+import (
+	"context"
+	"fmt"
+	"os/user"
+	"strings"
+)
+
+func (h *TestConnectionHandler) validateScriptUser() (string, []string) {
+	var errors []string
+	var info strings.Builder
+
+	scriptUserInfo, err := user.Lookup(ScriptUserName)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Script user '%s' not found: %v", ScriptUserName, err))
+	} else {
+		info.WriteString(fmt.Sprintf("Script user '%s' found (UID: %s, GID: %s)\n",
+			scriptUserInfo.Username, scriptUserInfo.Uid, scriptUserInfo.Gid))
+	}
+
+	// Check if the current user can run command as the script user via su
+	cmd, err := NewPredefinedScriptCommand(context.Background(), []string{"echo", "test"}, nil)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to build test command: %v", err))
+		return info.String(), errors
+	}
+	_, err = cmd.CombinedOutput()
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to check if the current user can use the script user: %v", err))
+	} else {
+		info.WriteString("Current user can use the script user.\n")
+	}
+
+	return info.String(), errors
+}
+

--- a/pkg/privateactionrunner/bundles/script/test_connection_windows.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection_windows.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+package com_datadoghq_script
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"os/user"
+	"strings"
+	"syscall"
+)
+
+func (h *TestConnectionHandler) validateScriptUser() (string, []string) {
+	var errors []string
+	var info strings.Builder
+
+	scriptUserInfo, err := user.Lookup(ScriptUserName)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Script user '%s' not found: %v. Run the provisioning script to create the account.", ScriptUserName, err))
+		return info.String(), errors
+	}
+	info.WriteString(fmt.Sprintf("Script user '%s' found (SID: %s)\n",
+		scriptUserInfo.Username, scriptUserInfo.Uid))
+
+	token, err := logonScriptUser()
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to logon as script user '%s': %v", ScriptUserName, err))
+		return info.String(), errors
+	}
+	defer token.Close()
+	info.WriteString(fmt.Sprintf("Successfully obtained logon token for '%s'.\n", ScriptUserName))
+
+	cmd := exec.Command("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", "whoami")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Token: token,
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Env = buildAllowedEnv(nil)
+
+	err = cmd.Run()
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("Failed to run test command as script user: %v", err))
+		return info.String(), errors
+	}
+
+	whoami := strings.TrimSpace(stdout.String())
+	if !strings.Contains(strings.ToLower(whoami), strings.ToLower(ScriptUserName)) {
+		errors = append(errors, fmt.Sprintf("Test command ran as '%s' instead of expected '%s'", whoami, ScriptUserName))
+	} else {
+		info.WriteString(fmt.Sprintf("Test command confirmed execution as '%s'.\n", whoami))
+	}
+
+	return info.String(), errors
+}
+


### PR DESCRIPTION
### What does this PR do?

This PR aligns the Windows Private Action Runner's PowerShell script execution with the Linux security model. 

At installation, the PAR on Windows will now be set up with a low-privilege `dd-scriptuser`. Later, we can decide to escalate its privileges at the OS level using service SDDLs via sc sdset, file ACLs via icacls or user rights via secedit.

### Motivation
Improve Powershell action security before release.

### Describe how you validated your changes
_TODO_

### Additional Notes
