### PR TITLE
Drop redundant `rootPath` from fleet installer config

### DIFF
--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -187,7 +187,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root) error {
 			return err
 		}
 		// Set proper ownership and permissions for the file
-		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), path), spec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, root, path, spec); err != nil {
 			return err
 		}
 		return nil
@@ -219,7 +219,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root) error {
 		}
 
 		// Set proper ownership and permissions for the destination file
-		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), destinationPath), destSpec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, root, destinationPath, destSpec); err != nil {
 			return err
 		}
 		return nil
@@ -240,7 +240,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root) error {
 		}
 
 		// Set proper ownership and permissions for the destination file
-		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), destinationPath), destSpec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, root, destinationPath, destSpec); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/fleet/installer/config/config.go
+++ b/pkg/fleet/installer/config/config.go
@@ -100,8 +100,7 @@ func (o *Operations) Apply(ctx context.Context, rootPath string) error {
 	}
 	defer root.Close()
 	for _, operation := range o.FileOperations {
-		// TODO (go.1.25): we won't need rootPath in 1.25
-		err := operation.apply(ctx, root, rootPath)
+		err := operation.apply(ctx, root)
 		if err != nil {
 			return err
 		}
@@ -117,7 +116,7 @@ type FileOperation struct {
 	Patch             json.RawMessage   `json:"patch,omitempty"`
 }
 
-func (a *FileOperation) apply(ctx context.Context, root *os.Root, rootPath string) error {
+func (a *FileOperation) apply(ctx context.Context, root *os.Root) error {
 	spec := getConfigFileSpec(a.FilePath)
 	if spec == nil {
 		return fmt.Errorf("modifying config file %s is not allowed", a.FilePath)
@@ -188,8 +187,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root, rootPath strin
 			return err
 		}
 		// Set proper ownership and permissions for the file
-		fullPath := filepath.Join(rootPath, path)
-		if err := setFileOwnershipAndPermissions(ctx, fullPath, spec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), path), spec); err != nil {
 			return err
 		}
 		return nil
@@ -221,8 +219,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root, rootPath strin
 		}
 
 		// Set proper ownership and permissions for the destination file
-		fullDestPath := filepath.Join(rootPath, destinationPath)
-		if err := setFileOwnershipAndPermissions(ctx, fullDestPath, destSpec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), destinationPath), destSpec); err != nil {
 			return err
 		}
 		return nil
@@ -243,8 +240,7 @@ func (a *FileOperation) apply(ctx context.Context, root *os.Root, rootPath strin
 		}
 
 		// Set proper ownership and permissions for the destination file
