### PR TITLE
[ AGNTLOG-236 ] Add sleep to CCA off e2e test containers

### DIFF
--- a/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
+++ b/test/new-e2e/tests/agent-log-pipelines/k8s-logs/file_tailing_cca_off_test.go
@@ -53,9 +53,11 @@ func (v *k8sCCAOffSuite) TestADAnnotations() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "annotations-job",
-							Image:   "ubuntu",
-							Command: []string{"echo", testLogMessage},
+							Name:  "annotations-job",
+							Image: "ubuntu",
+							// Sleep is added here so k8s doesn't kill the container before
+							// the agent container can detect it.
+							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,
@@ -98,9 +100,11 @@ func (v *k8sCCAOffSuite) TestCCAOff() {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "cca-off-job",
-							Image:   "ubuntu",
-							Command: []string{"echo", testLogMessage},
+							Name:  "cca-off-job",
+							Image: "ubuntu",
+							// Sleep is added here so k8s doesn't kill the container before
+							// the agent container can detect it.
+							Command: []string{"sh", "-c", "echo '" + testLogMessage + "' && sleep 10"},
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
## What does this PR do?

Adds a 10-second sleep to the ubuntu containers in `file_tailing_cca_off_test.go`, matching the fix already applied to `file_tailing_test.go` in fefe0aebe4a.

## Motivation

The `TestK8sCCAOff/TestADAnnotations` e2e test was failing because the ubuntu container exited immediately after `echo`, before the agent could discover and begin tailing it. With CCA (Container Collect All) off, only annotated containers are collected — but the annotated container's lifetime was too short for the agent to detect. This caused:

1. `TestADAnnotations` to fail with an empty log service list (`[]string{}` does not contain "ubuntu")
2. The DD auto-retry mechanism to retry `TestK8sCCAOff`, triggering a `t.Parallel called multiple times` panic
3. Cascading failures in `TestCCAOff`

The sleep keeps the container alive long enough for the agent to detect and tail it, consistent with the approach in `file_tailing_test.go`.

## Describe how you validated your changes

The same fix pattern was validated in fefe0aebe4a for `file_tailing_test.go`.