### PR TITLE
Add a ramp up version of file to blackhole 0ms latency in disabled cases for future reference

### DIFF
--- a/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/datadog-agent/conf.d/disk-listener.d/conf.yaml
+++ b/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/datadog-agent/conf.d/disk-listener.d/conf.yaml
@@ -1,0 +1,5 @@
+logs:
+  - type: file
+    path: "/smp-shared/*.log"
+    service: "my-service"
+    source: "my-client-app"

--- a/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/datadog-agent/datadog.yaml
+++ b/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/datadog-agent/datadog.yaml
@@ -1,0 +1,20 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dd_url: http://127.0.0.1:9091
+
+logs_enabled: true
+logs_config:
+  logs_dd_url: 127.0.0.1:9092
+  file_scan_period: 1
+  logs_no_ssl: true
+  force_use_http: true
+
+process_config.process_dd_url: http://localhost:9093
+
+telemetry.enabled: true
+telemetry.checks: '*'

--- a/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/experiment.yaml
+++ b/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/experiment.yaml
@@ -1,0 +1,39 @@
+optimization_goal: egress_throughput
+erratic: false
+
+target:
+  name: datadog-agent
+  cpu_allotment: 4
+  memory_allotment: 2GiB
+
+  environment:
+    DD_API_KEY: a0000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /smp-host/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+    DD_APM_INTERNAL_PROFILING_ENABLED: true
+
+checks:
+  - name: memory_usage
+    description: "Memory usage"
+    bounds:
+      series: total_pss_bytes
+      # The machine has 12GiB free.
+      upper_bound: 1.2GiB
+
+  - name: lost_bytes
+    description: "Available bytes not polled by log Agent"
+    bounds:
+      series: lost_bytes
+      upper_bound: 0KiB

--- a/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/lading/lading.yaml
+++ b/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/lading/lading.yaml
@@ -1,0 +1,31 @@
+generator:
+  - file_gen:
+      logrotate_fs:
+        seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+               59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+        load_profile:
+          linear:
+            initial_bytes_per_second: 100 KiB
+            rate: 50 KiB
+        concurrent_logs: 1
+        maximum_bytes_per_log: 500 MiB
+        total_rotations: 5
+        max_depth: 0
+        variant: "apache_common"
+        maximum_prebuild_cache_size_bytes: 300 MiB
+        mount_point: /smp-shared
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+      response_delay_millis: 0
+  - http:
+      binding_addr: "127.0.0.1:9093"
+
+target_metrics:
+  - prometheus: # core agent telemetry
+      uri: "http://127.0.0.1:5000/telemetry"
+      tags:
+        sub_agent: "core"


### PR DESCRIPTION
### What does this PR do?

- Adds a disabled version of file to blackhole 0ms latency test with ramp up as default instead of linear load

### Motivation

- Ramp up is used quite a bit in agent logs testing, it would be easier to see a quick example for future reference

### Describe how you validated your changes

- Manual QA. I used this same config in SMP playground and it had the same structure as the original test, just ramped up instead.
