### PR TITLE
[CONTP-1257] feat(kube_metadata): Migrate to EndpointSlice for NodeMetadataMapping

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_kubelet.go
@@ -11,6 +11,7 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	discv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -19,28 +20,54 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
-// NodeMetadataMapping only fetch the endpoints from Kubernetes apiserver and add the metadataMapper of the
-// node to the cache
+// NodeMetadataMapping fetches endpoints or endpointslices from Kubernetes apiserver and adds the metadataMapper
+// of the node to the cache
 // Only called when the node agent computes the metadata mapper locally and does not rely on the DCA.
 func (c *APIClient) NodeMetadataMapping(nodeName string, pods []*kubelet.Pod) error {
-	endpointList, err := c.Cl.CoreV1().Endpoints("").List(context.TODO(), metav1.ListOptions{TimeoutSeconds: pointer.Ptr(int64(c.defaultClientTimeout.Seconds())), ResourceVersion: "0"})
-	if err != nil {
-		log.Errorf("Could not collect endpoints from the API Server: %q", err.Error())
-		return err
-	}
-	if endpointList.Items == nil {
-		log.Debug("No endpoints collected from the API server")
-		return nil
-	}
-	log.Debugf("Successfully collected endpoints")
-
 	var node v1.Node
 	var nodeList v1.NodeList
 	node.Name = nodeName
-
 	nodeList.Items = append(nodeList.Items, node)
 
-	processKubeServices(&nodeList, pods, endpointList)
+	if UseEndpointSlices() {
+		sliceList, err := c.Cl.DiscoveryV1().EndpointSlices("").List(
+			context.TODO(),
+			metav1.ListOptions{
+				TimeoutSeconds:  pointer.Ptr(int64(c.defaultClientTimeout.Seconds())),
+				ResourceVersion: "0",
+			},
+		)
+		if err != nil {
+			log.Errorf("Could not collect endpointslices from the API Server: %q", err.Error())
+			return err
+		}
+		if len(sliceList.Items) == 0 {
+			log.Debug("No endpointslices collected from the API server")
+			return nil
+		}
+		log.Debugf("Successfully collected %d endpointslices", len(sliceList.Items))
+
+		processKubeServicesFromEndpointSlices(&nodeList, pods, sliceList.Items)
+	} else {
+		endpointList, err := c.Cl.CoreV1().Endpoints("").List(
+			context.TODO(),
+			metav1.ListOptions{
+				TimeoutSeconds:  pointer.Ptr(int64(c.defaultClientTimeout.Seconds())),
+				ResourceVersion: "0",
+			},
+		)
+		if err != nil {
+			log.Errorf("Could not collect endpoints from the API Server: %q", err.Error())
+			return err
+		}
+		if endpointList.Items == nil {
+			log.Debug("No endpoints collected from the API server")
+			return nil
+		}
+		log.Debugf("Successfully collected %d endpoints", len(endpointList.Items))
+
+		processKubeServices(&nodeList, pods, endpointList)
+	}
 	return nil
 }
 
@@ -53,32 +80,56 @@ func processKubeServices(nodeList *v1.NodeList, pods []*kubelet.Pod, endpointLis
 	for _, node := range nodeList.Items {
 		nodeName := node.Name
 		nodeNameCacheKey := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName)
-		freshness := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName, "freshness")
-
-		cacheData, found := cache.Cache.Get(nodeNameCacheKey)        // We get the old one with the dead pods. if diff reset metabundle and deleted key. Then compute again.
-		freshnessCache, freshnessFound := cache.Cache.Get(freshness) // if expired, freshness not found deal with that
-
 		newMetaBundle := NewMetadataMapperBundle()
