### PR TITLE
[CONTP-1257] feat(leader_election): Use EPS when enabled for leader election

### DIFF
--- a/comp/core/autodiscovery/providers/prometheus_services_eps.go
+++ b/comp/core/autodiscovery/providers/prometheus_services_eps.go
@@ -33,10 +33,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const (
-	kubernetesServiceNameLabel = "kubernetes.io/service-name"
-)
-
 // ServiceEndpointSlicesAPI abstracts the dependency on the Kubernetes API (useful for testing)
 type ServiceEndpointSlicesAPI interface {
 	// ListServices lists all Services
@@ -56,7 +52,7 @@ func (api *svcEndpointSlicesAPI) ListServices() ([]*v1.Service, error) {
 
 func (api *svcEndpointSlicesAPI) ListEndpointSlices(namespace, name string) ([]*discv1.EndpointSlice, error) {
 	return api.endpointSliceLister.EndpointSlices(namespace).List(
-		labels.Set{kubernetesServiceNameLabel: name}.AsSelector(),
+		labels.Set{apiserver.KubernetesServiceNameLabel: name}.AsSelector(),
 	)
 }
 
@@ -295,7 +291,7 @@ func (p *PrometheusServicesEndpointSlicesConfigProvider) invalidateIfChangedEndp
 	}
 
 	// Get service name from labels
-	serviceName := castedObj.Labels[kubernetesServiceNameLabel]
+	serviceName := castedObj.Labels[apiserver.KubernetesServiceNameLabel]
 	if serviceName == "" {
 		return
 	}

--- a/pkg/util/kubernetes/apiserver/endpoints_test.go
+++ b/pkg/util/kubernetes/apiserver/endpoints_test.go
@@ -204,8 +204,7 @@ func TestSearchTargetPerNameInEndpointSlices(t *testing.T) {
 				assert.Equal(t, tc.expectedErr.Error(), err.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedIP, result.IP)
-				assert.Equal(t, nodeName, result.NodeName)
+				assert.Equal(t, tc.expectedIP, result)
 			}
 		})
 	}

