### PR TITLE
[ACTP] Add cluster id to static tags

### DIFF
--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -124,6 +124,12 @@ func GetClusterAgentStaticTags(ctx context.Context, config config.Reader) map[st
 		tags = append(tags, taggertags.KubeDistribution+":"+kubeDistro)
 	}
 
+	// add orch_cluster_id global tag
+	clusterIDValue, _ := clustername.GetClusterID()
+	if clusterIDValue != "" {
+		tags = append(tags, taggertags.OrchClusterID+":"+clusterIDValue)
+	}
+
 	if tags == nil {
 		return nil
 	}

--- a/pkg/util/tags/static_tags.go
+++ b/pkg/util/tags/static_tags.go
@@ -124,7 +124,7 @@ func GetClusterAgentStaticTags(ctx context.Context, config config.Reader) map[st
 		tags = append(tags, taggertags.KubeDistribution+":"+kubeDistro)
 	}
 
-	// add orch_cluster_id global tag
+	// Orchestrator Cluster ID global tag
 	clusterIDValue, _ := clustername.GetClusterID()
 	if clusterIDValue != "" {
 		tags = append(tags, taggertags.OrchClusterID+":"+clusterIDValue)


### PR DESCRIPTION
## Summary
Add `orch_cluster_id` to cluster agent global static tags.

## Motivation
Private Action Runner (PAR) needs `orch_cluster_id` in global tags to properly tag auto-created connections. Currently, `orch_cluster_id` is only available in host tags via `GetStaticTagsSlice`, but not in global tags returned by `GetClusterAgentStaticTags`, preventing PAR from accessing it through the tagger component.

## Changes
- Add `orch_cluster_id` to `GetClusterAgentStaticTags()` in `pkg/util/tags/static_tags.go`
- Mirrors the implementation from `GetStaticTagsSlice()` (added in #35214)
- Enables PAR and other cluster agent components to access cluster ID through global tags