### PR TITLE
(windows) Enable system-probe when apm-inject is installed with host instrumentation

### DIFF
--- a/.gitlab/windows/test/e2e_install_packages/windows.yml
+++ b/.gitlab/windows/test/e2e_install_packages/windows.yml
@@ -262,3 +262,5 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentMSIInstallsAPMInject/TestInstallFromMSIWithJava$"
       - EXTRA_PARAMS: --run "TestInjectorStats/TestQueryStatsViaSystemProbe$"
       - EXTRA_PARAMS: --run "TestInjectorStats/TestQueryStatsAfterInjection$"
+      - EXTRA_PARAMS: --run "TestSystemProbeConfig/TestInstallScriptStartsSystemProbe$"
+      - EXTRA_PARAMS: --run "TestSystemProbeConfig/TestStandaloneInstallDoesNotStartSystemProbe$"

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	pkgExec "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -12,10 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
-
-	"go.yaml.in/yaml/v3"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	pkgExec "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"
@@ -99,39 +96,13 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 	return enableSystemProbeConfigAt(configPath)
 }
 
-// enableSystemProbeConfigAt sets system_probe_config.enabled: true in the given
-// config file, preserving any other existing settings. It is a no-op if already enabled.
+// enableSystemProbeConfigAt merges system_probe_config.enabled: true into the
+// given config file, preserving all existing settings.
 func enableSystemProbeConfigAt(configPath string) error {
-	cfg := config.SystemProbeConfig{}
-	existing, err := os.ReadFile(configPath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to read system-probe.yaml: %w", err)
+	update := config.SystemProbeConfig{
+		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(true)},
 	}
-	if len(existing) > 0 {
-		if err := yaml.Unmarshal(existing, &cfg); err != nil {
-			return fmt.Errorf("failed to unmarshal system-probe.yaml: %w", err)
-		}
-	}
-	if cfg.SystemProbeSettings.Enabled != nil && *cfg.SystemProbeSettings.Enabled {
-		return nil
-	}
-
-	cfg.SystemProbeSettings.Enabled = config.BoolToPtr(true)
-	data, err := yaml.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to marshal system-probe.yaml: %w", err)
-	}
-
-	// Atomic write via temp file + rename
-	tmpPath := configPath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0640); err != nil {
-		return fmt.Errorf("failed to write temporary system-probe.yaml: %w", err)
-	}
-	if err := os.Rename(tmpPath, configPath); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("failed to atomically replace system-probe.yaml: %w", err)
-	}
-	return nil
+	return config.WriteConfig(configPath, update, 0640, true)
 }
 
 // preRemoveAPMInject is called before the APM inject package is removed

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -96,7 +96,12 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 	defer func() { span.Finish(err) }()
 
 	configPath := filepath.Join(paths.AgentConfigDir, "system-probe.yaml")
+	return enableSystemProbeConfigAt(configPath)
+}
 