--- a/pkg/util/kubernetes/apiserver/endpoints_test.go
+++ b/pkg/util/kubernetes/apiserver/endpoints_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	discv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -109,6 +110,111 @@ func newFakeEndpointAddress(nodeName string, pod v1.Pod) v1.EndpointAddress {
 	return v1.EndpointAddress{
 		IP:       pod.Status.PodIP,
 		NodeName: &nodeName,
+		TargetRef: &v1.ObjectReference{
+			Kind:      pod.Kind,
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+			UID:       pod.UID,
+		},
+	}
+}
+
+func TestSearchTargetPerNameInEndpointSlices(t *testing.T) {
+	pod1 := newFakePod(
+		"foo",
+		"pod1_name",
+		"1111",
+		"1.1.1.1",
+	)
+
+	pod2 := newFakePod(
+		"foo",
+		"pod2_name",
+		"2222",
+		"2.2.2.2",
+	)
+
+	nodeName := "myNode"
+
+	for nb, tc := range []struct {
+		targetName  string
+		slices      []*discv1.EndpointSlice
+		expectedIP  string
+		expectedErr error
+	}{
+		{
+			"pod2_name",
+			[]*discv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc123",
+						Namespace: "foo",
+					},
+					Endpoints: []discv1.Endpoint{
+						{
+							Addresses: []string{},
+							TargetRef: nil, // Empty endpoint with nil targetRef
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-def456",
+						Namespace: "foo",
+					},
+					Endpoints: []discv1.Endpoint{
+						newFakeEndpointSliceEndpoint(nodeName, pod1),
+						newFakeEndpointSliceEndpoint(nodeName, pod2),
+					},
+				},
+			},
+			"2.2.2.2",
+			nil,
+		},
+		{
+			"pod_not_found",
+			[]*discv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-abc123",
+						Namespace: "foo",
+					},
+					Endpoints: []discv1.Endpoint{
+						newFakeEndpointSliceEndpoint(nodeName, pod1),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-def456",
+						Namespace: "foo",
+					},
+					Endpoints: []discv1.Endpoint{
+						newFakeEndpointSliceEndpoint(nodeName, pod2),
+					},
+				},
+			},
+			"",
+			errors.New("\"target named pod_not_found\" not found"),
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", nb, tc.targetName), func(t *testing.T) {
+			result, err := SearchTargetPerNameInEndpointSlices(tc.slices, tc.targetName)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				assert.Equal(t, tc.expectedErr.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedIP, result.IP)
+				assert.Equal(t, nodeName, result.NodeName)
+			}
+		})
+	}
+}
+
+func newFakeEndpointSliceEndpoint(nodeName string, pod v1.Pod) discv1.Endpoint {
+	return discv1.Endpoint{
+		Addresses: []string{pod.Status.PodIP},
+		NodeName:  &nodeName,
 		TargetRef: &v1.ObjectReference{
 			Kind:      pod.Kind,
 			Namespace: pod.Namespace,

--- a/pkg/util/kubernetes/apiserver/endpointslices.go
+++ b/pkg/util/kubernetes/apiserver/endpointslices.go
@@ -11,37 +11,49 @@ import (
 	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"golang.org/x/mod/semver"
 )
+
+const endpointSlicesCacheKey = "useEndpointSlices"
 
 // UseEndpointSlices returns true if the Agent config has enabled endpoint slices and the running
 // Kubernetes server version supports it. EndpointSlices became generally available starting from
 // Kubernetes version 1.21+. The Agent should fall back to the endpoints API if the config
 // is enabled but the server version does not support it.
 func UseEndpointSlices() bool {
+	if use, found := cache.Cache.Get(endpointSlicesCacheKey); found {
+		return use.(bool)
+	}
+
 	if !pkgconfigsetup.Datadog().GetBool("kubernetes_use_endpoint_slices") {
 		log.Debug("kubernetes_use_endpoint_slices is disabled, using deprecated endpoints API.")
+		cache.Cache.Set(endpointSlicesCacheKey, false, time.Hour)
 		return false
 	}
 
 	apiserverClient, err := GetAPIClient()
 	if err != nil {
 		log.Warnf("Couldn't get apiserver client, cannot check if kubernetes version supports endpoint slices.")
+		// Not caching because we don't want to cache the result of a failure.
 		return true
 	}
 
 	serverVersion, err := common.KubeServerVersion(apiserverClient.Cl.Discovery(), 10*time.Second)
 	if err != nil {
 		log.Warnf("Couldn't get apiserver version, cannot check if kubernetes version supports endpoint slices.")
-		// Fail open because the config was enabled, even though we can't check the version
+		// Fail open because the config was enabled, even though we can't check the version.
+		// Not caching because we don't want to cache the result of a failure.
 		return true
 	}
 
 	if semver.IsValid(serverVersion.String()) && semver.Compare(serverVersion.String(), "v1.21.0") >= 0 {
+		cache.Cache.Set(endpointSlicesCacheKey, true, time.Hour)
 		return true
 	}
 	log.Warnf("Endpoint Slices not supported in Kubernetes version %s. Falling back to core/v1/Endpoints.", serverVersion.String())
+	cache.Cache.Set(endpointSlicesCacheKey, false, time.Hour)
 	return false
 }

--- a/pkg/util/kubernetes/apiserver/endpointslices_test.go
+++ b/pkg/util/kubernetes/apiserver/endpointslices_test.go
@@ -88,14 +88,18 @@ func TestUseEndpointSlices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pkgconfigsetup.Datadog().Set("kubernetes_use_endpoint_slices", tt.configEnabled, pkgconfigmodel.SourceFile)
+			defer cache.Cache.Delete(endpointSlicesCacheKey)
 
+			pkgconfigsetup.Datadog().Set("kubernetes_use_endpoint_slices", tt.configEnabled, pkgconfigmodel.SourceFile)
 			cache.Cache.Set(serverVersionCacheKey, tt.version, time.Hour)
 
 			setupFakeAPIClient()
 
 			result := UseEndpointSlices()
 			assert.Equal(t, tt.expectedResult, result, tt.name)
+			use, found := cache.Cache.Get(endpointSlicesCacheKey)
+			assert.True(t, found)
+			assert.Equal(t, tt.expectedResult, use.(bool))
 		})
 	}
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -278,7 +278,6 @@ func (le *LeaderEngine) GetLeaderIP() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		cache.Cache.Set(cacheKey, targetIP, 5*time.Minute)
 	} else {
 		endpointList, err := le.coreClient.Endpoints(le.LeaderNamespace).Get(context.TODO(), le.ServiceName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -18,11 +18,14 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+	discv1 "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/discovery"
 	coordinationv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	discv1typed "k8s.io/client-go/kubernetes/typed/discovery/v1"
 	"k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 
@@ -63,6 +66,7 @@ type LeaderEngine struct {
 	LeaderNamespace     string
 	coreClient          corev1.CoreV1Interface
 	coordClient         coordinationv1.CoordinationV1Interface
+	discoveryClient     discv1typed.DiscoveryV1Interface
 	ServiceName         string
 	leaderIdentityMutex sync.RWMutex
 	leaderElector       *leaderelection.LeaderElector
@@ -164,6 +168,7 @@ func (le *LeaderEngine) init() error {
 
 	le.coreClient = apiClient.Cl.CoreV1()
 	le.coordClient = apiClient.Cl.CoordinationV1()
+	le.discoveryClient = apiClient.Cl.DiscoveryV1()
 
 	usingLease, err := CanUseLeases(apiClient.Cl.Discovery())
 	if err != nil {
@@ -265,6 +270,20 @@ func (le *LeaderEngine) GetLeaderIP() (string, error) {
 		return ip.(string), nil
 	}
 
+	var targetIP string
+	var err error
+
+	// Try EndpointSlices first if supported
+	if apiserver.UseEndpointSlices() {
+		targetIP, err = le.getLeaderIPFromEndpointSlices(leaderName)
+		if err == nil {
+			cache.Cache.Set(cacheKey, targetIP, 5*time.Minute)
+			return targetIP, nil
+		}
+		log.Debugf("Failed to get leader IP from EndpointSlices, falling back to Endpoints: %v", err)
+	}
+
+	// Fallback to Endpoints API
 	endpointList, err := le.coreClient.Endpoints(le.LeaderNamespace).Get(context.TODO(), le.ServiceName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -276,6 +295,37 @@ func (le *LeaderEngine) GetLeaderIP() (string, error) {
 	cache.Cache.Set(cacheKey, target.IP, 5*time.Minute)
 
 	return target.IP, nil
+}
+
+// getLeaderIPFromEndpointSlices retrieves the leader IP from EndpointSlices
+func (le *LeaderEngine) getLeaderIPFromEndpointSlices(leaderName string) (string, error) {
+	// List EndpointSlices for the service
+	sliceList, err := le.discoveryClient.EndpointSlices(le.LeaderNamespace).List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: labels.Set{apiserver.KubernetesServiceNameLabel: le.ServiceName}.String(),
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	if sliceList == nil || len(sliceList.Items) == 0 {
+		return "", fmt.Errorf("no endpointslices found for service %s", le.ServiceName)
+	}
+
+	// Convert Items to slice of pointers for SearchTargetPerNameInEndpointSlices
+	slices := make([]*discv1.EndpointSlice, len(sliceList.Items))
+	for i := range sliceList.Items {
+		slices[i] = &sliceList.Items[i]
+	}
+
+	result, err := apiserver.SearchTargetPerNameInEndpointSlices(slices, leaderName)
+	if err != nil {
+		return "", err
+	}
+
+	return result.IP, nil
 }
 
 // IsLeader returns true if the last observed leader was this client else returns false.

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -301,256 +301,284 @@ func TestSubscribe(t *testing.T) {
 
 func TestGetLeaderIPFollower_ConfigMap(t *testing.T) {
 	const leaseName = "datadog-leader-election"
-	const endpointsName = "datadog-cluster-agent"
+	const serviceName = "datadog-cluster-agent"
 
-	client := fake.NewSimpleClientset()
-
-	le := &LeaderEngine{
-		ctx:             context.Background(),
-		HolderIdentity:  "foo",
-		LeaseName:       leaseName,
-		ServiceName:     endpointsName,
-		LeaderNamespace: "default",
-		LeaseDuration:   120 * time.Second,
-		coreClient:      client.CoreV1(),
-		coordClient:     client.CoordinationV1(),
-		leaderMetric:    &dummyGauge{},
-		lockType:        cmLock.ConfigMapsResourceLock,
-	}
-
-	// Create leader-election configmap with current node as follower
-	electionCM := makeLeaderCM(leaseName, "default", "bar", 120)
-	_, err := client.CoreV1().ConfigMaps("default").Create(context.TODO(), electionCM, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	// Create endpoints
-	endpoints := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      endpointsName,
-			Namespace: "default",
+	testCases := []struct {
+		name              string
+		useEndpointSlices bool
+		setupEndpoints    func(*testing.T, *fake.Clientset, string)
+		removeLeader      func(*testing.T, *fake.Clientset, string)
+	}{
+		{
+			name:              "with Endpoints",
+			useEndpointSlices: false,
+			setupEndpoints: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				endpoints := &v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName,
+						Namespace: "default",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP:        "1.1.1.1",
+									TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "foo"},
+								},
+								{
+									IP:        "1.1.1.2",
+									TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "bar"},
+								},
+							},
+						},
+					},
+				}
+				_, err := client.CoreV1().Endpoints("default").Create(context.TODO(), endpoints, metav1.CreateOptions{})
+				require.NoError(t, err)
+			},
+			removeLeader: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				storedEndpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), serviceName, metav1.GetOptions{})
+				require.NoError(t, err)
+				storedEndpoints.Subsets[0].Addresses = storedEndpoints.Subsets[0].Addresses[0:1]
+				_, err = client.CoreV1().Endpoints("default").Update(context.TODO(), storedEndpoints, metav1.UpdateOptions{})
+				require.NoError(t, err)
+			},
 		},
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: []v1.EndpointAddress{
-					{
-						IP: "1.1.1.1",
-						TargetRef: &v1.ObjectReference{
-							Kind:      "pod",
-							Namespace: "default",
-							Name:      "foo",
+		{
+			name:              "with EndpointSlices",
+			useEndpointSlices: true,
+			setupEndpoints: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				nodeName := "test-node"
+				endpointSlice := &discv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName + "-abc123",
+						Namespace: "default",
+						Labels:    map[string]string{apiserver.KubernetesServiceNameLabel: serviceName},
+					},
+					Endpoints: []discv1.Endpoint{
+						{
+							Addresses: []string{"1.1.1.1"},
+							TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "foo"},
+							NodeName:  &nodeName,
+						},
+						{
+							Addresses: []string{"1.1.1.2"},
+							TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "bar"},
+							NodeName:  &nodeName,
 						},
 					},
-					{
-						IP: "1.1.1.2",
-						TargetRef: &v1.ObjectReference{
-							Kind:      "pod",
-							Namespace: "default",
-							Name:      "bar",
-						},
-					},
-				},
+				}
+				_, err := client.DiscoveryV1().EndpointSlices("default").Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
+				require.NoError(t, err)
+			},
+			removeLeader: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				storedSlice, err := client.DiscoveryV1().EndpointSlices("default").Get(context.TODO(), serviceName+"-abc123", metav1.GetOptions{})
+				require.NoError(t, err)
+				storedSlice.Endpoints = storedSlice.Endpoints[0:1]
+				_, err = client.DiscoveryV1().EndpointSlices("default").Update(context.TODO(), storedSlice, metav1.UpdateOptions{})
+				require.NoError(t, err)
 			},
 		},
 	}
