### PR TITLE
Remove CI build reliance on `bazel` "convenience symlinks"

### DIFF
--- a/.gitlab/build/binary_build/sd_agent.yml
+++ b/.gitlab/build/binary_build/sd_agent.yml
@@ -6,9 +6,7 @@
   rules:
     - when: on_success
   script:
-    - bazelisk build --config=sd-agent-release //pkg/discovery/module/rust:sd-agent
-    - mkdir -p sd-agent-build-outputs
-    - cp bazel-bin/pkg/discovery/module/rust/sd-agent sd-agent-build-outputs/
+    - bazel run --config=sd-agent-release //pkg/discovery/module/rust:install -- --destdir=$PWD/sd-agent-build-outputs
     - tar -cJf $CI_PROJECT_DIR/sd-agent-build-outputs.tar.xz sd-agent-build-outputs/
   artifacts:
     expire_in: 2 weeks


### PR DESCRIPTION
### What does this PR do?
Replace a `bazel build ...` + `mkdir ...` + `cp bazel-bin/...` sequence with `bazel run ...:install --destdir=...`.

### Motivation
`bazel-bin` is a "convenience symlink" (aimed at easing build debugging), that will be soon disabled in CI:
- #46694.

### Describe how you validated your changes
CI.
The `:install` target already existed in `pkg/discovery/module/rust/BUILD.bazel`, so it was just a matter of using it.