### PR TITLE
Use IsSet for no_proxy_nonexact_match

### DIFF
--- a/comp/metadata/host/hostimpl/utils/host.go
+++ b/comp/metadata/host/hostimpl/utils/host.go
@@ -151,7 +151,7 @@ func getInstallMethod(conf model.Reader) *InstallMethod {
 func getProxyMeta(conf model.Reader) *ProxyMeta {
 	NoProxyNonexactMatchExplicitlySetState := false
 	NoProxyNonexactMatch := false
-	if conf.IsSet("no_proxy_nonexact_match") {
+	if conf.IsConfigured("no_proxy_nonexact_match") {
 		NoProxyNonexactMatchExplicitlySetState = true
 		NoProxyNonexactMatch = conf.GetBool("no_proxy_nonexact_match")
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1652,7 +1652,7 @@ func debugging(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("tracemalloc_whitelist", "") // deprecated
 	config.BindEnvAndSetDefault("tracemalloc_blacklist", "") // deprecated
 	config.BindEnvAndSetDefault("run_path", defaultRunPath)
-	config.BindEnv("no_proxy_nonexact_match") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
+	config.BindEnvAndSetDefault("no_proxy_nonexact_match", false)
 }
 
 func telemetry(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
### What does this PR do?
Use IsSet for `no_proxy_nonexact_match` and add a default to the setting.

### Describe how you validated your changes

Running the CI.