-	storedEndpoints, err := client.CoreV1().Endpoints("default").Create(context.TODO(), endpoints, metav1.CreateOptions{})
-	require.NoError(t, err)
 
-	// Run leader election
-	le.leaderElector, err = le.newElection()
-	require.NoError(t, err)
-	err = le.EnsureLeaderElectionRuns()
-	require.NoError(t, err)
-	cm, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.Contains(t, cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
 
-	// We should be follower, and GetLeaderIP should return bar's IP
-	require.False(t, le.IsLeader())
-	ip, err := le.GetLeaderIP()
-	assert.NoError(t, err)
-	assert.Equal(t, "1.1.1.2", ip)
+			if tc.useEndpointSlices {
+				cache.Cache.Set("useEndpointSlices", true, time.Hour)
+				defer cache.Cache.Delete("useEndpointSlices")
+			}
 
-	// Remove bar from endpoints and clear cache
-	cache.Cache.Delete("ip://bar")
-	storedEndpoints.Subsets[0].Addresses = storedEndpoints.Subsets[0].Addresses[0:1]
-	_, err = client.CoreV1().Endpoints("default").Update(context.TODO(), storedEndpoints, metav1.UpdateOptions{})
-	require.NoError(t, err)
+			le := &LeaderEngine{
+				ctx:             context.Background(),
+				HolderIdentity:  "foo",
+				LeaseName:       leaseName,
+				ServiceName:     serviceName,
+				LeaderNamespace: "default",
+				LeaseDuration:   120 * time.Second,
+				coreClient:      client.CoreV1(),
+				coordClient:     client.CoordinationV1(),
+				discoveryClient: client.DiscoveryV1(),
+				leaderMetric:    &dummyGauge{},
+				lockType:        cmLock.ConfigMapsResourceLock,
+			}
 
-	// GetLeaderIP will "gracefully" error out
-	ip, err = le.GetLeaderIP()
-	assert.Equal(t, "", ip)
-	assert.True(t, dderrors.IsNotFound(err))
+			// Create leader-election configmap with current node as follower
+			electionCM := makeLeaderCM(leaseName, "default", "bar", 120)
+			_, err := client.CoreV1().ConfigMaps("default").Create(context.TODO(), electionCM, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			tc.setupEndpoints(t, client, serviceName)
+
+			// Run leader election
+			le.leaderElector, err = le.newElection()
+			require.NoError(t, err)
+			err = le.EnsureLeaderElectionRuns()
+			require.NoError(t, err)
+			cm, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Contains(t, cm.Annotations[rl.LeaderElectionRecordAnnotationKey], "\"leaderTransitions\":1")
+
+			// We should be follower, and GetLeaderIP should return bar's IP
+			require.False(t, le.IsLeader())
+			ip, err := le.GetLeaderIP()
+			assert.NoError(t, err)
+			assert.Equal(t, "1.1.1.2", ip, "GetLeaderIP should return same result for both APIs")
+
+			// Remove bar from endpoints/endpointslice and clear cache
+			cache.Cache.Delete("ip://bar")
+			tc.removeLeader(t, client, serviceName)
+
+			// GetLeaderIP will "gracefully" error out
+			// Same behavior expected for both APIs
+			ip, err = le.GetLeaderIP()
+			assert.Equal(t, "", ip, "GetLeaderIP should return empty when leader not found")
+			assert.True(t, dderrors.IsNotFound(err), "GetLeaderIP should return NotFound error")
+		})
+	}
 }
 
 func TestGetLeaderIPFollower_Lease(t *testing.T) {
 	const leaseName = "datadog-leader-election"
-	const endpointsName = "datadog-cluster-agent"
-
-	client := fake.NewSimpleClientset()
-
-	le := &LeaderEngine{
-		ctx:             context.Background(),
-		HolderIdentity:  "foo",
-		LeaseName:       leaseName,
-		ServiceName:     endpointsName,
-		LeaderNamespace: "default",
-		LeaseDuration:   120 * time.Second,
-		coreClient:      client.CoreV1(),
-		coordClient:     client.CoordinationV1(),
-		leaderMetric:    &dummyGauge{},
-		lockType:        rl.LeasesResourceLock,
-	}
-
-	// Create leader-election configmap with current node as follower
-	electionCM := makeLeaderLease(leaseName, "default", "bar", 120)
-	_, err := client.CoordinationV1().Leases("default").Create(context.TODO(), electionCM, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	// Create endpoints
-	endpoints := &v1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      endpointsName,
-			Namespace: "default",
-		},
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: []v1.EndpointAddress{
-					{
-						IP: "1.1.1.1",
-						TargetRef: &v1.ObjectReference{
-							Kind:      "pod",
-							Namespace: "default",
-							Name:      "foo",
-						},
-					},
-					{
-						IP: "1.1.1.2",
-						TargetRef: &v1.ObjectReference{
-							Kind:      "pod",
-							Namespace: "default",
-							Name:      "bar",
-						},
-					},
-				},
-			},
-		},
-	}
-	storedEndpoints, err := client.CoreV1().Endpoints("default").Create(context.TODO(), endpoints, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	// Run leader election
-	le.leaderElector, err = le.newElection()
-	require.NoError(t, err)
-	err = le.EnsureLeaderElectionRuns()
-	require.NoError(t, err)
-	lease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.NotNil(t, lease.Spec.LeaseTransitions)
-	require.Equal(t, int32(1), *lease.Spec.LeaseTransitions)
-
-	// We should be follower, and GetLeaderIP should return bar's IP
-	require.False(t, le.IsLeader())
-	ip, err := le.GetLeaderIP()
-	assert.NoError(t, err)
-	assert.Equal(t, "1.1.1.2", ip)
-
-	// Remove bar from endpoints and clear the cache
-	cache.Cache.Delete("ip://bar")
-	storedEndpoints.Subsets[0].Addresses = storedEndpoints.Subsets[0].Addresses[0:1]
-	_, err = client.CoreV1().Endpoints("default").Update(context.TODO(), storedEndpoints, metav1.UpdateOptions{})
-	require.NoError(t, err)
-
-	// GetLeaderIP will "gracefully" error out
-	ip, err = le.GetLeaderIP()
-	assert.Equal(t, "", ip)
-	assert.True(t, dderrors.IsNotFound(err))
-}
-
-func TestGetLeaderIPFollower_EndpointSlices(t *testing.T) {
-	const leaseName = "datadog-leader-election"
 	const serviceName = "datadog-cluster-agent"
 
-	client := fake.NewSimpleClientset()
-
-	le := &LeaderEngine{
-		ctx:             context.Background(),
-		HolderIdentity:  "foo",
-		LeaseName:       leaseName,
-		ServiceName:     serviceName,
-		LeaderNamespace: "default",
-		LeaseDuration:   120 * time.Second,
-		coreClient:      client.CoreV1(),
-		coordClient:     client.CoordinationV1(),
-		discoveryClient: client.DiscoveryV1(),
-		leaderMetric:    &dummyGauge{},
-		lockType:        rl.LeasesResourceLock,
-	}
-
-	// Create leader-election lease with current node as follower
-	electionLease := makeLeaderLease(leaseName, "default", "bar", 120)
-	_, err := client.CoordinationV1().Leases("default").Create(context.TODO(), electionLease, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	// Create EndpointSlice
-	nodeName := "test-node"
-	endpointSlice := &discv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName + "-abc123",
-			Namespace: "default",
-			Labels: map[string]string{
-				apiserver.KubernetesServiceNameLabel: serviceName,
+	testCases := []struct {
+		name              string
+		useEndpointSlices bool
+		setupEndpoints    func(*testing.T, *fake.Clientset, string)
+		removeLeader      func(*testing.T, *fake.Clientset, string)
+	}{
+		{
+			name:              "with Endpoints",
+			useEndpointSlices: false,
+			setupEndpoints: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				endpoints := &v1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName,
+						Namespace: "default",
+					},
+					Subsets: []v1.EndpointSubset{
+						{
+							Addresses: []v1.EndpointAddress{
+								{
+									IP:        "1.1.1.1",
+									TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "foo"},
+								},
+								{
+									IP:        "1.1.1.2",
+									TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "bar"},
+								},
+							},
+						},
+					},
+				}
+				_, err := client.CoreV1().Endpoints("default").Create(context.TODO(), endpoints, metav1.CreateOptions{})
+				require.NoError(t, err)
+			},
+			removeLeader: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				storedEndpoints, err := client.CoreV1().Endpoints("default").Get(context.TODO(), serviceName, metav1.GetOptions{})
+				require.NoError(t, err)
+				storedEndpoints.Subsets[0].Addresses = storedEndpoints.Subsets[0].Addresses[0:1]
+				_, err = client.CoreV1().Endpoints("default").Update(context.TODO(), storedEndpoints, metav1.UpdateOptions{})
+				require.NoError(t, err)
 			},
 		},
