### PR TITLE
Disable `bazel` "convenience symlinks" in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,7 @@ common:cache --remote_timeout=60
 # CI config ------------------------------------------------------------------------------------------------------------
 common:ci --config=adms
 common:ci --config=cache
+common:ci --noexperimental_convenience_symlinks # not CI-suitable: "These symlinks are only for the user's convenience"
 
 # For Rust targets, enable clippy and rustfmt checks during the build
 build:ci --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect


### PR DESCRIPTION
### What does this PR do?
Add `--noexperimental_convenience_symlinks` to the `ci` Bazel config.

### Motivation
After each build or test command, Bazel (re)creates workspace-root symlinks (`bazel-bin`, `bazel-out`, `bazel-testlogs`, …) pointing into the output base.

First, their presence is not guaranteed (they are absent under remote execution and when the workspace is not writable), and their names are subject to change (`--symlink_prefix`), making them an unreliable handle on build [outputs](https://bazel.build/remote/output-directories#layout):
> These symlinks are only for the user's convenience, as Bazel itself does not use them. Also, this is done only if the workspace root is writable.

Second, whereas accessing Bazel's output base is perfectly fine for build debugging purposes, it should be considered as a sanctuary in production: anything that needs to land outside it (installation, packaging) should therefore be driven by Bazel itself through a dedicated `run` target.

Disabling them in CI makes sure we're no longer relying on them, consistent with the existing `--noexperimental_convenience_symlinks` already set for Windows due to filesystem limitations, and also avoiding filesystem traversal issues (see below).

### Additional Notes
Some prior art and observed problems:
- bazelbuild/bazel#1293
- bazelbuild/bazel-gazelle#1384
- golang/go#41511
- googleapis/google-cloud-cpp#4933