### PR TITLE
Add remote_agent tag to logs.encoded_bytes_sent for COAT partitioning

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -229,7 +229,9 @@ var defaultProfiles = `
         - name: logs.dropped
         - name: logs.encoded_bytes_sent
           aggregate_tags:
+            - remote_agent
             - compression_kind
+          aggregate_total: true
         - name: logs.http_connectivity_check
           aggregate_tags:
             - status

--- a/comp/core/remoteagent/impl-systemprobe/remoteagent.go
+++ b/comp/core/remoteagent/impl-systemprobe/remoteagent.go
@@ -87,6 +87,7 @@ func (r *remoteagentImpl) GetTelemetry(_ context.Context, _ *pbcore.GetTelemetry
 		// Metrics to forward from system-probe to core agent.
 		// The remote_agent tag is set to "system-probe" via metrics.SetAgentIdentity() above.
 		"logs__bytes_sent",
+		"logs__encoded_bytes_sent",
 
 		// Windows Injector metrics (using double underscore format from telemetry component)
 		"injector__processes_added_to_injection_tracker",

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -334,7 +334,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	// Use GetAgentIdentityTag() to identify which agent is sending logs
 	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), metrics.GetAgentIdentityTag(), sourceTag)
 	metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
+	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), metrics.GetAgentIdentityTag(), sourceTag, compressionKind)
 
 	req, err := http.NewRequest("POST", d.url, bytes.NewReader(payload.Encoded))
 	if err != nil {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -690,7 +690,7 @@ func TestDestinationSourceTagBasedOnTelemetryName(t *testing.T) {
 	// Create telemetry mock
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"remote_agent", "source"}, "")
-	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"source", "compression_kind"}, "")
+	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"remote_agent", "source", "compression_kind"}, "")
 
 	// Create a new server
 	server := NewTestServer(200, cfg)
@@ -718,6 +718,7 @@ func TestDestinationSourceTagBasedOnTelemetryName(t *testing.T) {
 	metric, err = telemetryMock.(telemetry.Mock).GetCountMetric("logs", "encoded_bytes_sent")
 	assert.NoError(t, err)
 	assert.Len(t, metric, 1)
+	assert.Equal(t, "agent", metric[0].Tags()["remote_agent"])
 	assert.Equal(t, "logs", metric[0].Tags()["source"])
 }
 
@@ -728,7 +729,7 @@ func TestDestinationSourceTagEPForwarder(t *testing.T) {
 	// Create telemetry mock
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
 	metrics.TlmBytesSent = telemetryMock.NewCounter("logs", "bytes_sent", []string{"remote_agent", "source"}, "")
-	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"source", "compression_kind"}, "")
+	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"remote_agent", "source", "compression_kind"}, "")
 
 	// Create a new server
 	server := NewTestServer(200, cfg)
@@ -755,6 +756,7 @@ func TestDestinationSourceTagEPForwarder(t *testing.T) {
 	metric, err = telemetryMock.(telemetry.Mock).GetCountMetric("logs", "encoded_bytes_sent")
 	assert.NoError(t, err)
 	assert.Len(t, metric, 1)
+	assert.Equal(t, "agent", metric[0].Tags()["remote_agent"])
 	assert.Equal(t, "epforwarder", metric[0].Tags()["source"])
 }
 
@@ -764,7 +766,7 @@ func TestDestinationCompression(t *testing.T) {
 
 	// Create telemetry mock
 	telemetryMock := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
-	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"source", "compression_kind"}, "")
+	metrics.TlmEncodedBytesSent = telemetryMock.NewCounter("logs", "encoded_bytes_sent", []string{"remote_agent", "source", "compression_kind"}, "")
 
 	// Create a new server with compression enabled
 	server := NewTestServer(200, cfg)

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -133,7 +133,7 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 		// Use GetAgentIdentityTag() to identify which agent is sending logs
 		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), metrics.GetAgentIdentityTag(), sourceTag)
 		metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
+		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), metrics.GetAgentIdentityTag(), sourceTag, compressionKind)
 		output <- payload
 
 		if d.connManager.ShouldReset(d.connCreationTime) {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -59,8 +59,11 @@ var (
 	// EncodedBytesSent is the total number of sent bytes after encoding if any
 	EncodedBytesSent = expvar.Int{}
 	// TlmEncodedBytesSent is the total number of sent bytes after encoding if any
+	// The remote_agent tag identifies which agent sent the logs. Use GetAgentIdentityTag()
+	// to get the correct value for the current agent. This tag is used by COAT to partition
+	// encoded log bytes by agent type.
 	TlmEncodedBytesSent = telemetry.NewCounter("logs", "encoded_bytes_sent",
-		[]string{"source", "compression_kind"}, "Total number of sent bytes after encoding if any")
+		[]string{"remote_agent", "source", "compression_kind"}, "Total number of sent bytes after encoding if any")
 	// BytesMissed is the number of bytes lost before they could be consumed by the agent, such as after a log rotation
 	BytesMissed = expvar.Int{}
 	// TlmBytesMissed is the number of bytes lost before they could be consumed by the agent, such as after log rotation


### PR DESCRIPTION
### What does this PR do?

Adds the `remote_agent` tag to the `logs.encoded_bytes_sent` telemetry metric, bringing it to parity with `logs.bytes_sent` which already has this tag. This enables COAT to partition encoded bytes sent by agent type
  (core agent vs system-probe).

### Motivation

System-probe runs its own logs pipeline for CWS (Cloud Workload Security) events and sends encoded payloads independently from the core agent. Without the remote_agent tag on `logs.encoded_bytes_sent`, COAT reports could not distinguish encoded bytes originating from system-probe vs the core agent. This made it impossible to assess compression efficiency or actual network cost per agent type.

logs.bytes_sent already had this tag — logs.encoded_bytes_sent was the missing counterpart.

### Describe how you validated your changes

  - Unit tests updated and passing: go test ./pkg/logs/client/http/ -run "TestDestinationSourceTag|TestDestinationCompression" -tags test
  - Pre-commit hooks pass
  - Deployed to a dev VM running system-probe with CWS enabled and confirmed the metric is correctly exposed at the /telemetry endpoint:
  logs__encoded_bytes_sent{compression_kind="gzip",remote_agent="system-probe",source="logs"} 59976
  - tested that COAT telemetry was collected correctly by the backend, for my dev vm 

### Additional Notes

This follows the same pattern established for logs.bytes_sent in the remote_agent partitioning work. The COAT profile change adds aggregate_total: true so that the backend receives both per-agent breakdowns and a combined total.

See PR https://github.com/DataDog/datadog-agent/pull/45921 for reference