-		Endpoints: []discv1.Endpoint{
-			{
-				Addresses: []string{"1.1.1.1"},
-				TargetRef: &v1.ObjectReference{
-					Kind:      "Pod",
-					Namespace: "default",
-					Name:      "foo",
-				},
-				NodeName: &nodeName,
+		{
+			name:              "with EndpointSlices",
+			useEndpointSlices: true,
+			setupEndpoints: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				nodeName := "test-node"
+				endpointSlice := &discv1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      serviceName + "-abc123",
+						Namespace: "default",
+						Labels:    map[string]string{apiserver.KubernetesServiceNameLabel: serviceName},
+					},
+					Endpoints: []discv1.Endpoint{
+						{
+							Addresses: []string{"1.1.1.1"},
+							TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "foo"},
+							NodeName:  &nodeName,
+						},
+						{
+							Addresses: []string{"1.1.1.2"},
+							TargetRef: &v1.ObjectReference{Kind: "Pod", Namespace: "default", Name: "bar"},
+							NodeName:  &nodeName,
+						},
+					},
+				}
+				_, err := client.DiscoveryV1().EndpointSlices("default").Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
+				require.NoError(t, err)
 			},
-			{
-				Addresses: []string{"1.1.1.2"},
-				TargetRef: &v1.ObjectReference{
-					Kind:      "Pod",
-					Namespace: "default",
-					Name:      "bar",
-				},
-				NodeName: &nodeName,
+			removeLeader: func(t *testing.T, client *fake.Clientset, serviceName string) {
+				storedSlice, err := client.DiscoveryV1().EndpointSlices("default").Get(context.TODO(), serviceName+"-abc123", metav1.GetOptions{})
+				require.NoError(t, err)
+				storedSlice.Endpoints = storedSlice.Endpoints[0:1]
+				_, err = client.DiscoveryV1().EndpointSlices("default").Update(context.TODO(), storedSlice, metav1.UpdateOptions{})
+				require.NoError(t, err)
 			},
 		},
 	}
