### PR TITLE
Configure conductor to run the nightly build on main during the weekend in this repo

### DIFF
--- a/service.datadog.yaml
+++ b/service.datadog.yaml
@@ -97,6 +97,13 @@ extensions:
           options:
             disable_bia: true
             disable_failure_notifications: true
+        - name: "main-nightly-build"
+          branch: "main"
+          schedule: "0 3 * * 6,0"
+          build_only: true
+          options:
+            disable_bia: true
+            disable_failure_notifications: true
   datadoghq.com/change-detection:
     source_patterns:
       - service.datadog.yaml


### PR DESCRIPTION
### What does this PR do?

Configure conductor to run the nightly build on main during the weekend in this repo

### Motivation

Part 2 of https://github.com/DataDog/k8s-datadog-agent-ops/pull/7515 and make sure we have a daily job during the weekend

### Describe how you validated your changes

### Additional Notes
