### PR TITLE
Enhance Remote Agent Registry capabilities to include status and flare command fetching

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -89,6 +89,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/pid"
 	"github.com/DataDog/datadog-agent/comp/core/pid/pidimpl"
 	flareprofiler "github.com/DataDog/datadog-agent/comp/core/profiler/fx"
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	remoteagentregistryfx "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/fx"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
@@ -426,8 +427,12 @@ func getSharedFxOption() fx.Option {
 		fx.Provide(func(config config.Component) status.InformationProvider {
 			return status.NewInformationProvider(clusteragentStatus.GetProvider(config))
 		}),
-		fx.Provide(func(sysprobeconfig sysprobeconfig.Component) status.InformationProvider {
-			return status.NewInformationProvider(systemprobeStatus.GetProvider(sysprobeconfig))
+		fx.Provide(func(deps struct {
+			fx.In
+			SysProbeConfig sysprobeconfig.Component
+			RAR            remoteagentregistry.Component `optional:"true"`
+		}) status.InformationProvider {
+			return status.NewInformationProvider(systemprobeStatus.GetProvider(deps.SysProbeConfig, deps.RAR))
 		}),
 		fx.Provide(func(config config.Component) status.InformationProvider {
 			return status.NewInformationProvider(httpproxyStatus.GetProvider(config))

--- a/comp/core/remoteagent/helper/expvar.go
+++ b/comp/core/remoteagent/helper/expvar.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package helper
+
+import (
+	"encoding/json"
+	"expvar"
+)
+
+// ExpvarFields returns a map of all currently registered expvar key-value pairs
+func ExpvarFields() map[string]string {
+	fields := make(map[string]string)
+	expvar.Do(func(kv expvar.KeyValue) {
+		var v any
+		if err := json.Unmarshal([]byte(kv.Value.String()), &v); err == nil {
+			if pretty, err := json.MarshalIndent(v, "", "  "); err == nil {
+				fields[kv.Key] = string(pretty)
+				return
+			}
+		}
+		fields[kv.Key] = kv.Value.String()
+	})
+	return fields
+}
+
+// ExpvarData returns all currently registered expvar values as a structured map
+func ExpvarData() map[string]any {
+	data := make(map[string]any)
+	expvar.Do(func(kv expvar.KeyValue) {
+		var v any
+		if err := json.Unmarshal([]byte(kv.Value.String()), &v); err == nil {
+			data[kv.Key] = v
+		} else {
+			data[kv.Key] = kv.Value.String()
+		}
+	})
+	return data
+}

--- a/comp/core/remoteagent/impl-process/remoteagent.go
+++ b/comp/core/remoteagent/impl-process/remoteagent.go
@@ -8,7 +8,6 @@ package processimpl
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -100,22 +99,10 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 
 // GetStatusDetails returns the status details of the process agent
 func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
-	return &pbcore.GetStatusDetailsResponse{
-		MainSection: &pbcore.StatusSection{Fields: helper.ExpvarFields()},
-	}, nil
+	return helper.DefaultStatusResponse(), nil
 }
 
 // GetFlareFiles returns files for the process agent flare
 func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
-	files := make(map[string][]byte)
-
-	if data, err := json.MarshalIndent(helper.ExpvarData(), "", "  "); err == nil {
-		files["process_agent_status.json"] = data
-	}
-
-	if data, err := json.MarshalIndent(r.cfg.AllSettings(), "", "  "); err == nil {
-		files["process_agent_runtime_config_dump.json"] = data
-	}
-
-	return &pbcore.GetFlareFilesResponse{Files: files}, nil
+	return &pbcore.GetFlareFilesResponse{Files: helper.DefaultFlareFiles(r.cfg.AllSettings(), "process_agent")}, nil
 }

--- a/comp/core/remoteagent/impl-process/remoteagent_test.go
+++ b/comp/core/remoteagent/impl-process/remoteagent_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package processimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func TestGetStatusDetails(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetStatusDetails(context.Background(), &pbcore.GetStatusDetailsRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.MainSection)
+	assert.NotNil(t, resp.MainSection.Fields)
+	assert.Nil(t, resp.NamedSections)
+}
+
+func TestGetFlareFiles_ContainsExpectedFiles(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Files, "process_agent_status.json")
+	assert.Contains(t, resp.Files, "process_agent_runtime_config_dump.json")
+}
+
+func TestGetFlareFiles_FilesAreValidJSON(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+	require.NoError(t, err)
+
+	var statusData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["process_agent_status.json"], &statusData),
+		"process_agent_status.json should be valid JSON")
+
+	var configData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["process_agent_runtime_config_dump.json"], &configData),
+		"process_agent_runtime_config_dump.json should be valid JSON")
+}

