### PR TITLE
remote config yaml entry

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -622,6 +622,21 @@ api_key:
 #
 #   validation_period: 60
 
+## @param remote_configuration - custom object - optional
+## Configuration for Remote Configuration.
+## Remote Configuration allows you to configure your Agents from the Datadog UI.
+## See https://docs.datadoghq.com/agent/guide/setup_remote_config/ for more information.
+#
+# remote_configuration:
+
+#   # @param enabled - boolean - optional - default: true
+#   # @env DD_REMOTE_CONFIGURATION_ENABLED - boolean - optional - default: true
+#   # Set to true to enable Remote Configuration. Enabled by default.
+#   # Note: On GovCloud (ddog-gov.com), Remote Configuration is disabled by default
+#   # and must be explicitly enabled.
+#
+#   enabled: true
+
 ## @param fips - custom object - optional
 ## Uncomment this parameter and the one below to enable them.
 #


### PR DESCRIPTION
### What does this PR do?
addresses https://github.com/DataDog/datadog-agent/issues/45984 where the datadog docs contain `remote_configuration.enabled` while it is missing in the sample config. 

### Motivation
Consistency

### Describe how you validated your changes

### Additional Notes
This field is generally not expected to be touched by customers however because its mentioned in the docs, it makes sense to add it here for consistency

