### PR TITLE
Revert "[AGENTRUN-1039] Do not recreate the logger when changing log level"

### DIFF
--- a/comp/core/log/mock/mock.go
+++ b/comp/core/log/mock/mock.go
@@ -39,12 +39,12 @@ func New(t testing.TB) log.Component {
 
 	t.Cleanup(func() {
 		// stop using the logger to avoid a race condition
-		pkglog.SetupLogger(pkglog.Default(), pkglog.DebugStr)
-		iface.Close()
+		pkglog.ChangeLogLevel(pkglog.Default(), pkglog.DebugLvl)
+		iface.Flush()
 	})
 
 	// install the logger into pkg/util/log
-	pkglog.SetupLogger(iface, pkglog.DebugStr)
+	pkglog.ChangeLogLevel(iface, pkglog.DebugLvl)
 
 	return pkglog.NewWrapper(2)
 }

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log/slog"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -106,7 +105,7 @@ func TestLogBuffer(t *testing.T) {
 	w.Flush()
 
 	// Trace will not be logged, Error and Critical will directly be logged to Stderr
-	assert.Equal(t, 5, strings.Count(b.String(), "foo"), b.String())
+	assert.Equal(t, strings.Count(b.String(), "foo"), 5)
 }
 func TestLogBufferWithContext(t *testing.T) {
 	// reset buffer state
@@ -612,18 +611,23 @@ func TestChangeLogLevel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("change log level to "+tc.String(), func(t *testing.T) {
-			levelVar := new(slog.LevelVar)
-			levelVar.Set(slog.LevelDebug)
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
 
-			SetupLoggerWithLevelVar(Default(), levelVar)
+			l, _ := LoggerFromWriterWithMinLevelAndLvlFuncMsgFormat(w, DebugLvl)
 
-			err := ChangeLogLevel(tc)
+			SetupLogger(Default(), DebugStr)
+
+			err := ChangeLogLevel(l, tc)
 			assert.NoError(t, err)
 
 			// log level should have been updated
 			level, err := GetLogLevel()
 			require.NoError(t, err)
 			assert.Equal(t, tc, level)
+
+			// inner logger should have been replaced
+			assert.Equal(t, l, logger.Load().inner)
 		})
 	}
 }

