### PR TITLE
feat(par): add listLogFiles action to logs bundle

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -557,7 +557,7 @@ func start(log log.Component,
 	}
 
 	if config.GetBool("private_action_runner.enabled") {
-		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, tracerouteComp, eventPlatform)
+		drain, err := startPrivateActionRunner(mainCtx, config, hostnameGetter, rcClient, le, log, taggerComp, wmeta, tracerouteComp, eventPlatform)
 		if err != nil {
 			log.Errorf("Cannot start private action runner: %v", err)
 		} else {
@@ -694,6 +694,7 @@ func startPrivateActionRunner(
 	le *leaderelection.LeaderEngine,
 	log log.Component,
 	tagger tagger.Component,
+	wmeta workloadmeta.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
 ) (func(), error) {
@@ -704,7 +705,7 @@ func startPrivateActionRunner(
 		return nil, errors.New("leader election is not enabled on the Cluster Agent. The private action runner needs leader election for identity coordination across replicas")
 	}
 	le.StartLeaderElectionRun()
-	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, tracerouteComp, eventPlatform)
+	app, err := privateactionrunner.NewPrivateActionRunner(ctx, config, hostnameGetter, rcClient, log, tagger, wmeta, tracerouteComp, eventPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
@@ -60,6 +61,7 @@ type Requires struct {
 	RcClient      rcclient.Component
 	Hostname      hostname.Component
 	Tagger        tagger.Component
+	Wmeta         workloadmeta.Component
 	Traceroute    traceroute.Component
 	EventPlatform eventplatform.Component
 }
@@ -75,6 +77,7 @@ type PrivateActionRunner struct {
 	rcClient       pkgrcclient.Client
 	logger         log.Component
 	tagger         tagger.Component
+	wmeta          workloadmeta.Component
 	traceroute     traceroute.Component
 	eventPlatform  eventplatform.Component
 
@@ -95,7 +98,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 		return Provides{}, privateactionrunner.ErrNotEnabled
 	}
 
-	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform)
+	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Wmeta, reqs.Traceroute, reqs.EventPlatform)
 	if err != nil {
 		return Provides{}, err
 	}
