### PR TITLE
Make GetDefaultSecurityProfilesDir private

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -189,11 +189,6 @@ var (
 	StartTime = time.Now()
 )
 
-// GetDefaultSecurityProfilesDir is the default directory used to store Security Profiles by the runtime security module
-func GetDefaultSecurityProfilesDir() string {
-	return filepath.Join(defaultRunPath, "runtime-security", "profiles")
-}
-
 // List of integrations allowed to be configured by RC by default
 var defaultAllowedRCIntegrations = []string{}
 

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -6,9 +6,16 @@
 package setup
 
 import (
+	"path/filepath"
+
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 )
+
+// getDefaultSecurityProfilesDir is the default directory used to store Security Profiles by the runtime security module
+func getDefaultSecurityProfilesDir() string {
+	return filepath.Join(defaultRunPath, "runtime-security", "profiles")
+}
 
 func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	// CWS - general config
@@ -47,6 +54,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.container_exclude", []string{})
 	cfg.BindEnvAndSetDefault("runtime_security_config.container_include", []string{})
 	cfg.BindEnvAndSetDefault("runtime_security_config.exclude_pause_container", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.cmd_socket", "")
 
 	cfg.SetDefault("runtime_security_config.windows_filename_cache_max", 16384)
 	cfg.SetDefault("runtime_security_config.windows_registry_cache_max", 4096)
@@ -72,7 +80,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_timeout", "4500s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_differentiate_args", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.max_dumps_count", 100)
-	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.output_directory", GetDefaultSecurityProfilesDir())
+	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.output_directory", getDefaultSecurityProfilesDir())
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.formats", []string{"profile"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.local_storage.compression", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.syscall_monitor.period", "60s")
@@ -92,7 +100,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.v2.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_image_tags", 20)
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", GetDefaultSecurityProfilesDir())
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", getDefaultSecurityProfilesDir())
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_count", 400)

--- a/pkg/config/setup/system_probe_cws_notwin.go
+++ b/pkg/config/setup/system_probe_cws_notwin.go
@@ -16,5 +16,4 @@ import (
 func platformCWSConfig(cfg pkgconfigmodel.Setup) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
 	cfg.BindEnvAndSetDefault("runtime_security_config.socket", filepath.Join(InstallPath, "run/runtime-security.sock"))
-	cfg.BindEnvAndSetDefault("runtime_security_config.cmd_socket", "")
 }

--- a/pkg/config/setup/system_probe_cws_windows.go
+++ b/pkg/config/setup/system_probe_cws_windows.go
@@ -22,5 +22,4 @@ func platformCWSConfig(cfg pkgconfigmodel.Setup) {
 		cfg.BindEnvAndSetDefault("runtime_security_config.policies.dir", "c:\\programdata\\datadog\\runtime-security.d")
 	}
 	cfg.BindEnvAndSetDefault("runtime_security_config.socket", "localhost:3335")
-	cfg.BindEnvAndSetDefault("runtime_security_config.cmd_socket", "")
 }


### PR DESCRIPTION
### What does this PR do?

Make `GetDefaultSecurityProfilesDir` private and remove duplicate declaration of `runtime_security_config.cmd_socket`

### Describe how you validated your changes

Running the CI