+// enableSystemProbeConfigAt sets system_probe_config.enabled: true in the given
+// config file, preserving any other existing settings. It is a no-op if already enabled.
+func enableSystemProbeConfigAt(configPath string) error {
 	cfg := config.SystemProbeConfig{}
 	existing, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -123,7 +128,6 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 		return fmt.Errorf("failed to write temporary system-probe.yaml: %w", err)
 	}
 	if err := os.Rename(tmpPath, configPath); err != nil {
-		// Clean up the temp file on rename failure
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to atomically replace system-probe.yaml: %w", err)
 	}

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -92,11 +92,6 @@ func postInstallAPMInject(ctx HookContext) (err error) {
 // update) where the setup script config writing does not run. Needed for monitoring and crash
 // detection of driver crashes.
 func enableSystemProbeConfig(ctx HookContext) (err error) {
-	e := env.FromEnv()
-	if e.InstallScript.APMInstrumentationEnabled != env.APMInstrumentationEnabledHost {
-		return nil
-	}
-
 	span, _ := telemetry.StartSpanFromContext(ctx, "enable_system_probe_config")
 	defer func() { span.Finish(err) }()
 

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -89,10 +89,8 @@ func postInstallAPMInject(ctx HookContext) (err error) {
 
 // enableSystemProbeConfig writes windows_crash_detection.enabled: true into
 // system-probe.yaml when host instrumentation is enabled. This enables the
-// crash detection module (and implicitly injector telemetry) without triggering
-// the deprecated system_probe_config.enabled backward-compat path that
-// auto-enables NPM. This covers the standalone install path (e.g. remote
-// update) where the setup script config writing does not run.
+// crash detection module (and implicitly injector telemetry) to track the
+// ddinjector driver crashes and report its telemetry.
 func enableSystemProbeConfig(ctx HookContext) (err error) {
 	span, _ := telemetry.StartSpanFromContext(ctx, "enable_system_probe_config")
 	defer func() { span.Finish(err) }()

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -116,8 +116,16 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to marshal system-probe.yaml: %w", err)
 	}
-	if err := os.WriteFile(configPath, data, 0640); err != nil {
-		return fmt.Errorf("failed to write system-probe.yaml: %w", err)
+
+	// Atomic write via temp file + rename
+	tmpPath := configPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0640); err != nil {
+		return fmt.Errorf("failed to write temporary system-probe.yaml: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		// Clean up the temp file on rename failure
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("failed to atomically replace system-probe.yaml: %w", err)
 	}
 	return nil
 }

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -87,10 +87,12 @@ func postInstallAPMInject(ctx HookContext) (err error) {
 	return nil
 }
 
-// enableSystemProbeConfig writes system_probe_config.enabled: true into system-probe.yaml
-// when host instrumentation is enabled. This covers the standalone install path (e.g. remote
-// update) where the setup script config writing does not run. Needed for monitoring and crash
-// detection of driver crashes.
+// enableSystemProbeConfig writes windows_crash_detection.enabled: true into
+// system-probe.yaml when host instrumentation is enabled. This enables the
+// crash detection module (and implicitly injector telemetry) without triggering
+// the deprecated system_probe_config.enabled backward-compat path that
+// auto-enables NPM. This covers the standalone install path (e.g. remote
+// update) where the setup script config writing does not run.
 func enableSystemProbeConfig(ctx HookContext) (err error) {
 	span, _ := telemetry.StartSpanFromContext(ctx, "enable_system_probe_config")
 	defer func() { span.Finish(err) }()
@@ -99,8 +101,8 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 	return enableSystemProbeConfigAt(configPath)
 }
 
-// enableSystemProbeConfigAt merges system_probe_config.enabled: true into the
-// given config file, preserving all existing settings. No-op if already enabled.
+// enableSystemProbeConfigAt merges windows_crash_detection.enabled: true into
+// the given config file, preserving all existing settings. No-op if already enabled.
 func enableSystemProbeConfigAt(configPath string) error {
 	existing, err := os.ReadFile(configPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -111,13 +113,13 @@ func enableSystemProbeConfigAt(configPath string) error {
 		if err := yaml.Unmarshal(existing, &cfg); err != nil {
 			return fmt.Errorf("failed to unmarshal system-probe.yaml: %w", err)
 		}
-		if cfg.SystemProbeSettings.Enabled != nil && *cfg.SystemProbeSettings.Enabled {
+		if cfg.WindowsCrashDetection.Enabled != nil && *cfg.WindowsCrashDetection.Enabled {
 			return nil
 		}
 	}
 
 	update := config.SystemProbeConfig{
-		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(true)},
+		WindowsCrashDetection: config.WindowsCrashDetection{Enabled: config.BoolToPtr(true)},
 	}
 	return config.WriteConfig(configPath, update, 0640, true)
 }

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -12,11 +12,15 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	pkgExec "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -61,6 +65,10 @@ func postInstallAPMInject(ctx HookContext) (err error) {
 	span, _ := ctx.StartSpan("setup_apm_inject")
 	defer func() { span.Finish(err) }()
 
+	if err := enableSystemProbeConfig(ctx); err != nil {
+		return fmt.Errorf("failed to enable system-probe config: %w", err)
+	}
+
 	// Get the installer path
 	packagePath, err := filepath.EvalSymlinks(getAPMInjectTargetPath("stable"))
 	if err != nil {
@@ -76,6 +84,46 @@ func postInstallAPMInject(ctx HookContext) (err error) {
 		return fmt.Errorf("failed to install APM inject driver: %w", err)
 	}
 
+	return nil
+}
+
+// enableSystemProbeConfig writes system_probe_config.enabled: true into system-probe.yaml
+// when host instrumentation is enabled. This covers the standalone install path (e.g. remote
+// update) where the setup script config writing does not run. Needed for monitoring and crash
+// detection of driver crashes.
+func enableSystemProbeConfig(ctx HookContext) (err error) {
+	e := env.FromEnv()
+	if e.InstallScript.APMInstrumentationEnabled != env.APMInstrumentationEnabledHost {
+		return nil
+	}
+
+	span, _ := telemetry.StartSpanFromContext(ctx, "enable_system_probe_config")
+	defer func() { span.Finish(err) }()
+
+	configPath := filepath.Join(paths.AgentConfigDir, "system-probe.yaml")
+
+	cfg := config.SystemProbeConfig{}
+	existing, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read system-probe.yaml: %w", err)
+	}
+	if len(existing) > 0 {
+		if err := yaml.Unmarshal(existing, &cfg); err != nil {
+			return fmt.Errorf("failed to unmarshal system-probe.yaml: %w", err)
+		}
+	}
+	if cfg.SystemProbeSettings.Enabled != nil && *cfg.SystemProbeSettings.Enabled {
+		return nil
+	}
+
+	cfg.SystemProbeSettings.Enabled = config.BoolToPtr(true)
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal system-probe.yaml: %w", err)
+	}
+	if err := os.WriteFile(configPath, data, 0640); err != nil {
+		return fmt.Errorf("failed to write system-probe.yaml: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/fleet/installer/packages/apm_inject_windows.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows.go
@@ -12,7 +12,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
+
+	"go.yaml.in/yaml/v3"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	pkgExec "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/exec"
@@ -97,8 +100,22 @@ func enableSystemProbeConfig(ctx HookContext) (err error) {
 }
 
 // enableSystemProbeConfigAt merges system_probe_config.enabled: true into the
-// given config file, preserving all existing settings.
+// given config file, preserving all existing settings. No-op if already enabled.
 func enableSystemProbeConfigAt(configPath string) error {
+	existing, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read system-probe.yaml: %w", err)
+	}
+	if len(existing) > 0 {
+		var cfg config.SystemProbeConfig
+		if err := yaml.Unmarshal(existing, &cfg); err != nil {
+			return fmt.Errorf("failed to unmarshal system-probe.yaml: %w", err)
+		}
+		if cfg.SystemProbeSettings.Enabled != nil && *cfg.SystemProbeSettings.Enabled {
+			return nil
+		}
+	}
+
 	update := config.SystemProbeConfig{
 		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(true)},
 	}

--- a/pkg/fleet/installer/packages/apm_inject_windows_test.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows_test.go
@@ -34,39 +34,15 @@ func TestEnableSystemProbeConfig_NoExistingFile(t *testing.T) {
 	assert.True(t, *cfg.SystemProbeSettings.Enabled)
 }
 
-func TestEnableSystemProbeConfig_AlreadyEnabled(t *testing.T) {
-	dir := t.TempDir()
-	configPath := filepath.Join(dir, "system-probe.yaml")
-
-	initial := config.SystemProbeConfig{
-		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(true)},
-		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
-			Enabled: config.BoolToPtr(true),
-		},
-	}
-	writeYAML(t, configPath, initial)
-	infoBefore, _ := os.Stat(configPath)
-
-	err := enableSystemProbeConfigAt(configPath)
-	require.NoError(t, err)
-
-	infoAfter, _ := os.Stat(configPath)
-	assert.Equal(t, infoBefore.ModTime(), infoAfter.ModTime(), "file should not be rewritten when already enabled")
-}
-
 func TestEnableSystemProbeConfig_PreservesExistingSettings(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")
 
-	initial := config.SystemProbeConfig{
-		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
-			Enabled: config.BoolToPtr(true),
-		},
-		GPUMonitoringConfig: config.GPUMonitoringConfig{
-			Enabled: config.BoolToPtr(true),
-		},
-	}
-	writeYAML(t, configPath, initial)
+	writeFile(t, configPath, `runtime_security_config:
+  enabled: true
+gpu_monitoring:
+  enabled: true
+`)
 
 	err := enableSystemProbeConfigAt(configPath)
 	require.NoError(t, err)
@@ -88,13 +64,11 @@ func TestEnableSystemProbeConfig_FlipsDisabledToEnabled(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")
 
-	initial := config.SystemProbeConfig{
-		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(false)},
-		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
-			Enabled: config.BoolToPtr(true),
-		},
-	}
-	writeYAML(t, configPath, initial)
+	writeFile(t, configPath, `system_probe_config:
+  enabled: false
+runtime_security_config:
+  enabled: true
+`)
 
 	err := enableSystemProbeConfigAt(configPath)
 	require.NoError(t, err)
@@ -108,9 +82,46 @@ func TestEnableSystemProbeConfig_FlipsDisabledToEnabled(t *testing.T) {
 	assert.True(t, *result.RuntimeSecurityConfig.Enabled, "existing settings should be preserved")
 }
 
-func writeYAML(t *testing.T, path string, v any) {
-	t.Helper()
-	data, err := yaml.Marshal(v)
+func TestEnableSystemProbeConfig_PreservesUnknownKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	writeFile(t, configPath, `system_probe_config:
+  enabled: false
+  max_tracked_connections: 65536
+network_config:
+  enabled: true
+  conntrack: true
+some_future_key:
+  nested: value
+`)
+
+	err := enableSystemProbeConfigAt(configPath)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(path, data, 0640))
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	// Parse back as generic map to verify all keys survived
+	var raw map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &raw))
+
+	// system_probe_config.enabled should be flipped to true
+	spc := raw["system_probe_config"].(map[string]any)
+	assert.Equal(t, true, spc["enabled"])
+	// unknown key under system_probe_config preserved
+	assert.Equal(t, 65536, spc["max_tracked_connections"])
+
+	// top-level unknown sections preserved
+	nc := raw["network_config"].(map[string]any)
+	assert.Equal(t, true, nc["enabled"])
+	assert.Equal(t, true, nc["conntrack"])
+
+	sfk := raw["some_future_key"].(map[string]any)
+	assert.Equal(t, "value", sfk["nested"])
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0640))
 }