--- a/comp/core/remoteagent/impl-securityagent/remoteagent.go
+++ b/comp/core/remoteagent/impl-securityagent/remoteagent.go
@@ -7,6 +7,9 @@
 package securityagentimpl
 
 import (
+	"context"
+	"encoding/json"
+	"expvar"
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -14,6 +17,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagent "github.com/DataDog/datadog-agent/comp/core/remoteagent/def"
 	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
+	"github.com/DataDog/datadog-agent/comp/core/status"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -25,6 +29,7 @@ type Requires struct {
 	Log       log.Component
 	IPC       ipc.Component
 	Config    config.Component
+	Status    status.Component
 }
 
 // Provides defines the output of the remoteagent component
@@ -51,8 +56,12 @@ func NewComponent(reqs Requires) (Provides, error) {
 		log:               reqs.Log,
 		ipc:               reqs.IPC,
 		cfg:               reqs.Config,
+		statusComp:        reqs.Status,
 		remoteAgentServer: remoteAgentServer,
 	}
+
+	pbcore.RegisterStatusProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
+	pbcore.RegisterFlareProviderServer(remoteAgentServer.GetGRPCServer(), remoteagentImpl)
 
 	provides := Provides{
 		Comp: remoteagentImpl,
@@ -61,10 +70,59 @@ func NewComponent(reqs Requires) (Provides, error) {
 }
 
 type remoteagentImpl struct {
-	log log.Component
-	ipc ipc.Component
-	cfg config.Component
+	log        log.Component
+	ipc        ipc.Component
+	cfg        config.Component
+	statusComp status.Component
 
 	remoteAgentServer *helper.UnimplementedRemoteAgentServer
 	pbcore.UnimplementedTelemetryProviderServer
+	pbcore.UnimplementedStatusProviderServer
+	pbcore.UnimplementedFlareProviderServer
+}
+
+// GetStatusDetails returns the status details of the security agent
+func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
+	mainFields := make(map[string]string)
+
+	// expvar data
+	expvar.Do(func(kv expvar.KeyValue) {
+		mainFields[kv.Key] = kv.Value.String()
+	})
+
+	if statusJSON, err := r.statusComp.GetStatus("json", false); err == nil {
+		mainFields["status"] = string(statusJSON)
+	}
+
+	return &pbcore.GetStatusDetailsResponse{
+		MainSection: &pbcore.StatusSection{Fields: mainFields},
+	}, nil
+}
+
+// GetFlareFiles returns files for the security agent flare
+func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
+	files := make(map[string][]byte)
+
+	if statusJSON, err := r.statusComp.GetStatus("json", false); err == nil {
+		files["security_agent_status.json"] = statusJSON
+	}
+
+	expvarData := make(map[string]any)
+	expvar.Do(func(kv expvar.KeyValue) {
+		var v any
+		if err := json.Unmarshal([]byte(kv.Value.String()), &v); err == nil {
+			expvarData[kv.Key] = v
+		} else {
+			expvarData[kv.Key] = kv.Value.String()
+		}
+	})
+	if data, err := json.MarshalIndent(expvarData, "", "  "); err == nil {
+		files["security_agent_expvar_dump.json"] = data
+	}
+
+	if data, err := json.MarshalIndent(r.cfg.AllSettings(), "", "  "); err == nil {
+		files["security_agent_runtime_config_dump.json"] = data
+	}
+
+	return &pbcore.GetFlareFilesResponse{Files: files}, nil
 }

--- a/comp/core/remoteagent/impl-securityagent/remoteagent_test.go
+++ b/comp/core/remoteagent/impl-securityagent/remoteagent_test.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package securityagentimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/status"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+// statusMock is a minimal status.Component implementation for testing.
+type statusMock struct {
+	statusJSON []byte
+	err        error
+}
+
+func (m *statusMock) GetStatus(_ string, _ bool, _ ...string) ([]byte, error) {
+	return m.statusJSON, m.err
+}
+
+func (m *statusMock) GetSections() []string {
+	return nil
+}
+
+func (m *statusMock) GetStatusBySections(_ []string, _ string, _ bool) ([]byte, error) {
+	return m.statusJSON, m.err
+}
+
+var _ status.Component = (*statusMock)(nil)
+
+func newStatusMock(statusJSON []byte) *statusMock {
+	return &statusMock{statusJSON: statusJSON}
+}
+
+func TestGetStatusDetails_IncludesExpvarAndStatus(t *testing.T) {
+	statusJSON := []byte(`{"agent":"security-agent","status":"running"}`)
+	impl := &remoteagentImpl{
+		cfg:        config.NewMock(t),
+		statusComp: newStatusMock(statusJSON),
+	}
+
+	resp, err := impl.GetStatusDetails(context.Background(), &pbcore.GetStatusDetailsRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.MainSection)
+	assert.NotNil(t, resp.MainSection.Fields)
+	// Status JSON from the status component should be present
+	assert.Equal(t, string(statusJSON), resp.MainSection.Fields["status"])
+}
+
+func TestGetFlareFiles_ContainsExpectedFiles(t *testing.T) {
+	statusJSON := []byte(`{"agent":"security-agent"}`)
+	impl := &remoteagentImpl{
+		cfg:        config.NewMock(t),
+		statusComp: newStatusMock(statusJSON),
+	}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Files, "security_agent_status.json")
+	assert.Contains(t, resp.Files, "security_agent_expvar_dump.json")
+	assert.Contains(t, resp.Files, "security_agent_runtime_config_dump.json")
+}
+
+func TestGetFlareFiles_StatusFileMatchesStatusComponent(t *testing.T) {
+	statusJSON := []byte(`{"agent":"security-agent","status":"running"}`)
+	impl := &remoteagentImpl{
+		cfg:        config.NewMock(t),
+		statusComp: newStatusMock(statusJSON),
+	}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+	require.NoError(t, err)
+
+	assert.Equal(t, statusJSON, resp.Files["security_agent_status.json"])
+}
+
+func TestGetFlareFiles_FilesAreValidJSON(t *testing.T) {
+	impl := &remoteagentImpl{
+		cfg:        config.NewMock(t),
+		statusComp: newStatusMock([]byte(`{}`)),
+	}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+	require.NoError(t, err)
+
+	var expvarData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["security_agent_expvar_dump.json"], &expvarData),
+		"security_agent_expvar_dump.json should be valid JSON")
+
+	var configData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["security_agent_runtime_config_dump.json"], &configData),
+		"security_agent_runtime_config_dump.json should be valid JSON")
+}

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -9,7 +9,6 @@ package systemprobeimpl
 import (
 	"context"
 	"encoding/json"
-	"expvar"
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -126,12 +125,8 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 
 // GetStatusDetails returns the status details of system-probe
 func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
-	fields := make(map[string]string)
-	expvar.Do(func(kv expvar.KeyValue) {
-		fields[kv.Key] = kv.Value.String()
-	})
 	return &pbcore.GetStatusDetailsResponse{
-		MainSection: &pbcore.StatusSection{Fields: fields},
+		MainSection: &pbcore.StatusSection{Fields: helper.ExpvarFields()},
 	}, nil
 }
 
