### PR TITLE
Add shell subcommand to agent

### DIFF
--- a/cmd/agent/subcommands/shell/command.go
+++ b/cmd/agent/subcommands/shell/command.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package shell implements 'agent shell'.
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+)
+
+type runConfig struct {
+	stdin     io.Reader
+	stdout    io.Writer
+	stderr    io.Writer
+	stdinFile *os.File
+}
+
+func (c runConfig) isTerminal() bool {
+	if c.stdinFile == nil {
+		return false
+	}
+	return term.IsTerminal(int(c.stdinFile.Fd()))
+}
+
+// Commands returns a slice of subcommands for the 'agent' command.
+func Commands(_ *command.GlobalParams) []*cobra.Command {
+	var commandStr string
+
+	shellCmd := &cobra.Command{
+		Use:   "shell [path ...]",
+		Short: "Run a POSIX shell",
+		Args:  cobra.ArbitraryArgs,
+		Run: func(_ *cobra.Command, args []string) {
+			cfg := runConfig{
+				stdin:     os.Stdin,
+				stdout:    os.Stdout,
+				stderr:    os.Stderr,
+				stdinFile: os.Stdin,
+			}
+			os.Exit(runShell(commandStr, args, cfg))
+		},
+	}
+
+	shellCmd.Flags().StringVarP(&commandStr, "command", "c", "", "command to be executed")
+
+	return []*cobra.Command{shellCmd}
+}
+
+func runShell(commandStr string, paths []string, cfg runConfig) int {
+	err := runAll(commandStr, paths, cfg)
+	var exitStatus interp.ExitStatus
+	if errors.As(err, &exitStatus) {
+		return int(exitStatus)
+	}
+	if err != nil {
+		fmt.Fprintln(cfg.stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func runAll(commandStr string, paths []string, cfg runConfig) error {
+	r, err := interp.New(
+		interp.Interactive(true),
+		interp.StdIO(cfg.stdin, cfg.stdout, cfg.stderr),
+	)
+	if err != nil {
+		return err
+	}
+
+	if commandStr != "" {
+		return run(r, strings.NewReader(commandStr), "")
+	}
+
+	if len(paths) == 0 {
+		if cfg.isTerminal() {
+			return runInteractive(r, cfg.stdin, cfg.stdout, cfg.stderr)
+		}
+		return run(r, cfg.stdin, "")
+	}
+
+	for _, path := range paths {
+		if err := runPath(r, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func run(r *interp.Runner, reader io.Reader, name string) error {
+	prog, err := syntax.NewParser().Parse(reader, name)
+	if err != nil {
+		return err
+	}
+	r.Reset()
+	ctx := context.Background()
+	return r.Run(ctx, prog)
+}
+
+func runPath(r *interp.Runner, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return run(r, f, path)
+}
+
+func runInteractive(r *interp.Runner, stdin io.Reader, stdout, stderr io.Writer) error {
+	parser := syntax.NewParser()
+	fmt.Fprintf(stdout, "$ ")
+	for stmts, err := range parser.InteractiveSeq(stdin) {
+		if err != nil {
+			return err // stop at the first error
+		}
+		if parser.Incomplete() {
+			fmt.Fprintf(stdout, "> ")
+			continue
+		}
+		ctx := context.Background()
+		for _, stmt := range stmts {
+			err := r.Run(ctx, stmt)
+			if r.Exited() {
+				return err
+			}
+		}
+		fmt.Fprintf(stdout, "$ ")
+	}
+	return nil
+}

--- a/cmd/agent/subcommands/shell/command_test.go
+++ b/cmd/agent/subcommands/shell/command_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package shell
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestConfig() (runConfig, *bytes.Buffer, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cfg := runConfig{
+		stdin:  strings.NewReader(""),
+		stdout: stdout,
+		stderr: stderr,
+	}
+	return cfg, stdout, stderr
+}
+
+func TestRunShellCommand(t *testing.T) {
+	cfg, stdout, stderr := newTestConfig()
+
+	exitCode := runShell("echo hi", nil, cfg)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "hi\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunShellCommandIgnoresArgs(t *testing.T) {
+	cfg, stdout, stderr := newTestConfig()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "script.sh")
+	if err := os.WriteFile(path, []byte("echo file\n"), 0o600); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	exitCode := runShell("echo cmd", []string{path}, cfg)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "cmd\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunShellPathsReset(t *testing.T) {
+	cfg, stdout, stderr := newTestConfig()
+
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first.sh")
+	second := filepath.Join(dir, "second.sh")
+	if err := os.WriteFile(first, []byte("foo=bar\n"), 0o600); err != nil {
+		t.Fatalf("write first script: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("echo ${foo:-unset}\n"), 0o600); err != nil {
+		t.Fatalf("write second script: %v", err)
+	}
+
+	exitCode := runShell("", []string{first, second}, cfg)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "unset\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}
+
+func TestRunShellExitStatus(t *testing.T) {
+	cfg, stdout, stderr := newTestConfig()
+
+	exitCode := runShell("exit 7", nil, cfg)
+
+	if exitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("unexpected stderr: %q", got)
+	}
+}

--- a/cmd/agent/subcommands/subcommands.go
+++ b/cmd/agent/subcommands/subcommands.go
@@ -31,6 +31,7 @@ import (
 	cmdrun "github.com/DataDog/datadog-agent/cmd/agent/subcommands/run"
 	cmdsecret "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secret"
 	cmdsecrethelper "github.com/DataDog/datadog-agent/cmd/agent/subcommands/secrethelper"
+	cmdshell "github.com/DataDog/datadog-agent/cmd/agent/subcommands/shell"
 	cmdsnmp "github.com/DataDog/datadog-agent/cmd/agent/subcommands/snmp"
 	cmdstatus "github.com/DataDog/datadog-agent/cmd/agent/subcommands/status"
 	cmdstop "github.com/DataDog/datadog-agent/cmd/agent/subcommands/stop"
@@ -63,6 +64,7 @@ func AgentSubcommands() []command.SubcommandFactory {
 		cmdremoteconfig.Commands,
 		cmdrun.Commands,
 		cmdsecret.Commands,
+		cmdshell.Commands,
 		cmdsnmp.Commands,
 		cmdstatus.Commands,
 		cmdstreamlogs.Commands,

--- a/go.mod
+++ b/go.mod
@@ -1196,6 +1196,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	gopkg.in/neurosnap/sentences.v1 v1.0.7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	mvdan.cc/sh/v3 v3.12.0
 )
 
 // github.com/aws/karpenter-provider-aws requires alpha versions of K8s libraries. We are only using some constants from these packages.

--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -145,6 +145,16 @@ func (agent *agentCommandRunner) Secret(commandArgs ...agentclient.AgentArgsOpti
 	return agent.executeCommand("secret", commandArgs...)
 }
 
+// Shell runs the shell command and returns its output
+func (agent *agentCommandRunner) Shell(commandArgs ...agentclient.AgentArgsOption) string {
+	return agent.executeCommand("shell", commandArgs...)
+}
+
+// ShellWithError runs the shell command and returns its output or an error
+func (agent *agentCommandRunner) ShellWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
+	return agent.executeCommandWithError("shell", commandArgs...)
+}
+
 // IsReady runs status command and returns true if the command returns a zero exit code.
 // This function should rarely be used.
 func (agent *agentCommandRunner) IsReady() bool {

--- a/test/new-e2e/tests/agent-subcommands/shell/shell_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/shell/shell_common_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package shell
+
+import (
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
+)
+
+type baseShellSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func (s *baseShellSuite) TestShellEcho() {
+	output := s.Env().Agent.Client.Shell(agentclient.WithArgs([]string{"-c", "echo hi"}))
+	assert.Equal(s.T(), "hi", strings.TrimSpace(output))
+}

--- a/test/new-e2e/tests/agent-subcommands/shell/shell_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/shell/shell_nix_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package shell
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+type linuxShellSuite struct {
+	baseShellSuite
+}
+
+func TestLinuxShellSuite(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &linuxShellSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake()))
+}

--- a/test/new-e2e/tests/agent-subcommands/shell/shell_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/shell/shell_win_test.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package shell
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+type windowsShellSuite struct {
+	baseShellSuite
+}
+
+func TestWindowsShellSuite(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &windowsShellSuite{}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(awshost.WithRunOptions(ec2.WithEC2InstanceOptions(ec2.WithOS(os.WindowsServerDefault))))))
+}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"6a791daf-932e-4527-8dcc-3b448d012994","source":"chat","resourceId":"516ff637-49ff-469f-b616-f7b73c4fc3ff","workflowId":"3ed4602a-0673-4930-96ae-24148d190b81","codeChangeId":"3ed4602a-0673-4930-96ae-24148d190b81","sourceType":"chat"} -->
PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/516ff637-49ff-469f-b616-f7b73c4fc3ff)

Comment @datadog to request changes

Feedback (especially what can be better) welcome in [#code-gen-aka-bits-dev-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?

Implements a new `shell` subcommand for the agent that provides an interactive POSIX shell interpreter. The implementation uses the `mvdan.cc/sh/v3` library to parse and execute shell commands, mirroring the behavior of `gosh` from the mvdan/sh project.

### Motivation

This feature enables users to execute shell commands directly through the agent, supporting both interactive shell sessions and script execution. It provides flexibility for running arbitrary shell commands with proper exit status handling and terminal detection.

### Describe how you validated your changes

- Added comprehensive unit tests in `command_test.go` covering:
  - Basic command execution with `-c` flag
  - Command-line arguments handling
  - Exit status propagation
  - Script file execution with state isolation
- Added e2e tests for both Linux and Windows environments
- Verified consistency with existing subcommand patterns in the codebase
- Tested interactive mode, non-interactive stdin, and file-based execution paths

### Additional Notes

- The implementation follows the existing subcommand structure and patterns used by other agent subcommands
- Added `mvdan.cc/sh/v3` as a dependency in `go.mod`
- Added helper methods to the e2e test client for easy shell command execution
- The shell command supports `-c` flag for inline commands, file paths for script execution, and interactive mode when run as a terminal