--- a/pkg/fleet/installer/packages/apm_inject_windows_test.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows_test.go
@@ -34,6 +34,26 @@ func TestEnableSystemProbeConfig_NoExistingFile(t *testing.T) {
 	assert.True(t, *cfg.SystemProbeSettings.Enabled)
 }
 
+func TestEnableSystemProbeConfig_AlreadyEnabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	writeFile(t, configPath, `system_probe_config:
+  enabled: true
+runtime_security_config:
+  enabled: true
+`)
+	contentBefore, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	err = enableSystemProbeConfigAt(configPath)
+	require.NoError(t, err)
+
+	contentAfter, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(contentBefore), string(contentAfter), "file content should not change when already enabled")
+}
+
 func TestEnableSystemProbeConfig_PreservesExistingSettings(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")

--- a/pkg/fleet/installer/packages/apm_inject_windows_test.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows_test.go
@@ -1,0 +1,116 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
+)
+
+func TestEnableSystemProbeConfig_NoExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	err := enableSystemProbeConfigAt(configPath)
+	require.NoError(t, err)
+
+	var cfg config.SystemProbeConfig
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.NotNil(t, cfg.SystemProbeSettings.Enabled)
+	assert.True(t, *cfg.SystemProbeSettings.Enabled)
+}
+
+func TestEnableSystemProbeConfig_AlreadyEnabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	initial := config.SystemProbeConfig{
+		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(true)},
+		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
+			Enabled: config.BoolToPtr(true),
+		},
+	}
+	writeYAML(t, configPath, initial)
+	infoBefore, _ := os.Stat(configPath)
+
+	err := enableSystemProbeConfigAt(configPath)
+	require.NoError(t, err)
+
+	infoAfter, _ := os.Stat(configPath)
+	assert.Equal(t, infoBefore.ModTime(), infoAfter.ModTime(), "file should not be rewritten when already enabled")
+}
+
+func TestEnableSystemProbeConfig_PreservesExistingSettings(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	initial := config.SystemProbeConfig{
+		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
+			Enabled: config.BoolToPtr(true),
+		},
+		GPUMonitoringConfig: config.GPUMonitoringConfig{
+			Enabled: config.BoolToPtr(true),
+		},
+	}
+	writeYAML(t, configPath, initial)
+
+	err := enableSystemProbeConfigAt(configPath)
+	require.NoError(t, err)
+
+	var result config.SystemProbeConfig
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(data, &result))
+
+	require.NotNil(t, result.SystemProbeSettings.Enabled)
+	assert.True(t, *result.SystemProbeSettings.Enabled)
+	require.NotNil(t, result.RuntimeSecurityConfig.Enabled)
+	assert.True(t, *result.RuntimeSecurityConfig.Enabled)
+	require.NotNil(t, result.GPUMonitoringConfig.Enabled)
+	assert.True(t, *result.GPUMonitoringConfig.Enabled)
+}
+
+func TestEnableSystemProbeConfig_FlipsDisabledToEnabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "system-probe.yaml")
+
+	initial := config.SystemProbeConfig{
+		SystemProbeSettings: config.SystemProbeSettings{Enabled: config.BoolToPtr(false)},
+		RuntimeSecurityConfig: config.RuntimeSecurityConfig{
+			Enabled: config.BoolToPtr(true),
+		},
+	}
+	writeYAML(t, configPath, initial)
+
+	err := enableSystemProbeConfigAt(configPath)
+	require.NoError(t, err)
+
+	var result config.SystemProbeConfig
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(data, &result))
+
+	assert.True(t, *result.SystemProbeSettings.Enabled)
+	assert.True(t, *result.RuntimeSecurityConfig.Enabled, "existing settings should be preserved")
+}
+
+func writeYAML(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := yaml.Marshal(v)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0640))
+}