@@ -139,16 +134,7 @@ func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatu
 func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
 	files := make(map[string][]byte)
 
-	expvarData := make(map[string]any)
-	expvar.Do(func(kv expvar.KeyValue) {
-		var v any
-		if err := json.Unmarshal([]byte(kv.Value.String()), &v); err == nil {
-			expvarData[kv.Key] = v
-		} else {
-			expvarData[kv.Key] = kv.Value.String()
-		}
-	})
-	if data, err := json.MarshalIndent(expvarData, "", "  "); err == nil {
+	if data, err := json.MarshalIndent(helper.ExpvarData(), "", "  "); err == nil {
 		files["system_probe_stats.json"] = data
 	}
 
@@ -156,7 +142,6 @@ func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFil
 		files["system_probe_runtime_config_dump.json"] = data
 	}
 
-	// prometheus telemetry
 	prometheusText, err := r.telemetry.GatherText(false, telemetry.NoFilter)
 	if err == nil {
 		files["system_probe_telemetry.log"] = []byte(prometheusText)

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/remoteagent/helper"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
@@ -153,7 +152,7 @@ func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFil
 		files["system_probe_stats.json"] = data
 	}
 
-	if data, err := json.MarshalIndent(pkgconfigsetup.SystemProbe().AllSettings(), "", "  "); err == nil {
+	if data, err := json.MarshalIndent(r.cfg.AllSettings(), "", "  "); err == nil {
 		files["system_probe_runtime_config_dump.json"] = data
 	}
 

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent_test.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package systemprobeimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func TestGetStatusDetails(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetStatusDetails(context.Background(), &pbcore.GetStatusDetailsRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.MainSection)
+	assert.NotNil(t, resp.MainSection.Fields)
+	assert.Nil(t, resp.NamedSections)
+}
+
+func TestGetFlareFiles_ContainsExpectedFiles(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Files, "system_probe_stats.json")
+	assert.Contains(t, resp.Files, "system_probe_runtime_config_dump.json")
+	assert.Contains(t, resp.Files, "system_probe_telemetry.log")
+}
+
+func TestGetFlareFiles_FilesAreValidJSON(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t), telemetry: telemetryimpl.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+	require.NoError(t, err)
+
+	var statsData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["system_probe_stats.json"], &statsData),
+		"system_probe_stats.json should be valid JSON")
+
+	var configData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["system_probe_runtime_config_dump.json"], &configData),
+		"system_probe_runtime_config_dump.json should be valid JSON")
+}

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -9,7 +9,6 @@ package traceimpl
 import (
 	"context"
 	"encoding/json"
-	"expvar"
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -79,12 +78,8 @@ type remoteagentImpl struct {
 
 // GetStatusDetails returns the status details of the trace agent
 func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
-	fields := make(map[string]string)
-	expvar.Do(func(kv expvar.KeyValue) {
-		fields[kv.Key] = kv.Value.String()
-	})
 	return &pbcore.GetStatusDetailsResponse{
-		MainSection: &pbcore.StatusSection{Fields: fields},
+		MainSection: &pbcore.StatusSection{Fields: helper.ExpvarFields()},
 	}, nil
 }
 
@@ -92,16 +87,7 @@ func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatu
 func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
 	files := make(map[string][]byte)
 
-	expvarData := make(map[string]any)
-	expvar.Do(func(kv expvar.KeyValue) {
-		var v any
-		if err := json.Unmarshal([]byte(kv.Value.String()), &v); err == nil {
-			expvarData[kv.Key] = v
-		} else {
-			expvarData[kv.Key] = kv.Value.String()
-		}
-	})
-	if data, err := json.MarshalIndent(expvarData, "", "  "); err == nil {
+	if data, err := json.MarshalIndent(helper.ExpvarData(), "", "  "); err == nil {
 		files["trace_agent_status.json"] = data
 	}
 

--- a/comp/core/remoteagent/impl-trace/remoteagent.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent.go
@@ -8,7 +8,6 @@ package traceimpl
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -78,22 +77,10 @@ type remoteagentImpl struct {
 
 // GetStatusDetails returns the status details of the trace agent
 func (r *remoteagentImpl) GetStatusDetails(_ context.Context, _ *pbcore.GetStatusDetailsRequest) (*pbcore.GetStatusDetailsResponse, error) {
-	return &pbcore.GetStatusDetailsResponse{
-		MainSection: &pbcore.StatusSection{Fields: helper.ExpvarFields()},
-	}, nil
+	return helper.DefaultStatusResponse(), nil
 }
 
 // GetFlareFiles returns files for the trace agent flare
 func (r *remoteagentImpl) GetFlareFiles(_ context.Context, _ *pbcore.GetFlareFilesRequest) (*pbcore.GetFlareFilesResponse, error) {
-	files := make(map[string][]byte)
-
-	if data, err := json.MarshalIndent(helper.ExpvarData(), "", "  "); err == nil {
-		files["trace_agent_status.json"] = data
-	}
-
-	if data, err := json.MarshalIndent(r.cfg.AllSettings(), "", "  "); err == nil {
-		files["trace_agent_runtime_config_dump.json"] = data
-	}
-
-	return &pbcore.GetFlareFilesResponse{Files: files}, nil
+	return &pbcore.GetFlareFilesResponse{Files: helper.DefaultFlareFiles(r.cfg.AllSettings(), "trace_agent")}, nil
 }

--- a/comp/core/remoteagent/impl-trace/remoteagent_test.go
+++ b/comp/core/remoteagent/impl-trace/remoteagent_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package traceimpl
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+)
+
+func TestGetStatusDetails(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t)}
+
+	resp, err := impl.GetStatusDetails(context.Background(), &pbcore.GetStatusDetailsRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.MainSection)
+	assert.NotNil(t, resp.MainSection.Fields)
+	assert.Nil(t, resp.NamedSections)
+}
+
+func TestGetFlareFiles_ContainsExpectedFiles(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Contains(t, resp.Files, "trace_agent_status.json")
+	assert.Contains(t, resp.Files, "trace_agent_runtime_config_dump.json")
+}
+
+func TestGetFlareFiles_FilesAreValidJSON(t *testing.T) {
+	impl := &remoteagentImpl{cfg: config.NewMock(t)}
+
+	resp, err := impl.GetFlareFiles(context.Background(), &pbcore.GetFlareFilesRequest{})
+	require.NoError(t, err)
+
+	var statusData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["trace_agent_status.json"], &statusData),
+		"trace_agent_status.json should be valid JSON")
+
+	var configData map[string]any
+	require.NoError(t, json.Unmarshal(resp.Files["trace_agent_runtime_config_dump.json"], &configData),
+		"trace_agent_runtime_config_dump.json should be valid JSON")
+}

