### PR TITLE
[WINA-2108] rename PAR on Windows to datadog-agent-action

### DIFF
--- a/cmd/agent/subcommands/run/dependent_services_windows.go
+++ b/cmd/agent/subcommands/run/dependent_services_windows.go
@@ -86,7 +86,7 @@ func subservices(coreConf model.Reader, sysprobeConf model.Reader) []Servicedef 
 			configKeys: map[string]model.Reader{
 				"private_action_runner.enabled": coreConf,
 			},
-			serviceName:    "datadog-private-action-runner",
+			serviceName:    "datadog-agent-action",
 			serviceInit:    parInit,
 			shouldShutdown: true,
 		},

--- a/cmd/privateactionrunner/subcommands/run/service_windows.go
+++ b/cmd/privateactionrunner/subcommands/run/service_windows.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ServiceName = "datadog-private-action-runner"
+	ServiceName = "datadog-agent-action"
 )
 
 var (

--- a/pkg/fleet/installer/packages/service/windows/impl.go
+++ b/pkg/fleet/installer/packages/service/windows/impl.go
@@ -149,7 +149,7 @@ func (w *WinServiceManager) StopAllAgentServices(ctx context.Context) (err error
 		"datadog-process-agent",
 		"datadog-security-agent",
 		"datadog-system-probe",
-		"datadog-private-action-runner",
+		"datadog-agent-action",
 		"Datadog Installer",
 		"datadogagent",
 	}

--- a/pkg/fleet/installer/packages/service/windows/impl_test.go
+++ b/pkg/fleet/installer/packages/service/windows/impl_test.go
@@ -192,7 +192,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -214,7 +214,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -251,7 +251,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-otel-agent",
 					"datadog-process-agent",
 					"datadog-security-agent",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -288,7 +288,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-otel-agent",
 					"datadog-process-agent",
 					"datadog-security-agent",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -315,7 +315,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -345,7 +345,7 @@ func TestWinServiceManager_StopAllAgentServices(t *testing.T) {
 					"datadog-process-agent",
 					"datadog-security-agent",
 					"datadog-system-probe",
-					"datadog-private-action-runner",
+					"datadog-agent-action",
 					"Datadog Installer",
 					"datadogagent",
 				}
@@ -392,7 +392,7 @@ func TestWinServiceManager_RestartAgentServices(t *testing.T) {
 			"datadog-process-agent",
 			"datadog-security-agent",
 			"datadog-system-probe",
-			"datadog-private-action-runner",
+			"datadog-agent-action",
 			"Datadog Installer",
 			"datadogagent",
 		}
@@ -429,7 +429,7 @@ func TestWinServiceManager_RestartAgentServices(t *testing.T) {
 			"datadog-process-agent",
 			"datadog-security-agent",
 			"datadog-system-probe",
-			"datadog-private-action-runner",
+			"datadog-agent-action",
 			"Datadog Installer",
 			"datadogagent",
 		}

--- a/releasenotes/notes/windows-par-msi-service-registration-a4b7e2c1d9f03856.yaml
+++ b/releasenotes/notes/windows-par-msi-service-registration-a4b7e2c1d9f03856.yaml
@@ -1,7 +1,7 @@
 features:
   - |
     On Windows, the private action runner binary is now included in the MSI
-    installer and registered as the ``datadog-private-action-runner`` Windows
+    installer and registered as the ``datadog-agent-action`` Windows
     service. The service is installed as demand-start with a dependency on the
     main Agent service, and its credentials and ACLs are managed alongside the
     other Agent services during install, upgrade, and repair.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Constants.cs
@@ -8,7 +8,7 @@ namespace Datadog.CustomActions
         public const string ProcessAgentServiceName = "datadog-process-agent";
         public const string SystemProbeServiceName = "datadog-system-probe";
         public const string SecurityAgentServiceName = "datadog-security-agent";
-        public const string PrivateActionRunnerServiceName = "datadog-private-action-runner";
+        public const string PrivateActionRunnerServiceName = "datadog-agent-action";
         public const string InstallerServiceName = "Datadog Installer";
         public const string NpmServiceName = "ddnpm";
         public const string ProcmonServiceName = "ddprocmon";


### PR DESCRIPTION
### What does this PR do?
Renames PAR on Windows from `datadog-private-action-runner` to `datadog-agent-action`.

### Motivation
This change is part of the Private Action Runner integration with Agent on Windows. 
We aim to align PAR in agent service name across platforms: Linux already install private runner under the name `datadog-agent-action`.

### Describe how you validated your changes
Cleanup:
```
1) Stop PAR if there's one
sc.exe stop "datadog-private-action-runner"
sc.exe delete "datadog-private-action-runner"

2) Uninstall agent
$dd = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" |
  Where-Object { $_.DisplayName -eq "Datadog Agent" } |
  Select-Object -First 1
$dd.PSChildName  # this is the ProductCode GUID
msiexec /x $dd.PSChildName /qn /l*vx C:\tmp\ddagent-uninstall.log

3) Clean build dirs to ensure new WixSetup sources are used
Remove-Item -Recurse -Force C:\dev\msi\DatadogAgentInstaller\src
Remove-Item -Recurse -Force C:\dev\msi\DatadogAgentInstaller\output

4) Reboot vm
Restart-Computer -Force
```

Rebuild and restart the service:
```
1) Build PAR + MSI:
dda inv -- -e privateactionrunner.build
Copy-Item .\bin\privateactionrunner\privateactionrunner.exe C:\opt\datadog-agent\bin\agent\
Get-ChildItem C:\opt\datadog-agent\bin\agent\*.exe |
  Sort-Object LastWriteTime -Descending | Select-Object -First 1
dda inv -- -e msi.build

2) Re-install 
$msi = (Get-ChildItem C:\dev\msi\DatadogAgentInstaller\output\bin\x64\Release\*.msi | Sort-Object LastWriteTime | Select-Object -Last 1).FullName
$log = "C:\tmp\ddagent-install.log"
$proc = Start-Process msiexec -Wait -PassThru -ArgumentList "/i `"$msi`" /qn /l*vx `"$log`""
$proc.ExitCode  # should be 0
```

Test new service name:
```
sc.exe qc "datadog-agent-action"
sc.exe query "datadog-private-action-runner"  # should fail 1060
```

### Additional Notes
