### PR TITLE
don't coerce %%env_*%% template variable values

### DIFF
--- a/pkg/util/tmplvar/resolver.go
+++ b/pkg/util/tmplvar/resolver.go
@@ -341,11 +341,16 @@ func resolveStringWithAdHocTemplateVars(in string, res Resolvable, templateVaria
 		varIndexes[0][0] == 0 &&
 		varIndexes[0][1] == len(in) {
 
-		if i, e := strconv.ParseInt(out.(string), 0, 64); e == nil {
-			return i, err
-		}
-		if b, e := strconv.ParseBool(out.(string)); e == nil {
-			return b, err
+		// %%env_*%% values should not be coerced as they may mismatch with checks
+		// or be parsed incorrectly if they have a base like base-0 ex: "0123456" becomes 42798
+		singleVarName := in[varIndexes[0][2]:varIndexes[0][3]]
+		if singleVarName != "env" {
+			if i, e := strconv.ParseInt(out.(string), 0, 64); e == nil {
+				return i, err
+			}
+			if b, e := strconv.ParseBool(out.(string)); e == nil {
+				return b, err
+			}
 		}
 	}
 	return


### PR DESCRIPTION
### What does this PR do?
updates the tmplvar resolver to not coerce %%env_*%% template variable due to issues like this: https://github.com/DataDog/datadog-agent/issues/12065 ([JIRA](https://datadoghq.atlassian.net/browse/DBMON-6151))

### Motivation
While coercing variables is good for varaibles like `port`, it can cause issues with other variables such as converting numbers to a different base, or being rejected by checks as seen in the JIRA ticket.

### Describe how you validated your changes
CI, Test

You can use the unit tests added without the applied fix as a regression test 

QA Guide:

First build the agent without the fix
`dda inv agent.build --build-exclude=systemd `

export variables that we can check 
```
export DD_PG_PASS_NUMERIC="123456"
export DD_PG_PASS_OCTAL="0123456"
export DD_PG_PASS_BOOL="true"
```

create a test config
```
  cat > bin/agent/dist/conf.d/postgres.d/conf.yaml << 'EOF'                                  
  instances:
    - host: localhost
      port: 5432
      username: "%%env_DD_PG_PASS_NUMERIC%%"
      password: hunter2
  EOF
```

run the agent 
`./bin/agent/agent run -c bin/agent/dist/datadog.yaml`

in another terminal run config check
```
DD_PG_PASS_NUMERIC=123456 ./bin/agent/agent configcheck -c bin/agent/dist/datadog.yaml \
    2>/dev/null | grep -A8 "=== postgres"
```

This should return a coerced variable of 123456 (int)

then do the steps over again with the applied changes in this PR

That should return a non coerced variable of "123456"

### Additional Notes
