### PR TITLE
Remove duplicate declaration of 'cluster_name'

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1009,7 +1009,6 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.
 	config.SetDefault("metadata_providers", []map[string]interface{}{})
 	config.SetDefault("config_providers", []map[string]interface{}{})
-	config.SetDefault("cluster_name", "")
 	config.SetDefault("listeners", []map[string]interface{}{})
 
 	config.BindEnv("provider_kind") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'


### PR DESCRIPTION
### What does this PR do?

Remove duplicate declaration of `cluster_name`. This setting is already define line [417](https://github.com/DataDog/datadog-agent/blob/23b98bd5110c0909ac4f6170fb95b84ecf51b8d6/pkg/config/setup/config.go#L417).

### Describe how you validated your changes

Running the CI.