### PR TITLE
Bring `tools/bazel*` scripts on par re cache handling

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -7,24 +7,22 @@ if [ -z "${BAZEL_REAL:-}" ] || [ "${BAZELISK_SKIP_WRAPPER:-}" != true ]; then
   exit 2
 fi
 
-# CI specific setup
-if [ -n "${CI:-}" ]; then
-  if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
+# Ensure `XDG_CACHE_HOME` denotes a directory
+if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
+  if [ -n "${CI:-}" ]; then
     >&2 echo "🔴 XDG_CACHE_HOME (${XDG_CACHE_HOME:-}) must denote a directory in CI!"
     exit 2
   fi
-
+  if [[ -e /.dockerenv || -e /run/.containerenv ]]; then
+    >&2 echo "💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:"
+    # shellcheck disable=SC2016
+    >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
+  fi
+elif [ -n "${CI:-}" ]; then
   # Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` also honor them
   cat >"$(dirname "$(dirname "$0")")/user.bazelrc" <<EOF
 common --config=ci
 EOF
-fi
-
-# Warn non-CI users running `bazel` in a container without persisting its cache
-if [[ -z "${XDG_CACHE_HOME:-}" && ( -e /.dockerenv || -e /run/.containerenv ) ]]; then
-  >&2 echo "💡 To persist caches across restarts, consider sharing a directory and setting XDG_CACHE_HOME to its path:"
-  # shellcheck disable=SC2016
-  >&2 echo '    docker run --env=XDG_CACHE_HOME=/cache --volume="$HOME/.cache:/cache" ...'
 fi
 
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -9,12 +9,23 @@ exit /b 2
 :bazelisk_ok
 
 :: Ensure `XDG_CACHE_HOME` denotes a directory
-if defined CI (
-  if not exist "!XDG_CACHE_HOME!" (
+if not exist "%XDG_CACHE_HOME%" (
+  if defined CI (
     >&2 echo 🔴 XDG_CACHE_HOME ^(!XDG_CACHE_HOME!^) must denote a directory in CI!
     exit /b 2
   )
-) else if not defined XDG_CACHE_HOME (
+  if not defined DOTNET_RUNNING_IN_CONTAINER >nul 2>&1 sc query CExecSvc && set DOTNET_RUNNING_IN_CONTAINER=1
+  if defined DOTNET_RUNNING_IN_CONTAINER (
+    >&2 echo 💡 To persist caches across restarts, please set XDG_CACHE_HOME pointing to a mounted directory, e.g.:
+    >&2 echo     docker.exe run --env=XDG_CACHE_HOME=C:\cache --volume="$HOME\.cache:C:\cache" ...
+  )
+)
+
+:: Make `bazel` honor $XDG_CACHE_HOME if set as it does on POSIX OSes: https://github.com/bazelbuild/bazel/issues/27808
+if defined XDG_CACHE_HOME (
+  set "bazel_home=%XDG_CACHE_HOME%\bazel"
+  set bazel_home_startup_option="--output_user_root=!bazel_home!"
+) else (
   set "XDG_CACHE_HOME=%~dp0..\.cache"
 )
 
@@ -33,18 +44,15 @@ if not exist "!more_than_260_chars!" (
 
 :: Not in CI: simply execute `bazel` - done
 if not defined CI (
-  "%BAZEL_REAL%" %*
+  "%BAZEL_REAL%" !bazel_home_startup_option! %*
   exit /b !errorlevel!
 )
-
-:: In CI: make `bazel` honor $XDG_CACHE_HOME as it does on POSIX OSes: https://github.com/bazelbuild/bazel/issues/27808
-set "bazel_home=!XDG_CACHE_HOME!\bazel"
 
 :: Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
 (
   echo startup --connect_timeout_secs=5  # instead of 30s, for quicker iterations in diagnostics
   echo startup --local_startup_timeout_secs=30  # instead of 120s, to fail faster for diagnostics
-  echo startup --output_user_root=!bazel_home:\=/!  # forward slashes: https://github.com/bazelbuild/bazel/issues/3275
+  echo startup !bazel_home_startup_option:\=/!  # forward slashes: https://github.com/bazelbuild/bazel/issues/3275
   echo common --config=ci
 ) >"%~dp0..\user.bazelrc"
 
@@ -53,12 +61,12 @@ set "bazel_home=!XDG_CACHE_HOME!\bazel"
 
 :: Payload: execute `bazel` and remember exit status
 "%BAZEL_REAL%" %*
-set "bazel_exit=!errorlevel!"
+set bazel_exit=!errorlevel!
 
 :: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
 :: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
-set "should_diagnose=1"
-for %%c in (0 1 3 34 36 48) do if !bazel_exit!==%%c set "should_diagnose=0"
+set should_diagnose=1
+for %%c in (0 1 3 34 36 48) do if !bazel_exit!==%%c set should_diagnose=0
 if !should_diagnose!==1 (
   >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
   for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (


### PR DESCRIPTION
### What does this PR do?
- also forward `XDG_CACHE_HOME` to `bazel` in non-CI Windows setups,
- also warn when running `bazel` in a Windows container without `XDG_CACHE_HOME` pointing to an existing path, mirroring #46711.
  Detection relies on `DOTNET_RUNNING_IN_CONTAINER` (set by .NET Docker images) and `CExecSvc` (Container Execution Agent, present in most Windows containers),
- refactor both scripts to test `XDG_CACHE_HOME` validity once at the outer level, strengthening the condition from "unset" to "not an existing path".

### Motivation
Setting `XDG_CACHE_HOME` on Windows had no effect on `bazel`'s output root in non-CI, silently producing an inconsistent behavior vs. Linux/macOS.
Likewise, users of Windows containers had no guidance to persist the cache across container restarts, unlike their Linux counterparts since #46711.

### Describe how you validated your changes
Ran `tools/bazel.bat` through `bazelisk` locally and in CI.