### PR TITLE
[CWS] fix credentials of children of tracee

### DIFF
--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -174,7 +174,7 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.Open.Flags = syscallMsg.Open.Flags
 
 	case ebpfless.SyscallTypeSetUID:
-		p.Resolvers.ProcessResolver.UpdateUID(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetUID.UID, syscallMsg.SetUID.EUID)
+		p.Resolvers.ProcessResolver.UpdateUser(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetUID.UID, syscallMsg.SetUID.EUID, syscallMsg.SetUID.User, syscallMsg.SetUID.EUser)
 		event.Type = uint32(model.SetuidEventType)
 		event.SetUID.UID = uint32(syscallMsg.SetUID.UID)
 		event.SetUID.User = syscallMsg.SetUID.User
@@ -182,7 +182,7 @@ func (p *EBPFLessProbe) handleSyscallMsg(cl *client, syscallMsg *ebpfless.Syscal
 		event.SetUID.EUser = syscallMsg.SetUID.EUser
 
 	case ebpfless.SyscallTypeSetGID:
-		p.Resolvers.ProcessResolver.UpdateGID(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetGID.GID, syscallMsg.SetGID.EGID)
+		p.Resolvers.ProcessResolver.UpdateGroup(process.CacheResolverKey{Pid: syscallMsg.PID, NSID: cl.nsID}, syscallMsg.SetGID.GID, syscallMsg.SetGID.EGID, syscallMsg.SetGID.Group, syscallMsg.SetGID.EGroup)
 		event.Type = uint32(model.SetgidEventType)
 		event.SetGID.GID = uint32(syscallMsg.SetGID.GID)
 		event.SetGID.Group = syscallMsg.SetGID.Group

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -63,17 +63,18 @@ type Opts struct {
 type CWSPtracerCtx struct {
 	Tracer
 
-	opts         *Opts
-	wg           sync.WaitGroup
-	cancel       context.Context
-	cancelFnc    context.CancelFunc
-	containerID  containerutils.ContainerID
-	probeAddr    string
-	client       net.Conn
-	clientReady  chan bool
-	msgDataChan  chan []byte
-	helloMsg     *ebpfless.Message
-	processCache *ProcessCache
+	opts            *Opts
+	wg              sync.WaitGroup
+	cancel          context.Context
+	cancelFnc       context.CancelFunc
+	containerID     containerutils.ContainerID
+	probeAddr       string
+	client          net.Conn
+	clientReady     chan bool
+	msgDataChan     chan []byte
+	helloMsg        *ebpfless.Message
+	processCache    *ProcessCache
+	traceesReported []int
 }
 
 type syscallHandlerFunc func(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, disableStats bool) error

--- a/pkg/security/ptracer/hooks.go
+++ b/pkg/security/ptracer/hooks.go
@@ -58,7 +58,10 @@ func (ctx *CWSPtracerCtx) handlePreHooks(nr int, pid int, regs syscall.PtraceReg
 	case ExecveNr:
 		// Top level pids, add ctx.opts.Creds. For the other PIDs the creds will be propagated at the probe side
 		for _, pid := range ctx.PIDs {
-			if process.Pid == pid {
+			if process.Pid == pid && !slices.Contains(ctx.traceesReported, pid) {
+				// report the creds for the first time
+				ctx.traceesReported = append(ctx.traceesReported, pid)
+
 				var uid, gid uint32
 
 				if ctx.opts.Creds.UID != nil {

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -239,7 +239,7 @@ func (p *EBPFLessResolver) Resolve(key CacheResolverKey) *model.ProcessCacheEntr
 }
 
 // UpdateUID updates the credentials of the provided pid
-func (p *EBPFLessResolver) UpdateUID(key CacheResolverKey, uid int32, euid int32) {
+func (p *EBPFLessResolver) UpdateUser(key CacheResolverKey, uid int32, euid int32, user string, euser string) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -247,15 +247,17 @@ func (p *EBPFLessResolver) UpdateUID(key CacheResolverKey, uid int32, euid int32
 	if entry != nil {
 		if uid != -1 {
 			entry.Credentials.UID = uint32(uid)
+			entry.Credentials.User = user
 		}
 		if euid != -1 {
 			entry.Credentials.EUID = uint32(euid)
+			entry.Credentials.EUser = euser
 		}
 	}
 }
 
 // UpdateGID updates the credentials of the provided pid
-func (p *EBPFLessResolver) UpdateGID(key CacheResolverKey, gid int32, egid int32) {
+func (p *EBPFLessResolver) UpdateGroup(key CacheResolverKey, gid int32, egid int32, group string, egroup string) {
 	p.Lock()
 	defer p.Unlock()
 
@@ -263,9 +265,11 @@ func (p *EBPFLessResolver) UpdateGID(key CacheResolverKey, gid int32, egid int32
 	if entry != nil {
 		if gid != -1 {
 			entry.Credentials.GID = uint32(gid)
+			entry.Credentials.Group = group
 		}
 		if egid != -1 {
 			entry.Credentials.EGID = uint32(egid)
+			entry.Credentials.EGroup = egroup
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fix UID when the tracee -> setuid -> exec. In that case the setuid is overriden by the credential of the tracee because the entry point share the same PID as the executed process after the setuid. This PR makes sure that we send the creds only once. 

### Motivation

### Describe how you validated your changes

### Additional Notes
