### PR TITLE
[pkg/dyninst] Update log uploader to debugger v2

### DIFF
--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -147,7 +147,7 @@ const (
 
 	traceAgentURLEnvVar = "DD_TRACE_AGENT_URL"
 
-	logUploaderPath   = "/debugger/v1/input"
+	logUploaderPath   = "/debugger/v2/input"
 	diagsUploaderPath = "/debugger/v1/diagnostics"
 	symdbUploaderPath = "/symdb/v1/input"
 )


### PR DESCRIPTION
### What does this PR do?

Writes debugger logs to the new `/debugger/v2/input` endpoint which forwards them to the debugger track.

### Motivation

The debugger track has custom logic that ensures all logs are passed through SDS by default without needing users to set it up.

### Describe how you validated your changes

N/A

### Additional Notes
