### PR TITLE
[O11YINFRA-123] Suppress system-probe check errors when system-probe never started

### DIFF
--- a/pkg/system-probe/api/client/client.go
+++ b/pkg/system-probe/api/client/client.go
@@ -26,6 +26,11 @@ var (
 	// accessed while it hasn't started yet (and could still be reasonably
 	// expected to)
 	ErrNotStartedYet = errors.New("system-probe not started yet")
+	// ErrNotAvailable is an error used when system-probe failed to start
+	// within the startup timeout and is considered permanently unavailable
+	// for this agent lifetime. Checks should use IgnoreStartupError() to
+	// suppress this error and avoid noisy error reporting in Fleet Automation.
+	ErrNotAvailable = errors.New("system-probe not available")
 )
 
 // Get returns a http client configured to talk to the system-probe


### PR DESCRIPTION
## What does this change do?

When system-probe fails to start within the startup timeout, checks like `oom_kill` and `tcp_queue_length` generate **permanent** "connection refused" errors in Fleet Automation on every check run. This happens on nodes where system-probe is not enabled or lacks the required kernel capabilities.

Previously, errors were only suppressed during the startup grace period (`ErrNotStartedYet`). After the timeout expired, the raw connection error was returned and reported as an integration error — forever.

## How does it work?

- Added `ErrNotAvailable` sentinel error for when system-probe is permanently unreachable
- When the startup timeout expires without system-probe responding, `ensureStarted()` sets a `neverStarted` flag and returns `ErrNotAvailable`
- `IgnoreStartupError()` now suppresses both `ErrNotStartedYet` and `ErrNotAvailable`
- A warning is logged once when transitioning to unavailable
- If system-probe WAS successfully started but later crashes, the existing error reporting is preserved (real failures still surfaced)

## Why is this important?

These errors are a top contributor in Fleet Automation's integration error dashboard. On nodes where system-probe will never start, they generate noise on every check interval indefinitely.

## Test plan

- Updated existing test in `check_test.go` to verify:
  - Past startup timeout → returns `ErrNotAvailable` (not raw error)
  - `IgnoreStartupError` suppresses `ErrNotAvailable`
  - Subsequent calls return `ErrNotAvailable` without retrying (fast path)
  - System-probe coming up later still works after reset