### PR TITLE
[NETPATH-640][datadog-agent] Remove CNM as codeowners from Network Path directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -224,7 +224,7 @@
 /cmd/agent/dist/conf.d/jetson.d/        @DataDog/agent-runtimes
 /cmd/agent/dist/conf.d/oracle.d/    @DataDog/database-monitoring
 /cmd/agent/dist/conf.d/oracle-dbm.d/    @DataDog/database-monitoring
-/cmd/agent/dist/conf.d/network_path.d/ @DataDog/cloud-network-monitoring @DataDog/network-path
+/cmd/agent/dist/conf.d/network_path.d/  @DataDog/network-path
 /cmd/agent/dist/conf.d/orchestrator_ecs.d/  @DataDog/ecs-experiences
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/agent-security @DataDog/container-integrations
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
@@ -251,7 +251,7 @@
 /cmd/system-probe/modules/eventmonitor* @DataDog/agent-security
 /cmd/system-probe/modules/compliance*   @DataDog/agent-cspm
 /cmd/system-probe/modules/tcp_queue_tracer* @DataDog/container-integrations
-/cmd/system-probe/modules/traceroute*  @DataDog/cloud-network-monitoring @DataDog/network-path
+/cmd/system-probe/modules/traceroute*   @DataDog/network-path
 /cmd/system-probe/modules/ping*         @DataDog/ndm-core
 /cmd/system-probe/modules/language_detection* @DataDog/container-experiences @DataDog/agent-discovery
 /cmd/system-probe/modules/dynamic_instrumentation* @DataDog/debugger-go
@@ -329,7 +329,7 @@
 /comp/metadata @DataDog/agent-configuration
 /comp/ndmtmp @DataDog/ndm-core
 /comp/netflow @DataDog/ndm-integrations
-/comp/networkpath @DataDog/cloud-network-monitoring @DataDog/network-path
+/comp/networkpath @DataDog/network-path
 /comp/otelcol @DataDog/opentelemetry-agent
 /comp/process @DataDog/container-experiences
 /comp/remote-config @DataDog/remote-config
@@ -690,9 +690,9 @@
 /comp/core/workloadmeta/collectors/internal/process          @DataDog/container-experiences @DataDog/container-platform
 /comp/core/tagger/collectors            @DataDog/container-platform @DataDog/container-integrations
 /pkg/sbom/                              @DataDog/agent-security @DataDog/container-integrations
-/pkg/networkpath/                       @DataDog/cloud-network-monitoring @DataDog/network-path
-/pkg/networkpath/traceroute/            @DataDog/cloud-network-monitoring @DataDog/windows-products @DataDog/network-path
-/pkg/collector/corechecks/networkpath/  @DataDog/cloud-network-monitoring @DataDog/network-path
+/pkg/networkpath/                       @DataDog/network-path
+/pkg/networkpath/traceroute/            @DataDog/windows-products @DataDog/network-path
+/pkg/collector/corechecks/networkpath/  @DataDog/network-path
 
 /releasenotes/                          @DataDog/documentation
 /releasenotes-dca/                      @DataDog/documentation
@@ -807,7 +807,7 @@
 /test/new-e2e/tests/language-detection        @DataDog/container-experiences
 /test/new-e2e/tests/ndm                       @DataDog/ndm-core
 /test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
-/test/new-e2e/tests/netpath                   @DataDog/cloud-network-monitoring @DataDog/windows-products @DataDog/network-path
+/test/new-e2e/tests/netpath                   @DataDog/windows-products @DataDog/network-path
 /test/new-e2e/tests/npm                       @DataDog/cloud-network-monitoring
 /test/new-e2e/tests/npm/ec2_1host_wkit_test.go @DataDog/cloud-network-monitoring @DataDog/windows-products
 /test/new-e2e/tests/npm/ecs_1host_test.go    @DataDog/ecs-experiences

--- a/comp/README.md
+++ b/comp/README.md
@@ -468,7 +468,7 @@ It does not expose any public methods.
 
 ## [comp/networkpath](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkpath) (Component Bundle)
 
-*Datadog Team*: cloud-network-monitoring network-path
+*Datadog Team*: network-path
 
 Package networkpath implements the "networkpath" bundle,
 

--- a/comp/networkpath/bundle.go
+++ b/comp/networkpath/bundle.go
@@ -12,7 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl"
 )
 
-// team: cloud-network-monitoring network-path
+// team: network-path
 
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {

--- a/comp/networkpath/npcollector/component.go
+++ b/comp/networkpath/npcollector/component.go
@@ -12,7 +12,7 @@ import (
 	npmodel "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/model"
 )
 
-// team: cloud-network-monitoring network-path
+// team: network-path
 
 // Component is the component type.
 type Component interface {

--- a/comp/networkpath/traceroute/def/component.go
+++ b/comp/networkpath/traceroute/def/component.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
 )
 
-// team: cloud-network-monitoring network-path
+// team: network-path
 
 // Component is the component type.
 type Component interface {


### PR DESCRIPTION
### What does this PR do?
Removes Cloud Network Monitoring team from Network Path related directories. 

### Motivation
Network Path is now an official team. We should avoid pinging CNM for changes in Network Path specific directories.

### Describe how you validated your changes

### Additional Notes
