### PR TITLE
[EBPF] gpu: replace map with fixed-size array for memory usage tracking

### DIFF
--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -179,10 +179,7 @@ func (agg *aggregator) getRawStats() model.UtilizationMetrics {
 		}
 	}
 
-	memTsBuilders := make(map[memAllocType]*tseriesBuilder)
-	for i := memAllocType(0); i < memAllocTypeCount; i++ {
-		memTsBuilders[memAllocType(i)] = &tseriesBuilder{}
-	}
+	var memTsBuilders [memAllocTypeCount]tseriesBuilder
 
 	for _, alloc := range agg.currentAllocs {
 		memTsBuilders[alloc.allocType].AddEventStart(alloc.startKtime, int64(alloc.size))
@@ -192,8 +189,8 @@ func (agg *aggregator) getRawStats() model.UtilizationMetrics {
 		memTsBuilders[alloc.allocType].AddEvent(alloc.startKtime, alloc.endKtime, int64(alloc.size))
 	}
 
-	for _, memTsBuilder := range memTsBuilders {
-		lastValue, maxValue := memTsBuilder.GetLastAndMax()
+	for allocType := range memTsBuilders {
+		lastValue, maxValue := memTsBuilders[allocType].GetLastAndMax()
 		stats.Memory.CurrentBytes += uint64(lastValue)
 		stats.Memory.MaxBytes += uint64(maxValue)
 	}

--- a/releasenotes/notes/gpu-memory-map-to-array-3e6513cb3139594d.yaml
+++ b/releasenotes/notes/gpu-memory-map-to-array-3e6513cb3139594d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    GPU monitoring: Replace map with fixed-size array for GPU memory usage
+    tracking, reducing CPU overhead when monitoring CUDA kernels.

--- a/releasenotes/notes/gpu-memory-map-to-array-3e6513cb3139594d.yaml
+++ b/releasenotes/notes/gpu-memory-map-to-array-3e6513cb3139594d.yaml
@@ -1,5 +1,0 @@
----
-enhancements:
-  - |
-    GPU monitoring: Replace map with fixed-size array for GPU memory usage
-    tracking, reducing CPU overhead when monitoring CUDA kernels.


### PR DESCRIPTION
### What does this PR do?

Replaces `map[memAllocType]uint64` with `[memAllocTypeCount]uint64` fixed-size arrays in the GPU monitoring hot path. This affects two locations:
  - `kernelSpan.avgMemoryUsage` in stream.go — accessed on every CUDA synchronization event
  - `memTsBuilders` in aggregator.go — used when computing per-process GPU memory stats\

If new memory types are added in the future, adding a new constant before `memAllocTypeCount` in the `memAllocType` enum is all that's needed.

### Motivation

`memAllocType` is a 4-value enum (kernel binary, global, shared, constant memory). Using a map here adds overhead: hash computation, bucket lookups, and heap allocations on every access. A fixed-size array replaces this with direct indexing.

A benchmarking script shows 6-23x speedup depending on workload (number of kernel launches between syncs), with allocations dropping from 240 B/op to 64 B/op.

### Describe how you validated your changes

Existing unit tests in `stream_test.go` and `stats_test.go` already index `avgMemoryUsage` by `memAllocType` constants (e.g., `span.avgMemoryUsage[sharedMemAlloc]`), which works for both arrays and maps.

Wrote standalone microbenchmarks reproducing the exact access patterns of `getCurrentKernelSpan` and `getRawStats`, comparing map vs array across varying kernel launch counts.

  | Launches | Map | Array | Speedup (per sync call) |
  |----------|-----|-------|---------|
  | 1 | 260 ns | 29 ns | **9.0x** |
  | 10 | 555 ns | 42 ns | **13.2x** |
  | 100 | 3.4 μs | 164 ns | **20.5x** |
  | 500 | 15.9 μs | 700 ns | **22.6x** |
  | 1000 | 31.5 μs | 1.4 μs | **23.0x** |

In a production setting, serving an LLM like `Qwen3.5-397B-A17B`, we might expect 1500-3000+ kernel launches per forward pass and 10+ forward passes per second - so this can cumulatively save **~20+ms of agent CPU time per second**.
