### PR TITLE
[ACTP] disable script connection testing on windows

### DIFF
--- a/pkg/privateactionrunner/bundles/script/test_connection.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build !windows
+
 package com_datadoghq_script
 
 import (

--- a/pkg/privateactionrunner/bundles/script/test_connection_windows.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection_windows.go
@@ -9,6 +9,7 @@ package com_datadoghq_script
 
 import (
 	"context"
+	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"

--- a/pkg/privateactionrunner/bundles/script/test_connection_windows.go
+++ b/pkg/privateactionrunner/bundles/script/test_connection_windows.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build windows
+
+package com_datadoghq_script
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type TestConnectionHandler struct {
+}
+
+func NewTestConnectionHandler() *TestConnectionHandler {
+	return &TestConnectionHandler{}
+}
+
+func (h *TestConnectionHandler) Run(
+	ctx context.Context,
+	task *types.Task,
+	credentials *privateconnection.PrivateCredentials,
+) (interface{}, error) {
+	return nil, errors.New("Testing script connection is not available on Windows")
+}


### PR DESCRIPTION
### What does this PR do?

Disables connection testing for script in windows

### Motivation

Testing connection aciton relies on linux behavior


### Describe how you validated your changes

### Additional Notes