-		fullDestPath := filepath.Join(rootPath, destinationPath)
-		if err := setFileOwnershipAndPermissions(ctx, fullDestPath, destSpec); err != nil {
+		if err := setFileOwnershipAndPermissions(ctx, filepath.Join(root.Name(), destinationPath), destSpec); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/fleet/installer/config/config_nix.go
+++ b/pkg/fleet/installer/config/config_nix.go
@@ -146,18 +146,18 @@ func replaceConfigDirectory(oldDir, newDir string) (err error) {
 // setFileOwnershipAndPermissions sets the ownership and permissions for a file based on its configFileSpec.
 // If the user doesn't exist (e.g., in tests) or if we don't have permission
 // to change ownership, the function logs a warning and continues without failing.
-func setFileOwnershipAndPermissions(ctx context.Context, filePath string, spec *configFileSpec) error {
+func setFileOwnershipAndPermissions(ctx context.Context, root *os.Root, path string, spec *configFileSpec) error {
 	// Set file permissions
 	if spec.mode != 0 {
-		if err := os.Chmod(filePath, spec.mode); err != nil {
-			return fmt.Errorf("error setting file permissions for %s: %w", filePath, err)
+		if err := root.Chmod(path, spec.mode); err != nil {
+			return fmt.Errorf("error setting file permissions for %s: %w", path, err)
 		}
 	}
 
 	// Set file ownership
-	err := file.Chown(ctx, filePath, spec.owner, spec.group)
+	err := file.Chown(ctx, filepath.Join(root.Name(), path), spec.owner, spec.group)
 	if err != nil {
-		log.Warnf("error setting file ownership for %s: %v", filePath, err)
+		log.Warnf("error setting file ownership for %s: %v", path, err)
 	}
 
 	return nil

--- a/pkg/fleet/installer/config/config_test.go
+++ b/pkg/fleet/installer/config/config_test.go
@@ -38,7 +38,7 @@ func TestOperationApply_Patch(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check file content
@@ -78,7 +78,7 @@ func TestOperationApply_MergePatch(t *testing.T) {
 		Patch:             []byte(mergePatch),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -106,7 +106,7 @@ func TestOperationApply_Delete(t *testing.T) {
 		FilePath:          "/datadog.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 	_, err = os.Stat(filePath)
 	assert.Error(t, err)
@@ -130,7 +130,7 @@ func TestOperationApply_EmptyYAMLFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check that the file now contains the patched value
@@ -157,7 +157,7 @@ func TestOperationApply_NoFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	filePath := filepath.Join(tmpDir, "datadog.yaml")
@@ -186,7 +186,7 @@ func TestOperationApply_DisallowedFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not allowed")
 }
@@ -214,7 +214,7 @@ func TestOperationApply_NestedConfigFile(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	updated, err := os.ReadFile(filePath)
@@ -405,7 +405,7 @@ func TestOperationApply_Copy(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check that source file still exists
@@ -438,7 +438,7 @@ func TestOperationApply_Move(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check that source file no longer exists
@@ -473,7 +473,7 @@ func TestOperationApply_CopyWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -507,7 +507,7 @@ func TestOperationApply_MoveWithNestedDestination(t *testing.T) {
 		DestinationPath:   "/conf.d/mycheck.d/config.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check that nested directories were created
@@ -538,7 +538,7 @@ func TestOperationApply_CopyMissingSource(t *testing.T) {
 		DestinationPath:   "/security-agent.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.Error(t, err)
 }
 
@@ -555,7 +555,7 @@ func TestOperationApply_MoveMissingSource(t *testing.T) {
 		DestinationPath:   "/otel-config.yaml",
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.Error(t, err)
 }
 
@@ -679,7 +679,7 @@ api_key: "KEY_2"
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check file content, should now have api_key: NEW_KEY
@@ -716,7 +716,7 @@ func TestOperationApply_ApplicationMonitoringPermissions(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check file permissions - should be world-readable (0644)
@@ -756,7 +756,7 @@ func TestOperationApply_NestedMaps(t *testing.T) {
 		Patch:             []byte(patchJSON),
 	}
 
-	err = op.apply(context.Background(), root, tmpDir)
+	err = op.apply(context.Background(), root)
 	assert.NoError(t, err)
 
 	// Check file content

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -178,6 +178,6 @@ func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath str
 
 // setFileOwnershipAndPermissions is a no-op on Windows as file ownership and permissions
 // are handled differently through ACLs, not POSIX ownership and modes.
-func setFileOwnershipAndPermissions(_ context.Context, _ string, _ *configFileSpec) error {
+func setFileOwnershipAndPermissions(_ context.Context, _ *os.Root, _ string, _ *configFileSpec) error {
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?
1. remove the `rootPath` parameter from `FileOperation.apply()`, replacing `filepath.Join(rootPath, ...)` calls with `filepath.Join(root.Name(), ...)`.
2. pass `*os.Root` into `setFileOwnershipAndPermissions` and use `root.Chmod()` in place of `os.Chmod()`, but:
   - `root.Chown()` is not used as it requires numeric uid/gid,
   - `file.Chown()` still handles the name lookup internally and requires a full path.

### Motivation
1. address a trivial TODO, follow-up of #46592: once `root.RemoveAll()` replaced the last os-level `filepath.Join(rootPath, ...)` call, `rootPath`'s sole remaining purpose was feeding `setFileOwnershipAndPermissions`: `root.Name()` returns the equivalent value,
2. address [review comment](https://github.com/DataDog/datadog-agent/pull/46719#discussion_r2834106679): use `os.Root` APIs where possible instead of reconstructing full paths at call sites.

### Describe how you validated your changes
Existing unit tests pass unchanged.