### PR TITLE
[ACIX-1309] Use base images from `registry.ddbuild.io` for windows Docker builds

### DIFF
--- a/.gitlab/deploy/container_build/docker_windows_agent7.yml
+++ b/.gitlab/deploy/container_build/docker_windows_agent7.yml
@@ -3,14 +3,14 @@
 # Change base images here to update all builds
 .windows_1809_nanoserver: &windows_1809_nanoserver
   VARIANT: "1809"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:lts-nanoserver-1809"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/powershell:lts-nanoserver-1809"
   WINDOWS_RUNNER: "windows-v2:2019"
   OS_TYPE: "nano"
   OS_DISPLAY_NAME: "windows nanoserver"
 
 .windows_1809_servercore: &windows_1809_servercore
   VARIANT: "1809"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/powershell:windowsservercore-1809"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/powershell:windowsservercore-1809"
   WINDOWS_RUNNER: "windows-v2:2019"
   OS_TYPE: "core"
   OS_DISPLAY_NAME: "windows server core"
@@ -18,14 +18,14 @@
 
 .windows_ltsc2022_nanoserver: &windows_ltsc2022_nanoserver
   VARIANT: "ltsc2022"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2022"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/dotnet/sdk:9.0-nanoserver-ltsc2022"
   WINDOWS_RUNNER: "windows-v2:2022"
   OS_TYPE: "nano"
   OS_DISPLAY_NAME: "windows nanoserver"
 
 .windows_ltsc2022_servercore: &windows_ltsc2022_servercore
   VARIANT: "ltsc2022"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2022"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/dotnet/sdk:9.0-windowsservercore-ltsc2022"
   WINDOWS_RUNNER: "windows-v2:2022"
   OS_TYPE: "core"
   OS_DISPLAY_NAME: "windows server core"
@@ -33,14 +33,14 @@
 
 .windows_ltsc2025_nanoserver: &windows_ltsc2025_nanoserver
   VARIANT: "ltsc2025"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-nanoserver-ltsc2025"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/dotnet/sdk:9.0-nanoserver-ltsc2025"
   WINDOWS_RUNNER: "windows-v2:2025"
   OS_TYPE: "nano"
   OS_DISPLAY_NAME: "windows nanoserver"
 
 .windows_ltsc2025_servercore: &windows_ltsc2025_servercore
   VARIANT: "ltsc2025"
-  SERVER_BASE_IMAGE: "mcr.microsoft.com/dotnet/sdk:9.0-windowsservercore-ltsc2025"
+  SERVER_BASE_IMAGE: "registry.ddbuild.io/images/mirror/dotnet/sdk:9.0-windowsservercore-ltsc2025"
   WINDOWS_RUNNER: "windows-v2:2025"
   OS_TYPE: "core"
   OS_DISPLAY_NAME: "windows server core"

--- a/Dockerfiles/agent/windows/README.md
+++ b/Dockerfiles/agent/windows/README.md
@@ -53,6 +53,6 @@ docker build -t mycustomagent \
   --build-arg VARIANT=1809 \
   -f .\windows\amd64\Dockerfile .
 ```
-> Tip: As a Datadog employee, you can also use `registry.ddbuild.io` as a registry for the base images if you are within AppGate: `--build-arg BASE_IMAGE=registry.ddbuild.io/powershell:windowsservercore-1809`. This can be useful in case you are facing rate limits.
+> Tip: As a Datadog employee, you can also use `registry.ddbuild.io` as a registry for the base images if you are within AppGate: `--build-arg BASE_IMAGE=registry.ddbuild.io/images/mirror/powershell:windowsservercore-1809`. This can be useful in case you are facing rate limits.
 
 If you need JMX, change `WITH_JMX` to `true`.

--- a/Dockerfiles/agent/windows/README.md
+++ b/Dockerfiles/agent/windows/README.md
@@ -53,5 +53,6 @@ docker build -t mycustomagent \
   --build-arg VARIANT=1809 \
   -f .\windows\amd64\Dockerfile .
 ```
+> Tip: As a Datadog employee, you can also use `registry.ddbuild.io` as a registry for the base images if you are within AppGate: `--build-arg BASE_IMAGE=registry.ddbuild.io/powershell:windowsservercore-1809`. This can be useful in case you are facing rate limits.
 
 If you need JMX, change `WITH_JMX` to `true`.


### PR DESCRIPTION
# What does this PR do?
Updates test files and Dockerfiles to use `registry.ddbuild.io` instead of an upstream repo for Windows images.

# Motivation
Avoiding rate limits and increasing CI reliability.

# Describe how you validated your changes
Running CI

# Additional Notes
This PR depends on DataDog/images#8816