### PR TITLE
fix(cluster-agent): Guard against re-admission for APM auto-instrumentation in image_volume mode

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -143,6 +143,8 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectNoChange: true,
 		},
+		// Re-admission guard: when the webhook runs again on an already-injected pod we must not
+		// mutate further (e.g. must not append to LD_PRELOAD or add duplicate init containers).
 		"re-admission with init_container mode init container already present does not mutate": {
 			configPath: "testdata/filter_simple_namespace.yaml",
 			in: mutatecommon.FakePodSpec{

--- a/releasenotes/notes/guard-readmission-ssi-imgvol-e9dfef7c4b5b8b0d.yaml
+++ b/releasenotes/notes/guard-readmission-ssi-imgvol-e9dfef7c4b5b8b0d.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixes a bug in the admission controller webhook that allowed admission to re-run for pods that already had APM Injection in image-volume mode.
+    Fixes a bug in the admission controller webhook that allowed admission to re-run for pods that already had APM injection in image-volume mode.

--- a/releasenotes/notes/guard-readmission-ssi-imgvol-e9dfef7c4b5b8b0d.yaml
+++ b/releasenotes/notes/guard-readmission-ssi-imgvol-e9dfef7c4b5b8b0d.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixes a bug in the admission controller webhook that allowed admission to re-run for pods that already had APM Injection in image-volume mode.


### PR DESCRIPTION
### What does this PR do?
Avoid double-injection by returning early if the pod already has image_volume mode's init containers. 
Init_container mode was already guarded by checking for per-language init containers (e.g. datadog-lib-python-init). This change adds the same style of guard for image_volume mode by checking for the datadog-apm-inject-preload init container.

### Motivation
The webhook may be run twice, but we do not want to inject twice. CSI mode needs a guard in the future as well.

### Describe how you validated your changes
Tests in target_mutator_test.go were added for both re-admission cases: one for init_container mode and one for image_volume mode. The test asserts that the pod is not changed ("mutated") at all in the case that the representative init container(s) are present.

### Additional Notes
