### PR TITLE
Remove go.mod from KMT trigger paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -644,8 +644,6 @@ workflow:
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
   - test/e2e-framework/scenarios/aws/microVMs/**/*
-  - test/new-e2e/go.mod
-  - go.mod
   - tasks/security_agent.py
   - tasks/kmt.py
   - tasks/kernel_matrix_testing/*
@@ -700,8 +698,6 @@ workflow:
   - test/e2e-framework/testing/runner/**/*
   - test/e2e-framework/testing/utils/**/*
   - test/e2e-framework/scenarios/aws/microVMs/**/*
-  - test/new-e2e/go.mod
-  - go.mod
   - tasks/system_probe.py
   - tasks/kmt.py
   - tasks/kernel_matrix_testing/*


### PR DESCRIPTION
### What does this PR do?

Remove go.mod from the path that should trigger KMT.

### Motivation

go.mod updates are quite frequent and they currently trigger KMT tests that are heavy and long running. While in theory updates to go.mod can impact those tests, it is likely that most updates do not have any impact on them

### Describe how you validated your changes

### Additional Notes
