### PR TITLE
[CWS] Add root_domain accessor for connect & accept hostname fields

### DIFF
--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -529,6 +529,7 @@ An accept was executed
 | -------- | ------------- |
 | [`accept.addr.family`](#accept-addr-family-doc) | Address family |
 | [`accept.addr.hostname`](#accept-addr-hostname-doc) | Address hostname (if available) |
+| [`accept.addr.hostname.root_domain`](#common-string-root_domain-doc) | Root domain of the corresponding element |
 | [`accept.addr.ip`](#common-ipportcontext-ip-doc) | IP address |
 | [`accept.addr.is_public`](#common-ipportcontext-is_public-doc) | Whether the IP address belongs to a public network |
 | [`accept.addr.port`](#common-ipportcontext-port-doc) | Port number |
@@ -745,6 +746,7 @@ A connect was executed
 | -------- | ------------- |
 | [`connect.addr.family`](#connect-addr-family-doc) | Address family |
 | [`connect.addr.hostname`](#connect-addr-hostname-doc) | Address hostname (if available) |
+| [`connect.addr.hostname.root_domain`](#common-string-root_domain-doc) | Root domain of the corresponding element |
 | [`connect.addr.ip`](#common-ipportcontext-ip-doc) | IP address |
 | [`connect.addr.is_public`](#common-ipportcontext-is_public-doc) | Whether the IP address belongs to a public network |
 | [`connect.addr.port`](#common-ipportcontext-port-doc) | Port number |
@@ -763,7 +765,7 @@ A DNS request was sent
 | [`dns.question.length`](#dns-question-length-doc) | the total DNS request size in bytes |
 | [`dns.question.name`](#dns-question-name-doc) | the queried domain name |
 | [`dns.question.name.length`](#common-string-length-doc) | Length of the corresponding element |
-| [`dns.question.name.root_domain`](#dns-question-name-root_domain-doc) | Root domain of the corresponding element |
+| [`dns.question.name.root_domain`](#common-string-root_domain-doc) | Root domain of the corresponding element |
 | [`dns.question.type`](#dns-question-type-doc) | a two octet code which specifies the DNS question type |
 | [`dns.response.code`](#dns-response-code-doc) | Response code of the DNS response according to RFC 1035 |
 | [`network.destination.ip`](#common-ipportcontext-ip-doc) | IP address |
@@ -3573,6 +3575,15 @@ Constants: [File mode constants](#file-mode-constants)
 
 
 
+### `*.root_domain` {#common-string-root_domain-doc}
+Type: string
+
+Definition: Root domain of the corresponding element
+
+`*.root_domain` has 3 possible prefixes:
+`accept.addr.hostname` `connect.addr.hostname` `dns.question.name`
+
+
 ### `*.session_type` {#common-usersessioncontext-session_type-doc}
 Type: int
 
@@ -4024,13 +4035,6 @@ Definition: the total DNS request size in bytes
 Type: string
 
 Definition: the queried domain name
-
-
-
-### `dns.question.name.root_domain` {#dns-question-name-root_domain-doc}
-Type: string
-
-Definition: Root domain of the corresponding element
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -1727,6 +1727,11 @@
           "property_doc_link": "accept-addr-hostname-doc"
         },
         {
+          "name": "accept.addr.hostname.root_domain",
+          "definition": "Root domain of the corresponding element",
+          "property_doc_link": "common-string-root_domain-doc"
+        },
+        {
           "name": "accept.addr.ip",
           "definition": "IP address",
           "property_doc_link": "common-ipportcontext-ip-doc"
@@ -2553,6 +2558,11 @@
           "property_doc_link": "connect-addr-hostname-doc"
         },
         {
+          "name": "connect.addr.hostname.root_domain",
+          "definition": "Root domain of the corresponding element",
+          "property_doc_link": "common-string-root_domain-doc"
+        },
+        {
           "name": "connect.addr.ip",
           "definition": "IP address",
           "property_doc_link": "common-ipportcontext-ip-doc"
@@ -2619,7 +2629,7 @@
         {
           "name": "dns.question.name.root_domain",
           "definition": "Root domain of the corresponding element",
-          "property_doc_link": "dns-question-name-root_domain-doc"
+          "property_doc_link": "common-string-root_domain-doc"
         },
         {
           "name": "dns.question.type",
@@ -14580,6 +14590,20 @@
       "examples": []
     },
     {
+      "name": "*.root_domain",
+      "link": "common-string-root_domain-doc",
+      "type": "string",
+      "definition": "Root domain of the corresponding element",
+      "prefixes": [
+        "accept.addr.hostname",
+        "connect.addr.hostname",
+        "dns.question.name"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
       "name": "*.session_type",
       "link": "common-usersessioncontext-session_type-doc",
       "type": "int",
@@ -15463,18 +15487,6 @@
       "definition": "the queried domain name",
       "prefixes": [
         "dns.question"
-      ],
-      "constants": "",
-      "constants_link": "",
-      "examples": []
-    },
-    {
-      "name": "dns.question.name.root_domain",
-      "link": "dns-question-name-root_domain-doc",
-      "type": "string",
-      "definition": "Root domain of the corresponding element",
-      "prefixes": [
-        "dns.question.name"
       ],
       "constants": "",
       "constants_link": "",

--- a/pkg/security/generators/accessors/accessors.go
+++ b/pkg/security/generators/accessors/accessors.go
@@ -896,7 +896,7 @@ func newField(allFields map[string]*common.StructField, fieldName string, inputF
 				if !strings.HasPrefix(fieldName, "process.") && !strings.HasPrefix(fieldName, "exec.") && !strings.HasPrefix(fieldName, "exit.") && !strings.HasPrefix(fieldName, "ptrace.") {
 					result += fmt.Sprintf("if ev.%s == nil { ev.%s = &%s{} }\n", field.Name, field.Name, field.OrigType)
 				}
-			} else if field.IsArray && fieldPath != inputField.Name {
+			} else if field.IsArray && fieldPath != inputField.Name && !inputField.IsRootDomain && !inputField.IsLength {
 				result += fmt.Sprintf("if len(ev.%s) == 0 { ev.%s = append(ev.%s, %s{}) }\n", field.Name, field.Name, field.Name, field.OrigType)
 			}
 		}

--- a/pkg/security/generators/accessors/accessors.tmpl
+++ b/pkg/security/generators/accessors/accessors.tmpl
@@ -272,7 +272,11 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 						{{else}}
 							{{if $Field.IsRootDomain}}
 								{{- if not $Field.IsIterator}}
+									{{- if $Field.IsArray}}
+									return eval.GetPublicTLDs({{".root_domain" | TrimSuffix $Return}})
+									{{- else}}
 									return eval.GetPublicTLD({{".root_domain" | TrimSuffix $Return}})
+									{{- end}}
 								{{end}}
 							{{else}}
 								return {{$Return}}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -853,8 +853,8 @@ type BindEvent struct {
 type ConnectEvent struct {
 	SyscallEvent
 
-	Addr       IPPortContext `field:"addr"`                                                       // Connection address
-	Hostnames  []string      `field:"addr.hostname,handler:ResolveConnectHostnames,opts:skip_ad"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
+	Addr       IPPortContext `field:"addr"`                                                                      // Connection address
+	Hostnames  []string      `field:"addr.hostname,handler:ResolveConnectHostnames,opts:skip_ad|root_domain"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
 	AddrFamily uint16        `field:"addr.family"`                                                // SECLDoc[addr.family] Definition:`Address family`
 	Protocol   uint16        `field:"protocol"`                                                   // SECLDoc[protocol] Definition:`Socket Protocol`
 }
@@ -863,8 +863,8 @@ type ConnectEvent struct {
 type AcceptEvent struct {
 	SyscallEvent
 
-	Addr       IPPortContext `field:"addr"`                                                      // Connection address
-	Hostnames  []string      `field:"addr.hostname,handler:ResolveAcceptHostnames,opts:skip_ad"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
+	Addr       IPPortContext `field:"addr"`                                                                     // Connection address
+	Hostnames  []string      `field:"addr.hostname,handler:ResolveAcceptHostnames,opts:skip_ad|root_domain"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
 	AddrFamily uint16        `field:"addr.family"`                                               // SECLDoc[addr.family] Definition:`Address family`
 }
 

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -853,19 +853,19 @@ type BindEvent struct {
 type ConnectEvent struct {
 	SyscallEvent
 
-	Addr       IPPortContext `field:"addr"`                                                                      // Connection address
+	Addr       IPPortContext `field:"addr"`                                                                   // Connection address
 	Hostnames  []string      `field:"addr.hostname,handler:ResolveConnectHostnames,opts:skip_ad|root_domain"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
-	AddrFamily uint16        `field:"addr.family"`                                                // SECLDoc[addr.family] Definition:`Address family`
-	Protocol   uint16        `field:"protocol"`                                                   // SECLDoc[protocol] Definition:`Socket Protocol`
+	AddrFamily uint16        `field:"addr.family"`                                                            // SECLDoc[addr.family] Definition:`Address family`
+	Protocol   uint16        `field:"protocol"`                                                               // SECLDoc[protocol] Definition:`Socket Protocol`
 }
 
 // AcceptEvent represents an accept event
 type AcceptEvent struct {
 	SyscallEvent
 
-	Addr       IPPortContext `field:"addr"`                                                                     // Connection address
+	Addr       IPPortContext `field:"addr"`                                                                  // Connection address
 	Hostnames  []string      `field:"addr.hostname,handler:ResolveAcceptHostnames,opts:skip_ad|root_domain"` // SECLDoc[addr.hostname] Definition:`Address hostname (if available)`
-	AddrFamily uint16        `field:"addr.family"`                                               // SECLDoc[addr.family] Definition:`Address family`
+	AddrFamily uint16        `field:"addr.family"`                                                           // SECLDoc[addr.family] Definition:`Address family`
 }
 
 // NetDevice represents a network device


### PR DESCRIPTION
Extend the SECL model to expose root_domain on address hostnames for connect and accept events, mirroring the existing dns.question.name.root_domain field.


### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
