### PR TITLE
Remove embedded3.COMPRESSED file

### DIFF
--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -272,6 +272,15 @@ def _build_wxs(ctx, env, outdir, ca_dll):
     if not os.path.exists(wixsetup):
         raise Exit(f"WXS builder not found: {wixsetup}")
 
+    # Delete stale embedded3.COMPRESSED so that debug builds always re-compress
+    # from the current source directory (e.g. after fetch_artifacts updates
+    # C:\opt\datadog-agent\embedded3). In debug builds CompressedDir.cs skips
+    # re-compression when the file already exists.
+    compressed_file = os.path.join(BUILD_SOURCE_DIR, 'WixSetup', 'embedded3.COMPRESSED')
+    if os.path.exists(compressed_file):
+        print(f"Deleting stale compressed file: {compressed_file}")
+        os.remove(compressed_file)
+
     # Run the builder to produce the WXS
     # Set an env var to tell WixSetup.exe where to put the output
     env['AGENT_MSI_OUTDIR'] = outdir

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -272,15 +272,6 @@ def _build_wxs(ctx, env, outdir, ca_dll):
     if not os.path.exists(wixsetup):
         raise Exit(f"WXS builder not found: {wixsetup}")
 
-    # Delete stale embedded3.COMPRESSED so that debug builds always re-compress
-    # from the current source directory (e.g. after fetch_artifacts updates
-    # C:\opt\datadog-agent\embedded3). In debug builds CompressedDir.cs skips
-    # re-compression when the file already exists.
-    compressed_file = os.path.join(BUILD_SOURCE_DIR, 'WixSetup', 'embedded3.COMPRESSED')
-    if os.path.exists(compressed_file):
-        print(f"Deleting stale compressed file: {compressed_file}")
-        os.remove(compressed_file)
-
     # Run the builder to produce the WXS
     # Set an env var to tell WixSetup.exe where to put the output
     env['AGENT_MSI_OUTDIR'] = outdir
@@ -712,6 +703,14 @@ def fetch_artifacts(ctx, ref: str | None = None) -> None:
                 zip_ref.extractall(dest)
 
         print("Extraction complete")
+
+    # Delete stale embedded3.COMPRESSED so the next debug build re-compresses
+    # from the fresh artifacts. In debug builds CompressedDir.cs skips
+    # re-compression when the file already exists.
+    compressed_file = os.path.join(BUILD_SOURCE_DIR, 'WixSetup', 'embedded3.COMPRESSED')
+    if os.path.exists(compressed_file):
+        print(f"Deleting stale compressed file: {compressed_file}")
+        os.remove(compressed_file)
 
 
 def download_latest_artifacts_for_ref(project: Project, ref_name: str, output_dir: str) -> None:


### PR DESCRIPTION
### What does this PR do?
Deletes stale embedded3.COMPRESSED so that debug builds always re-compress from the current source directory (e.g. after `msi.fetch_artifacts` updates `C:\opt\datadog-agent\embedded3)`. In debug builds `CompressedDir.cs` skips re-compression when the file already exists, causing the python integrations to not be updated when running the MSI.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2390

### Describe how you validated your changes
Run `dda inv msi.build --debug` and run the MSI. `C:\Program Files\Datadog\Datadog Agent\embedded3` should now be updated from the fetch artifacts.

### Additional Notes
