### PR TITLE
Ensure ownership of all BUILD.bazel files goes to Agent Build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,6 @@
 /bazel/                                 @DataDog/agent-build
 /bazel/configs/sdagent.bazelrc               @DataDog/agent-discovery
 /MODULE.bazel*                          @DataDog/agent-build
-# Temporary during Bazel migration
-/**/BUILD.bazel                         @DataDog/agent-build
 /deps/                                  @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
@@ -859,6 +857,10 @@
 /internal/third_party/client-go         @DataDog/container-platform
 /internal/third_party/kubernetes        @DataDog/container-integrations
 /internal/third_party/golang/           @DataDog/container-integrations
+
+# Temporary during Bazel migration
+# This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
+/**/BUILD.bazel                         @DataDog/agent-build
 
 # With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
 # Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.


### PR DESCRIPTION
### What does this PR do?

It moves the line specifying ownership of all BUILD.bazel files to near the end of the CODEOWNERS file, to enforce it over other rules that would encompass them.

### Motivation

Actually enforcing the intention of this line originally. For example, https://github.com/DataDog/datadog-agent/blob/main/rtloader/BUILD.bazel is not recognized as owned by agent-build, which we'd like to have for now (for reviews, etc.).

### Describe how you validated your changes

### Additional Notes

From https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.

Based on that and what is already done for the go.mod, etc. files, moving the line towards the bottom (after all lines referencing folders) looks like the right solution.