### PR TITLE
[ACTP] Add k8s namespace tag to connections

### DIFF
--- a/pkg/privateactionrunner/autoconnections/tags_provider.go
+++ b/pkg/privateactionrunner/autoconnections/tags_provider.go
@@ -21,6 +21,7 @@ var tagSet = map[string]struct{}{
 	tagNames.KubeClusterName:  {},
 	tagNames.OrchClusterID:    {},
 	tagNames.KubeDistribution: {},
+	tagNames.KubeNamespace:    {},
 }
 
 // TagsProvider builds connection tags


### PR DESCRIPTION
Adds the Kubernetes namespace tag (`kube_namespace`) to auto-created PAR connections.