--- a/pkg/fleet/installer/packages/apm_inject_windows_test.go
+++ b/pkg/fleet/installer/packages/apm_inject_windows_test.go
@@ -30,15 +30,15 @@ func TestEnableSystemProbeConfig_NoExistingFile(t *testing.T) {
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	require.NoError(t, yaml.Unmarshal(data, &cfg))
-	require.NotNil(t, cfg.SystemProbeSettings.Enabled)
-	assert.True(t, *cfg.SystemProbeSettings.Enabled)
+	require.NotNil(t, cfg.WindowsCrashDetection.Enabled)
+	assert.True(t, *cfg.WindowsCrashDetection.Enabled)
 }
 
 func TestEnableSystemProbeConfig_AlreadyEnabled(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")
 
-	writeFile(t, configPath, `system_probe_config:
+	writeFile(t, configPath, `windows_crash_detection:
   enabled: true
 runtime_security_config:
   enabled: true
@@ -72,8 +72,8 @@ gpu_monitoring:
 	require.NoError(t, err)
 	require.NoError(t, yaml.Unmarshal(data, &result))
 
-	require.NotNil(t, result.SystemProbeSettings.Enabled)
-	assert.True(t, *result.SystemProbeSettings.Enabled)
+	require.NotNil(t, result.WindowsCrashDetection.Enabled)
+	assert.True(t, *result.WindowsCrashDetection.Enabled)
 	require.NotNil(t, result.RuntimeSecurityConfig.Enabled)
 	assert.True(t, *result.RuntimeSecurityConfig.Enabled)
 	require.NotNil(t, result.GPUMonitoringConfig.Enabled)
@@ -84,7 +84,7 @@ func TestEnableSystemProbeConfig_FlipsDisabledToEnabled(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")
 
-	writeFile(t, configPath, `system_probe_config:
+	writeFile(t, configPath, `windows_crash_detection:
   enabled: false
 runtime_security_config:
   enabled: true
@@ -98,7 +98,7 @@ runtime_security_config:
 	require.NoError(t, err)
 	require.NoError(t, yaml.Unmarshal(data, &result))
 
-	assert.True(t, *result.SystemProbeSettings.Enabled)
+	assert.True(t, *result.WindowsCrashDetection.Enabled)
 	assert.True(t, *result.RuntimeSecurityConfig.Enabled, "existing settings should be preserved")
 }
 
@@ -106,8 +106,9 @@ func TestEnableSystemProbeConfig_PreservesUnknownKeys(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "system-probe.yaml")
 
-	writeFile(t, configPath, `system_probe_config:
+	writeFile(t, configPath, `windows_crash_detection:
   enabled: false
+system_probe_config:
   max_tracked_connections: 65536
 network_config:
   enabled: true
@@ -126,10 +127,12 @@ some_future_key:
 	var raw map[string]any
 	require.NoError(t, yaml.Unmarshal(data, &raw))
 
-	// system_probe_config.enabled should be flipped to true
-	spc := raw["system_probe_config"].(map[string]any)
-	assert.Equal(t, true, spc["enabled"])
+	// windows_crash_detection.enabled should be flipped to true
+	wcd := raw["windows_crash_detection"].(map[string]any)
+	assert.Equal(t, true, wcd["enabled"])
+
 	// unknown key under system_probe_config preserved
+	spc := raw["system_probe_config"].(map[string]any)
 	assert.Equal(t, 65536, spc["max_tracked_connections"])
 
 	// top-level unknown sections preserved

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -182,9 +182,15 @@ type InjectTracerConfigEnvVar struct {
 
 // SystemProbeConfig represents the configuration to write in /etc/datadog-agent/system-probe.yaml
 type SystemProbeConfig struct {
+	SystemProbeSettings   SystemProbeSettings   `yaml:"system_probe_config,omitempty"`
 	RuntimeSecurityConfig RuntimeSecurityConfig `yaml:"runtime_security_config,omitempty"`
 	GPUMonitoringConfig   GPUMonitoringConfig   `yaml:"gpu_monitoring,omitempty"`
 	PrivilegedLogsConfig  PrivilegedLogsConfig  `yaml:"privileged_logs,omitempty"`
+}
+
+// SystemProbeSettings represents the top-level system_probe_config settings
+type SystemProbeSettings struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // RuntimeSecurityConfig represents the configuration for the runtime security

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -24,30 +24,30 @@ var (
 
 // WriteConfigs writes the configuration files to the given directory.
 func WriteConfigs(config Config, configDir string) error {
-	err := writeConfig(filepath.Join(configDir, datadogConfFile), config.DatadogYAML, 0640, true)
+	err := WriteConfig(filepath.Join(configDir, datadogConfFile), config.DatadogYAML, 0640, true)
 	if err != nil {
 		return fmt.Errorf("could not write datadog.yaml: %w", err)
 	}
 	if config.SecurityAgentYAML != nil {
-		err = writeConfig(filepath.Join(configDir, "security-agent.yaml"), config.SecurityAgentYAML, 0640, true)
+		err = WriteConfig(filepath.Join(configDir, "security-agent.yaml"), config.SecurityAgentYAML, 0640, true)
 		if err != nil {
 			return fmt.Errorf("could not write security-agent.yaml: %w", err)
 		}
 	}
 	if config.SystemProbeYAML != nil {
-		err = writeConfig(filepath.Join(configDir, "system-probe.yaml"), config.SystemProbeYAML, 0640, true)
+		err = WriteConfig(filepath.Join(configDir, "system-probe.yaml"), config.SystemProbeYAML, 0640, true)
 		if err != nil {
 			return fmt.Errorf("could not write system-probe.yaml: %w", err)
 		}
 	}
 	if config.ApplicationMonitoringYAML != nil {
-		err = writeConfig(filepath.Join(configDir, "application_monitoring.yaml"), config.ApplicationMonitoringYAML, 0644, true)
+		err = WriteConfig(filepath.Join(configDir, "application_monitoring.yaml"), config.ApplicationMonitoringYAML, 0644, true)
 		if err != nil {
 			return fmt.Errorf("could not write application_monitoring.yaml: %w", err)
 		}
 	}
 	for name, config := range config.IntegrationConfigs {
-		err = writeConfig(filepath.Join(configDir, "conf.d", name), config, 0644, false)
+		err = WriteConfig(filepath.Join(configDir, "conf.d", name), config, 0644, false)
 		if err != nil {
 			return fmt.Errorf("could not write %s.yaml: %w", name, err)
 		}

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -182,20 +182,14 @@ type InjectTracerConfigEnvVar struct {
 
 // SystemProbeConfig represents the configuration to write in /etc/datadog-agent/system-probe.yaml
 type SystemProbeConfig struct {
-	SystemProbeSettings      SystemProbeSettings      `yaml:"system_probe_config,omitempty"`
-	RuntimeSecurityConfig    RuntimeSecurityConfig    `yaml:"runtime_security_config,omitempty"`
-	GPUMonitoringConfig      GPUMonitoringConfig      `yaml:"gpu_monitoring,omitempty"`
-	PrivilegedLogsConfig     PrivilegedLogsConfig     `yaml:"privileged_logs,omitempty"`
-	WindowsCrashDetection    WindowsCrashDetection    `yaml:"windows_crash_detection,omitempty"`
+	RuntimeSecurityConfig RuntimeSecurityConfig `yaml:"runtime_security_config,omitempty"`
+	GPUMonitoringConfig   GPUMonitoringConfig   `yaml:"gpu_monitoring,omitempty"`
+	PrivilegedLogsConfig  PrivilegedLogsConfig  `yaml:"privileged_logs,omitempty"`
+	WindowsCrashDetection WindowsCrashDetection `yaml:"windows_crash_detection,omitempty"`
 }
 
 // WindowsCrashDetection represents the configuration for Windows crash detection
 type WindowsCrashDetection struct {
-	Enabled *bool `yaml:"enabled,omitempty"`
-}
-
-// SystemProbeSettings represents the top-level system_probe_config settings
-type SystemProbeSettings struct {
 	Enabled *bool `yaml:"enabled,omitempty"`
 }
 

--- a/pkg/fleet/installer/setup/config/config.go
+++ b/pkg/fleet/installer/setup/config/config.go
@@ -182,10 +182,16 @@ type InjectTracerConfigEnvVar struct {
 
 // SystemProbeConfig represents the configuration to write in /etc/datadog-agent/system-probe.yaml
 type SystemProbeConfig struct {
-	SystemProbeSettings   SystemProbeSettings   `yaml:"system_probe_config,omitempty"`
-	RuntimeSecurityConfig RuntimeSecurityConfig `yaml:"runtime_security_config,omitempty"`
-	GPUMonitoringConfig   GPUMonitoringConfig   `yaml:"gpu_monitoring,omitempty"`
-	PrivilegedLogsConfig  PrivilegedLogsConfig  `yaml:"privileged_logs,omitempty"`
+	SystemProbeSettings      SystemProbeSettings      `yaml:"system_probe_config,omitempty"`
+	RuntimeSecurityConfig    RuntimeSecurityConfig    `yaml:"runtime_security_config,omitempty"`
+	GPUMonitoringConfig      GPUMonitoringConfig      `yaml:"gpu_monitoring,omitempty"`
+	PrivilegedLogsConfig     PrivilegedLogsConfig     `yaml:"privileged_logs,omitempty"`
+	WindowsCrashDetection    WindowsCrashDetection    `yaml:"windows_crash_detection,omitempty"`
+}
+
+// WindowsCrashDetection represents the configuration for Windows crash detection
+type WindowsCrashDetection struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // SystemProbeSettings represents the top-level system_probe_config settings

--- a/pkg/fleet/installer/setup/config/write.go
+++ b/pkg/fleet/installer/setup/config/write.go
@@ -17,7 +17,11 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-func writeConfig(path string, config any, perms os.FileMode, merge bool) error {
+// WriteConfig writes a config struct to a YAML file. When merge is true it
+// preserves existing key ordering and keys not present in the struct. Comment
+// text is preserved but its formatting (whitespace, indentation, blank lines)
+// may change.
+func WriteConfig(path string, config any, perms os.FileMode, merge bool) error {
 	err := os.MkdirAll(filepath.Dir(path), 0755)
 	if err != nil {
 		return fmt.Errorf("could not create config directory: %w", err)

--- a/pkg/fleet/installer/setup/config/write_test.go
+++ b/pkg/fleet/installer/setup/config/write_test.go
@@ -44,7 +44,7 @@ func runWriteConfigTestCase(t *testing.T, tc writeConfigTestCase) {
 	// Call writeConfig twice to ensure that the content does not change on re-run
 	// e.g. disclaimer added once or not at all
 	for i := 0; i < 2; i++ {
-		err := writeConfig(configPath, tc.config, 0644, tc.merge)
+		err := WriteConfig(configPath, tc.config, 0644, tc.merge)
 		if err != nil {
 			t.Fatalf("writeConfig failed: %v", err)
 		}

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -110,18 +110,6 @@ func SetupDefaultScript(s *common.Setup) error {
 		return fmt.Errorf("failed to setup APM SSI script: %w", err)
 	}
 
-	// On Windows, enable system-probe when host instrumentation is requested so that
-	// system-probe.yaml is written before the agent starts (first install). This is
-	// needed for monitoring and crash detection of driver crashes.
-	if runtime.GOOS == "windows" {
-		if apmMethod, ok := os.LookupEnv("DD_APM_INSTRUMENTATION_ENABLED"); ok && apmMethod == env.APMInstrumentationEnabledHost {
-			if s.Config.SystemProbeYAML == nil {
-				s.Config.SystemProbeYAML = &config.SystemProbeConfig{}
-			}
-			s.Config.SystemProbeYAML.SystemProbeSettings.Enabled = config.BoolToPtr(true)
-		}
-	}
-
 	s.NoConfig = false
 	return nil
 }

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -110,6 +110,18 @@ func SetupDefaultScript(s *common.Setup) error {
 		return fmt.Errorf("failed to setup APM SSI script: %w", err)
 	}
 
+	// On Windows, enable system-probe when host instrumentation is requested so that
+	// system-probe.yaml is written before the agent starts (first install). This is
+	// needed for monitoring and crash detection of driver crashes.
+	if runtime.GOOS == "windows" {
+		if apmMethod, ok := os.LookupEnv("DD_APM_INSTRUMENTATION_ENABLED"); ok && apmMethod == env.APMInstrumentationEnabledHost {
+			if s.Config.SystemProbeYAML == nil {
+				s.Config.SystemProbeYAML = &config.SystemProbeConfig{}
+			}
+			s.Config.SystemProbeYAML.SystemProbeSettings.Enabled = config.BoolToPtr(true)
+		}
+	}
+
 	s.NoConfig = false
 	return nil
 }

--- a/releasenotes/notes/ssi-use-windows-crash-detection-config-b5787251e03880f0.yaml
+++ b/releasenotes/notes/ssi-use-windows-crash-detection-config-b5787251e03880f0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    On Windows, the APM SSI installer now automatically enables system-probe
+    to report injection telemetry from the ddinjector driver.

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -229,6 +229,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/go-containerregistry v0.20.7
 	github.com/hairyhenderson/go-codeowners v0.7.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -354,7 +355,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
 )

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package injecttests
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
+	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
+	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+)
+
+type testSystemProbeConfig struct {
+	baseSuite
+}
+
+// TestSystemProbeConfig tests that system-probe is enabled when apm-inject
+// is installed with host instrumentation.
+func TestSystemProbeConfig(t *testing.T) {
+	e2e.Run(t, &testSystemProbeConfig{},
+		e2e.WithProvisioner(
+			winawshost.ProvisionerNoAgentNoFakeIntake()))
+}
+
+func (s *testSystemProbeConfig) AfterTest(suiteName, testName string) {
+	s.Installer().Purge()
+	s.baseSuite.AfterTest(suiteName, testName)
+}
+
+// TestInstallScriptEnablesSystemProbe tests the setup script path: installing
+// via the install script with DD_APM_INSTRUMENTATION_ENABLED=host writes
+// system_probe_config.enabled: true in system-probe.yaml before the agent starts.
+func (s *testSystemProbeConfig) TestInstallScriptEnablesSystemProbe() {
+	output, err := s.InstallScript().Run(
+		installerwindows.WithExtraEnvVars(map[string]string{
+			"DD_APM_INSTRUMENTATION_ENABLED": "host",
+			// TODO: remove override once image is published in prod
+			"DD_INSTALLER_REGISTRY_URL":                           "install.datad0g.com",
+			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT": s.currentAPMInjectVersion.PackageVersion(),
+			"DD_APM_INSTRUMENTATION_LIBRARIES":                    "dotnet:3",
+		}),
+	)
+	if s.NoError(err) {
+		fmt.Printf("%s\n", output)
+	}
+	s.Require().NoErrorf(err, "failed to install: %s", output)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"ddinjector"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+
+	s.assertSystemProbeEnabled()
+}
+
+// TestStandaloneInstallEnablesSystemProbe tests the standalone install path:
+// the agent is already running, then apm-inject is installed separately with
+// DD_APM_INSTRUMENTATION_ENABLED=host. The postInstall hook must write
+// system_probe_config.enabled: true into system-probe.yaml.
+func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
+	// Install agent without APM inject
+	output, err := s.InstallScript().Run()
+	if s.NoError(err) {
+		fmt.Printf("%s\n", output)
+	}
+	s.Require().NoErrorf(err, "failed to install agent: %s", output)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogInstallerService().
+		HasARunningDatadogAgentService()
+
+	// Install apm-inject package separately with host instrumentation
+	s.Env().RemoteHost.MustExecute(
+		fmt.Sprintf(`[Environment]::SetEnvironmentVariable("DD_APM_INSTRUMENTATION_ENABLED", "host", "Process")`),
+	)
+	pkgOutput, err := s.Installer().InstallPackage("apm-inject-package",
+		installer.WithVersion(s.currentAPMInjectVersion.PackageVersion()),
+		installer.WithRegistry("install.datad0g.com"),
+	)
+	s.Require().NoError(err, "failed to install apm-inject package: %s", pkgOutput)
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"ddinjector"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+
+	s.assertSystemProbeEnabled()
+}
+
+// assertSystemProbeEnabled reads system-probe.yaml and asserts that
+// system_probe_config.enabled is true.
+func (s *testSystemProbeConfig) assertSystemProbeEnabled() {
+	host := s.Env().RemoteHost
+	configRoot, err := windowsAgent.GetConfigRootFromRegistry(host)
+	s.Require().NoError(err)
+	configPath := filepath.Join(configRoot, "system-probe.yaml")
+
+	configBytes, err := host.ReadFile(configPath)
+	s.Require().NoErrorf(err, "failed to read system-probe.yaml")
+
+	cfg := map[string]interface{}{}
+	s.Require().NoError(yaml.Unmarshal(configBytes, &cfg), "failed to unmarshal system-probe.yaml")
+
+	spCfg, ok := cfg["system_probe_config"].(map[string]interface{})
+	s.Require().True(ok, "system_probe_config key missing in system-probe.yaml, got: %v", cfg)
+	s.Require().Equal(true, spCfg["enabled"], "system_probe_config.enabled should be true")
+}

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -36,6 +36,9 @@ func TestSystemProbeConfig(t *testing.T) {
 
 func (s *testSystemProbeConfig) AfterTest(suiteName, testName string) {
 	s.Installer().Purge()
+	// Purge does not remove config files; wipe the config directory so that
+	// leftover system-probe.yaml does not leak between tests.
+	_, _ = s.Env().RemoteHost.Execute(`Remove-Item -Path 'C:\ProgramData\Datadog\*' -Recurse -Force`)
 	s.baseSuite.AfterTest(suiteName, testName)
 }
 

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -38,14 +38,10 @@ func (s *testSystemProbeConfig) AfterTest(suiteName, testName string) {
 	s.baseSuite.AfterTest(suiteName, testName)
 }
 
-// TestInstallScriptEnablesSystemProbe tests the setup script path: installing
-// via the install script with DD_APM_INSTRUMENTATION_ENABLED=host writes
-// system_probe_config.enabled: true in system-probe.yaml before the agent starts.
 func (s *testSystemProbeConfig) TestInstallScriptEnablesSystemProbe() {
 	output, err := s.InstallScript().Run(
 		installerwindows.WithExtraEnvVars(map[string]string{
-			"DD_APM_INSTRUMENTATION_ENABLED": "host",
-			// TODO: remove override once image is published in prod
+			"DD_APM_INSTRUMENTATION_ENABLED":                      "host",
 			"DD_INSTALLER_REGISTRY_URL":                           "install.datad0g.com",
 			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT": s.currentAPMInjectVersion.PackageVersion(),
 			"DD_APM_INSTRUMENTATION_LIBRARIES":                    "dotnet:3",
@@ -61,10 +57,6 @@ func (s *testSystemProbeConfig) TestInstallScriptEnablesSystemProbe() {
 	s.assertSystemProbeEnabled()
 }
 
-// TestStandaloneInstallEnablesSystemProbe tests the standalone install path:
-// the agent is already running, then apm-inject is installed separately with
-// DD_APM_INSTRUMENTATION_ENABLED=host. The postInstall hook must write
-// system_probe_config.enabled: true into system-probe.yaml.
 func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
 	// Install agent without APM inject
 	output, err := s.InstallScript().Run()
@@ -77,16 +69,12 @@ func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
 		HasARunningDatadogInstallerService().
 		HasARunningDatadogAgentService()
 
-	// Install apm-inject package separately with host instrumentation
-	s.Env().RemoteHost.MustExecute(
-		`[Environment]::SetEnvironmentVariable("DD_APM_INSTRUMENTATION_ENABLED", "host", "Process")`,
-	)
+	// Install apm-inject package separately
 	pkgOutput, err := s.Installer().InstallPackage("apm-inject-package",
 		installer.WithVersion(s.currentAPMInjectVersion.PackageVersion()),
 		installer.WithRegistry("install.datad0g.com"),
 	)
 	s.Require().NoError(err, "failed to install apm-inject package: %s", pkgOutput)
-	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"ddinjector"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
 
 	s.assertSystemProbeEnabled()
 }

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -82,7 +82,7 @@ func (s *testSystemProbeConfig) TestStandaloneInstallDoesNotStartSystemProbe() {
 }
 
 // assertSystemProbeEnabled reads system-probe.yaml and asserts that
-// system_probe_config.enabled is true.
+// windows_crash_detection.enabled is true.
 func (s *testSystemProbeConfig) assertSystemProbeEnabled() {
 	host := s.Env().RemoteHost
 	configRoot, err := windowsAgent.GetConfigRootFromRegistry(host)
@@ -95,7 +95,7 @@ func (s *testSystemProbeConfig) assertSystemProbeEnabled() {
 	cfg := map[string]interface{}{}
 	s.Require().NoError(yaml.Unmarshal(configBytes, &cfg), "failed to unmarshal system-probe.yaml")
 
-	spCfg, ok := cfg["system_probe_config"].(map[string]interface{})
-	s.Require().True(ok, "system_probe_config key missing in system-probe.yaml, got: %v", cfg)
-	s.Require().Equal(true, spCfg["enabled"], "system_probe_config.enabled should be true")
+	wcdCfg, ok := cfg["windows_crash_detection"].(map[string]interface{})
+	s.Require().True(ok, "windows_crash_detection key missing in system-probe.yaml, got: %v", cfg)
+	s.Require().Equal(true, wcdCfg["enabled"], "windows_crash_detection.enabled should be true")
 }

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -79,7 +79,7 @@ func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
 
 	// Install apm-inject package separately with host instrumentation
 	s.Env().RemoteHost.MustExecute(
-		fmt.Sprintf(`[Environment]::SetEnvironmentVariable("DD_APM_INSTRUMENTATION_ENABLED", "host", "Process")`),
+		`[Environment]::SetEnvironmentVariable("DD_APM_INSTRUMENTATION_ENABLED", "host", "Process")`,
 	)
 	pkgOutput, err := s.Installer().InstallPackage("apm-inject-package",
 		installer.WithVersion(s.currentAPMInjectVersion.PackageVersion()),

--- a/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-inject-package/system_probe_config_test.go
@@ -18,6 +18,7 @@ import (
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
@@ -38,7 +39,7 @@ func (s *testSystemProbeConfig) AfterTest(suiteName, testName string) {
 	s.baseSuite.AfterTest(suiteName, testName)
 }
 
-func (s *testSystemProbeConfig) TestInstallScriptEnablesSystemProbe() {
+func (s *testSystemProbeConfig) TestInstallScriptStartsSystemProbe() {
 	output, err := s.InstallScript().Run(
 		installerwindows.WithExtraEnvVars(map[string]string{
 			"DD_APM_INSTRUMENTATION_ENABLED":                      "host",
@@ -50,24 +51,20 @@ func (s *testSystemProbeConfig) TestInstallScriptEnablesSystemProbe() {
 	if s.NoError(err) {
 		fmt.Printf("%s\n", output)
 	}
-	s.Require().NoErrorf(err, "failed to install: %s", output)
-	s.Require().NoError(s.WaitForInstallerService("Running"))
-	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"ddinjector"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
-
 	s.assertSystemProbeEnabled()
+	s.Require().NoError(
+		s.WaitForServicesWithBackoff("Running", []string{"datadog-system-probe"},
+			backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))),
+		"system-probe service should be running after install script",
+	)
 }
 
-func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
+func (s *testSystemProbeConfig) TestStandaloneInstallDoesNotStartSystemProbe() {
 	// Install agent without APM inject
 	output, err := s.InstallScript().Run()
 	if s.NoError(err) {
 		fmt.Printf("%s\n", output)
 	}
-	s.Require().NoErrorf(err, "failed to install agent: %s", output)
-	s.Require().NoError(s.WaitForInstallerService("Running"))
-	s.Require().Host(s.Env().RemoteHost).
-		HasARunningDatadogInstallerService().
-		HasARunningDatadogAgentService()
 
 	// Install apm-inject package separately
 	pkgOutput, err := s.Installer().InstallPackage("apm-inject-package",
@@ -76,7 +73,12 @@ func (s *testSystemProbeConfig) TestStandaloneInstallEnablesSystemProbe() {
 	)
 	s.Require().NoError(err, "failed to install apm-inject package: %s", pkgOutput)
 
+	// We don't restart the agent so the system probe will only be enabled at the next agent restart
 	s.assertSystemProbeEnabled()
+	status, err := windowsCommon.GetServiceStatus(s.Env().RemoteHost, "datadog-system-probe")
+	s.Require().NoError(err)
+	s.Require().NotEqual("Running", status,
+		"system-probe service should not be running after standalone apm-inject install")
 }
 
 // assertSystemProbeEnabled reads system-probe.yaml and asserts that


### PR DESCRIPTION
### What does this PR do?

When DD_APM_INSTRUMENTATION_ENABLED=host, system-probe should be enabled to support monitoring and crash detection of driver crashes. This is handled in two code paths:

1. Setup script (first install): system_probe_config.enabled is set in the config struct before WriteConfigs runs, ensuring system-probe.yaml is written before the agent starts.

2. Standalone install (e.g. remote update): the new enableSystemProbeConfig method on InjectorInstaller writes/merges system_probe_config.enabled: true into /etc/datadog-agent/system-probe.yaml using the fileMutator pattern.

### Motivation

### Describe how you validated your changes

E2E tests

### Additional Notes