-	storedSlice, err := client.DiscoveryV1().EndpointSlices("default").Create(context.TODO(), endpointSlice, metav1.CreateOptions{})
-	require.NoError(t, err)
 
-	// Run leader election
-	le.leaderElector, err = le.newElection()
-	require.NoError(t, err)
-	err = le.EnsureLeaderElectionRuns()
-	require.NoError(t, err)
-	lease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
-	require.NoError(t, err)
-	require.NotNil(t, lease.Spec.LeaseTransitions)
-	require.Equal(t, int32(1), *lease.Spec.LeaseTransitions)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
 
-	// We should be follower, and GetLeaderIP should return bar's IP
-	require.False(t, le.IsLeader())
-	ip, err := le.GetLeaderIP()
-	assert.NoError(t, err)
-	assert.Equal(t, "1.1.1.2", ip)
+			// Set up config for EndpointSlices if needed
+			if tc.useEndpointSlices {
+				cache.Cache.Set("useEndpointSlices", true, time.Hour)
+				defer cache.Cache.Delete("useEndpointSlices")
+			}
 
-	// Remove bar from endpointslice and clear cache
-	cache.Cache.Delete("ip://bar")
-	storedSlice.Endpoints = storedSlice.Endpoints[0:1]
-	_, err = client.DiscoveryV1().EndpointSlices("default").Update(context.TODO(), storedSlice, metav1.UpdateOptions{})
-	require.NoError(t, err)
+			le := &LeaderEngine{
+				ctx:             context.Background(),
+				HolderIdentity:  "foo",
+				LeaseName:       leaseName,
+				ServiceName:     serviceName,
+				LeaderNamespace: "default",
+				LeaseDuration:   120 * time.Second,
+				coreClient:      client.CoreV1(),
+				coordClient:     client.CoordinationV1(),
+				discoveryClient: client.DiscoveryV1(),
+				leaderMetric:    &dummyGauge{},
+				lockType:        rl.LeasesResourceLock,
+			}
 
