### PR TITLE
[ACTP] Fix special connection names added to actions allowlist

### DIFF
--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -118,7 +118,6 @@ func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[strin
 	for _, specialAction := range BundleInheritedAllowedActions {
 		specialBundleID, specialActionName := actions.SplitFQN(specialAction)
 		specialBundleID = strings.ToLower(specialBundleID)
-		specialActionName = strings.ToLower(specialActionName)
 
 		actionsSet, ok := actionsAllowlist[specialBundleID]
 		if !ok || actionsSet.Len() == 0 {

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -24,7 +24,7 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 				"com.datadoghq.script": sets.New[string]("action1"),
 			},
 			expectedInheritedActions: map[string]sets.Set[string]{
-				"com.datadoghq.script": sets.New[string]("testconnection", "enrichscript"),
+				"com.datadoghq.script": sets.New[string]("testConnection", "enrichScript"),
 			},
 		},
 		{
@@ -55,9 +55,9 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 				"com.datadoghq.kubernetes.core": sets.New[string]("action3"),
 			},
 			expectedInheritedActions: map[string]sets.Set[string]{
-				"com.datadoghq.script":          sets.New[string]("testconnection", "enrichscript"),
-				"com.datadoghq.gitlab.users":    sets.New[string]("testconnection"),
-				"com.datadoghq.kubernetes.core": sets.New[string]("testconnection"),
+				"com.datadoghq.script":          sets.New[string]("testConnection", "enrichScript"),
+				"com.datadoghq.gitlab.users":    sets.New[string]("testConnection"),
+				"com.datadoghq.kubernetes.core": sets.New[string]("testConnection"),
 			},
 		},
 	}


### PR DESCRIPTION
### Summary
Switches from using lower case to using camelCase for special connection names added to actions allowlist.

### Motivation
Currently, connections cannot be tested because the action name included in the task doesn't match the action name included in the allowlist. 

