### PR TITLE
[ACTP] Retry transient K8s errors in PAR follower secret fetching

### DIFF
--- a/pkg/privateactionrunner/enrollment/k8s_secret_test.go
+++ b/pkg/privateactionrunner/enrollment/k8s_secret_test.go
@@ -1,0 +1,239 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package enrollment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+const testPollInterval = 10 * time.Millisecond
+
+func makeTestSecret(ns, name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{
+			privateKeyField: []byte("test-key"),
+			urnField:        []byte("urn:test"),
+		},
+	}
+}
+
+func newServerTimeoutError() *k8serrors.StatusError {
+	return k8serrors.NewServerTimeout(
+		schema.GroupResource{Group: "", Resource: "secrets"},
+		"get",
+		5,
+	)
+}
+
+func TestWaitForLeaderAndSecret_RetriesTransientThenSucceeds(t *testing.T) {
+	secret := makeTestSecret("default", "test-secret")
+
+	client := fake.NewSimpleClientset()
+	var callCount atomic.Int32
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		n := callCount.Add(1)
+		if n <= 3 {
+			return true, nil, newServerTimeoutError()
+		}
+		return true, secret, nil
+	})
+
+	leadershipChange := make(chan struct{})
+	isLeader := func() bool { return false }
+
+	ctx := context.Background()
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "test-secret", result.Name)
+	assert.GreaterOrEqual(t, callCount.Load(), int32(4))
+}
+
+// Tests that alternating between transient errors and NotFound responses
+// doesn't break the function — it continues waiting and eventually succeeds.
+func TestWaitForLeaderAndSecret_HandlesAlternatingTransientAndNotFound(t *testing.T) {
+	secret := makeTestSecret("default", "test-secret")
+
+	client := fake.NewSimpleClientset()
+	var callCount atomic.Int32
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		n := callCount.Add(1)
+		switch {
+		case n <= 2:
+			return true, nil, newServerTimeoutError()
+		case n <= 4:
+			return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "test-secret")
+		case n == 5:
+			return true, nil, newServerTimeoutError()
+		default:
+			return true, secret, nil
+		}
+	})
+
+	leadershipChange := make(chan struct{})
+	isLeader := func() bool { return false }
+
+	ctx := context.Background()
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "test-secret", result.Name)
+}
+
+func TestWaitForLeaderAndSecret_ExitsOnContextCancel(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, newServerTimeoutError()
+	})
+
+	leadershipChange := make(chan struct{})
+	isLeader := func() bool { return false }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestWaitForLeaderAndSecret_ReturnsNilWhenBecomesLeader(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "test-secret")
+	})
+
+	leadershipChange := make(chan struct{}, 1)
+	var leader atomic.Bool
+	isLeader := func() bool { return leader.Load() }
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		leader.Store(true)
+		leadershipChange <- struct{}{}
+	}()
+
+	ctx := context.Background()
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestWaitForLeaderAndSecret_ReturnsNilIfAlreadyLeader(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	leadershipChange := make(chan struct{})
+	isLeader := func() bool { return true }
+
+	ctx := context.Background()
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.NoError(t, err)
+	require.Nil(t, result)
+}
+
+func TestWaitForLeaderAndSecret_FailsImmediatelyOnNonTransientError(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(
+			schema.GroupResource{Resource: "secrets"}, "test-secret", fmt.Errorf("RBAC denied"))
+	})
+
+	leadershipChange := make(chan struct{})
+	isLeader := func() bool { return false }
+
+	ctx := context.Background()
+	result, err := waitForLeaderAndSecret(
+		ctx, leadershipChange, isLeader, client, "default", "test-secret",
+		testPollInterval,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	assert.True(t, k8serrors.IsForbidden(errors.Unwrap(err)))
+}
+
+func TestIsNonTransientK8sError(t *testing.T) {
+	gr := schema.GroupResource{Resource: "secrets"}
+
+	nonTransient := []struct {
+		name string
+		err  error
+	}{
+		{"Forbidden", k8serrors.NewForbidden(gr, "s", fmt.Errorf("denied"))},
+		{"Unauthorized", k8serrors.NewUnauthorized("bad token")},
+		{"BadRequest", k8serrors.NewBadRequest("malformed")},
+		{"MethodNotSupported", k8serrors.NewMethodNotSupported(gr, "PATCH")},
+		{"Gone", k8serrors.NewGone("expired")},
+	}
+	for _, tc := range nonTransient {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, isNonTransientK8sError(tc.err), "expected %s to be non-transient", tc.name)
+		})
+	}
+
+	transient := []struct {
+		name string
+		err  error
+	}{
+		{"ServerTimeout", k8serrors.NewServerTimeout(gr, "get", 5)},
+		{"TooManyRequests", k8serrors.NewTooManyRequests("slow down", 1)},
+		{"ServiceUnavailable", k8serrors.NewServiceUnavailable("down")},
+		{"InternalError", k8serrors.NewInternalError(fmt.Errorf("oops"))},
+		{"NotFound", k8serrors.NewNotFound(gr, "s")},
+		{"NetworkError", fmt.Errorf("connection refused")},
+	}
+	for _, tc := range transient {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.False(t, isNonTransientK8sError(tc.err), "expected %s to be transient", tc.name)
+		})
+	}
+}

