### PR TITLE
[tagger/tagstore] Delete unused Lookup func

### DIFF
--- a/comp/core/tagger/tagstore/tagstore.go
+++ b/comp/core/tagger/tagstore/tagstore.go
@@ -287,12 +287,6 @@ func (s *TagStore) LookupHashedWithCompleteness(entityID types.EntityID, cardina
 	return storedTags.getHashedTags(cardinality), storedTags.getIsComplete(), nil
 }
 
-// Lookup gets tags from the store and returns them concatenated in a string slice.
-func (s *TagStore) Lookup(entityID types.EntityID, cardinality types.TagCardinality) []string {
-	tags, _ := s.LookupHashed(entityID, cardinality)
-	return tags.Get()
-}
-
 // LookupStandard returns the standard tags recorded for a given entity
 func (s *TagStore) LookupStandard(entityID types.EntityID) ([]string, error) {
 	storedTags, err := s.getEntityTags(entityID)

--- a/comp/core/tagger/tagstore/tagstore_bench_test.go
+++ b/comp/core/tagger/tagstore/tagstore_bench_test.go
@@ -75,7 +75,7 @@ func BenchmarkTagStoreThroughput(b *testing.B) {
 		go func() {
 			for i := 0; i < 1000; i++ {
 				id := types.NewEntityID("", ids[rand.Intn(nEntities)])
-				store.Lookup(id, types.HighCardinality)
+				store.LookupHashed(id, types.HighCardinality)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
### What does this PR do?

This PR is a cleanup. It Deletes the `Lookup` function from the tag store, because it's only called from tests.
The affected tests have been adapted to call `LookupHashed` instead.

### Describe how you validated your changes

CI
