### PR TITLE
Add site to extension config in converter

### DIFF
--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -15,7 +15,10 @@ import (
 
 var ddAutoconfiguredSuffix = "dd-autoconfigured"
 
-const secretRegex = "ENC\\[.*\\][ \t]*$"
+const (
+	defaultSite = "datadoghq.com"
+	secretRegex = "ENC\\[.*\\][ \t]*$"
+)
 
 type component struct {
 	Type         string
@@ -44,9 +47,14 @@ func (c *ddConverter) enhanceConfig(conf *confmap.Conf) {
 			if c.coreConfig == nil || c.coreConfig.GetString("api_key") == "" {
 				continue
 			}
+			site := defaultSite
+			if c.coreConfig.GetString("site") != "" {
+				site = c.coreConfig.GetString("site")
+			}
 			extension.Config = map[string]any{
 				"api": map[string]any{
-					"key": c.coreConfig.GetString("api_key"),
+					"key":  c.coreConfig.GetString("api_key"),
+					"site": site,
 				},
 			}
 		}

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -110,6 +110,12 @@ func TestConvert(t *testing.T) {
 			agentConfig:    "extensions/other-extensions/datadog/acfg.yaml",
 		},
 		{
+			name:           "extensions/other-extensions/datadog-site",
+			provided:       "extensions/other-extensions/datadog-site/config.yaml",
+			expectedResult: "extensions/other-extensions/datadog-site/config-result.yaml",
+			agentConfig:    "extensions/other-extensions/datadog-site/acfg.yaml",
+		},
+		{
 			name:           "extensions/no-changes/datadog",
 			provided:       "extensions/no-changes/datadog/config.yaml",
 			expectedResult: "extensions/no-changes/datadog/config.yaml",

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -117,7 +117,7 @@ func addAPIKeySite(conf *confmap.Conf, coreCfg config.Component, compType string
 					// if site is nil or empty string, and core config site is unset, set default
 					// site. Site defaults to an empty string in helm chart:
 					// https://github.com/DataDog/helm-charts/blob/datadog-3.86.0/charts/datadog/templates/_otel_agent_config.yaml#L24.
-					apiMap["site"] = "datadoghq.com"
+					apiMap["site"] = defaultSite
 				}
 			}
 

--- a/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/datadog/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/datadog/config-result.yaml
@@ -12,6 +12,7 @@ extensions:
   datadog/dd-autoconfigured:
     api:
       key: ggggg77777
+      site: "datadoghq.com"
 
 service:
   extensions:

--- a/comp/otelcol/converter/impl/testdata/extensions/no-extensions/datadog/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/no-extensions/datadog/config-result.yaml
@@ -12,6 +12,7 @@ extensions:
   datadog/dd-autoconfigured:
     api:
       key: ggggg77777
+      site: "datadoghq.com"
 
 service:
   extensions:

--- a/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/acfg.yaml
@@ -1,0 +1,5 @@
+api_key: ggggg77777
+site: us5.datadoghq.com
+otelcollector:
+  converter:
+    features: [pprof, zpages, health_check, datadog]

--- a/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/config-result.yaml
@@ -5,24 +5,25 @@ exporters:
   nop:
 
 extensions:
+  otlp_encoding/user-defined:
+    protocol: otlp_proto
   pprof/dd-autoconfigured:
   health_check/dd-autoconfigured:
   zpages/dd-autoconfigured:
     endpoint: "localhost:55679"
   datadog/dd-autoconfigured:
     api:
-      key: "ggggg77777"
-      site: "datadoghq.com"
-  ddflare/dd-autoconfigured:
+      key: ggggg77777
+      site: "us5.datadoghq.com"
 
 service:
   extensions:
     [
+      otlp_encoding/user-defined,
       pprof/dd-autoconfigured,
       zpages/dd-autoconfigured,
       health_check/dd-autoconfigured,
       datadog/dd-autoconfigured,
-      ddflare/dd-autoconfigured,
     ]
   pipelines:
     traces:

--- a/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog-site/config.yaml
@@ -1,0 +1,22 @@
+receivers:
+    otlp:
+
+exporters:
+    nop:
+
+extensions:
+  otlp_encoding/user-defined:
+    protocol: otlp_proto
+
+service:
+    extensions: [otlp_encoding/user-defined]
+    pipelines:
+        traces:
+            receivers: [nop]
+            exporters: [nop]
+        metrics:
+            receivers: [nop]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/other-extensions/datadog/config-result.yaml
@@ -14,6 +14,7 @@ extensions:
   datadog/dd-autoconfigured:
     api:
       key: ggggg77777
+      site: "datadoghq.com"
 
 service:
   extensions:

--- a/comp/otelcol/converter/impl/testdata/features/all-features/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/features/all-features/config-result.yaml
@@ -8,6 +8,7 @@ extensions:
   datadog/dd-autoconfigured:
     api:
       key: "ggggg77777"
+      site: "datadoghq.eu"
   ddflare/dd-autoconfigured:
   health_check/dd-autoconfigured:
   pprof/dd-autoconfigured:

--- a/comp/otelcol/converter/impl/testdata/features/no-defined-features/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/features/no-defined-features/config-result.yaml
@@ -8,6 +8,7 @@ extensions:
   datadog/dd-autoconfigured:
     api:
       key: "ggggg77777"
+      site: "datadoghq.eu"
   ddflare/dd-autoconfigured:
   health_check/dd-autoconfigured:
   pprof/dd-autoconfigured:


### PR DESCRIPTION
### What does this PR do?
Updates the converter to automatically add `site` to extension configs.

### Motivation
The OSS datadog extension was added to DDOT in https://github.com/DataDog/datadog-agent/pull/44856, but the converter doesn't automatically add `site` to the extension config.

### Describe how you validated your changes
Tested e2e locally with different site and added unit tests

### Additional Notes