-	// GetLeaderIP will "gracefully" error out
-	ip, err = le.GetLeaderIP()
-	assert.Equal(t, "", ip)
-	assert.True(t, dderrors.IsNotFound(err))
+			// Create leader-election lease with current node as follower
+			electionLease := makeLeaderLease(leaseName, "default", "bar", 120)
+			_, err := client.CoordinationV1().Leases("default").Create(context.TODO(), electionLease, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			tc.setupEndpoints(t, client, serviceName)
+
+			// Run leader election
+			le.leaderElector, err = le.newElection()
+			require.NoError(t, err)
+			err = le.EnsureLeaderElectionRuns()
+			require.NoError(t, err)
+			lease, err := client.CoordinationV1().Leases("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, lease.Spec.LeaseTransitions)
+			require.Equal(t, int32(1), *lease.Spec.LeaseTransitions)
+
+			// We should be follower, and GetLeaderIP should return bar's IP
+			require.False(t, le.IsLeader())
+			ip, err := le.GetLeaderIP()
+			assert.NoError(t, err)
+			assert.Equal(t, "1.1.1.2", ip, "GetLeaderIP should return same result for both APIs")
+
+			// Remove bar from endpoints/endpointslice and clear cache
+			cache.Cache.Delete("ip://bar")
+			tc.removeLeader(t, client, serviceName)
+
+			// GetLeaderIP will "gracefully" error out
+			// Same behavior expected for both APIs
+			ip, err = le.GetLeaderIP()
+			assert.Equal(t, "", ip, "GetLeaderIP should return empty when leader not found")
+			assert.True(t, dderrors.IsNotFound(err), "GetLeaderIP should return NotFound error")
+		})
+	}
 }
 
 type dummyGauge struct{}


### PR DESCRIPTION
### What does this PR do?

Configures leader election, specifically leader IP resolution, to use EndpointSlices when `kubernetes_use_endpoint_slices` is enabled.

### Motivation

This is part of an effort to keep the datadog agent up to date with the latest kubernetes APIs, specifically using [EndpointSlice as the default](https://datadoghq.atlassian.net/browse/CONTP-1238) instead of the recently deprecated Endpoints API.

### Describe how you validated your changes

- Updated leadership election test suite ✅ 
- QA'd confirming leader election continues to work

**Follower & Leader assigned:**
<img width="1482" height="543" alt="image" src="https://github.com/user-attachments/assets/b1f8f2aa-6511-4296-89d9-1cd4abde5005" />

<img width="854" height="437" alt="image" src="https://github.com/user-attachments/assets/00080daa-2548-41e1-a0ff-5eeeb4cee096" />

### Additional Notes