-		if !found {
-			cache.Cache.Set(freshness, len(pods), metadataMapExpire)
-		}
-
-		// We want to churn the cache every `metadataMapExpire` and if the number of entries varies between 2 runs..
-		// If a pod is killed and rescheduled during a run, we will only keep the old entry for another run, which is acceptable.
-		if found && freshnessCache != len(pods) || !freshnessFound {
-			cache.Cache.Set(freshness, len(pods), metadataMapExpire)
-			log.Debugf("Refreshing cache for %s", nodeNameCacheKey)
-		} else {
-			oldMetadataBundle, ok := cacheData.(*MetadataMapperBundle)
-			if ok {
-				newMetaBundle.DeepCopy(oldMetadataBundle)
-			}
-		}
+		cacheMetadata(nodeName, nodeNameCacheKey, newMetaBundle, pods)
 
 		if err := newMetaBundle.mapServices(nodeName, pods, *endpointList); err != nil {
 			log.Errorf("Could not map the services on node %s: %s", node.Name, err.Error())
 			continue
 		}
 		cache.Cache.Set(nodeNameCacheKey, newMetaBundle, metadataMapExpire)
+	}
+}
+
+// processKubeServicesFromEndpointSlices adds services to the metadataMapper cache using EndpointSlices
+func processKubeServicesFromEndpointSlices(nodeList *v1.NodeList, pods []*kubelet.Pod, slices []discv1.EndpointSlice) {
+	if nodeList.Items == nil || len(pods) == 0 || len(slices) == 0 {
+		return
+	}
+	log.Debugf("Identified: %d node, %d pod, %d endpointslices", len(nodeList.Items), len(pods), len(slices))
+	for _, node := range nodeList.Items {
+		nodeName := node.Name
+		nodeNameCacheKey := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName)
+		newMetaBundle := NewMetadataMapperBundle()
+		cacheMetadata(nodeName, nodeNameCacheKey, newMetaBundle, pods)
+
+		if err := newMetaBundle.mapServicesFromEndpointSlices(nodeName, pods, slices); err != nil {
+			log.Errorf("Could not map the services on node %s: %s", node.Name, err.Error())
+			continue
+		}
+		cache.Cache.Set(nodeNameCacheKey, newMetaBundle, metadataMapExpire)
+	}
+}
+
+func cacheMetadata(nodeName string, cacheKey string, bundle *MetadataMapperBundle, pods []*kubelet.Pod) {
+	freshness := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName, "freshness")
+
+	cacheData, found := cache.Cache.Get(cacheKey)                // We get the old one with the dead pods. if diff reset metabundle and deleted key. Then compute again.
+	freshnessCache, freshnessFound := cache.Cache.Get(freshness) // if expired, freshness not found deal with that
+
+	if !found {
+		cache.Cache.Set(freshness, len(pods), metadataMapExpire)
+	}
+
+	// We want to churn the cache every `metadataMapExpire` and if the number of entries varies between 2 runs..
+	// If a pod is killed and rescheduled during a run, we will only keep the old entry for another run, which is acceptable.
+	if found && freshnessCache != len(pods) || !freshnessFound {
+		cache.Cache.Set(freshness, len(pods), metadataMapExpire)
+		log.Debugf("Refreshing cache for %s", cacheKey)
+	} else {
+		oldMetadataBundle, ok := cacheData.(*MetadataMapperBundle)
+		if ok {
+			bundle.DeepCopy(oldMetadataBundle)
+		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Migrates node agent's `NodeMetadataMapping` to use EndpointSlices when `kubernetes_use_endpoint_slices` is enabled. This completes the EndpointSlices migration by updating the last remaining component that queries the Endpoints API.

### Motivation

This is part of an ongoing effort to migrate the Datadog Agent to use [EndpointSlices as the default](https://datadoghq.atlassian.net/browse/CONTP-1238) instead of the recently deprecated Endpoints API.

`NodeMetadataMapping` is only used when the node agent runs without DCA (uncommon configuration), but it's the last piece that needed migration. The function lists **all** Endpoints/EndpointSlices across the cluster to build
  pod→service mappings for tagging.

### Describe how you validated your changes

### Additional Notes

**RBAC Consideration:** Node agents deployed with older Helm charts may not have EndpointSlices list permissions. If RBAC is missing, the agent will log an error and could fail to populate service tags. https://github.com/DataDog/helm-charts/pull/2399 adds 'endpointslices' read permissions to the node agent.

To address this concern, we could add an RBAC-aware fallback mechanism into `UseEndpointSlices` to check if the agent the permissions it needs.
