### PR TITLE
Use `TryLock` in pdhhelper refresh interval check

### DIFF
--- a/pkg/util/pdhutil/pdhhelper.go
+++ b/pkg/util/pdhutil/pdhhelper.go
@@ -106,10 +106,11 @@ func refreshPdhObjectCache(forceRefresh bool) (didrefresh bool, err error) {
 	// Only refresh at most every refresh_interval seconds
 	// or when forceRefresh=true
 	if !forceRefresh {
-		// TODO: use TryLock in golang 1.18
-		//       we don't need to block here
-		//       worst case the counter is skipped again until next interval.
-		lockLastPdhRefreshTime.Lock()
+		if !lockLastPdhRefreshTime.TryLock() {
+			// we don't need to block here
+			// worst case the counter is skipped again until next interval.
+			return false, nil
+		}
 		defer lockLastPdhRefreshTime.Unlock()
 		timenow := time.Now()
 		// time.Time.Sub() uses a monotonic clock


### PR DESCRIPTION
### What does this PR do?
Replace `Lock()` with `TryLock()` when checking whether a PDH object cache refresh is due.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-582
Address a TODO blocked on Go **1.18**: blocking on the mutex is unnecessary: if another goroutine holds it, skipping the refresh is acceptable, as the counter will retry after the next interval.

### Describe how you validated your changes
- `GOOS=windows go vet` passes,
- CI passes.

### Additional Notes
Behavioral change is limited to the non-blocking path: concurrent callers no longer queue up behind the lock.