### PR TITLE
[AGNTLOG-231] Fixed UTF-16 encoding at byte level by updating framer contentLenLimit

### DIFF
--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -91,8 +91,16 @@ func NewFramer(
 	case UTF8Newline:
 		matcher = &oneByteNewLineMatcher{contentLenLimit}
 	case UTF16BENewline:
+		contentLenLimit = contentLenLimit & ^0x1 // align to 2-byte character boundary for UTF-16
+		if contentLenLimit < 2 {
+			contentLenLimit = 2
+		}
 		matcher = &twoByteNewLineMatcher{contentLenLimit: contentLenLimit, newline: Utf16beEOL}
 	case UTF16LENewline:
+		contentLenLimit = contentLenLimit & ^0x1 // align to 2-byte character boundary for UTF-16
+		if contentLenLimit < 2 {
+			contentLenLimit = 2
+		}
 		matcher = &twoByteNewLineMatcher{contentLenLimit: contentLenLimit, newline: Utf16leEOL}
 	case SHIFTJISNewline:
 		// No special handling required for the newline matcher since Shift JIS does not use

--- a/releasenotes/notes/utf-16-truncation-fix-4e06b5e3385ffe2f.yaml
+++ b/releasenotes/notes/utf-16-truncation-fix-4e06b5e3385ffe2f.yaml
@@ -1,0 +1,18 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug where tailing UTF-16 encoded log files (UTF-16-LE or UTF-16-BE) could
+    produce mojibake (garbled text) when log lines exceeded the configured
+    ``logs_config.max_message_size_bytes`` limit (default 900KB). The truncation was
+    performed at the byte level without respecting 2-byte UTF-16 character boundaries,
+    which could split a character in half and produce Unicode replacement characters
+    (U+FFFD) after decoding. The framer now aligns the truncation limit to a 2-byte
+    boundary for UTF-16 encodings, ensuring that truncated frames always contain
+    valid UTF-16 data.


### PR DESCRIPTION
### What does this PR do?

- Aligns contentLenLimit to a 2-byte boundary at construction time in NewFramer() for UTF-16 framing types. This ensures the fallback truncation path in Framer.Process (which slices at buf[:contentLenLimit] when no newline is found) doesn't split a UTF-16 character in half. This previously caused U+FFFD replacement characters (mojibake) after decoding. Also clamps the minimum to 2 to avoid a degenerate zero-length frame loop.

### Motivation

[Ticket](https://datadoghq.atlassian.net/jira/software/c/projects/AGNTLOG/boards/8654?quickFilter=10125&selectedIssue=AGNTLOG-231)

### Describe how you validated your changes
- Added framer unit tests covering both truncation paths (matcher and fallback) with odd contentLenLimit for UTF-16-LE and UTF-16-BE, verifying all frame content has even byte length.
- Added an end-to-end test that feeds a long UTF-16-LE line through the framer with an odd limit and asserts no characters are split.

#### Manual QA

I used a test script to validate my changes:

```bash
bash test_utf16_truncation_qa.sh
```

**Script**:
```bash
#!/usr/bin/env bash
# This script:
#   1. Generates a UTF-16-LE log file with lines that exceed the truncation limit
#   2. Sets up agent config for UTF-16-LE tailing
#   3. Builds and starts the agent in the background
#   4. Appends new lines to trigger tailing
#   5. Captures stream-logs output
#   6. Checks for mojibake (U+FFFD replacement characters)
#
# Prerequisites:
#   - Run from the datadog-agent repo root
#   - dda inv available for building

set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
cd "$SCRIPT_DIR"

LOG_FILE="/tmp/utf16_test.log"
STREAM_OUTPUT="/tmp/stream_logs_output.txt"
MAX_MSG_SIZE=500
AGENT_BIN="./bin/agent/agent"
AGENT_CONF="bin/agent/dist/datadog.yaml"
DEV_CONF_D="dev/dist/conf.d/custom_logs.d"
BIN_CONF_D="bin/agent/dist/conf.d/custom_logs.d"
CHAR_LIMIT=$((MAX_MSG_SIZE / 2))  # UTF-16 = 2 bytes per char

cleanup() {
    echo "Cleaning up..."
    [[ -n "${AGENT_PID:-}" ]] && kill "$AGENT_PID" 2>/dev/null || true
    [[ -n "${STREAM_PID:-}" ]] && kill "$STREAM_PID" 2>/dev/null || true
    rm -f "$LOG_FILE"
    # Keep $STREAM_OUTPUT for post-run inspection
}
trap cleanup EXIT

# ── 0. Ensure agent config is set up ────────────────────────────────────────
echo "==> Setting up agent config..."

# Ensure logs_config.max_message_size_bytes is set in datadog.yaml
for yaml in dev/dist/datadog.yaml bin/agent/dist/datadog.yaml; do
    if [[ -f "$yaml" ]] && ! grep -q 'max_message_size_bytes' "$yaml" 2>/dev/null; then
        cat >> "$yaml" <<EOF

logs_enabled: true
logs_config:
  max_message_size_bytes: $MAX_MSG_SIZE
EOF
        echo "   Added logs_config.max_message_size_bytes: $MAX_MSG_SIZE to $yaml"
    else
        echo "   $yaml already has max_message_size_bytes configured (or doesn't exist yet)"
    fi
done

# Ensure the custom log source for UTF-16-LE tailing exists in both dev and bin dirs
CONF_YAML_CONTENT="---
logs:
  - type: file
    path: $LOG_FILE
    encoding: utf-16-le
    service: utf16-qa-test
    source: utf16-qa-test"

for conf_d in "$DEV_CONF_D" "$BIN_CONF_D"; do
    mkdir -p "$conf_d"
    echo "$CONF_YAML_CONTENT" > "$conf_d/conf.yaml"
    echo "   Wrote $conf_d/conf.yaml (encoding: utf-16-le, path: $LOG_FILE)"
done

# ── 1. Generate UTF-16-LE test log file ──────────────────────────────────────
echo "==> Generating UTF-16-LE test log: $LOG_FILE"

generate_utf16le_line() {
    # Convert ASCII string to UTF-16-LE bytes (each char -> char + \x00)
    local text="$1"
    printf '%s' "$text" | iconv -f UTF-8 -t UTF-16LE
    # UTF-16-LE newline
    printf '\n\x00'
}

# Write BOM + test lines
printf '\xff\xfe' > "$LOG_FILE"

# Short line (well under limit)
generate_utf16le_line "[0001|short] $(printf 'A%.0s' $(seq 1 30))" >> "$LOG_FILE"

# Exactly at limit
padding=$(printf 'B%.0s' $(seq 1 $((CHAR_LIMIT - 20))))
generate_utf16le_line "[0002|at_limit] $padding" >> "$LOG_FILE"

# Over limit — should be truncated
padding=$(printf 'C%.0s' $(seq 1 $((CHAR_LIMIT * 2))))
generate_utf16le_line "[0003|over_limit] $padding" >> "$LOG_FILE"

# Way over limit
padding=$(printf 'D%.0s' $(seq 1 $((CHAR_LIMIT * 3))))
generate_utf16le_line "[0004|way_over] $padding" >> "$LOG_FILE"

echo "   Generated $(wc -c < "$LOG_FILE") bytes"

# ── 2. Build & start the agent ───────────────────────────────────────────────
if [[ -x "$AGENT_BIN" ]]; then
    echo "==> Agent binary already exists at $AGENT_BIN, skipping build."
    echo "   (Delete it and re-run if you want a fresh build.)"
else
    echo "==> Building agent..."
    dda inv agent.build --build-exclude=systemd
    if [[ ! -x "$AGENT_BIN" ]]; then
        echo "ERROR: Build failed — $AGENT_BIN not found."
        exit 1
    fi
fi

echo "==> Starting agent in background..."
$AGENT_BIN run -c "$AGENT_CONF" &>/dev/null &
AGENT_PID=$!
sleep 5

# ── 3. Start stream-logs capture ─────────────────────────────────────────────
echo "==> Capturing stream-logs output..."
$AGENT_BIN stream-logs -c "$AGENT_CONF" > "$STREAM_OUTPUT" 2>/dev/null &
STREAM_PID=$!
sleep 3

# ── 4. Append new lines to trigger tailing ───────────────────────────────────
echo "==> Appending lines to trigger tailing..."
for i in $(seq 1 5); do
    if (( i % 2 == 0 )); then
        # Long line — triggers truncation
        padding=$(printf 'X%.0s' $(seq 1 $((CHAR_LIMIT * 2))))
        generate_utf16le_line "[APPEND|long_$i] $padding" >> "$LOG_FILE"
    else
        generate_utf16le_line "[APPEND|short_$i] Hello from line $i" >> "$LOG_FILE"
    fi
    sleep 1
done

sleep 5
kill "$STREAM_PID" 2>/dev/null || true
wait "$STREAM_PID" 2>/dev/null || true
unset STREAM_PID

# ── 5. Verify output ─────────────────────────────────────────────────────────
echo "==> Verifying stream-logs output for mojibake..."
echo ""

if [[ ! -s "$STREAM_OUTPUT" ]]; then
    echo "WARNING: stream-logs output is empty. Check that the agent started correctly."
    echo "You can verify manually: $AGENT_BIN stream-logs -c $AGENT_CONF"
    exit 1
fi

# Look for U+FFFD (UTF-8 bytes: 0xEF 0xBF 0xBD) which is the replacement character
if grep -P '\xef\xbf\xbd' "$STREAM_OUTPUT" > /dev/null 2>&1; then
    echo "FAIL: Mojibake detected (U+FFFD replacement characters found)"
    echo ""
    echo "Lines with issues:"
    grep -n -P '\xef\xbf\xbd' "$STREAM_OUTPUT" | head -5
    exit 1
else
    echo "PASS: No mojibake detected"
fi

# Confirm truncation actually happened — long lines get split into continuation
# chunks whose Message field starts with raw content (no [tag] prefix).
CONTINUATION_COUNT=$(grep -c '| Message: XXXX' "$STREAM_OUTPUT" || true)
if [[ "$CONTINUATION_COUNT" -gt 0 ]]; then
    echo "  Found $CONTINUATION_COUNT continuation chunk(s) — truncation is working correctly."
else
    echo "  WARNING: No continuation chunks found — lines may not have exceeded the limit."
    echo "  Check logs_config.max_message_size_bytes is set to $MAX_MSG_SIZE in $AGENT_CONF"
fi

echo ""
echo "Done. Output saved to: $STREAM_OUTPUT"
```

**Results**:
<img width="1381" height="277" alt="image" src="https://github.com/user-attachments/assets/00d993ce-2a08-486e-8037-3c5118a4c86a" />

- Look at the [APPEND|long_2] and [APPEND|long_4] lines. Each long line got split into exactly 3 chunks:
[APPEND|long_2] XXXX...XXXX, first 250 chars (500 bytes = the max_message_size_bytes limit)
XXXX...XXXX, next 250 chars (continuation chunk)
XXXXXXXXXXXXXXXX, remaining 16 chars (tail end)
That's because each long line was CHAR_LIMIT * 2 = 500 characters = 1000 UTF-16-LE bytes, plus the [APPEND|long_N] prefix (~17 chars). So ~517 chars total, which at 2 bytes each = ~1034 bytes. With a 500-byte limit, it takes 3 chunks to deliver the full line.

