### PR TITLE
Bump integration_tests_otel memory limit

### DIFF
--- a/.gitlab/test/integration_test/otel.yml
+++ b/.gitlab/test/integration_test/otel.yml
@@ -7,6 +7,9 @@ integration_tests_otel:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
   needs: ["go_deps"]
+  variables:
+    KUBERNETES_MEMORY_REQUEST: 16Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
   script:
     - !reference [.retrieve_linux_go_deps]
     - dda inv -- check-otel-build


### PR DESCRIPTION
### What does this PR do?
Increase memory limit for the otel integration test job to 16GiB (similar to other jobs).

### Motivation
Got OOM in CI https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1444150010

### Describe how you validated your changes

### Additional Notes
