### PR TITLE
[cluster-autoscaling] small fix for propagating labels

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -230,6 +230,8 @@ func UpdateNodePoolObject(targetNp, datadogNp *karpenterv1.NodePool, npi NodePoo
 		npCopy = targetNp.DeepCopy()
 		// Preserve ObjectMeta from Datadog-created NodePool
 		npCopy.ObjectMeta = datadogNp.ObjectMeta
+		// Allow label updates to propagate from target to replica
+		npCopy.ObjectMeta.Labels = targetNp.GetLabels()
 
 		modifyReplicaNodePool(npCopy, npi, false)
 	} else {

--- a/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
+++ b/pkg/clusteragent/autoscaling/cluster/model/node_pool_internal.go
@@ -8,6 +8,7 @@
 package model
 
 import (
+	"maps"
 	"slices"
 
 	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
@@ -231,7 +232,7 @@ func UpdateNodePoolObject(targetNp, datadogNp *karpenterv1.NodePool, npi NodePoo
 		// Preserve ObjectMeta from Datadog-created NodePool
 		npCopy.ObjectMeta = datadogNp.ObjectMeta
 		// Allow label updates to propagate from target to replica
-		npCopy.ObjectMeta.Labels = targetNp.GetLabels()
+		npCopy.ObjectMeta.Labels = maps.Clone(targetNp.GetLabels())
 
 		modifyReplicaNodePool(npCopy, npi, false)
 	} else {


### PR DESCRIPTION
### What does this PR do?

Small fix for labels propagation following PR https://github.com/DataDog/datadog-agent/pull/46564 . The intention was to allow NodePool metadata labels set by users to be propagated to the replica NodePool.

### Motivation

### Describe how you validated your changes

### Additional Notes
