### PR TITLE
GNT-634: Add pod check annotation JSON validation and improve error visibility

### DIFF
--- a/cmd/agent/subcommands/subcommands.go
+++ b/cmd/agent/subcommands/subcommands.go
@@ -37,6 +37,7 @@ import (
 	cmdstreamep "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamep"
 	cmdstreamlogs "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamlogs"
 	cmdtaggerlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/taggerlist"
+	cmdvalidatepodannotation "github.com/DataDog/datadog-agent/cmd/agent/subcommands/validatepodannotation"
 	cmdversion "github.com/DataDog/datadog-agent/cmd/agent/subcommands/version"
 	cmdworkloadfilterlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/workloadfilterlist"
 	cmdworkloadlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/workloadlist"
@@ -68,6 +69,7 @@ func AgentSubcommands() []command.SubcommandFactory {
 		cmdstreamlogs.Commands,
 		cmdstreamep.Commands,
 		cmdtaggerlist.Commands,
+		cmdvalidatepodannotation.Commands,
 		cmdversion.Commands,
 		cmdworkloadlist.Commands,
 		cmdworkloadfilterlist.Commands,

--- a/cmd/agent/subcommands/validatepodannotation/command.go
+++ b/cmd/agent/subcommands/validatepodannotation/command.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package validatepodannotation implements 'agent validate-pod-annotation'.
+// It validates the JSON used in Kubernetes pod check annotations
+// (ad.datadoghq.com/<container>.checks) and exits with an error on invalid JSON.
+package validatepodannotation
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
+)
+
+// Commands returns a slice of subcommands for the 'agent' command.
+func Commands(_ *command.GlobalParams) []*cobra.Command {
+	validateCmd := &cobra.Command{
+		Use:   "validate-pod-annotation [file]",
+		Short: "Validate Kubernetes pod check annotation JSON",
+		Long: `Validates the JSON used in Kubernetes pod check annotations
+(ad.datadoghq.com/<container>.checks). Read from file or stdin.
+Exits with code 1 and prints the error on invalid JSON.
+Use this to catch syntax errors before applying annotations to pods.`,
+		RunE: run,
+	}
+	validateCmd.Args = cobra.MaximumNArgs(1)
+	return []*cobra.Command{validateCmd}
+}
+
+func run(_ *cobra.Command, args []string) error {
+	var input []byte
+	var err error
+	if len(args) == 1 {
+		input, err = os.ReadFile(args[0])
+		if err != nil {
+			return fmt.Errorf("reading file: %w", err)
+		}
+	} else {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			input = append(input, scanner.Bytes()...)
+			input = append(input, '\n')
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("reading stdin: %w", err)
+		}
+	}
+
+	if err := utils.ValidatePodChecksAnnotation(string(input)); err != nil {
+		return fmt.Errorf("invalid pod check annotation JSON: %w", err)
+	}
+	return nil
+}

