### PR TITLE
Load libdd_discovery

### DIFF
--- a/pkg/discovery/module/impl_linux.go
+++ b/pkg/discovery/module/impl_linux.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build !cgo
+
 package module
 
 import (

--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -5,126 +5,30 @@
 
 // This doesn't need BPF, but it's built with this tag to only run with
 // system-probe tests.
-//go:build test && linux_bpf
+//go:build test && linux_bpf && !cgo
 
 package module
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"net"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 
-	gorillamux "github.com/gorilla/mux"
 	"github.com/prometheus/procfs"
-	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 
-	"github.com/DataDog/datadog-agent/pkg/discovery/core"
 	"github.com/DataDog/datadog-agent/pkg/discovery/language"
-	"github.com/DataDog/datadog-agent/pkg/discovery/model"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
-	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
-
-func findService(pid int, services []model.Service) *model.Service {
-	for _, s := range services {
-		if s.PID == pid {
-			return &s
-		}
-	}
-
-	return nil
-}
-
-type testDiscoveryModule struct {
-	url string
-}
-
-func setupDiscoveryModule(t *testing.T) *testDiscoveryModule {
-	t.Helper()
-	mux := gorillamux.NewRouter()
-
-	mod, err := NewDiscoveryModule(nil, module.FactoryDependencies{})
-	require.NoError(t, err)
-	discovery := mod.(*discovery)
-
-	discovery.Register(module.NewRouter(string(config.DiscoveryModule), mux))
-	t.Cleanup(discovery.Close)
-
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	return &testDiscoveryModule{
-		url: srv.URL,
-	}
-}
-
-// makeRequest wraps the request to the discovery module, setting the JSON body if provided,
-// and returning the response as the given type.
-func makeRequest[T any](t require.TestingT, url string, params *core.Params) *T {
-	var body *bytes.Buffer
-	if params != nil {
-		jsonData, err := params.ToJSON()
-		require.NoError(t, err, "failed to serialize params to JSON")
-		body = bytes.NewBuffer(jsonData)
-	}
-
-	var req *http.Request
-	var err error
-	if body != nil {
-		req, err = http.NewRequest(http.MethodPost, url, body)
-		req.Header.Set("Content-Type", "application/json")
-	} else {
-		req, err = http.NewRequest(http.MethodPost, url, nil)
-	}
-	require.NoError(t, err, "failed to create request")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err, "failed to send request")
-	defer resp.Body.Close()
-
-	res := new(T)
-	err = json.NewDecoder(resp.Body).Decode(res)
-	require.NoError(t, err, "failed to decode response")
-
-	return res
-}
-
-// getRunningPids wraps the process.Pids function, returning a slice of ints
-// that can be used as the pids query param.
-func getRunningPids(t require.TestingT) []int32 {
-	pids, err := process.Pids()
-	require.NoError(t, err)
-	return pids
-}
-
-func startTCPServer(t *testing.T, proto string, address string) (*os.File, *net.TCPAddr) {
-	listener, err := net.Listen(proto, address)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = listener.Close() })
-	tcpAddr := listener.Addr().(*net.TCPAddr)
-
-	f, err := listener.(*net.TCPListener).File()
-	defer listener.Close()
-	require.NoError(t, err)
-
-	return f, tcpAddr
-}
 
 func startTCPClient(t *testing.T, proto string, server *net.TCPAddr) (*os.File, *net.TCPAddr) {
 	client, err := net.DialTCP(proto, nil, server)
@@ -160,30 +64,6 @@ func startUDPClient(t *testing.T, proto string, server *net.UDPAddr) (*os.File, 
 	require.NoError(t, err)
 
 	return f, udpClient.LocalAddr().(*net.UDPAddr)
-}
-
-func disableCloseOnExec(t *testing.T, f *os.File) {
-	_, _, syserr := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), syscall.F_SETFD, 0)
-	require.Equal(t, syscall.Errno(0x0), syserr)
-}
-
-func startProcessWithFile(t *testing.T, f *os.File) *exec.Cmd {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Disable close-on-exec so that the process gets it
-	t.Cleanup(func() { f.Close() })
-	disableCloseOnExec(t, f)
-
-	cmd := exec.CommandContext(ctx, "sleep", "1000")
-	t.Cleanup(func() {
-		cancel()
-		_ = cmd.Wait()
-	})
-	err := cmd.Start()
-	require.NoError(t, err)
-	f.Close()
-
-	return cmd
 }
 
 func makeAlias(t *testing.T, alias string, serverBin string) string {

--- a/pkg/discovery/module/impl_services_cgo_linux.go
+++ b/pkg/discovery/module/impl_services_cgo_linux.go
@@ -1,0 +1,278 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// CGO-backed implementation using the Rust libdd_discovery shared library.
+// When CGO is disabled, impl_linux.go is compiled instead.
+
+//go:build cgo
+
+package module
+
+/*
+#cgo CFLAGS:  -I${SRCDIR}/rust/include
+#cgo LDFLAGS: -L${SRCDIR}/rust -L${SRCDIR}/rust/target/release -L${SRCDIR}/rust/target/debug -ldd_discovery
+#include "dd_discovery.h"
+*/
+import "C"
+
+import (
+	"net/http"
+	"sync"
+	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+	"github.com/DataDog/datadog-agent/pkg/discovery/servicetype"
+	"github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata"
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/privileged"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	pathServices = "/services"
+)
+
+// Ensure discovery implements the module.Module interface.
+var _ module.Module = &discovery{}
+
+// discovery is an implementation of the Module interface for the discovery module.
+type discovery struct {
+	core core.Discovery
+
+	config *core.DiscoveryConfig
+
+	mux *sync.RWMutex
+
+	// privilegedDetector is used to detect the language of a process.
+	privilegedDetector privileged.LanguageDetector
+}
+
+// NewDiscoveryModule creates a new discovery system probe module.
+func NewDiscoveryModule(_ *sysconfigtypes.Config, _ module.FactoryDependencies) (module.Module, error) {
+	cfg := core.NewConfig()
+
+	d := &discovery{
+		core: core.Discovery{
+			Config: cfg,
+		},
+		config:             cfg,
+		mux:                &sync.RWMutex{},
+		privilegedDetector: privileged.NewLanguageDetector(),
+	}
+
+	return d, nil
+}
+
+// GetStats returns the stats of the discovery module.
+func (s *discovery) GetStats() map[string]any {
+	return nil
+}
+
+// Register registers the discovery module with the provided HTTP mux.
+func (s *discovery) Register(httpMux *module.Router) error {
+	httpMux.HandleFunc("/status", s.handleStatusEndpoint)
+	httpMux.HandleFunc("/state", s.handleStateEndpoint)
+	httpMux.HandleFunc(pathServices, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleServices))
+
+	return nil
+}
+
+// Close cleans resources used by the discovery module.
+func (s *discovery) Close() {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	s.core.Close()
+}
+
+// handleStatusEndpoint is the handler for the /status endpoint.
+// Reports the status of the discovery module.
+func (s *discovery) handleStatusEndpoint(w http.ResponseWriter, _ *http.Request) {
+	_, _ = w.Write([]byte("Discovery Module is running"))
+}
+
+// handleStateEndpoint is the handler for the /state endpoint.
+// Returns the internal state of the discovery module.
+func (s *discovery) handleStateEndpoint(w http.ResponseWriter, _ *http.Request) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	state := make(map[string]interface{})
+
+	utils.WriteAsJSON(w, state, utils.CompactOutput)
+}
+
+func (s *discovery) handleServices(w http.ResponseWriter, req *http.Request) {
+	params, err := core.ParseParamsFromRequest(req)
+	if err != nil {
+		_ = log.Errorf("invalid params to /discovery%s: %v", pathServices, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	services, err := s.getServices(params)
+	if err != nil {
+		_ = log.Errorf("failed to handle /discovery%s: %v", pathServices, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	utils.WriteAsJSON(w, services, utils.CompactOutput)
+}
+
+func (s *discovery) getServices(params core.Params) (*model.ServicesResponse, error) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	// Pre-filter heartbeat PIDs by comm name before passing to Rust.
+	hbPids := params.HeartbeatPids
+	if s.config.IgnoreComms != nil && len(params.HeartbeatPids) > 0 {
+		filtered := make([]int32, 0, len(params.HeartbeatPids))
+		for _, pid := range params.HeartbeatPids {
+			if !s.shouldIgnoreComm(pid) {
+				filtered = append(filtered, pid)
+			}
+		}
+		hbPids = filtered
+	}
+
+	// Tag heartbeat PIDs so the loop below can skip servicetype.Detect for them.
+	// Rust returns new-PID and heartbeat-PID services in a single flat array.
+	hbPidSet := make(map[int32]struct{}, len(hbPids))
+	for _, pid := range hbPids {
+		hbPidSet[pid] = struct{}{}
+	}
+
+	// NewPids are not pre-filtered: comm-ignored PIDs can still appear in
+	// InjectedPIDs, so the full list is passed to Rust and filtered afterwards.
+	var newPidsPtr *C.int32_t
+	var newPidsLen C.size_t
+	if len(params.NewPids) > 0 {
+		newPidsPtr = (*C.int32_t)(unsafe.Pointer(&params.NewPids[0]))
+		newPidsLen = C.size_t(len(params.NewPids))
+	}
+
+	var hbPidsPtr *C.int32_t
+	var hbPidsLen C.size_t
+	if len(hbPids) > 0 {
+		hbPidsPtr = (*C.int32_t)(unsafe.Pointer(&hbPids[0]))
+		hbPidsLen = C.size_t(len(hbPids))
+	}
+
+	result := C.dd_discovery_get_services(newPidsPtr, newPidsLen, hbPidsPtr, hbPidsLen)
+	if result == nil {
+		return &model.ServicesResponse{Services: make([]model.Service, 0)}, nil
+	}
+	defer C.dd_discovery_free(result)
+
+	response := &model.ServicesResponse{
+		Services: make([]model.Service, 0, int(result.services_len)),
+	}
+
+	if result.services_len > 0 && result.services != nil {
+		cServices := unsafe.Slice(result.services, result.services_len)
+		for i := range cServices {
+			svc := cgoConvertService(&cServices[i])
+			_, isHeartbeat := hbPidSet[int32(svc.PID)]
+			if !isHeartbeat && s.shouldIgnoreComm(int32(svc.PID)) {
+				continue
+			}
+			if !isHeartbeat {
+				svc.Type = string(servicetype.Detect(svc.TCPPorts, svc.UDPPorts))
+			}
+			response.Services = append(response.Services, svc)
+		}
+	}
+
+	if result.injected_pids_len > 0 && result.injected_pids != nil {
+		cPids := unsafe.Slice(result.injected_pids, result.injected_pids_len)
+		response.InjectedPIDs = make([]int, len(cPids))
+		for i, pid := range cPids {
+			response.InjectedPIDs[i] = int(pid)
+		}
+	}
+
+	return response, nil
+}
+
+// cgoStr converts a length-delimited C dd_str to a Go string.
+func cgoStr(s C.struct_dd_str) string {
+	if s.data == nil || s.len == 0 {
+		return ""
+	}
+	return C.GoStringN(s.data, C.int(s.len))
+}
+
+// cgoConvertService converts a C dd_service to a model.Service, copying all
+// fields into Go memory. Type is not set; the caller applies servicetype.Detect
+// for new-PID services and leaves it empty for heartbeat services.
+func cgoConvertService(svc *C.struct_dd_service) model.Service {
+	result := model.Service{
+		PID:                 int(svc.pid),
+		GeneratedName:       cgoStr(svc.generated_name),
+		GeneratedNameSource: cgoStr(svc.generated_name_source),
+		APMInstrumentation:  bool(svc.apm_instrumentation),
+		Language:            cgoStr(svc.language),
+		UST: model.UST{
+			Service: cgoStr(svc.ust.service),
+			Env:     cgoStr(svc.ust.env),
+			Version: cgoStr(svc.ust.version),
+		},
+	}
+
+	if svc.additional_generated_names.len > 0 && svc.additional_generated_names.data != nil {
+		names := unsafe.Slice(svc.additional_generated_names.data, svc.additional_generated_names.len)
+		result.AdditionalGeneratedNames = make([]string, len(names))
+		for i, n := range names {
+			result.AdditionalGeneratedNames[i] = cgoStr(n)
+		}
+	}
+
+	if svc.tracer_metadata.len > 0 && svc.tracer_metadata.data != nil {
+		metas := unsafe.Slice(svc.tracer_metadata.data, svc.tracer_metadata.len)
+		result.TracerMetadata = make([]tracermetadata.TracerMetadata, len(metas))
+		for i, m := range metas {
+			result.TracerMetadata[i] = tracermetadata.TracerMetadata{
+				SchemaVersion:  uint8(m.schema_version),
+				RuntimeID:      cgoStr(m.runtime_id),
+				TracerLanguage: cgoStr(m.tracer_language),
+				TracerVersion:  cgoStr(m.tracer_version),
+				Hostname:       cgoStr(m.hostname),
+				ServiceName:    cgoStr(m.service_name),
+				ServiceEnv:     cgoStr(m.service_env),
+				ServiceVersion: cgoStr(m.service_version),
+			}
+		}
+	}
+
+	if svc.tcp_ports.len > 0 && svc.tcp_ports.data != nil {
+		ports := unsafe.Slice(svc.tcp_ports.data, svc.tcp_ports.len)
+		result.TCPPorts = make([]uint16, len(ports))
+		for i, p := range ports {
+			result.TCPPorts[i] = uint16(p)
+		}
+	}
+
+	if svc.udp_ports.len > 0 && svc.udp_ports.data != nil {
+		ports := unsafe.Slice(svc.udp_ports.data, svc.udp_ports.len)
+		result.UDPPorts = make([]uint16, len(ports))
+		for i, p := range ports {
+			result.UDPPorts[i] = uint16(p)
+		}
+	}
+
+	if svc.log_files.len > 0 && svc.log_files.data != nil {
+		logs := unsafe.Slice(svc.log_files.data, svc.log_files.len)
+		result.LogFiles = make([]string, len(logs))
+		for i, l := range logs {
+			result.LogFiles[i] = cgoStr(l)
+		}
+	}
+
+	return result
+}

--- a/pkg/discovery/module/impl_services_cgo_linux_test.go
+++ b/pkg/discovery/module/impl_services_cgo_linux_test.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Parity tests for the CGO-backed getServices path.  They cover behaviours
+// that are implemented in the Go wrapper rather than inside the Rust library:
+//
+//   - service_type must be non-empty (computed by servicetype.Detect on the Go
+//     side; the Rust library always sets it to an empty string).
+//   - Processes in IgnoreComms must be absent from Services: NewPids are
+//     post-filtered after the Rust library returns; HeartbeatPids are
+//     pre-filtered before being passed to the Rust library.
+
+//go:build test && linux_bpf && cgo
+
+package module
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+	"time"
+
+	gorillamux "github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+)
+
+// TestCGOServiceTypePopulated verifies that service_type is populated by the
+// Go wrapper via servicetype.Detect. The Rust library always returns an empty
+// string for this field.
+func TestCGOServiceTypePopulated(t *testing.T) {
+	disc := setupDiscoveryModule(t)
+
+	serverf, _ := startTCPServer(t, "tcp4", "")
+	cmd := startProcessWithFile(t, serverf)
+	pid := cmd.Process.Pid
+
+	location := disc.url + "/" + string(config.DiscoveryModule) + pathServices
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		params := &core.Params{NewPids: getRunningPids(collect)}
+		resp := makeRequest[model.ServicesResponse](collect, location, params)
+		svc := findService(pid, resp.Services)
+		require.NotNilf(collect, svc, "service for pid %d not found", pid)
+		assert.NotEmpty(collect, svc.Type)
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+// TestCGOIgnoreCommFiltering verifies that NewPids in IgnoreComms are filtered
+// from Services by the Go wrapper after the Rust library returns.
+func TestCGOIgnoreCommFiltering(t *testing.T) {
+	mod, err := NewDiscoveryModule(nil, module.FactoryDependencies{})
+	require.NoError(t, err)
+	d := mod.(*discovery)
+	d.config.IgnoreComms = map[string]struct{}{"sleep": {}}
+
+	mux := gorillamux.NewRouter()
+	d.Register(module.NewRouter(string(config.DiscoveryModule), mux))
+	t.Cleanup(d.Close)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	listener, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+	f, err := listener.(*net.TCPListener).File()
+	listener.Close()
+	require.NoError(t, err)
+	disableCloseOnExec(t, f)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sleep", "1000")
+	require.NoError(t, cmd.Start())
+	f.Close()
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	pid := cmd.Process.Pid
+	location := srv.URL + "/" + string(config.DiscoveryModule) + pathServices
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		params := &core.Params{NewPids: getRunningPids(t)}
+		resp := makeRequest[model.ServicesResponse](t, location, params)
+		if svc := findService(pid, resp.Services); svc != nil {
+			t.Fatalf("pid %d ('sleep') appeared in Services despite being in IgnoreComms", pid)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestCGOHeartbeatIgnoreCommFiltering verifies that HeartbeatPids in IgnoreComms
+// are pre-filtered by the Go wrapper before being passed to the Rust library.
+func TestCGOHeartbeatIgnoreCommFiltering(t *testing.T) {
+	mod, err := NewDiscoveryModule(nil, module.FactoryDependencies{})
+	require.NoError(t, err)
+	d := mod.(*discovery)
+	d.config.IgnoreComms = map[string]struct{}{"sleep": {}}
+
+	mux := gorillamux.NewRouter()
+	d.Register(module.NewRouter(string(config.DiscoveryModule), mux))
+	t.Cleanup(d.Close)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	listener, err := net.Listen("tcp", "")
+	require.NoError(t, err)
+	f, err := listener.(*net.TCPListener).File()
+	listener.Close()
+	require.NoError(t, err)
+	disableCloseOnExec(t, f)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sleep", "1000")
+	require.NoError(t, cmd.Start())
+	f.Close()
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	pid := cmd.Process.Pid
+	location := srv.URL + "/" + string(config.DiscoveryModule) + pathServices
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		params := &core.Params{HeartbeatPids: []int32{int32(pid)}}
+		resp := makeRequest[model.ServicesResponse](t, location, params)
+		if svc := findService(pid, resp.Services); svc != nil {
+			t.Fatalf("pid %d ('sleep') appeared in Services via HeartbeatPids despite being in IgnoreComms", pid)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/pkg/discovery/module/impl_services_test.go
+++ b/pkg/discovery/module/impl_services_test.go
@@ -5,7 +5,7 @@
 
 // This doesn't need BPF, but it's built with this tag to only run with
 // system-probe tests.
-//go:build test && linux_bpf
+//go:build test && linux_bpf && !cgo
 
 package module
 

--- a/pkg/discovery/module/impl_test_helpers_linux_test.go
+++ b/pkg/discovery/module/impl_test_helpers_linux_test.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// This doesn't need BPF, but it's built with this tag to only run with
+// system-probe tests.
+//go:build test && linux_bpf
+
+package module
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	gorillamux "github.com/gorilla/mux"
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/discovery/core"
+	"github.com/DataDog/datadog-agent/pkg/discovery/model"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
+)
+
+func findService(pid int, services []model.Service) *model.Service {
+	for _, s := range services {
+		if s.PID == pid {
+			return &s
+		}
+	}
+
+	return nil
+}
+
+type testDiscoveryModule struct {
+	url string
+}
+
+func setupDiscoveryModule(t *testing.T) *testDiscoveryModule {
+	t.Helper()
+	mux := gorillamux.NewRouter()
+
+	mod, err := NewDiscoveryModule(nil, module.FactoryDependencies{})
+	require.NoError(t, err)
+	discovery := mod.(*discovery)
+
+	discovery.Register(module.NewRouter(string(config.DiscoveryModule), mux))
+	t.Cleanup(discovery.Close)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &testDiscoveryModule{
+		url: srv.URL,
+	}
+}
+
+// makeRequest wraps the request to the discovery module, setting the JSON body if provided,
+// and returning the response as the given type.
+func makeRequest[T any](t require.TestingT, url string, params *core.Params) *T {
+	var body *bytes.Buffer
+	if params != nil {
+		jsonData, err := params.ToJSON()
+		require.NoError(t, err, "failed to serialize params to JSON")
+		body = bytes.NewBuffer(jsonData)
+	}
+
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequest(http.MethodPost, url, body)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequest(http.MethodPost, url, nil)
+	}
+	require.NoError(t, err, "failed to create request")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "failed to send request")
+	defer resp.Body.Close()
+
+	res := new(T)
+	err = json.NewDecoder(resp.Body).Decode(res)
+	require.NoError(t, err, "failed to decode response")
+
+	return res
+}
+
+// getRunningPids wraps the process.Pids function, returning a slice of ints
+// that can be used as the pids query param.
+func getRunningPids(t require.TestingT) []int32 {
+	pids, err := process.Pids()
+	require.NoError(t, err)
+	return pids
+}
+
+func startTCPServer(t *testing.T, proto string, address string) (*os.File, *net.TCPAddr) {
+	listener, err := net.Listen(proto, address)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	tcpAddr := listener.Addr().(*net.TCPAddr)
+
+	f, err := listener.(*net.TCPListener).File()
+	defer listener.Close()
+	require.NoError(t, err)
+
+	return f, tcpAddr
+}
+
+func disableCloseOnExec(t *testing.T, f *os.File) {
+	_, _, syserr := syscall.Syscall(syscall.SYS_FCNTL, f.Fd(), syscall.F_SETFD, 0)
+	require.Equal(t, syscall.Errno(0x0), syserr)
+}
+
+func startProcessWithFile(t *testing.T, f *os.File) *exec.Cmd {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Disable close-on-exec so that the process gets it
+	t.Cleanup(func() { f.Close() })
+	disableCloseOnExec(t, f)
+
+	cmd := exec.CommandContext(ctx, "sleep", "1000")
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+	})
+	err := cmd.Start()
+	require.NoError(t, err)
+	f.Close()
+
+	return cmd
+}

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -145,9 +145,20 @@ pkg_files(
     ),
 )
 
+pkg_files(
+    name = "libdd_discovery_pkg",
+    srcs = [":libdd_discovery"],
+    attributes = pkg_attributes(
+        mode = "0755",
+    ),
+)
+
 pkg_install(
     name = "install",
-    srcs = [":sd-agent_pkg"],
+    srcs = [
+        ":libdd_discovery_pkg",
+        ":sd-agent_pkg",
+    ],
 )
 
 # Disco CLI tool for service discovery


### PR DESCRIPTION
### What does this PR do?
Replaces the Go implementation of getServices with a call to the Rust libdd_discovery shared library via CGO. When CGO is enabled (the default for system-probe builds), service discovery is delegated to the Rust library. The Go implementation is kept as a fallback for CGO_ENABLED=0 builds.

The Go wrapper applies two post-processing steps that the Rust library does not handle: comm-name filtering (ignored_command_names) and service_type detection via servicetype.Detect. Heartbeat PIDs are pre-filtered before being passed to Rust; new PIDs are filtered after, so that comm-ignored processes can still appear in InjectedPIDs.

The Rust library is installed into the expected linker search path via the updated Bazel :install target.

### Motivation
[DSCVR-369](https://datadoghq.atlassian.net/browse/DSCVR-369)

### Describe how you validated your changes

### Additional Notes


[DSCVR-369]: https://datadoghq.atlassian.net/browse/DSCVR-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