### PR TITLE
Fix(diskv2): prevent custom tags from leaking between check instances

### DIFF
--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -8,6 +8,8 @@
 package mocksender
 
 import (
+	"slices"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/check/stats"
 	"github.com/DataDog/datadog-agent/pkg/metrics/event"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -18,7 +20,7 @@ func (m *MockSender) tagsWithCheckTags(tags []string) []string {
 	if len(m.checkTags) == 0 {
 		return tags
 	}
-	return append(tags, m.checkTags...)
+	return slices.Concat(tags, m.checkTags)
 }
 
 // Rate adds a rate type to the mock calls.

--- a/pkg/aggregator/mocksender/mocked_methods.go
+++ b/pkg/aggregator/mocksender/mocked_methods.go
@@ -14,54 +14,61 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/types"
 )
 
+func (m *MockSender) tagsWithCheckTags(tags []string) []string {
+	if len(m.checkTags) == 0 {
+		return tags
+	}
+	return append(tags, m.checkTags...)
+}
+
 // Rate adds a rate type to the mock calls.
 func (m *MockSender) Rate(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // Count adds a count type to the mock calls.
 func (m *MockSender) Count(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // MonotonicCount adds a monotonic count type to the mock calls.
 func (m *MockSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // MonotonicCountWithFlushFirstValue adds a monotonic count type to the mock calls with flushFirstValue parameter
 func (m *MockSender) MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool) {
-	m.Called(metric, value, hostname, tags, flushFirstValue)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags), flushFirstValue)
 }
 
 // Counter adds a counter type to the mock calls.
 func (m *MockSender) Counter(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // Histogram adds a histogram type to the mock calls.
 func (m *MockSender) Histogram(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // Historate adds a historate type to the mock calls.
 func (m *MockSender) Historate(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // Gauge adds a gauge type to the mock calls.
 func (m *MockSender) Gauge(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // Distribution adds a distribution type to the mock calls.
 func (m *MockSender) Distribution(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // GaugeNoIndex adds a gauge type to the mock calls that is not indexed.
 func (m *MockSender) GaugeNoIndex(metric string, value float64, hostname string, tags []string) {
-	m.Called(metric, value, hostname, tags)
+	m.Called(metric, value, hostname, m.tagsWithCheckTags(tags))
 }
 
 // ServiceCheck enables the service check mock call.
@@ -95,7 +102,10 @@ func (m *MockSender) Commit() {
 }
 
 // SetCheckCustomTags enables the set of check custom tags mock call.
+// Tags are stored so that subsequent metric calls append them, mirroring
+// the real checkSender.sendMetricSample behavior.
 func (m *MockSender) SetCheckCustomTags(tags []string) {
+	m.checkTags = tags
 	m.Called(tags)
 }
 

--- a/pkg/aggregator/mocksender/mocksender.go
+++ b/pkg/aggregator/mocksender/mocksender.go
@@ -68,6 +68,7 @@ func SetSender(sender *MockSender, id checkid.ID) {
 type MockSender struct {
 	mock.Mock
 	senderManager sender.SenderManager
+	checkTags     []string
 }
 
 // GetSenderManager returns the instance of sender.SenderManager

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_nix_test.go
@@ -62,10 +62,7 @@ func setupPlatformMocks() {
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -117,11 +114,8 @@ func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLower
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("lowercase_device_tag: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -137,11 +131,8 @@ func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLower
 func TestGivenADiskCheckWithIncludeAllDevicesTrueConfigured_WhenCheckRuns_ThenAllUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("include_all_devices: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -162,11 +153,8 @@ func TestGivenADiskCheckWithIncludeAllDevicesTrueConfigured_WhenCheckRuns_ThenAl
 func TestGivenADiskCheckWithIncludeAllDevicesFalseConfigured_WhenCheckRuns_ThenOnlyPhysicalDevicesUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("include_all_devices: false"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -200,10 +188,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 			},
 		}, errors.New("error reading some partitions")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// No error returned, and metrics are reported for the partitions that were returned
@@ -233,10 +218,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturn
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -267,11 +249,8 @@ func TestGivenADiskCheckWithAllPartitionsFalseConfigured_WhenCheckRunsAndPartiti
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("all_partitions: false"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -302,11 +281,8 @@ func TestGivenADiskCheckWithAllPartitionsTrueConfigured_WhenCheckRunsAndPartitio
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("all_partitions: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -321,14 +297,11 @@ func TestGivenADiskCheckWithAllPartitionsTrueConfigured_WhenCheckRunsAndPartitio
 func TestGivenADiskCheckWithDeviceIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_include:
   - /dev/sda.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -349,14 +322,11 @@ device_include:
 func TestGivenADiskCheckWithDeviceWhiteListConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_whitelist:
   - /dev/sda.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -392,10 +362,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -425,10 +392,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -443,14 +407,11 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 func TestGivenADiskCheckWithFileSystemGlobalExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 file_system_global_exclude:
   - tmp.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -471,14 +432,11 @@ file_system_global_exclude:
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 file_system_global_blacklist:
   - tmpfs
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -499,14 +457,11 @@ file_system_global_blacklist:
 func TestGivenADiskCheckWithExcludedFileSystemsConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 excluded_filesystems:
   - tmp.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -519,14 +474,13 @@ excluded_filesystems:
 func TestGivenADiskCheckWithExcludedFileSystemsIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 excluded_filesystems:
   - tmpfs(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, initConfig, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, initConfig, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -549,14 +503,11 @@ func TestGivenADiskCheckWithExcludedFileSystemsConfiguredWithTmpfs_WhenCheckRuns
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 excluded_filesystems:
   - tmpfs
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -571,14 +522,11 @@ excluded_filesystems:
 func TestGivenADiskCheckWithFileSystemExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_exclude:
   - tmp.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -591,14 +539,11 @@ file_system_exclude:
 func TestGivenADiskCheckWithFileSystemBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_blacklist:
   - tmp.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -611,14 +556,11 @@ file_system_blacklist:
 func TestGivenADiskCheckWithFileSystemIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseFileSystemsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_include:
   - ext.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -631,14 +573,11 @@ file_system_include:
 func TestGivenADiskCheckWithFileSystemWhiteListConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseFileSystemsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_whitelist:
   - ext.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -651,15 +590,12 @@ file_system_whitelist:
 func TestGivenADiskCheckWithDeviceTagReConfigured_WhenCheckRuns_ThenUsageMetricsAreReportedWithTheseTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_tag_re:
   /dev/sda.*: role:primary
   tmp.*: role:tmp
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -680,10 +616,7 @@ device_tag_re:
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllIOCountersMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -700,13 +633,10 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllIOCountersMetrics
 func TestGivenADiskCheckWithTagByLabelConfiguredFalse_WhenCheckRuns_ThenBlkidLabelsAreNotReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 tag_by_label: false
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -721,10 +651,7 @@ tag_by_label: false
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenBlkidLabelsAreReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -739,10 +666,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenBlkidLabelsAreReport
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenEmptyBlkidLabelsAreNotReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -754,13 +678,10 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenEmptyBlkidLabelsAreN
 func TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRuns_ThenBlkidLabelsAreReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 tag_by_label: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -778,13 +699,10 @@ func TestGivenADiskCheckWithTagByLabelConfiguredTrue_WhenCheckRunsAndBlkidReturn
 		return "", errors.New("error calling blkid")
 	}
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 tag_by_label: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -799,13 +717,10 @@ tag_by_label: true
 func TestGivenADiskCheckWithUseLsblkConfiguredTrue_WhenCheckRuns_ThenLsblkLabelsAreReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 use_lsblk: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -820,14 +735,11 @@ use_lsblk: true
 func TestGivenADiskCheckWithTagByLabelConfiguredTrueAndUseLsblk_WhenCheckRuns_ThenLsblkLabelsAreNotReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 tag_by_label: true
 use_lsblk: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -842,14 +754,11 @@ use_lsblk: true
 func TestGivenADiskCheckWithTagByLabelConfiguredFalseAndUseLsblk_WhenCheckRuns_ThenLsblkLabelsAreNotReportedAsTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 tag_by_label: false
 use_lsblk: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -867,13 +776,10 @@ func TestGivenADiskCheckWithUseLsblkConfiguredTrue_WhenLsblkReturnsError_ThenLsb
 		return "", errors.New("error calling lsblk")
 	}
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 use_lsblk: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -893,13 +799,10 @@ func TestGivenADiskCheckWithBlkidCacheFileConfigured_WhenCheckRuns_ThenBlkidCach
 		return blkidCacheData, nil
 	}
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 blkid_cache_file: /run/blkid/blkid.tab
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -920,13 +823,10 @@ func TestGivenADiskCheckWithBlkidCacheFileConfigured_WhenBlkidCacheReturnsError_
 		return "", errors.New("error calling blkid cache")
 	}
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 blkid_cache_file: /run/blkid/blkid.tab
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -953,13 +853,10 @@ func TestGivenADiskCheckWithBlkidCacheFileConfigured_WhenBlkidCacheHasWrongLines
 `), nil
 	}
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 blkid_cache_file: /run/blkid/blkid.tab
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -975,14 +872,11 @@ blkid_cache_file: /run/blkid/blkid.tab
 func TestGivenADiskCheckWithMountPointGlobalExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 mount_point_global_exclude:
   - /dev/shm
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1003,14 +897,11 @@ mount_point_global_exclude:
 func TestGivenADiskCheckWithMountPointGlobalBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 mount_point_global_blacklist:
   - /dev/shm
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1031,14 +922,11 @@ mount_point_global_blacklist:
 func TestGivenADiskCheckWithMountPointExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_exclude:
   - /dev/.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1059,14 +947,11 @@ mount_point_exclude:
 func TestGivenADiskCheckWithMountPointBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_blacklist:
   - /dev/.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1087,11 +972,8 @@ mount_point_blacklist:
 func TestGivenADiskCheckWithExcludedMountPointReConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("excluded_mountpoint_re: /dev/.*"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1112,11 +994,8 @@ func TestGivenADiskCheckWithExcludedMountPointReConfigured_WhenCheckRuns_ThenUsa
 func TestGivenADiskCheckWithUseMountConfigured_WhenCheckRuns_ThenUsageMetricsAreReportedWithMountPointTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("use_mount: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1137,13 +1016,10 @@ func TestGivenADiskCheckWithUseMountConfigured_WhenCheckRuns_ThenUsageMetricsAre
 func TestGivenADiskCheckWithServiceCheckRwTrueConfigured_WhenCheckRuns_ThenReadWriteServiceCheckReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 service_check_rw: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1191,13 +1067,10 @@ func TestResolveRootDeviceFlagTrue(t *testing.T) {
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 resolve_root_device: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1243,13 +1116,10 @@ UEVENT_SEQNUM=42
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	}), fakeStatFn), fs)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 resolve_root_device: false
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1312,10 +1182,7 @@ func TestDeviceMapperResolution_WhenGopsutilReturnsDmDevice_ThenMetricsHaveFrien
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1366,10 +1233,7 @@ func TestDeviceMapperResolution_WhenSymlinkResolutionFails_ThenMetricsHaveOrigin
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1417,11 +1281,8 @@ func TestDeviceMapperResolution_WithLowercaseDeviceTag(t *testing.T) {
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("lowercase_device_tag: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1477,10 +1338,7 @@ func TestDeviceMapperResolution_WithMixedDeviceTypes(t *testing.T) {
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1517,10 +1375,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenInodeMetricsAreRepor
 			},
 		}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1559,10 +1414,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndInodesIsZero_ThenInode
 			},
 		}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1597,10 +1449,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturn
 		}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1637,11 +1486,8 @@ func TestGivenADiskCheckWithAllPartitionsTrueConfigured_WhenCheckRunsAndPartitio
 		}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("all_partitions: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1713,13 +1559,10 @@ DEVNAME=sda1
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 resolve_root_device: false
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	// Check should succeed even when falling back to mounts file
@@ -1779,13 +1622,10 @@ func TestGivenADiskCheckWithResolveRootDeviceFalse_WhenProc1MountinfoFails_ThenF
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 resolve_root_device: false
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1841,15 +1681,12 @@ func TestGivenADiskCheckWithProcMountinfoPathConfigured_WhenCheckRuns_ThenCustom
 		}, nil
 	}), fakeStatFn), fs), "linux")
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	// Configure custom proc_mountinfo_path
 	config := integration.Data([]byte(`
 resolve_root_device: false
 proc_mountinfo_path: /host/proc/1/mountinfo
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1864,10 +1701,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
 		return nil, errors.New("incorrect function")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// Check should succeed — partition metrics must be committed despite IOCounters failure

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/disk/diskv2"
@@ -199,11 +198,21 @@ func (sc *signalClock) After(d time.Duration) <-chan time.Time {
 	return ch
 }
 
+func configureCheck(t *testing.T, diskCheck check.Check, config, initConfig integration.Data) *mocksender.MockSender {
+	t.Helper()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, initConfig, "test")
+	require.NoError(t, err)
+	m := mocksender.NewMockSenderWithSenderManager(diskCheck.ID(), senderManager)
+	m.SetupAcceptAll()
+	return m
+}
+
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, []byte(`min_collection_interval: "string_value"`), nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, []byte(`min_collection_interval: "string_value"`), nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -211,10 +220,10 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckIsConfigured_ThenErrorIsRetur
 func TestGivenADiskCheckAndStoppedSender(t *testing.T) {
 	stoppedSenderError := errors.New("demultiplexer is stopped")
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
-	m.GetSenderManager().(*aggregator.AgentDemultiplexer).Stop(false)
+	diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+	senderManager.Stop(false)
 	err := diskCheck.Run()
 
 	assert.Equal(t, stoppedSenderError, err)
@@ -226,10 +235,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return nil, errors.New("error calling disk.DiskPartitions")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// Complete failure (error + no partitions) returns the error
@@ -243,10 +249,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 	diskCheck = diskv2.WithDiskPartitionsWithContext(diskCheck, func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		return []gopsutil_disk.PartitionStat{}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// No error returned, but a warning should be logged (no metrics reported)
@@ -260,8 +263,6 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndUsageSystemCallReturns
 	diskCheck = diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
 		return nil, errors.New("error calling diskUsage")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -269,7 +270,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndUsageSystemCallReturns
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -291,8 +292,6 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
 		return nil, errors.New("error calling diskIOCounters")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -300,7 +299,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err = diskCheck.Run()
 
 	// IO counter failure should NOT cause the check to fail
@@ -318,8 +317,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersSystemCallRe
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 file_system_global_blacklist:
   - ext4
@@ -330,7 +328,7 @@ file_system_global_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`file_system_global_blacklist` is deprecated and will be removed in a future release. Please use `file_system_global_exclude` instead.")
@@ -339,8 +337,7 @@ file_system_global_blacklist:
 func TestGivenADiskCheckWithDeviceGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 device_global_blacklist:
   - shm
@@ -351,7 +348,7 @@ device_global_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`device_global_blacklist` is deprecated and will be removed in a future release. Please use `device_global_exclude` instead.")
@@ -360,8 +357,7 @@ device_global_blacklist:
 func TestGivenADiskCheckWithMountpointGlobalBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 mount_point_global_blacklist:
   - /dev/shm
@@ -372,7 +368,7 @@ mount_point_global_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`mount_point_global_blacklist` is deprecated and will be removed in a future release. Please use `mount_point_global_exclude` instead.")
@@ -381,8 +377,7 @@ mount_point_global_blacklist:
 func TestGivenADiskCheckWithFileSystemWhiteListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 file_system_whitelist:
   - ext4
@@ -393,7 +388,7 @@ file_system_whitelist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`file_system_whitelist` is deprecated and will be removed in a future release. Please use `file_system_include` instead.")
@@ -402,8 +397,7 @@ file_system_whitelist:
 func TestGivenADiskCheckWithFileSystemBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 file_system_blacklist:
   - ext4
@@ -414,7 +408,7 @@ file_system_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`file_system_blacklist` is deprecated and will be removed in a future release. Please use `file_system_exclude` instead.")
@@ -423,8 +417,7 @@ file_system_blacklist:
 func TestGivenADiskCheckWithDeviceWhiteListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 device_whitelist:
   - ext4
@@ -435,7 +428,7 @@ device_whitelist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`device_whitelist` is deprecated and will be removed in a future release. Please use `device_include` instead.")
@@ -444,8 +437,7 @@ device_whitelist:
 func TestGivenADiskCheckWithDeviceBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 device_blacklist:
   - ext4
@@ -456,7 +448,7 @@ device_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`device_blacklist` is deprecated and will be removed in a future release. Please use `device_exclude` instead.")
@@ -465,8 +457,7 @@ device_blacklist:
 func TestGivenADiskCheckWithMountPointWhiteListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 mount_point_whitelist:
   - ext4
@@ -477,7 +468,7 @@ mount_point_whitelist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`mount_point_whitelist` is deprecated and will be removed in a future release. Please use `mount_point_include` instead.")
@@ -486,8 +477,7 @@ mount_point_whitelist:
 func TestGivenADiskCheckWithMountPointBlackListConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 mount_point_blacklist:
   - ext4
@@ -498,7 +488,7 @@ mount_point_blacklist:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`mount_point_blacklist` is deprecated and will be removed in a future release. Please use `mount_point_exclude` instead.")
@@ -507,8 +497,7 @@ mount_point_blacklist:
 func TestGivenADiskCheckWithExcludedMountPointReConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 excluded_mountpoint_re:
   - ext4
@@ -519,7 +508,7 @@ excluded_mountpoint_re:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`excluded_mountpoint_re` is deprecated and will be removed in a future release. Please use `mount_point_exclude` instead.")
@@ -528,8 +517,7 @@ excluded_mountpoint_re:
 func TestGivenADiskCheckWithExcludedFileSystemsConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 excluded_filesystems:
   - ext4
@@ -540,7 +528,7 @@ excluded_filesystems:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`excluded_filesystems` is deprecated and will be removed in a future release. Please use `file_system_exclude` instead.")
@@ -549,8 +537,7 @@ excluded_filesystems:
 func TestGivenADiskCheckWithExcludedDisksConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 excluded_disks:
   - ext4
@@ -561,7 +548,7 @@ excluded_disks:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`excluded_disks` is deprecated and will be removed in a future release. Please use `device_exclude` instead.")
@@ -570,8 +557,7 @@ excluded_disks:
 func TestGivenADiskCheckWithExcludedDisksReConfigured_WhenCheckIsConfigured_ThenWarningMessagedIsLogged(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 excluded_disk_re:
   - ext4
@@ -582,7 +568,7 @@ excluded_disk_re:
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "debug")
 
-	_ = diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	_ = diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	w.Flush()
 	assert.Contains(t, b.String(), "`excluded_disk_re` is deprecated and will be removed in a future release. Please use `device_exclude` instead.")
@@ -591,8 +577,6 @@ excluded_disk_re:
 func TestGivenADiskCheckWithDeviceGlobalExcludeAndDeviceExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 device_global_exclude:
   - /dev/sda1
@@ -602,7 +586,7 @@ device_exclude:
   - /dev/sda2
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, initConfig, "test")
+	m := configureCheck(t, diskCheck, config, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -623,8 +607,6 @@ device_exclude:
 func TestGivenADiskCheckWithDeviceGlobalBlackListAndDeviceExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 device_global_blacklist:
   - /dev/sda1
@@ -634,7 +616,7 @@ device_exclude:
   - /dev/sda2
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, initConfig, "test")
+	m := configureCheck(t, diskCheck, config, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -655,14 +637,13 @@ device_exclude:
 func TestGivenADiskCheckWithDeviceGlobalExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 device_global_exclude:
   - /dev/sda(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	assert.NotNil(t, err)
 }
@@ -670,14 +651,12 @@ device_global_exclude:
 func TestGivenADiskCheckWithDeviceExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_exclude:
   - /dev/sda.*
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -698,14 +677,12 @@ device_exclude:
 func TestGivenADiskCheckWithDeviceBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_blacklist:
   - /dev/sda.*
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -726,14 +703,12 @@ device_blacklist:
 func TestGivenADiskCheckWithExcludedDisksConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 excluded_disks:
   - /dev/sda.*
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -763,14 +738,12 @@ func TestGivenADiskCheckWithExcludedDisksConfiguredWithDa2_WhenCheckRuns_ThenUsa
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 excluded_disks:
   - da2
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -782,14 +755,13 @@ excluded_disks:
 func TestGivenADiskCheckWithDeviceExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 device_exclude:
   - /dev/sda(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -797,11 +769,9 @@ device_exclude:
 func TestGivenADiskCheckWithExcludedDiskReConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseDevices(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("excluded_disk_re: /dev/sda.*"))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -822,11 +792,10 @@ func TestGivenADiskCheckWithExcludedDiskReConfigured_WhenCheckRuns_ThenUsageMetr
 func TestGivenADiskCheckWithExcludedDiskReIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte("excluded_disk_re: /dev/sda(.*"))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -834,14 +803,13 @@ func TestGivenADiskCheckWithExcludedDiskReIncorrectlyConfigured_WhenCheckIsConfi
 func TestGivenADiskCheckWithDeviceIncludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 device_include:
   - /dev/sda(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -849,14 +817,13 @@ device_include:
 func TestGivenADiskCheckWithFileSystemGlobalExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 file_system_global_exclude:
   - tmp(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	assert.NotNil(t, err)
 }
@@ -864,14 +831,13 @@ file_system_global_exclude:
 func TestGivenADiskCheckWithFileSystemExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 file_system_exclude:
   - tmp(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -879,14 +845,13 @@ file_system_exclude:
 func TestGivenADiskCheckWithFileSystemIncludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 file_system_include:
   - ext(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -922,10 +887,7 @@ func TestGivenADiskCheckWithMountPointGlobalExcludeNotConfigured_WhenCheckRuns_T
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -940,14 +902,13 @@ func TestGivenADiskCheckWithMountPointGlobalExcludeNotConfigured_WhenCheckRuns_T
 func TestGivenADiskCheckWithMountPointGlobalExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	initConfig := integration.Data([]byte(`
 mount_point_global_exclude:
   - /dev/shm(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, initConfig, "test")
 
 	assert.NotNil(t, err)
 }
@@ -955,14 +916,13 @@ mount_point_global_exclude:
 func TestGivenADiskCheckWithMountPointExcludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 mount_point_exclude:
   - /dev/(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -970,11 +930,10 @@ mount_point_exclude:
 func TestGivenADiskCheckWithExcludedMountPointReIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte("excluded_mountpoint_re: /dev/(.*"))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -982,14 +941,12 @@ func TestGivenADiskCheckWithExcludedMountPointReIncorrectlyConfigured_WhenCheckI
 func TestGivenADiskCheckWithMountPointIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseMountPointsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_include:
   - /dev/.*
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1010,14 +967,12 @@ mount_point_include:
 func TestGivenADiskCheckWithMountPointWhiteListConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseMountPointsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_whitelist:
   - /dev/.*
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1038,14 +993,13 @@ mount_point_whitelist:
 func TestGivenADiskCheckWithMountPointIncludeIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 mount_point_include:
   - /dev/(.*
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -1075,10 +1029,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndUsageSystemCallReturns
 				Opts:       []string{"rw", "nosuid", "nodev"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1111,8 +1062,6 @@ func TestGivenADiskCheckWithMinDiskSizeConfiguredTo1MiBConfig_WhenCheckRunsAndUs
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`min_disk_size: 1`))
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -1120,7 +1069,7 @@ func TestGivenADiskCheckWithMinDiskSizeConfiguredTo1MiBConfig_WhenCheckRunsAndUs
 	assert.Nil(t, err)
 	log.SetupLogger(logger, "info")
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err = diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1156,11 +1105,9 @@ func TestGivenADiskCheckWithMinDiskSizeConfiguredTo1MiBConfig_WhenCheckRunsAndUs
 			}}, nil
 	})
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`min_disk_size: 1`))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1170,10 +1117,7 @@ func TestGivenADiskCheckWithMinDiskSizeConfiguredTo1MiBConfig_WhenCheckRunsAndUs
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenUsageMetricsAreNotReportedWithFileSystemTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1194,11 +1138,9 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenUsageMetricsAreNotRe
 func TestGivenADiskCheckWithTagByFileSystemFalseConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedWithFileSystemTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("tag_by_filesystem: false"))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1219,11 +1161,9 @@ func TestGivenADiskCheckWithTagByFileSystemFalseConfigured_WhenCheckRuns_ThenUsa
 func TestGivenADiskCheckWithTagByFileSystemTrueConfigured_WhenCheckRuns_ThenUsageMetricsAreReportedWithFileSystemTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("tag_by_filesystem: true"))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1244,10 +1184,7 @@ func TestGivenADiskCheckWithTagByFileSystemTrueConfigured_WhenCheckRuns_ThenUsag
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenUsageMetricsAreNotReportedWithMountPointTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1268,15 +1205,14 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenUsageMetricsAreNotRe
 func TestGivenADiskCheckWithDeviceTagReIncorrectlyConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 device_tag_re:
   /dev/sda.*: role:primary
   tmp.(*: role:tmp
 `))
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.NotNil(t, err)
 }
@@ -1284,15 +1220,14 @@ device_tag_re:
 func TestGivenADiskCheckWithUseLsblkAndBlkidCacheFileConfigured_WhenCheckIsConfigured_ThenErrorIsReturned(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 	config := integration.Data([]byte(`
 use_lsblk: true
 blkid_cache_file: /run/blkid/blkid.tab
 `))
 	expectedError := "only one of 'use_lsblk' and 'blkid_cache_file' can be set at the same time"
 
-	err := diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 
 	assert.EqualError(t, err, expectedError)
 }
@@ -1300,10 +1235,7 @@ blkid_cache_file: /run/blkid/blkid.tab
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenReadWriteServiceCheckNotReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1313,13 +1245,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenReadWriteServiceChec
 func TestGivenADiskCheckWithServiceCheckRwFalseConfigured_WhenCheckRuns_ThenReadWriteServiceCheckNotReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createDiskCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 service_check_rw: false
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1361,10 +1291,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsagePartitionTimeout_ThenUsageMet
 			}}, nil
 	}), testClock)
 
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+	m := mocksender.NewMockSenderWithSenderManager(diskCheck.ID(), senderManager)
+	m.SetupAcceptAll()
 	done := make(chan error, 1)
 	go func() {
 		done <- diskCheck.Run()
@@ -1396,8 +1327,8 @@ func TestDiskCheckNonDefaultFlavor(t *testing.T) {
 			require.True(t, ok)
 			diskCheck := diskCheckFunc()
 
-			mock := mocksender.NewMockSender(diskCheck.ID())
-			err := diskCheck.Configure(mock.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+			senderManager := mocksender.CreateDefaultDemultiplexer()
+			err := diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
 			require.NoError(t, err)
 		})
 	}
@@ -1437,15 +1368,13 @@ func TestGivenADiskCheckWithMountPointExcludeConfigured_WhenMountPointHasDeleted
 			},
 		}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	// Exclude /mnt/nfs_share - should match even though the actual mountpoint has " (deleted)" suffix
 	config := integration.Data([]byte(`
 mount_point_exclude:
   - /mnt/nfs_share
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1486,15 +1415,13 @@ func TestGivenADiskCheckWithDeviceTagReConfiguredWithMultipleTags_WhenCheckRuns_
 			},
 		}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	// Configure device_tag_re with multiple comma-separated tags
 	config := integration.Data([]byte(`
 device_tag_re:
   /dev/sda.*: role:primary, type:ssd, tier:fast
 `))
 
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -1504,4 +1431,26 @@ device_tag_re:
 			slices.Contains(tags, "type:ssd") &&
 			slices.Contains(tags, "tier:fast")
 	}))
+}
+
+func TestGivenMultipleDiskInstances_WhenConfiguredWithDifferentTags_ThenEachInstanceGetsUniqueCheckID(t *testing.T) {
+	setupDefaultMocks()
+	check1 := createDiskCheck(t)
+	check2 := createDiskCheck(t)
+
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+
+	config1 := integration.Data([]byte(`tags:
+  - "poi.monitors:disk:wxe100gb"
+`))
+	config2 := integration.Data([]byte(``))
+
+	err := check1.Configure(senderManager, 1, config1, nil, "test")
+	require.NoError(t, err)
+	err = check2.Configure(senderManager, 2, config2, nil, "test")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, check1.ID(), check2.ID(),
+		"disk check instances with different configs must have unique IDs; "+
+			"shared IDs cause a shared sender, which leaks custom tags between instances")
 }

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -201,8 +201,7 @@ func (sc *signalClock) After(d time.Duration) <-chan time.Time {
 func configureCheck(t *testing.T, diskCheck check.Check, config, initConfig integration.Data) *mocksender.MockSender {
 	t.Helper()
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	err := diskCheck.Configure(senderManager, integration.FakeConfigHash, config, initConfig, "test")
-	require.NoError(t, err)
+	diskCheck.Configure(senderManager, integration.FakeConfigHash, config, initConfig, "test") //nolint:errcheck
 	m := mocksender.NewMockSenderWithSenderManager(diskCheck.ID(), senderManager)
 	m.SetupAcceptAll()
 	return m

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_windows_test.go
@@ -83,10 +83,7 @@ func createWindowsCheck(t *testing.T) check.Check {
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -98,11 +95,8 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllUsageMetricsAreRe
 func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLowercaseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("lowercase_device_tag: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -118,11 +112,8 @@ func TestGivenADiskCheckWithLowercaseDeviceTagConfigured_WhenCheckRuns_ThenLower
 func TestGivenADiskCheckWithIncludeAllDevicesTrueConfigured_WhenCheckRuns_ThenAllUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("include_all_devices: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -134,11 +125,8 @@ func TestGivenADiskCheckWithIncludeAllDevicesTrueConfigured_WhenCheckRuns_ThenAl
 func TestGivenADiskCheckWithIncludeAllDevicesFalseConfigured_WhenCheckRuns_ThenOnlyPhysicalDevicesUsageMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("include_all_devices: false"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -165,10 +153,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturn
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -208,10 +193,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 			},
 		}, errors.New("error reading some partitions")
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// No error returned, and metrics are reported for the partitions that were returned
@@ -224,14 +206,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemCallRe
 func TestGivenADiskCheckWithDeviceIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_include:
   - \\?\Vol.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -243,14 +222,11 @@ device_include:
 func TestGivenADiskCheckWithDeviceWhiteListConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseDevicesAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_whitelist:
   - \\?\Vol.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -277,10 +253,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -310,10 +283,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 				Opts:       []string{"rw", "relatime"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -328,10 +298,7 @@ func TestGivenADiskCheckWithFileSystemGlobalExcludeNotConfigured_WhenCheckRuns_T
 func TestGivenADiskCheckWithDefaultConfig_WhenCheckRuns_ThenAllIOCountersMetricsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -349,8 +316,6 @@ func TestGivenADiskCheckWithCreateMountsConfigured_WhenCheckIsConfigured_ThenMou
 		return nil
 	}
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 create_mounts:
 - mountpoint: "p:"
@@ -367,8 +332,7 @@ create_mounts:
   share: /mnt/nfs_share
   type: nfs
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -444,14 +408,11 @@ create_mounts:
 func TestGivenADiskCheckWithDeviceTagReConfigured_WhenCheckRuns_ThenUsageMetricsAreReportedWithTheseTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 device_tag_re:
   \\\\\?\\Vol.*: role:primary
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -463,14 +424,11 @@ device_tag_re:
 func TestGivenADiskCheckWithFileSystemGlobalExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 file_system_global_exclude:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -482,14 +440,11 @@ file_system_global_exclude:
 func TestGivenADiskCheckWithFileSystemGlobalBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 file_system_global_blacklist:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -501,14 +456,11 @@ file_system_global_blacklist:
 func TestGivenADiskCheckWithExcludedFileSystemsConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 excluded_filesystems:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -520,14 +472,11 @@ excluded_filesystems:
 func TestGivenADiskCheckWithFileSystemExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_exclude:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -539,14 +488,11 @@ file_system_exclude:
 func TestGivenADiskCheckWithFileSystemBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseFileSystems(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_blacklist:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -558,14 +504,11 @@ file_system_blacklist:
 func TestGivenADiskCheckWithFileSystemIncludeConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseFileSystemsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_include:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -577,14 +520,11 @@ file_system_include:
 func TestGivenADiskCheckWithFileSystemWhiteListConfigured_WhenCheckRuns_ThenOnlyUsageMetricsForPartitionsWithThoseFileSystemsAreReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 file_system_whitelist:
   - ntfs.*
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -596,14 +536,11 @@ file_system_whitelist:
 func TestGivenADiskCheckWithMountPointGlobalExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 mount_point_global_exclude:
   - D:\\
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -615,14 +552,11 @@ mount_point_global_exclude:
 func TestGivenADiskCheckWithMountPointGlobalBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	initConfig := integration.Data([]byte(`
 mount_point_global_blacklist:
   - D:\\
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, initConfig, "test")
+	m := configureCheck(t, diskCheck, nil, initConfig)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -634,14 +568,11 @@ mount_point_global_blacklist:
 func TestGivenADiskCheckWithMountPointExcludeConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_exclude:
   - D:\\
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -653,14 +584,11 @@ mount_point_exclude:
 func TestGivenADiskCheckWithMountPointBlackListConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 mount_point_blacklist:
   - D:\\
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -672,11 +600,8 @@ mount_point_blacklist:
 func TestGivenADiskCheckWithExcludedMountPointReConfigured_WhenCheckRuns_ThenUsageMetricsAreNotReportedForPartitionsWithThoseMountPoints(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`excluded_mountpoint_re: D:\\`))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -688,11 +613,8 @@ func TestGivenADiskCheckWithExcludedMountPointReConfigured_WhenCheckRuns_ThenUsa
 func TestGivenADiskCheckWithUseMountConfigured_WhenCheckRuns_ThenUsageMetricsAreReportedWithMountPointTags(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte("use_mount: true"))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -705,13 +627,10 @@ func TestGivenADiskCheckWithUseMountConfigured_WhenCheckRuns_ThenUsageMetricsAre
 func TestGivenADiskCheckWithServiceCheckRwTrueConfigured_WhenCheckRuns_ThenReadWriteServiceCheckReported(t *testing.T) {
 	setupDefaultMocks()
 	diskCheck := createWindowsCheck(t)
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
 	config := integration.Data([]byte(`
 service_check_rw: true
 `))
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, config, nil, "test")
+	m := configureCheck(t, diskCheck, config, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -738,10 +657,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionHasCdromInOpts_ThenPartit
 				Opts:       []string{"rw"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -773,10 +689,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionHasEmptyFstype_ThenPartit
 				Opts:       []string{"rw"},
 			}}, nil
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	assert.Nil(t, err)
@@ -794,10 +707,7 @@ func TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndIOCountersReturnsError
 	diskCheck = diskv2.WithDiskIOCounters(diskCheck, func(...string) (map[string]gopsutil_disk.IOCountersStat, error) {
 		return nil, windows.ERROR_INVALID_FUNCTION
 	})
-	m := mocksender.NewMockSender(diskCheck.ID())
-	m.SetupAcceptAll()
-
-	diskCheck.Configure(m.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test")
+	m := configureCheck(t, diskCheck, nil, nil)
 	err := diskCheck.Run()
 
 	// ERROR_INVALID_FUNCTION is expected on systems where disk perf counters are disabled

--- a/releasenotes/notes/fix-diskv2-tag-leaking-between-instances.yaml
+++ b/releasenotes/notes/fix-diskv2-tag-leaking-between-instances.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a bug in the disk Go check (diskv2) where custom tags from one
+    check instance would leak into metrics from other instances. Tags are
+    now correctly isolated per instance.


### PR DESCRIPTION
### What does this PR do?

Fixes a tag leaking bug in the `diskv2` check where custom tags configured on one check instance would propagate to all other instances' metrics.

The root cause was that `diskv2.Check.Configure()` did not call `BuildID()`, so all instances shared the same default check ID. This meant they all shared the same `checkSender` and its `checkTags` field -- when `CommonConfigure` called `SetCheckCustomTags` for one instance, those tags leaked into every other instance's metrics.

The fix adds a `BuildID(integrationConfigDigest, data, initConfig)` call before `CommonConfigure` so each instance gets a unique ID and its own isolated sender.

Additionally:
- Enhances `MockSender` to store and append `checkTags` in metric-sending methods, mirroring the real `checkSender` behavior, so tests can properly assert custom tags on metrics.
- Adds a regression test that verifies multiple disk instances with different tags get unique check IDs.
- DRYs up test boilerplate across `disk_test.go`, `disk_nix_test.go`, and `disk_windows_test.go` with a `configureCheck` helper.

### Motivation

Customers upgrading from Agent 7.71.2 to 7.75.1 reported that custom tags (e.g. `tags: ["poi.monitors:disk:wxe100gb"]`) applied to a single disk check instance were appearing on metrics from all other disk check instances.

### Describe how you validated your changes

- Added `TestGivenMultipleDiskInstances_WhenConfiguredWithDifferentTags_ThenEachInstanceGetsUniqueCheckID` which fails without the `BuildID` fix and passes with it.

### Additional Notes

- The `MockSender` change (`checkTags` field + `tagsWithCheckTags` helper) is additive and backward-compatible. Existing tests that don't set custom tags are unaffected since `tagsWithCheckTags` is a no-op when `checkTags` is empty.
- The test refactoring (`configureCheck` helper) is a pure cleanup with no behavioral changes -- it replaces ~80 instances of a 3-4 line boilerplate pattern with a single-line call.