@@ -113,6 +116,7 @@ func NewPrivateActionRunner(
 	rcClient pkgrcclient.Client,
 	logger log.Component,
 	taggerComp tagger.Component,
+	wmeta workloadmeta.Component,
 	tracerouteComp traceroute.Component,
 	eventPlatform eventplatform.Component,
 ) (*PrivateActionRunner, error) {
@@ -122,6 +126,7 @@ func NewPrivateActionRunner(
 		rcClient:       rcClient,
 		logger:         logger,
 		tagger:         taggerComp,
+		wmeta:          wmeta,
 		traceroute:     tracerouteComp,
 		eventPlatform:  eventPlatform,
 		startChan:      make(chan struct{}),
@@ -195,7 +200,7 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	taskVerifier := taskverifier.NewTaskVerifier(keysManager, cfg)
 	opmsClient := opms.NewClient(cfg)
 
-	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.traceroute, p.eventPlatform)
+	p.workflowRunner, err = runners.NewWorkflowRunner(cfg, keysManager, taskVerifier, opmsClient, p.wmeta, p.traceroute, p.eventPlatform)
 	if err != nil {
 		return err
 	}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/collect_filesystem_logs.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/collect_filesystem_logs.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// collectFilesystemLogs walks /var/log (excluding K8s/Docker subdirs) plus
+// any user-specified additional directories.
+func collectFilesystemLogs(hostPrefix string, additionalDirs []string) ([]LogFileEntry, []string) {
+	var entries []LogFileEntry
+	var errs []string
+
+	// Walk /var/log with the isLogFile heuristic
+	varLogDir := toHostPath(hostPrefix, "/var/log")
+	if _, err := os.Stat(varLogDir); err == nil {
+		err := filepath.WalkDir(varLogDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			outputPath := toOutputPath(hostPrefix, path)
+			if isLogFile(outputPath) {
+				entries = append(entries, LogFileEntry{
+					Path:   outputPath,
+					Source: "filesystem",
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, "error walking /var/log: "+err.Error())
+		}
+	}
+
+	// Walk additional directories — include all regular files
+	for _, dir := range additionalDirs {
+		hostDir := toHostPath(hostPrefix, dir)
+		if _, err := os.Stat(hostDir); os.IsNotExist(err) {
+			errs = append(errs, "additional directory not found: "+dir)
+			continue
+		}
+		err := filepath.WalkDir(hostDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			entries = append(entries, LogFileEntry{
+				Path:   toOutputPath(hostPrefix, path),
+				Source: "filesystem",
+			})
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, "error walking "+dir+": "+err.Error())
+		}
+	}
+
+	return entries, errs
+}
+
+// isLogFile mirrors the heuristic from pkg/discovery/module/logs.go but
+// without the //go:build linux constraint so it can run cross-platform.
+func isLogFile(path string) bool {
+	// Files in /var/log are log files even if they don't end with .log.
+	if strings.HasPrefix(path, "/var/log/") {
+		// Ignore Kubernetes pods logs since they are collected by other means.
+		if strings.HasPrefix(path, "/var/log/pods") {
+			return false
+		}
+		// Ignore Kubernetes container symlinks.
+		if strings.HasPrefix(path, "/var/log/containers") {
+			return false
+		}
+		// Ignore Docker container logs.
+		if strings.HasPrefix(path, "/var/log/docker") {
+			return false
+		}
+		return true
+	}
+
+	if strings.HasSuffix(path, ".log") {
+		// Ignore Docker container logs since they are collected by other means.
+		return !strings.HasPrefix(path, "/var/lib/docker/containers")
+	}
+
+	return false
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/collect_k8s_logs.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/collect_k8s_logs.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// k8sLogDirs are the host directories that contain Kubernetes log files.
+var k8sLogDirs = []string{
+	"/var/log/pods",
+	"/var/log/containers",
+}
+
+// collectK8sLogs walks Kubernetes log directories and returns all *.log files
+// found. Non-existent directories are silently skipped.
+func collectK8sLogs(hostPrefix string) ([]LogFileEntry, []string) {
+	var entries []LogFileEntry
+	var errs []string
+
+	for _, dir := range k8sLogDirs {
+		hostDir := toHostPath(hostPrefix, dir)
+
+		if _, err := os.Stat(hostDir); os.IsNotExist(err) {
+			continue
+		}
+
+		err := filepath.WalkDir(hostDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil // skip entries we cannot read
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(d.Name(), ".log") {
+				entries = append(entries, LogFileEntry{
+					Path:   toOutputPath(hostPrefix, path),
+					Source: "kubernetes",
+				})
+			}
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, "error walking "+dir+": "+err.Error())
+		}
+	}
+	return entries, errs
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/collect_process_logs.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/collect_process_logs.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// collectProcessLogs queries workloadmeta for all processes and extracts their
+// associated log files. Paths from workloadmeta are already host-relative.
+func collectProcessLogs(wmeta workloadmeta.Component) []LogFileEntry {
+	if wmeta == nil {
+		return nil
+	}
+
+	processes := wmeta.ListProcesses()
+	var entries []LogFileEntry
+	for _, proc := range processes {
+		if proc.Service == nil || len(proc.Service.LogFiles) == 0 {
+			continue
+		}
+		for _, logPath := range proc.Service.LogFiles {
+			entries = append(entries, LogFileEntry{
+				Path:        logPath,
+				Source:      "process",
+				ProcessName: proc.Name,
+				PID:         proc.Pid,
+				ServiceName: proc.Service.GeneratedName,
+			})
+		}
+	}
+	return entries
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/entrypoint.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+// LogsBundle implements the types.Bundle interface for the com.datadoghq.ddagent.logs bundle.
+type LogsBundle struct {
+	actions map[string]types.Action
+}
+
+// NewLogs creates a new LogsBundle with all log-related actions registered.
+func NewLogs(wmeta workloadmeta.Component) types.Bundle {
+	return &LogsBundle{
+		actions: map[string]types.Action{
+			"listLogFiles": NewListLogFilesHandler(wmeta),
+		},
+	}
+}
+
+// GetAction returns the action registered under the given name.
+func (b *LogsBundle) GetAction(actionName string) types.Action {
+	return b.actions[actionName]
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/host_prefix.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/host_prefix.go
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// getHostPrefix returns "/host" when running inside a container (where host
+// directories are bind-mounted under /host), or "" when running directly on
+// the host.
+func getHostPrefix() string {
+	if _, err := os.Stat("/host/proc"); err == nil {
+		return "/host"
+	}
+	return ""
+}
+
+// toHostPath converts a host-relative path (e.g. "/var/log") into the
+// corresponding container path (e.g. "/host/var/log").
+func toHostPath(prefix, path string) string {
+	if prefix == "" {
+		return path
+	}
+	return filepath.Join(prefix, path)
+}
+
+// toOutputPath strips the host prefix from a container-local path so the
+// caller sees the original host-relative path.
+func toOutputPath(prefix, path string) string {
+	if prefix == "" {
+		return path
+	}
+	return strings.TrimPrefix(path, prefix)
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/list_log_files.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/list_log_files.go
@@ -1,0 +1,126 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+// ListLogFilesInputs are the optional inputs for the listLogFiles action.
+type ListLogFilesInputs struct {
+	AdditionalDirs []string `json:"additionalDirs,omitempty"`
+}
+
+// LogFileEntry represents a single log file discovered by the action.
+type LogFileEntry struct {
+	Path        string `json:"path"`                  // host-relative path
+	Source      string `json:"source"`                // "process", "kubernetes", or "filesystem"
+	ProcessName string `json:"processName,omitempty"` // set when source is "process"
+	PID         int32  `json:"pid,omitempty"`         // set when source is "process"
+	ServiceName string `json:"serviceName,omitempty"` // set when source is "process"
+}
+
+// ListLogFilesOutputs is the output returned by the listLogFiles action.
+type ListLogFilesOutputs struct {
+	LogFiles []LogFileEntry `json:"logFiles"`
+	Errors   []string       `json:"errors,omitempty"`
+}
+
+// ListLogFilesHandler implements the listLogFiles action.
+type ListLogFilesHandler struct {
+	wmeta workloadmeta.Component
+}
+
+// NewListLogFilesHandler creates a new ListLogFilesHandler.
+func NewListLogFilesHandler(wmeta workloadmeta.Component) *ListLogFilesHandler {
+	return &ListLogFilesHandler{wmeta: wmeta}
+}
+
+// Run executes the listLogFiles action.
+func (h *ListLogFilesHandler) Run(
+	_ context.Context,
+	task *types.Task,
+	_ *privateconnection.PrivateCredentials,
+) (interface{}, error) {
+	inputs, err := types.ExtractInputs[ListLogFilesInputs](task)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateAdditionalDirs(inputs.AdditionalDirs); err != nil {
+		return nil, err
+	}
+
+	hostPrefix := getHostPrefix()
+	seen := make(map[string]struct{})
+	var allEntries []LogFileEntry
+	var allErrors []string
+
+	// 1. Process logs from workloadmeta
+	for _, entry := range collectProcessLogs(h.wmeta) {
+		if _, ok := seen[entry.Path]; ok {
+			continue
+		}
+		seen[entry.Path] = struct{}{}
+		allEntries = append(allEntries, entry)
+	}
+
+	// 2. Kubernetes logs
+	k8sEntries, k8sErrs := collectK8sLogs(hostPrefix)
+	allErrors = append(allErrors, k8sErrs...)
+	for _, entry := range k8sEntries {
+		if _, ok := seen[entry.Path]; ok {
+			continue
+		}
+		seen[entry.Path] = struct{}{}
+		allEntries = append(allEntries, entry)
+	}
+
+	// 3. Filesystem logs
+	fsEntries, fsErrs := collectFilesystemLogs(hostPrefix, inputs.AdditionalDirs)
+	allErrors = append(allErrors, fsErrs...)
+	for _, entry := range fsEntries {
+		if _, ok := seen[entry.Path]; ok {
+			continue
+		}
+		seen[entry.Path] = struct{}{}
+		allEntries = append(allEntries, entry)
+	}
+
+	if allEntries == nil {
+		allEntries = []LogFileEntry{}
+	}
+
+	return &ListLogFilesOutputs{
+		LogFiles: allEntries,
+		Errors:   allErrors,
+	}, nil
+}
+
+// validateAdditionalDirs checks that all additional directories are absolute
+// paths and do not contain path traversal components.
+func validateAdditionalDirs(dirs []string) error {
+	for _, dir := range dirs {
+		if !filepath.IsAbs(dir) {
+			return fmt.Errorf("additional directory must be absolute: %s", dir)
+		}
+		// Check the raw input for ".." path components before filepath.Clean
+		// resolves them away.
+		for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+			if part == ".." {
+				return fmt.Errorf("additional directory must not contain '..': %s", dir)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/privateactionrunner/bundles/ddagent/logs/list_log_files_test.go
+++ b/pkg/privateactionrunner/bundles/ddagent/logs/list_log_files_test.go
@@ -1,0 +1,259 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_ddagent_logs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+)
+
+// --- collectProcessLogs tests ---
+
+func TestCollectProcessLogs_NilWmeta(t *testing.T) {
+	entries := collectProcessLogs(nil)
+	assert.Nil(t, entries)
+}
+
+func TestCollectProcessLogs_WithMock(t *testing.T) {
+	mock := &mockWorkloadMeta{
+		processes: []*workloadmeta.Process{
+			{
+				Pid:  1234,
+				Name: "myapp",
+				Service: &workloadmeta.Service{
+					GeneratedName: "my-service",
+					LogFiles:      []string{"/var/log/myapp.log", "/var/log/myapp-error.log"},
+				},
+			},
+			{
+				Pid:     5678,
+				Name:    "no-service",
+				Service: nil,
+			},
+			{
+				Pid:  9999,
+				Name: "empty-logs",
+				Service: &workloadmeta.Service{
+					GeneratedName: "empty-svc",
+					LogFiles:      nil,
+				},
+			},
+		},
+	}
+
+	entries := collectProcessLogs(mock)
+	require.Len(t, entries, 2)
+
+	assert.Equal(t, "/var/log/myapp.log", entries[0].Path)
+	assert.Equal(t, "process", entries[0].Source)
+	assert.Equal(t, "myapp", entries[0].ProcessName)
+	assert.Equal(t, int32(1234), entries[0].PID)
+	assert.Equal(t, "my-service", entries[0].ServiceName)
+
+	assert.Equal(t, "/var/log/myapp-error.log", entries[1].Path)
+}
+
+// --- collectK8sLogs tests ---
+
+func TestCollectK8sLogs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create /var/log/pods structure
+	podsDir := filepath.Join(tmpDir, "var", "log", "pods", "ns_pod_uid", "container")
+	require.NoError(t, os.MkdirAll(podsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(podsDir, "0.log"), []byte("log"), 0644))
+
+	// Create /var/log/containers structure
+	containersDir := filepath.Join(tmpDir, "var", "log", "containers")
+	require.NoError(t, os.MkdirAll(containersDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(containersDir, "container.log"), []byte("log"), 0644))
+
+	// Create a non-.log file that should be ignored
+	require.NoError(t, os.WriteFile(filepath.Join(containersDir, "not-a-log.txt"), []byte("nope"), 0644))
+
+	entries, errs := collectK8sLogs(tmpDir)
+	assert.Empty(t, errs)
+	assert.Len(t, entries, 2)
+
+	for _, e := range entries {
+		assert.Equal(t, "kubernetes", e.Source)
+		assert.NotEmpty(t, e.Path)
+	}
+}
+
+func TestCollectK8sLogs_NonExistentDir(t *testing.T) {
+	entries, errs := collectK8sLogs("/nonexistent/prefix")
+	assert.Empty(t, errs)
+	assert.Empty(t, entries)
+}
+
+// --- collectFilesystemLogs tests ---
+
+func TestCollectFilesystemLogs_VarLog(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// /var/log/ with some files
+	varLog := filepath.Join(tmpDir, "var", "log")
+	require.NoError(t, os.MkdirAll(varLog, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(varLog, "syslog"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(varLog, "messages"), []byte("data"), 0644))
+
+	// /var/log/pods should be excluded by isLogFile
+	podsDir := filepath.Join(varLog, "pods")
+	require.NoError(t, os.MkdirAll(podsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(podsDir, "pod.log"), []byte("data"), 0644))
+
+	entries, errs := collectFilesystemLogs(tmpDir, nil)
+	assert.Empty(t, errs)
+
+	// syslog and messages should be included; pods/pod.log should not
+	var paths []string
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+		assert.Equal(t, "filesystem", e.Source)
+	}
+	assert.Contains(t, paths, "/var/log/syslog")
+	assert.Contains(t, paths, "/var/log/messages")
+	assert.NotContains(t, paths, "/var/log/pods/pod.log")
+}
+
+func TestCollectFilesystemLogs_AdditionalDirs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an additional directory with mixed files
+	appLogs := filepath.Join(tmpDir, "opt", "app", "logs")
+	require.NoError(t, os.MkdirAll(appLogs, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(appLogs, "app.log"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(appLogs, "app.txt"), []byte("data"), 0644))
+
+	entries, errs := collectFilesystemLogs(tmpDir, []string{"/opt/app/logs"})
+	assert.Empty(t, errs)
+
+	// Both files should be included (additional dirs include all regular files)
+	var paths []string
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	assert.Contains(t, paths, "/opt/app/logs/app.log")
+	assert.Contains(t, paths, "/opt/app/logs/app.txt")
+}
+
+func TestCollectFilesystemLogs_AdditionalDirNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	entries, errs := collectFilesystemLogs(tmpDir, []string{"/nonexistent/dir"})
+	assert.Empty(t, entries)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "additional directory not found")
+}
+
+// --- isLogFile tests ---
+
+func TestIsLogFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/var/log/syslog", true},
+		{"/var/log/messages", true},
+		{"/var/log/auth.log", true},
+		{"/var/log/nginx/access.log", true},
+		{"/var/log/pods/something.log", false},
+		{"/var/log/containers/test.log", false},
+		{"/var/log/docker/something.log", false},
+		{"/opt/app/app.log", true},
+		{"/opt/app/data.txt", false},
+		{"/var/lib/docker/containers/abc/abc.log", false},
+		{"/home/user/output.log", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLogFile(tt.path), "isLogFile(%q)", tt.path)
+		})
+	}
+}
+
+// --- validateAdditionalDirs tests ---
+
+func TestValidateAdditionalDirs(t *testing.T) {
+	tests := []struct {
+		name    string
+		dirs    []string
+		wantErr bool
+	}{
+		{"nil dirs", nil, false},
+		{"empty dirs", []string{}, false},
+		{"valid absolute paths", []string{"/opt/logs", "/var/custom"}, false},
+		{"relative path", []string{"relative/path"}, true},
+		{"path with ..", []string{"/opt/../etc"}, true},
+		{"mixed valid and invalid", []string{"/opt/logs", "relative"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAdditionalDirs(tt.dirs)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// --- Deduplication test ---
+
+func TestDeduplication(t *testing.T) {
+	// Simulate two sources returning the same path
+	seen := make(map[string]struct{})
+	var result []LogFileEntry
+
+	entries := []LogFileEntry{
+		{Path: "/var/log/syslog", Source: "process"},
+		{Path: "/var/log/syslog", Source: "filesystem"},
+		{Path: "/var/log/other.log", Source: "filesystem"},
+	}
+
+	for _, entry := range entries {
+		if _, ok := seen[entry.Path]; ok {
+			continue
+		}
+		seen[entry.Path] = struct{}{}
+		result = append(result, entry)
+	}
+
+	assert.Len(t, result, 2)
+	assert.Equal(t, "process", result[0].Source) // first seen wins
+}
+
+// --- Host path conversion tests ---
+
+func TestToHostPath(t *testing.T) {
+	assert.Equal(t, "/host/var/log", toHostPath("/host", "/var/log"))
+	assert.Equal(t, "/var/log", toHostPath("", "/var/log"))
+}
+
+func TestToOutputPath(t *testing.T) {
+	assert.Equal(t, "/var/log", toOutputPath("/host", "/host/var/log"))
+	assert.Equal(t, "/var/log", toOutputPath("", "/var/log"))
+}
+
+// --- mockWorkloadMeta implements the subset of workloadmeta.Component we need ---
+
+type mockWorkloadMeta struct {
+	workloadmeta.Component
+	processes []*workloadmeta.Process
+}
+
+func (m *mockWorkloadMeta) ListProcesses() []*workloadmeta.Process {
+	return m.processes
+}

--- a/pkg/privateactionrunner/bundles/registry.go
+++ b/pkg/privateactionrunner/bundles/registry.go
@@ -8,10 +8,12 @@
 package privatebundles
 
 import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
+	com_datadoghq_ddagent_logs "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent/logs"
 	com_datadoghq_ddagent_networkpath "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent/networkpath"
 	com_datadoghq_gitlab_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/branches"
 	com_datadoghq_gitlab_commits "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/commits"
@@ -50,10 +52,11 @@ type Registry struct {
 	Bundles map[string]types.Bundle
 }
 
-func NewRegistry(configuration *config.Config, traceroute traceroute.Component, eventPlatform eventplatform.Component) *Registry {
+func NewRegistry(configuration *config.Config, wmeta workloadmeta.Component, traceroute traceroute.Component, eventPlatform eventplatform.Component) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),
+			"com.datadoghq.ddagent.logs":               com_datadoghq_ddagent_logs.NewLogs(wmeta),
 			"com.datadoghq.ddagent.networkpath":        com_datadoghq_ddagent_networkpath.NewNetworkPath(traceroute, eventPlatform),
 			"com.datadoghq.gitlab.branches":            com_datadoghq_gitlab_branches.NewGitlabBranches(),
 			"com.datadoghq.gitlab.commits":             com_datadoghq_gitlab_commits.NewGitlabCommits(),

--- a/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
+++ b/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
@@ -9,10 +9,12 @@
 package privatebundles
 
 import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/config"
 	com_datadoghq_ddagent "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent"
+	com_datadoghq_ddagent_logs "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent/logs"
 	com_datadoghq_ddagent_networkpath "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/ddagent/networkpath"
 	com_datadoghq_gitlab_branches "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/branches"
 	com_datadoghq_gitlab_commits "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/gitlab/commits"
@@ -51,10 +53,11 @@ type Registry struct {
 	Bundles map[string]types.Bundle
 }
 
-func NewRegistry(configuration *config.Config, traceroute traceroute.Component, eventPlatform eventplatform.Component) *Registry {
+func NewRegistry(configuration *config.Config, _ workloadmeta.Component, traceroute traceroute.Component, eventPlatform eventplatform.Component) *Registry {
 	return &Registry{
 		Bundles: map[string]types.Bundle{
 			"com.datadoghq.ddagent":                    com_datadoghq_ddagent.NewAgentActions(),
+			"com.datadoghq.ddagent.logs":               com_datadoghq_ddagent_logs.NewLogs(nil),
 			"com.datadoghq.ddagent.networkpath":        com_datadoghq_ddagent_networkpath.NewNetworkPath(traceroute, eventPlatform),
 			"com.datadoghq.gitlab.branches":            com_datadoghq_gitlab_branches.NewGitlabBranches(),
 			"com.datadoghq.gitlab.commits":             com_datadoghq_gitlab_commits.NewGitlabCommits(),

--- a/pkg/privateactionrunner/runners/workflow_runner.go
+++ b/pkg/privateactionrunner/runners/workflow_runner.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"time"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
@@ -42,11 +43,12 @@ func NewWorkflowRunner(
 	keysManager taskverifier.KeysManager,
 	verifier *taskverifier.TaskVerifier,
 	opmsClient opms.Client,
+	wmeta workloadmeta.Component,
 	traceroute traceroute.Component,
 	eventPlatform eventplatform.Component,
 ) (*WorkflowRunner, error) {
 	return &WorkflowRunner{
-		registry:     privatebundles.NewRegistry(configuration, traceroute, eventPlatform),
+		registry:     privatebundles.NewRegistry(configuration, wmeta, traceroute, eventPlatform),
 		opmsClient:   opmsClient,
 		resolver:     resolver.NewPrivateCredentialResolver(),
 		config:       configuration,


### PR DESCRIPTION
## Summary
- Add `listLogFiles` action to new `com.datadoghq.ddagent.logs` PAR bundle that aggregates log files from three sources: process logs (via workloadmeta `Service.LogFiles`), Kubernetes logs (`/var/log/pods/` and `/var/log/containers/`), and filesystem logs (`/var/log/` plus user-specified additional directories)
- Thread `workloadmeta.Component` through the PAR dependency chain (privateactionrunner → workflow_runner → registry → bundle)
- Results are deduplicated by path; process-sourced entries carry PID, process name, and service name metadata

## Test plan
- [x] `go test ./pkg/privateactionrunner/bundles/ddagent/logs/...` — all tests pass
- [x] `go build ./pkg/privateactionrunner/...` — full PAR package compiles
- [ ] `dda inv agent.build --build-exclude=systemd` — full agent build
- [ ] Deploy to local Kind cluster and verify listLogFiles returns expected entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Companion PR (dd-source):** https://github.com/DataDog/dd-source/pull/363630