--- a/pkg/privateactionrunner/enrollment/k8s_secret_test.go
+++ b/pkg/privateactionrunner/enrollment/k8s_secret_test.go
@@ -10,7 +10,6 @@ package enrollment
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -184,7 +183,7 @@ func TestWaitForLeaderAndSecret_FailsImmediatelyOnNonTransientError(t *testing.T
 	client := fake.NewSimpleClientset()
 	client.PrependReactor("get", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, k8serrors.NewForbidden(
-			schema.GroupResource{Resource: "secrets"}, "test-secret", fmt.Errorf("RBAC denied"))
+			schema.GroupResource{Resource: "secrets"}, "test-secret", errors.New("RBAC denied"))
 	})
 
 	leadershipChange := make(chan struct{})
@@ -208,7 +207,7 @@ func TestIsNonTransientK8sError(t *testing.T) {
 		name string
 		err  error
 	}{
-		{"Forbidden", k8serrors.NewForbidden(gr, "s", fmt.Errorf("denied"))},
+		{"Forbidden", k8serrors.NewForbidden(gr, "s", errors.New("denied"))},
 		{"Unauthorized", k8serrors.NewUnauthorized("bad token")},
 		{"BadRequest", k8serrors.NewBadRequest("malformed")},
 		{"MethodNotSupported", k8serrors.NewMethodNotSupported(gr, "PATCH")},
@@ -227,9 +226,9 @@ func TestIsNonTransientK8sError(t *testing.T) {
 		{"ServerTimeout", k8serrors.NewServerTimeout(gr, "get", 5)},
 		{"TooManyRequests", k8serrors.NewTooManyRequests("slow down", 1)},
 		{"ServiceUnavailable", k8serrors.NewServiceUnavailable("down")},
-		{"InternalError", k8serrors.NewInternalError(fmt.Errorf("oops"))},
+		{"InternalError", k8serrors.NewInternalError(errors.New("oops"))},
 		{"NotFound", k8serrors.NewNotFound(gr, "s")},
-		{"NetworkError", fmt.Errorf("connection refused")},
+		{"NetworkError", errors.New("connection refused")},
 	}
 	for _, tc := range transient {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Follower replicas now retry transient K8s API errors when polling for the PAR identity secret, instead of failing permanently.

| Checker | HTTP | Reason | Transient? | Notes |
|---|---|---|---|---|
| `IsServerTimeout` | 500 | ServerTimeout | **Yes** | API server couldn't complete in time |
| `IsTimeout` | 504 | Timeout | **Yes** | Request timeout (gateway/proxy) |
| `IsTooManyRequests` | 429 | TooManyRequests | **Yes** | Rate limited (Priority & Fairness) |
| `IsServiceUnavailable` | 503 | ServiceUnavailable | **Yes** | API server down/rolling |
| `IsInternalError` | 500 | InternalError | **Yes** | API server bug or etcd hiccup |
| `IsStoreReadError` | 500 | StorageReadError | **Yes** | etcd read failure |
| `IsUnauthorized` | 401 | Unauthorized | **No** | Auth/ServiceAccount issue |
| `IsForbidden` | 403 | Forbidden | **No** | RBAC misconfiguration |
| `IsBadRequest` | 400 | BadRequest | **No** | Malformed request |
| `IsMethodNotSupported` | 405 | MethodNotAllowed | **No** | Wrong HTTP verb |
| `IsNotAcceptable` | 406 | NotAcceptable | **No** | Content negotiation |
| `IsConflict` | 409 | Conflict | **No** | Can't happen on GET |
| `IsGone` | 410 | Gone | **No** | Resource version expired |
| `IsInvalid` | 422 | Invalid | **No** | Validation failure |
| `IsRequestEntityTooLargeError` | 413 | RequestEntityTooLarge | **No** | Can't happen on GET |
| `IsUnsupportedMediaType` | 415 | UnsupportedMediaType | **No** | Content type issue |


## Motivation
A transient API error (timeout, rate limiting, 5xx) on `Secrets().Get()` killed PAR enrollment permanently with no retry. This was observed in production with "client rate limiter Wait returned an error: context deadline exceeded".

## Changes
- `getIdentityFromK8sSecret`: fall through to retry loop on transient errors instead of returning immediately
- `waitForLeaderAndSecret`: log and continue on transient errors; fail fast on non-transient errors (Forbidden, Unauthorized, etc.)
- Add `isNonTransientK8sError` helper to classify permanent K8s API errors
- Add unit tests for retry, non-transient failure, context cancellation, and leader election transitions