### PR TITLE
Remove Docs as CODEOWNERS for release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -699,8 +699,9 @@
 /pkg/networkpath/traceroute/            @DataDog/cloud-network-monitoring @DataDog/windows-products @DataDog/network-path
 /pkg/collector/corechecks/networkpath/  @DataDog/cloud-network-monitoring @DataDog/network-path
 
-/releasenotes/                          @DataDog/documentation
-/releasenotes-dca/                      @DataDog/documentation
+# release notes accompany code changes, so code owners will review anyway
+/releasenotes/                          # do not notify anyone
+/releasenotes-dca/                      # do not notify anyone
 
 /rtloader/                              @DataDog/agent-runtimes
 


### PR DESCRIPTION
### What does this PR do?

Removes the Documentation team as codeowners for `/releasenotes/` and `/releasenotes-dca/`. Release notes are always part of larger PRs that include code changes, so the relevant code-owning teams already review these PRs. The Documentation team doesn't need to be notified separately.

### Motivation

- Reduce unnecessary review requests for the Documentation team.
- This also prevents the Documentation team from unintentionally blocking time-sensitive PRs, such as incident fixes or patches, that include release notes.

### Describe how you validated your changes

### Additional Notes
