### PR TITLE
(workload-selection) Fix race condition on policy writes

### DIFF
--- a/comp/workloadselection/impl/workloadselection_windows.go
+++ b/comp/workloadselection/impl/workloadselection_windows.go
@@ -80,7 +80,12 @@ func (c *workloadselectionComponent) compileAndWriteConfig(rawConfig []byte) err
 		return err
 	}
 
-	tmpPath := configPath + ".tmp"
+	tmpFile, err := os.CreateTemp(filepath.Dir(configPath), "workload-policy-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
 	defer os.Remove(tmpPath)
 
 	cmd := exec.Command(getCompilePolicyBinaryPath(), "--input-string", string(rawConfig), "--output-file", tmpPath)

--- a/releasenotes/notes/atomic-wls-policy-write-dc822d75e98fc014.yaml
+++ b/releasenotes/notes/atomic-wls-policy-write-dc822d75e98fc014.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Use atomic file replacement (write to temp file then rename) when writing
+    APM workload selection policy files, preventing concurrent readers from
+    seeing partially-written data.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race condition, because the writes were not atomic readers could read a corrupted version of the file.

### Motivation

### Describe how you validated your changes

Existing test suite

### Additional Notes