--- a/comp/process/status/statusimpl/status_test.go
+++ b/comp/process/status/statusimpl/status_test.go
@@ -8,49 +8,66 @@ package statusimpl
 import (
 	"bytes"
 	"embed"
-	"net/http"
-	"net/http/httptest"
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 )
 
 //go:embed fixtures
 var fixturesTemplates embed.FS
 
-func fakeStatusServer(t *testing.T, errCode int, response []byte) *httptest.Server {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+// mockRAR is a minimal implementation of remoteagentregistry.Component for testing.
+type mockRAR struct {
+	statuses []remoteagentregistry.StatusData
+}
 
-		if errCode != 200 {
-			http.NotFound(w, r)
-		} else {
-			_, err := w.Write(response)
-			require.NoError(t, err)
-		}
+func (m *mockRAR) RegisterRemoteAgent(_ *remoteagentregistry.RegistrationData) (string, uint32, error) {
+	return "", 0, nil
+}
+func (m *mockRAR) RefreshRemoteAgent(_ string) bool                           { return false }
+func (m *mockRAR) GetRegisteredAgents() []remoteagentregistry.RegisteredAgent { return nil }
+func (m *mockRAR) GetRegisteredAgentStatuses() []remoteagentregistry.StatusData {
+	return m.statuses
+}
+
+func makeProcessAgentRAR(t *testing.T) *mockRAR {
+	jsonBytes, err := fixturesTemplates.ReadFile("fixtures/expvar_response.tmpl")
+	require.NoError(t, err)
+
+	var full map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(jsonBytes, &full))
+
+	return &mockRAR{
+		statuses: []remoteagentregistry.StatusData{
+			{
+				RegisteredAgent: remoteagentregistry.RegisteredAgent{
+					Flavor:      "process_agent",
+					DisplayName: "Process Agent",
+					LastSeen:    time.Now(),
+				},
+				MainSection: remoteagentregistry.StatusSection{
+					"process_agent": string(full["process_agent"]),
+				},
+			},
+		},
 	}
-
-	return httptest.NewServer(http.HandlerFunc(handler))
 }
 
 func TestStatus(t *testing.T) {
-	jsonBytes, err := fixturesTemplates.ReadFile("fixtures/expvar_response.tmpl")
-	assert.NoError(t, err)
-
-	server := fakeStatusServer(t, 200, jsonBytes)
-	defer server.Close()
-
 	configComponent := config.NewMock(t)
 
 	headerProvider := statusProvider{
-		testServerURL: server.URL,
-		config:        configComponent,
-		hostname:      hostnameimpl.NewHostnameService(),
+		config:   configComponent,
+		hostname: hostnameimpl.NewHostnameService(),
+		rar:      makeProcessAgentRAR(t),
 	}
 
 	tests := []struct {
@@ -94,17 +111,27 @@ func TestStatus(t *testing.T) {
 }
 
 func TestStatusError(t *testing.T) {
-	server := fakeStatusServer(t, 500, []byte{})
-	defer server.Close()
-
 	errorResponse, err := fixturesTemplates.ReadFile("fixtures/text_error_response.tmpl")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	configComponent := config.NewMock(t)
 
+	// RAR reports the process agent as failed.
+	rar := &mockRAR{
+		statuses: []remoteagentregistry.StatusData{
+			{
+				RegisteredAgent: remoteagentregistry.RegisteredAgent{
+					Flavor:   "process_agent",
+					LastSeen: time.Now(),
+				},
+				FailureReason: "connection refused",
+			},
+		},
+	}
+
 	headerProvider := statusProvider{
-		testServerURL: server.URL,
-		config:        configComponent,
+		config: configComponent,
+		rar:    rar,
 	}
 
 	tests := []struct {

--- a/comp/trace/status/statusimpl/status.go
+++ b/comp/trace/status/statusimpl/status.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -24,7 +23,6 @@ type dependencies struct {
 	fx.In
 
 	Config config.Component
-	Client ipc.HTTPClient
 	RAR    remoteagentregistry.Component `optional:"true"`
 }
 
@@ -42,7 +40,6 @@ func Module() fxutil.Module {
 
 type statusProvider struct {
 	Config config.Component
-	Client ipc.HTTPClient
 	RAR    remoteagentregistry.Component
 }
 
@@ -50,7 +47,6 @@ func newStatus(deps dependencies) provides {
 	return provides{
 		StatusProvider: status.NewInformationProvider(statusProvider{
 			Config: deps.Config,
-			Client: deps.Client,
 			RAR:    deps.RAR,
 		}),
 	}

--- a/comp/trace/status/statusimpl/status_templates/traceagent.tmpl
+++ b/comp/trace/status/statusimpl/status_templates/traceagent.tmpl
@@ -1,7 +1,7 @@
 {{- with .apmStats }}
 {{- if .error }}
 
-  Status: Not running or unreachable on localhost:{{.port}}.
+  Status: Not running or unreachable
   Error: {{.error}}
 {{- else}}
   Status: Running

--- a/comp/trace/status/statusimpl/status_test.go
+++ b/comp/trace/status/statusimpl/status_test.go
@@ -7,61 +7,158 @@ package statusimpl
 
 import (
 	"bytes"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
-	ipcmock "github.com/DataDog/datadog-agent/comp/core/ipc/mock"
-
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestStatusOut(t *testing.T) {
-	deps := fxutil.Test[dependencies](t, fx.Options(
-		fx.Provide(func() config.Component { return config.NewMock(t) }),
-		fx.Provide(func() ipc.HTTPClient {
-			return ipcmock.New(t).GetClient()
-		}),
-	))
+// mockRAR is a minimal implementation of remoteagentregistry.Component for testing.
+type mockRAR struct {
+	statuses []remoteagentregistry.StatusData
+}
 
+func (m *mockRAR) RegisterRemoteAgent(_ *remoteagentregistry.RegistrationData) (string, uint32, error) {
+	return "", 0, nil
+}
+func (m *mockRAR) RefreshRemoteAgent(_ string) bool                             { return false }
+func (m *mockRAR) GetRegisteredAgents() []remoteagentregistry.RegisteredAgent   { return nil }
+func (m *mockRAR) GetRegisteredAgentStatuses() []remoteagentregistry.StatusData { return m.statuses }
+
+func TestStatusWiring(t *testing.T) {
+	// RAR is optional — wiring should succeed with no dependencies provided.
+	deps := fxutil.Test[dependencies](t, fx.Options())
 	provides := newStatus(deps)
+	assert.NotNil(t, provides.StatusProvider.Provider)
+}
 
-	headerProvider := provides.StatusProvider.Provider
-
+func TestPopulateStatus(t *testing.T) {
 	tests := []struct {
-		name       string
-		assertFunc func(t *testing.T)
+		name   string
+		p      statusProvider
+		assert func(t *testing.T, result map[string]interface{})
 	}{
-		{"JSON", func(t *testing.T) {
-			stats := make(map[string]interface{})
-			headerProvider.JSON(false, stats)
-
-			assert.NotEmpty(t, stats)
-		}},
-		{"Text", func(t *testing.T) {
-			b := new(bytes.Buffer)
-			err := headerProvider.Text(false, b)
-
-			assert.NoError(t, err)
-
-			assert.NotEmpty(t, b.String())
-		}},
-		{"HTML", func(t *testing.T) {
-			b := new(bytes.Buffer)
-			err := headerProvider.HTML(false, b)
-
-			assert.NoError(t, err)
-
-			assert.NotEmpty(t, b.String())
-		}},
+		{
+			name: "valid RAR data",
+			p: statusProvider{RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{
+						RegisteredAgent: remoteagentregistry.RegisteredAgent{Flavor: "trace_agent", LastSeen: time.Now()},
+						// expvar values are JSON strings (as returned by expvar.Value.String())
+						MainSection: remoteagentregistry.StatusSection{"pid": "12345", "uptime": "60"},
+					},
+				},
+			}},
+			assert: func(t *testing.T, r map[string]interface{}) {
+				assert.Empty(t, r["error"])
+				assert.Equal(t, float64(12345), r["pid"])
+			},
+		},
+		{
+			name: "failure reason propagates as error",
+			p: statusProvider{RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{
+						RegisteredAgent: remoteagentregistry.RegisteredAgent{Flavor: "trace_agent", LastSeen: time.Now()},
+						FailureReason:   "connection refused",
+					},
+				},
+			}},
+			assert: func(t *testing.T, r map[string]interface{}) {
+				assert.Equal(t, "connection refused", r["error"])
+			},
+		},
+		{
+			name: "non-trace_agent flavor is skipped",
+			p: statusProvider{RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{RegisteredAgent: remoteagentregistry.RegisteredAgent{Flavor: "system_probe", LastSeen: time.Now()}},
+				},
+			}},
+			assert: func(t *testing.T, r map[string]interface{}) {
+				assert.Equal(t, "not running or unreachable", r["error"])
+			},
+		},
+		{
+			name: "nil RAR reports not running",
+			p:    statusProvider{RAR: nil},
+			assert: func(t *testing.T, r map[string]interface{}) {
+				assert.Equal(t, "not running or unreachable", r["error"])
+			},
+		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.assertFunc(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t, tt.p.populateStatus())
 		})
 	}
+}
+
+func TestJSON(t *testing.T) {
+	t.Run("valid data", func(t *testing.T) {
+		p := statusProvider{RAR: &mockRAR{
+			statuses: []remoteagentregistry.StatusData{
+				{
+					RegisteredAgent: remoteagentregistry.RegisteredAgent{
+						Flavor:   "trace_agent",
+						LastSeen: time.Now(),
+					},
+					MainSection: remoteagentregistry.StatusSection{"pid": "12345"},
+				},
+			},
+		}}
+		stats := make(map[string]interface{})
+		err := p.JSON(false, stats)
+		assert.NoError(t, err)
+
+		val, ok := stats["apmStats"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Empty(t, val["error"])
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		p := statusProvider{RAR: nil}
+		stats := make(map[string]interface{})
+		err := p.JSON(false, stats)
+		assert.NoError(t, err)
+
+		val, ok := stats["apmStats"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.NotEmpty(t, val["error"])
+	})
+}
+
+func TestText(t *testing.T) {
+	t.Run("renders Not running when no RAR", func(t *testing.T) {
+		p := statusProvider{RAR: nil}
+		b := new(bytes.Buffer)
+		err := p.Text(false, b)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(b.String(), "Not running or unreachable"))
+	})
+
+	t.Run("renders failure reason in error output", func(t *testing.T) {
+		p := statusProvider{RAR: &mockRAR{
+			statuses: []remoteagentregistry.StatusData{
+				{
+					RegisteredAgent: remoteagentregistry.RegisteredAgent{
+						Flavor:   "trace_agent",
+						LastSeen: time.Now(),
+					},
+					FailureReason: "dial tcp: connection refused",
+				},
+			},
+		}}
+		b := new(bytes.Buffer)
+		err := p.Text(false, b)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(b.String(), "dial tcp"))
+	})
+
 }

--- a/pkg/status/systemprobe/status.go
+++ b/pkg/status/systemprobe/status.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	sysprobeclient "github.com/DataDog/datadog-agent/pkg/system-probe/api/client"
@@ -21,60 +22,41 @@ import (
 // GetStatus returns the expvar stats of the system probe
 func GetStatus(stats map[string]interface{}, socketPath string) {
 	client := sysprobeclient.Get(socketPath)
-	systemProbeDetails, err := getStats(client)
-	if err != nil {
-		stats["systemProbeStats"] = map[string]interface{}{
-			"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err),
-		}
-		return
-	}
-	stats["systemProbeStats"] = systemProbeDetails
-}
-
-func getStats(client *http.Client) (map[string]interface{}, error) {
 	url := sysprobeclient.DebugURL("/stats")
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, err
+		stats["systemProbeStats"] = map[string]interface{}{"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err)}
+		return
 	}
-
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		stats["systemProbeStats"] = map[string]interface{}{"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err)}
+		return
 	}
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("conn request failed: url: %s, status code: %d", req.URL, resp.StatusCode)
+		stats["systemProbeStats"] = map[string]interface{}{"Errors": fmt.Sprintf("conn request failed: url: %s, status code: %d", req.URL, resp.StatusCode)}
+		return
 	}
-
 	body, err := sysprobeclient.ReadAllResponseBody(resp)
 	if err != nil {
-		return nil, err
+		stats["systemProbeStats"] = map[string]interface{}{"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err)}
+		return
 	}
-
-	stats := make(map[string]interface{})
-	err = json.Unmarshal(body, &stats)
-	if err != nil {
-		return nil, err
+	result := make(map[string]interface{})
+	if err := json.Unmarshal(body, &result); err != nil {
+		stats["systemProbeStats"] = map[string]interface{}{"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err)}
+		return
 	}
-
-	return stats, nil
-}
-
-// Provider provides the functionality to populate the status output
-type Provider struct {
-	SocketPath string
+	stats["systemProbeStats"] = result
 }
 
 // GetProvider if system probe is enabled returns status.Provider otherwise returns nil
-func GetProvider(config sysprobeconfig.Component) status.Provider {
+func GetProvider(config sysprobeconfig.Component, rar remoteagentregistry.Component) status.Provider {
 	systemProbeConfig := config.SysProbeObject()
 
 	if systemProbeConfig.Enabled {
-		return Provider{
-			SocketPath: systemProbeConfig.SocketAddress,
-		}
+		return Provider{RAR: rar}
 	}
 
 	return nil
@@ -82,6 +64,11 @@ func GetProvider(config sysprobeconfig.Component) status.Provider {
 
 //go:embed status_templates
 var templatesFS embed.FS
+
+// Provider provides the functionality to populate the status output
+type Provider struct {
+	RAR remoteagentregistry.Component
+}
 
 // Name returns the name
 func (Provider) Name() string {
@@ -95,8 +82,7 @@ func (Provider) Section() string {
 
 // JSON populates the status map
 func (p Provider) JSON(_ bool, stats map[string]interface{}) error {
-	GetStatus(stats, p.SocketPath)
-
+	p.populateStatus(stats)
 	return nil
 }
 
@@ -106,14 +92,42 @@ func (p Provider) Text(_ bool, buffer io.Writer) error {
 }
 
 // HTML renders the html output
-func (p Provider) HTML(_ bool, _ io.Writer) error {
+func (Provider) HTML(_ bool, _ io.Writer) error {
 	return nil
 }
 
 func (p Provider) getStatusInfo() map[string]interface{} {
 	stats := make(map[string]interface{})
-
-	GetStatus(stats, p.SocketPath)
-
+	p.populateStatus(stats)
 	return stats
+}
+
+func (p Provider) populateStatus(stats map[string]interface{}) {
+	if p.RAR != nil {
+		for _, agentStatus := range p.RAR.GetRegisteredAgentStatuses() {
+			if agentStatus.Flavor != "system_probe" {
+				continue
+			}
+			if agentStatus.FailureReason != "" {
+				stats["systemProbeStats"] = map[string]interface{}{
+					"Errors": agentStatus.FailureReason,
+				}
+				return
+			}
+			// The system-probe publishes module stats under the "modules" expvar key,
+			// which is the same data previously served at /debug/stats.
+			if raw, ok := agentStatus.MainSection["modules"]; ok {
+				var moduleStats map[string]interface{}
+				if err := json.Unmarshal([]byte(raw), &moduleStats); err == nil {
+					stats["systemProbeStats"] = moduleStats
+					return
+				}
+			}
+			return
+		}
+	}
+
+	stats["systemProbeStats"] = map[string]interface{}{
+		"Errors": "not running or unreachable",
+	}
 }

--- a/pkg/status/systemprobe/status_test.go
+++ b/pkg/status/systemprobe/status_test.go
@@ -1,0 +1,223 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package systemprobe
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+)
+
+// mockRAR is a minimal implementation of remoteagentregistry.Component for testing.
+type mockRAR struct {
+	statuses []remoteagentregistry.StatusData
+}
+
+func (m *mockRAR) RegisterRemoteAgent(_ *remoteagentregistry.RegistrationData) (string, uint32, error) {
+	return "", 0, nil
+}
+func (m *mockRAR) RefreshRemoteAgent(_ string) bool                             { return false }
+func (m *mockRAR) GetRegisteredAgents() []remoteagentregistry.RegisteredAgent   { return nil }
+func (m *mockRAR) GetRegisteredAgentStatuses() []remoteagentregistry.StatusData { return m.statuses }
+
+func makeModuleStatsJSON(t *testing.T) string {
+	t.Helper()
+	stats := map[string]interface{}{
+		"uptime":     "1h",
+		"updated_at": float64(time.Now().Unix()),
+	}
+	b, err := json.Marshal(stats)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestPopulateStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    Provider
+		assertStats func(t *testing.T, stats map[string]interface{})
+	}{
+		{
+			name: "valid RAR data sets module stats",
+			provider: Provider{
+				RAR: &mockRAR{
+					statuses: []remoteagentregistry.StatusData{
+						{
+							RegisteredAgent: remoteagentregistry.RegisteredAgent{
+								Flavor:   "system_probe",
+								LastSeen: time.Now(),
+							},
+							MainSection: remoteagentregistry.StatusSection{
+								"modules": makeModuleStatsJSON(t),
+							},
+						},
+					},
+				},
+			},
+			assertStats: func(t *testing.T, stats map[string]interface{}) {
+				val, ok := stats["systemProbeStats"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Empty(t, val["Errors"])
+				assert.NotEmpty(t, val["uptime"])
+			},
+		},
+		{
+			name: "failure reason propagates as error",
+			provider: Provider{
+				RAR: &mockRAR{
+					statuses: []remoteagentregistry.StatusData{
+						{
+							RegisteredAgent: remoteagentregistry.RegisteredAgent{
+								Flavor:   "system_probe",
+								LastSeen: time.Now(),
+							},
+							FailureReason: "connection refused",
+						},
+					},
+				},
+			},
+			assertStats: func(t *testing.T, stats map[string]interface{}) {
+				val, ok := stats["systemProbeStats"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "connection refused", val["Errors"])
+			},
+		},
+		{
+			name: "non-system_probe flavors are skipped",
+			provider: Provider{
+				RAR: &mockRAR{
+					statuses: []remoteagentregistry.StatusData{
+						{
+							RegisteredAgent: remoteagentregistry.RegisteredAgent{
+								Flavor:   "trace_agent",
+								LastSeen: time.Now(),
+							},
+						},
+					},
+				},
+			},
+			assertStats: func(t *testing.T, stats map[string]interface{}) {
+				val, ok := stats["systemProbeStats"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "not running or unreachable", val["Errors"])
+			},
+		},
+		{
+			name:     "nil RAR reports not running",
+			provider: Provider{RAR: nil},
+			assertStats: func(t *testing.T, stats map[string]interface{}) {
+				val, ok := stats["systemProbeStats"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "not running or unreachable", val["Errors"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := make(map[string]interface{})
+			tt.provider.populateStatus(stats)
+			tt.assertStats(t, stats)
+		})
+	}
+}
+
+func TestJSON(t *testing.T) {
+	t.Run("valid data", func(t *testing.T) {
+		p := Provider{
+			RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{
+						RegisteredAgent: remoteagentregistry.RegisteredAgent{
+							Flavor:   "system_probe",
+							LastSeen: time.Now(),
+						},
+						MainSection: remoteagentregistry.StatusSection{
+							"modules": makeModuleStatsJSON(t),
+						},
+					},
+				},
+			},
+		}
+		stats := make(map[string]interface{})
+		err := p.JSON(false, stats)
+		assert.NoError(t, err)
+
+		val, ok := stats["systemProbeStats"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Empty(t, val["Errors"])
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		p := Provider{RAR: nil}
+		stats := make(map[string]interface{})
+		err := p.JSON(false, stats)
+		assert.NoError(t, err)
+
+		val, ok := stats["systemProbeStats"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.NotEmpty(t, val["Errors"])
+	})
+}
+
+func TestText(t *testing.T) {
+	t.Run("renders Running when data is present", func(t *testing.T) {
+		p := Provider{
+			RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{
+						RegisteredAgent: remoteagentregistry.RegisteredAgent{
+							Flavor:   "system_probe",
+							LastSeen: time.Now(),
+						},
+						MainSection: remoteagentregistry.StatusSection{
+							"modules": makeModuleStatsJSON(t),
+						},
+					},
+				},
+			},
+		}
+		b := new(bytes.Buffer)
+		err := p.Text(false, b)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(b.String(), "Running"))
+	})
+
+	t.Run("renders Not running on error", func(t *testing.T) {
+		p := Provider{RAR: nil}
+		b := new(bytes.Buffer)
+		err := p.Text(false, b)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(b.String(), "Not running or unreachable"))
+	})
+
+	t.Run("renders failure reason in error output", func(t *testing.T) {
+		p := Provider{
+			RAR: &mockRAR{
+				statuses: []remoteagentregistry.StatusData{
+					{
+						RegisteredAgent: remoteagentregistry.RegisteredAgent{
+							Flavor:   "system_probe",
+							LastSeen: time.Now(),
+						},
+						FailureReason: "dial unix /var/run/sysprobe.sock: no such file",
+					},
+				},
+			},
+		}
+		b := new(bytes.Buffer)
+		err := p.Text(false, b)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(b.String(), "dial unix"))
+	})
+}


### PR DESCRIPTION
### What does this PR do?

### Motivation

### Describe how you validated your changes

```
2026-02-18 22:17:29 EST | CORE | INFO | (comp/core/remoteagentregistry/impl/registry.go:200 in RegisterRemoteAgent) | Remote agent 'Trace Agent' (flavor: trace_agent, session_id: f60d4cdb-24a6-46f7-be30-f37a8aca3f79) registered. (exposed services: [datadog.remoteagent.flare.v1.FlareProvider datadog.remoteagent.status.v1.StatusProvider])
```
<img width="749" height="84" alt="image" src="https://github.com/user-attachments/assets/672ea98b-2949-4f51-904e-2f89d024fbec" />


### Additional Notes
