### PR TITLE
[CWS] Do not delay file hashing on exec events

### DIFF
--- a/pkg/security/probe/file_hasher.go
+++ b/pkg/security/probe/file_hasher.go
@@ -64,7 +64,14 @@ func (p *FileHasher) FlushPendingReports() {
 		report.Lock()
 		defer report.Unlock()
 
-		if time.Now().After(report.seenAt.Add(defaultHashActionFlushDelay)) {
+		hashDelay := defaultHashActionFlushDelay
+		if report.eventType == model.ExecEventType {
+			// Exec events can be hashed immediately since the executable file
+			// is already on disk when we process the exec event
+			hashDelay = 0
+		}
+
+		if time.Now().After(report.seenAt.Add(hashDelay)) {
 			report.Trigger = HashTriggerTimeout
 			p.hash(report)
 			return true

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -769,7 +769,7 @@ func TestActionHash(t *testing.T) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.state == 'Done')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
-				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.trigger == 'process_exit')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_actions[?(@.trigger == 'timeout')]`); err != nil || el == nil || len(el.([]interface{})) == 0 {
 					t.Errorf("element not found %s => %v", string(msg.Data), err)
 				}
 				if el, err := jsonpath.JsonPathLookup(obj, `$.file.hashes`); err != nil || el == nil || len(el.([]interface{})) == 0 {


### PR DESCRIPTION
### What does this PR do?

Avoids delaying by 5 seconds the hash computation of executed files.

### Motivation

Exec events can be hashed immediately since the executable file is already on disk when we process the exec event.

### Describe how you validated your changes

### Additional Notes
