### PR TITLE
[CASCL-876] feat(orchestrator): add EKS Auto Mode CRD collection for eks.amazonaws.com

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -44,6 +44,7 @@ const (
 	KarpenterAPIGroup       = "karpenter.sh"
 	KarpenterAWSAPIGroup    = "karpenter.k8s.aws"
 	KarpenterAzureAPIGroup  = "karpenter.azure.com"
+	EKSAPIGroup             = "eks.amazonaws.com"
 )
 
 var (
@@ -525,6 +526,9 @@ func newBuiltinCRDConfigs() []builtinCRDConfig {
 		newBuiltinCRDConfig(KarpenterAPIGroup, "", isOOTBCRDEnabled, "v1"),
 		newBuiltinCRDConfig(KarpenterAWSAPIGroup, "", isOOTBCRDEnabled, "v1"),
 		newBuiltinCRDConfig(KarpenterAzureAPIGroup, "", isOOTBCRDEnabled, "v1beta1"),
+
+		// EKS Auto Mode resources (for now only nodeclasses, but we can easily add more in the future if needed)
+		newBuiltinCRDConfig(EKSAPIGroup, "nodeclasses", isOOTBCRDEnabled, "v1", "v1beta1"),
 	}
 }
 

--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go
@@ -426,6 +426,9 @@ func TestNewBuiltinCRDConfigs(t *testing.T) {
 		"karpenter.sh/v1/",
 		"karpenter.k8s.aws/v1/",
 		"karpenter.azure.com/v1beta1/",
+
+		// EKS Auto Mode NodeClass resource
+		"eks.amazonaws.com/v1/nodeclasses",
 	}
 
 	// Verify all expected configs are present

--- a/releasenotes-dca/notes/collect-eks-automode-custom-resources-by-default-cascl876.yaml
+++ b/releasenotes-dca/notes/collect-eks-automode-custom-resources-by-default-cascl876.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the ability to collect NodeClasses EKS Auto Mode custom resources (``eks.amazonaws.com`` API group) by default.


### PR DESCRIPTION
## Summary

- Adds automatic collection of NodeClasses CRDs from the `eks.amazonaws.com` API group via the existing OOTB built-in CRD collection infrastructure
- Prefers version `v1`, with `v1beta1` as a fallback
- Consistent with how Karpenter resources (`karpenter.sh/v1`, `karpenter.k8s.aws/v1`, `karpenter.azure.com/v1beta1`) are already collected
- Enabled/disabled via the existing `orchestrator_explorer.custom_resources.ootb.enabled` config flag

## Changes

- `pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go`: add `EKSAPIGroup` constant and register the API group in `newBuiltinCRDConfigs()`
- `pkg/collector/corechecks/cluster/orchestrator/collector_bundler_test.go`: add `eks.amazonaws.com/v1/` to expected built-in CRD config list

## Test plan

- [x] `TestNewBuiltinCRDConfigs` — PASS
- [x] `TestImportBuiltinCollectors` — PASS
- [x] `TestGetDatadogCustomResourceCollectors` — PASS
- [x] `TestFilterCRCollectorsByPermission` — PASS

Jira: CASCL-876

🤖 Generated with [Claude Code](https://claude.com/claude-code)