--- a/pkg/util/log/setup/log.go
+++ b/pkg/util/log/setup/log.go
@@ -32,18 +32,18 @@ const (
 // if a non empty logFile is provided, it will also log to the file
 // a non empty syslogURI will enable syslog, and format them following RFC 5424 if specified
 // you can also specify to log to the console and in JSON format
-func SetupLogger(loggerName LoggerName, strLogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) error {
-	logLevel, err := log.ValidateLogLevel(strLogLevel)
+func SetupLogger(loggerName LoggerName, logLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) error {
+	seelogLogLevel, err := log.ValidateLogLevel(logLevel)
 	if err != nil {
 		return err
 	}
-	loggerInterface, levelVar, err := buildLogger(loggerName, logLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+	loggerInterface, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
 		return err
 	}
 	handler := loggerInterface.(*slog.Wrapper).Handler()
 	stdslog.SetDefault(stdslog.New(handler))
-	log.SetupLoggerWithLevelVar(loggerInterface, levelVar)
+	log.SetupLogger(loggerInterface, seelogLogLevel.String())
 
 	// Registering a callback in case of "log_level" update
 	cfg.OnUpdate(func(setting string, _ pkgconfigmodel.Source, oldValue, newValue any, _ uint64) {
@@ -57,9 +57,14 @@ func SetupLogger(loggerName LoggerName, strLogLevel, logFile, syslogURI string, 
 			log.Warnf("Unable to set new log level: %v", err)
 			return
 		}
-		if err := log.ChangeLogLevel(seelogLogLevel); err != nil {
-			log.Warnf("Unable to change log level: %v", err)
+		loggerInterface, err := buildLogger(loggerName, seelogLogLevel, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+		if err != nil {
+			return
 		}
+		handler := loggerInterface.(*slog.Wrapper).Handler()
+		stdslog.SetDefault(stdslog.New(handler))
+		// We wire the new logger with the Datadog logic
+		log.ChangeLogLevel(loggerInterface, seelogLogLevel)
 	})
 	return nil
 }
@@ -72,7 +77,7 @@ func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonForm
 	// The JMX logger always logs at level "info", because JMXFetch does its
 	// own level filtering on and provides all messages to seelog at the info
 	// or error levels, via log.JMXInfo and log.JMXError.
-	logger, _, err := buildLogger(JMXLoggerName, log.InfoLvl, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
+	logger, err := buildLogger(JMXLoggerName, log.InfoLvl, logFile, syslogURI, syslogRFC, logToConsole, jsonFormat, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -82,14 +87,14 @@ func BuildJMXLogger(logFile, syslogURI string, syslogRFC, logToConsole, jsonForm
 // SetupDogstatsdLogger returns a logger with dogstatsd logger name and log level
 // if a non empty logFile is provided, it will also log to the file
 func SetupDogstatsdLogger(logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
-	logger, _, err := buildDogstatsdLogger(DogstatsDLoggerName, log.InfoLvl, logFile, cfg)
+	logger, err := buildDogstatsdLogger(DogstatsDLoggerName, log.InfoLvl, logFile, cfg)
 	if err != nil {
 		return nil, err
 	}
 	return logger, nil
 }
 
-func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
+func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile string, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	config := seelogCfg.NewSeelogConfig(string(loggerName), seelogLogLevel.String(), "common", false, nil, commonFormatter(loggerName, cfg))
 
 	// Configuring max roll for log file, if dogstatsd_log_file_max_rolls env var is not set (or set improperly ) within datadog.yaml then default value is 3
@@ -105,7 +110,7 @@ func buildDogstatsdLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, lo
 	return generateLoggerInterface(config, cfg)
 }
 
-func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
+func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, syslogURI string, syslogRFC, logToConsole, jsonFormat bool, cfg pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	formatID := "common"
 	if jsonFormat {
 		formatID = "json"
@@ -123,7 +128,7 @@ func buildLogger(loggerName LoggerName, seelogLogLevel log.LogLevel, logFile, sy
 }
 
 // generateLoggerInterface return a logger Interface from a log config
-func generateLoggerInterface(logConfig *seelogCfg.Config, _ pkgconfigmodel.Reader) (log.LoggerInterface, *stdslog.LevelVar, error) {
+func generateLoggerInterface(logConfig *seelogCfg.Config, _ pkgconfigmodel.Reader) (log.LoggerInterface, error) {
 	return logConfig.SlogLogger()
 }
 

--- a/pkg/util/log/setup/log_nix_test.go
+++ b/pkg/util/log/setup/log_nix_test.go
@@ -39,9 +39,8 @@ func TestGetSyslogURI(t *testing.T) {
 func TestSetupLoggingNowhere(t *testing.T) {
 	// setup logger so that it logs nowhere: i.e.  not to file, not to syslog, not to console
 	mockConfig := configmock.New(t)
-	loggerInterface, levelVar, err := buildLogger("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
+	loggerInterface, err := buildLogger("agent", log.InfoLvl, "", "", false, false, false, mockConfig)
 
 	assert.Nil(t, loggerInterface)
-	assert.Nil(t, levelVar)
 	assert.NotNil(t, err)
 }

--- a/pkg/util/log/setup/log_test.go
+++ b/pkg/util/log/setup/log_test.go
@@ -6,7 +6,6 @@
 package logs
 
 import (
-	"log/slog"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -22,12 +21,10 @@ func BenchmarkSlogParallel(b *testing.B) {
 	b.StopTimer()
 
 	cfg := initConfig(b)
-	logger, levelVar, err := cfg.SlogLogger()
+	logger, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-
-	levelVar.Set(slog.LevelDebug)
-	log.SetupLoggerWithLevelVar(logger, levelVar)
+	log.SetupLogger(logger, "debug")
 
 	runLogParallel(b)
 }
@@ -52,12 +49,10 @@ func BenchmarkSlogLogger(b *testing.B) {
 	b.StopTimer()
 
 	cfg := initConfig(b)
-	logger, levelVar, err := cfg.SlogLogger()
+	logger, err := cfg.SlogLogger()
 	require.NoError(b, err)
 	require.NotNil(b, logger)
-
-	levelVar.Set(slog.LevelDebug)
-	log.SetupLoggerWithLevelVar(logger, levelVar)
+	log.SetupLogger(logger, "debug")
 
 	runLog(b)
 }


### PR DESCRIPTION
Reverts DataDog/datadog-agent#46600

This caused a race in CI.
The race isn't introduced in the PR but I think the PR changes timing and makes it worse.

https://github.com/DataDog/datadog-agent/pull/46796 actually fixes the race.