### PR TITLE
Warn when running `bazel` in a container without persisting its cache

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -20,4 +20,11 @@ common --config=ci
 EOF
 fi
 
+# Warn non-CI users running `bazel` in a container without persisting its cache
+if [[ -z "${XDG_CACHE_HOME:-}" && ( -e /.dockerenv || -e /run/.containerenv ) ]]; then
+  >&2 echo "💡 To persist caches across restarts, consider sharing a directory and setting XDG_CACHE_HOME to its path:"
+  # shellcheck disable=SC2016
+  >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
+fi
+
 exec "$BAZEL_REAL" "$@"


### PR DESCRIPTION
### What does this PR do?
Emit a 💡 tip to stderr suggesting to mount a volume and set `XDG_CACHE_HOME` accordingly when running `bazel` in a container without persisting its cache.

### Motivation
Without `XDG_CACHE_HOME` pointing to a mounted volume, the `bazel` cache is silently lost when the container stops.
This also applies to `pip`, `uv`, as well as any other `XDG`-compliant tool.

### Additional Notes
Detection via `/.dockerenv` (Docker) and `/run/.containerenv` (Podman, CRI-O) works across Linux cgroup v1/v2 and macOS (unlike `/proc/1/cgroup` which shows `0::/` on cgroup v2).