--- a/comp/core/autodiscovery/common/utils/pod_annotations.go
+++ b/comp/core/autodiscovery/common/utils/pod_annotations.go
@@ -91,7 +91,7 @@ func parseChecksJSON(adIdentifier string, checksJSON string) ([]integration.Conf
 
 	err := json.Unmarshal([]byte(checksJSON), &namedChecks)
 	if err != nil {
-		return nil, fmt.Errorf("invalid JSON in pod check annotation (ad.datadoghq.com/<container>.checks): %w", err)
+		return nil, fmt.Errorf("invalid JSON in check configuration (ad.datadoghq.com/<container>.checks): %w", err)
 	}
 
 	checks := make([]integration.Config, 0, len(namedChecks))

--- a/comp/core/autodiscovery/common/utils/pod_annotations.go
+++ b/comp/core/autodiscovery/common/utils/pod_annotations.go
@@ -7,6 +7,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -59,7 +60,7 @@ func ExtractTemplatesFromAnnotations(entityName string, annotations map[string]s
 // reported in the "Configuration Errors" section of `agent status`.
 func ValidatePodChecksAnnotation(checksJSON string) error {
 	if checksJSON == "" {
-		return fmt.Errorf("pod check annotation JSON is empty")
+		return errors.New("pod check annotation JSON is empty")
 	}
 	var namedChecks map[string]struct {
 		Name                    string          `json:"name"`

--- a/docs/dev/kubernetes-autodiscovery-annotations.md
+++ b/docs/dev/kubernetes-autodiscovery-annotations.md
@@ -1,0 +1,58 @@
+# Kubernetes Autodiscovery and Pod Check Annotations
+
+This document describes how the Datadog Agent uses Kubernetes pod annotations for integration (check) autodiscovery and how to avoid common pitfalls.
+
+## Pod check annotations
+
+Many customers use Kubernetes pod annotations to run checks. The annotation format is:
+
+- **Annotation key**: `ad.datadoghq.com/<container_name>.checks`
+- **Annotation value**: A **JSON object** that maps check names to their configuration (init_config, instances, etc.).
+
+Example:
+
+```yaml
+annotations:
+  ad.datadoghq.com/my-container.checks: |
+    {
+      "openmetrics": {
+        "init_config": {},
+        "instances": [
+          {
+            "openmetrics_endpoint": "http://%%host%%:8080/metrics"
+          }
+        ]
+      }
+    }
+```
+
+## Invalid JSON causes the check to fail
+
+**Any incorrect or invalid JSON in the pod check annotation will cause the check to fail**, even if the pod is found via autodiscovery. The agent will not run the check when the annotation value is not valid JSON (e.g. missing comma, trailing comma, wrong quotes, or malformed structure).
+
+Common mistakes include:
+
+- Missing comma between `"init_config": {}` and `"instances": [...]`
+- Trailing comma in arrays or objects (e.g. `"instances": [{},]`)
+- Using a string for `init_config` instead of an object (e.g. `"init_config": "{}"` instead of `"init_config": {}`)
+
+When the JSON is invalid, the agent does **not** run the check and there is no check instance to show in `agent status` for that integration. The error is reported in the **Configuration Errors** section of `agent status` (under the "Autodiscovery" / "Configuration Errors" block), so always check that section when a pod-annotated check does not appear.
+
+## Validating annotation JSON
+
+To validate pod check annotation JSON before applying it to a pod (or to troubleshoot failures), use the agent CLI:
+
+```bash
+# Validate JSON from a file
+agent validate-pod-annotation /path/to/annotation.json
+
+# Validate JSON from stdin (e.g. paste or pipe)
+echo '{"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}}' | agent validate-pod-annotation
+```
+
+If the JSON is invalid, the command prints the error and exits with code 1. If valid, it exits with code 0.
+
+## Related documentation
+
+- [Kubernetes and Integrations](https://docs.datadoghq.com/containers/kubernetes/integrations/) (Datadog docs) — setup and examples for annotations.
+- Run `agent status` and look at **Configuration Errors** when a check discovered via annotations is not running.

--- a/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
+++ b/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
@@ -1,0 +1,9 @@
+---
+agent:
+  - |
+    **Kubernetes pod check annotations**: Invalid JSON in pod check annotations
+    (ad.datadoghq.com/<container>.checks) now produces a clear error message
+    in the "Configuration Errors" section of `agent status`. A new CLI command
+    `agent validate-pod-annotation` validates annotation JSON from a file or
+    stdin and exits with an error on invalid syntax, so you can catch mistakes
+    before applying annotations to pods.

--- a/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
+++ b/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
@@ -1,5 +1,5 @@
 ---
-agent:
+features:
   - |
     **Kubernetes pod check annotations**: Invalid JSON in pod check annotations
     (ad.datadoghq.com/<container>.checks) now produces a clear error message

--- a/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
+++ b/releasenotes/notes/validate-pod-annotation-json-kubernetes-ad-7f8a9b0c1d2e3f4a.yaml
@@ -3,7 +3,7 @@ features:
   - |
     **Kubernetes pod check annotations**: Invalid JSON in pod check annotations
     (ad.datadoghq.com/<container>.checks) now produces a clear error message
-    in the "Configuration Errors" section of `agent status`. A new CLI command
-    `agent validate-pod-annotation` validates annotation JSON from a file or
+    in the "Configuration Errors" section of ``agent status``. A new CLI command
+    ``agent validate-pod-annotation`` validates annotation JSON from a file or
     stdin and exits with an error on invalid syntax, so you can catch mistakes
     before applying annotations to pods.


### PR DESCRIPTION
### What does this PR do?

- Addresses [GNT-634](https://datadoghq.atlassian.net/browse/GNT-634)
- Validation API: Adds V`alidatePodChecksAnnotation(checksJSON string) error` in `comp/core/autodiscovery/common/utils/pod_annotations.go` to validate the JSON used in Kubernetes pod check annotations (`ad.datadoghq.com/<container>.checks`). It returns a clear error on invalid or malformed JSON.
- Clearer runtime errors: Updates the error returned when parsing fails so it explicitly says `invalid JSON in pod check annotation (ad.datadoghq.com/<container>.checks): ...`, making it obvious in agent status → Configuration Errors.
- CLI: Adds `agent validate-pod-annotation [file]` to validate annotation JSON from a file or stdin. Exits 0 when valid and 1 (and prints the error) when invalid.
- Docs: Adds `docs/dev/kubernetes-autodiscovery-annotations.md` describing that invalid JSON in pod check annotations causes the check to fail, common mistakes, where errors appear (agent status), and how to use the new command.
- Release note: Adds a release note for the new behavior and CLI.

### Motivation
Customers often use Kubernetes pod annotations for integration autodiscovery. If the annotation value is invalid JSON (e.g. missing comma, trailing comma, or `"init_config": "{}"` instead of `"init_config": {}`), the check does not run and there was no clear signal. Feedback from [support](https://datadoghq.atlassian.net/wiki/spaces/TS/pages/5429362993/Q325+Agent+Integrations+VoC+Customer+Signals#Step-2a---TAP-Analysis) (e.g. [#2206552](https://datadog.zendesk.com/agent/tickets/2206552), [#2075292](https://datadog.zendesk.com/agent/tickets/2075292), [#2180594](https://datadog.zendesk.com/agent/tickets/2180594), [#2085466](https://datadog.zendesk.com/agent/tickets/2085466)) was that invalid JSON caused checks to “fail silently” and that errors were hard to find. This PR:

1. Surfaces a clear error in the existing “Configuration Errors” section of agent status.
2. Lets users validate annotation JSON before applying it via agent validate-pod-annotation.
3. Documents that invalid JSON causes the check to fail and how to troubleshoot it.

### Describe how you validated your changes
- Unit tests: Added TestValidatePodChecksAnnotation in comp/core/autodiscovery/common/utils/pod_annotations_test.go covering valid minimal JSON, valid multi-check JSON, empty input, invalid JSON (missing comma, trailing comma, non-object root). Existing TestExtractTemplatesFromAnnotations cases still pass, including invalid JSON cases that assert on the new error message.
- Manual: Ran agent validate-pod-annotation with valid and invalid JSON from stdin and from a file; confirmed exit 0 vs 1 and error output. Confirmed agent status shows the updated error text under Configuration Errors when a pod has invalid annotation JSON (container provider path).
- Build: Agent build succeeds with the new subcommand registered.

Usage Examples:
```
# From file
agent validate-pod-annotation /path/to/annotation.json

# From stdin
echo '{"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}}' | agent validate-pod-annotation
```

To run tests and build locally:
```
go test ./comp/core/autodiscovery/common/utils/... -run TestValidatePodChecksAnnotation -v
dda inv agent.build --build-exclude=systemd   # or your usual agent build
```

Trying the `validate-pod-annotation` CLI

Valid JSON (exit 0):
```
# From stdin
echo '{"openmetrics":{"init_config":{},"instances":[{"openmetrics_endpoint":"http://%%host%%:8080/metrics"}]}}' | ./bin/agent/agent validate-pod-annotation

# From a file
echo '{"redis":{"init_config":{},"instances":[{}]}}' > /tmp/valid.json
./bin/agent/agent validate-pod-annotation /tmp/valid.json
```

Invalid JSON (exit 1 + error message):
```
# Missing comma (like ticket #2206552)
echo '{"envoy":{"init_config":{}"instances":[{"stats_url":"http://%%host%%:9900/stats"}]}}' | ./bin/agent/agent validate-pod-annotation

# Trailing comma
echo '{"karpenter":{"init_config":{},"instances":[{},]}}' | ./bin/agent/agent validate-pod-annotation

# Empty
echo '' | ./bin/agent/agent validate-pod-annotation
```

### Additional Notes

[GNT-634]: https://datadoghq.atlassian.net/browse/GNT-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