### PR TITLE
[AGENTCFG-626] Enforce client cert (strict mTLS) for the IPC used by RAR and config stream

### DIFF
--- a/internal/remote-agent/README.md
+++ b/internal/remote-agent/README.md
@@ -1,0 +1,74 @@
+# Remote Agent Example
+
+A standalone example client that implements the Remote Agent Registry (RAR) contract: it registers with the core agent over IPC, runs a gRPC server (Status, Flare, Telemetry), and refreshes its registration periodically.
+
+## Purpose
+
+Used to test and demonstrate RAR integration: the core agent discovers the remote agent’s gRPC endpoint, calls Status/Flare/Telemetry as needed, and keeps the session alive via refresh. This binary is not for production; it is a minimal reference implementation.
+
+## Building
+
+```bash
+# With invoke (from repo root)
+dda inv agent.build-remote-agent
+
+# Or with go
+go build -o bin/remote-agent ./internal/remote-agent
+```
+
+The binary is produced at `bin/remote-agent`.
+
+## Prerequisites
+
+1. **Running core agent** with RAR enabled (`remote_agent_registry.enabled: true`, which is typical).
+2. **Auth token file** – same as the core agent’s (e.g. `bin/agent/dist/auth_token` after the agent has run).
+3. **IPC certificate file** – same PEM file the core agent uses for IPC (e.g. `bin/agent/dist/ipc_cert.pem`). Required for mTLS to the agent’s IPC server and for the remote agent’s gRPC server TLS.
+
+Ensure the core agent has run at least once so `auth_token` and `ipc_cert.pem` exist under its config/dist directory.
+
+## Running (testing)
+
+All of the following flags are required.
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-agent-flavor` | Flavor reported to RAR | `my-remote-agent` |
+| `-display-name` | Display name in RAR | `Test Remote Agent` |
+| `-listen-addr` | Address for the remote agent’s gRPC server | `127.0.0.1:0` (any port) or `127.0.0.1:50051` |
+| `-agent-ipc-address` | Core agent IPC address | `localhost:5001` |
+| `-agent-auth-token-file` | Path to auth token file | `bin/agent/dist/auth_token` |
+| `-agent-cert-file` | Path to IPC cert PEM (cert + key) | `bin/agent/dist/ipc_cert.pem` |
+
+Example from repo root (core agent must be running and listening on `localhost:5001`):
+
+```bash
+./bin/remote-agent \
+  -agent-flavor test-remote-agent \
+  -display-name "Test Remote Agent" \
+  -listen-addr 127.0.0.1:50051 \
+  -agent-ipc-address localhost:5001 \
+  -agent-auth-token-file bin/agent/dist/auth_token \
+  -agent-cert-file bin/agent/dist/ipc_cert.pem
+```
+
+You should see logs like:
+
+- `Spawned remote agent gRPC server on 127.0.0.1:50051.`
+- `Registering with Core Agent at localhost:5001...`
+- `Registered with Core Agent. Recommended refresh interval of N seconds.`
+- `Refreshed registration with Core Agent.` (repeating)
+
+## How to test that it works
+
+1. **Build** the core agent and run it so `bin/agent/dist/auth_token` and `bin/agent/dist/ipc_cert.pem` exist.
+2. **Start the core agent** (e.g. `./bin/agent/agent run -c bin/agent/dist/datadog.yaml`).
+3. **Build** the remote-agent: `dda inv agent.build-remote-agent` or `go build -o bin/remote-agent ./internal/remote-agent`.
+4. **Run** the remote-agent with the six flags above, using `bin/agent/dist` for `-agent-auth-token-file` and `-agent-cert-file`.
+5. **Check logs**: registration and periodic “Refreshed registration” confirm the client cert and RAR flow work. You can also run `agent status` or use the GUI/API to see the registered remote agent.
+
+If the core agent is not running or the cert/token paths are wrong, you will see connection or auth errors instead of registration success.
+
+## See also
+
+- **Remote Agent Registry:** `comp/core/remoteagentregistry/`
+- **Config stream test client:** `cmd/config-stream-client/` (also connects to agent IPC with client cert)

--- a/test/e2e-framework/testing/utils/e2e/client/agent_client.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_client.go
@@ -67,9 +67,8 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 		if err := waitForReadyTimeout(commandRunner, agentReadyTimeout); err != nil {
 			return nil, err
 		}
+		waitForAgentsReady(context.T(), host, params)
 	}
-
-	waitForAgentsReady(context.T(), host, params)
 
 	return commandRunner, nil
 }

--- a/test/e2e-framework/testing/utils/e2e/client/agentclientparams/agent_client_params.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agentclientparams/agent_client_params.go
@@ -37,6 +37,7 @@ type Params struct {
 
 	AuthToken         string
 	AuthTokenPath     string
+	IPCCertPath       string // path to IPC cert PEM on the remote host (for mTLS to agent APIs)
 	ProcessAgentPort  int
 	TraceAgentPort    int
 	SecurityAgentPort int
@@ -53,6 +54,7 @@ func NewParams(osfam osComp.Family, options ...Option) *Params {
 	p := &Params{
 		ShouldWaitForReady: true,
 		AuthTokenPath:      defaultAuthTokenPath(osfam),
+		IPCCertPath:        defaultIPCCertPath(osfam),
 		WaitForDuration:    1 * time.Minute,
 		WaitForTick:        5 * time.Second,
 	}
@@ -94,6 +96,14 @@ func WithAuthToken(authToken string) Option {
 func WithAuthTokenPath(path string) Option {
 	return func(p *Params) {
 		p.AuthTokenPath = path
+	}
+}
+
+// WithIPCCertPath sets the path to the IPC certificate file on the remote host.
+// Used for mTLS when connecting to agent HTTPS endpoints (process-agent, security-agent, core API).
+func WithIPCCertPath(path string) Option {
+	return func(p *Params) {
+		p.IPCCertPath = path
 	}
 }
 
@@ -155,6 +165,18 @@ func defaultAuthTokenPath(osfam osComp.Family) string {
 		return "C:\\ProgramData\\Datadog\\auth_token"
 	case osComp.MacOSFamily:
 		return "/opt/datadog-agent/etc/auth_token"
+	}
+	panic(fmt.Sprintf("unsupported OS family %d", osfam))
+}
+
+func defaultIPCCertPath(osfam osComp.Family) string {
+	switch osfam {
+	case osComp.LinuxFamily:
+		return "/etc/datadog-agent/ipc_cert.pem"
+	case osComp.WindowsFamily:
+		return "C:\\ProgramData\\Datadog\\ipc_cert.pem"
+	case osComp.MacOSFamily:
+		return "/opt/datadog-agent/etc/ipc_cert.pem"
 	}
 	panic(fmt.Sprintf("unsupported OS family %d", osfam))
 }

--- a/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_common.go
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_common.go
@@ -43,12 +43,16 @@ var (
 )
 
 // assertAgentsUseKey checks that all agents are using the given key.
-func assertAgentsUseKey(t assert.TestingT, host *components.RemoteHost, authtoken, key string) {
+// ipcCertPath is the path to the IPC cert PEM on the remote host (e.g. /etc/datadog-agent/ipc_cert.pem) for mTLS to agent HTTPS endpoints.
+func assertAgentsUseKey(t assert.TestingT, host *components.RemoteHost, ipcCertPath, authtoken, key string) {
 	if h, ok := t.(testing.TB); ok {
 		h.Helper()
 	}
 
-	hostHTTPClient := host.NewHTTPClient()
+	hostHTTPClient, err := host.NewHTTPClientWithIPCCert(ipcCertPath)
+	if !assert.NoErrorf(t, err, "create HTTP client with IPC cert") {
+		return
+	}
 	for _, endpoint := range []agentConfigEndpointInfo{
 		traceConfigEndpoint(apmCmdPort),
 		processConfigEndpoint(processCmdPort),

--- a/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_nix_test.go
@@ -38,6 +38,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 	v.Env().RemoteHost.MkdirAll(rootDir)
 
 	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	ipcCertPath := "/etc/datadog-agent/ipc_cert.pem"
 	secretResolverPath := filepath.Join(rootDir, "secret-resolver.py")
 
 	v.T().Log("Setting up the secret resolver and the initial api key file")
@@ -83,7 +84,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsUseKey(v.T(), v.Env().RemoteHost, ipcCertPath, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -97,7 +98,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
+		assertAgentsUseKey(t, v.Env().RemoteHost, ipcCertPath, authtoken, apiKey2)
 	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
 }
 
@@ -106,6 +107,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 	v.Env().RemoteHost.MkdirAll(rootDir)
 
 	authTokenFilePath := "/etc/datadog-agent/auth_token"
+	ipcCertPath := "/etc/datadog-agent/ipc_cert.pem"
 	secretResolverPath := filepath.Join(rootDir, "secret-resolver.py")
 
 	v.T().Log("Setting up the secret resolver and the initial api key file")
@@ -151,7 +153,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsUseKey(v.T(), v.Env().RemoteHost, ipcCertPath, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -165,6 +167,6 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
+		assertAgentsUseKey(t, v.Env().RemoteHost, ipcCertPath, authtoken, apiKey2)
 	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
 }

--- a/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/non_core_agents_sync_win_test.go
@@ -87,10 +87,11 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 	require.NoError(v.T(), err)
 
 	authtoken := strings.TrimSpace(string(authtokenContent))
+	ipcCertPath := "C:\\ProgramData\\Datadog\\ipc_cert.pem"
 
 	// check that the agents are using the first key
 	// initially they all resolve it using the secret resolver
-	assertAgentsUseKey(v.T(), v.Env().RemoteHost, authtoken, apiKey1)
+	assertAgentsUseKey(v.T(), v.Env().RemoteHost, ipcCertPath, authtoken, apiKey1)
 
 	// update api_key
 	v.T().Log("Updating the api key")
@@ -104,6 +105,6 @@ func (v *configRefreshWindowsSuite) TestConfigRefresh() {
 
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		assertAgentsUseKey(t, v.Env().RemoteHost, authtoken, apiKey2)
+		assertAgentsUseKey(t, v.Env().RemoteHost, ipcCertPath, authtoken, apiKey2)
 	}, 2*configRefreshIntervalSec*time.Second, 1*time.Second)
 }

--- a/test/new-e2e/tests/agent-configuration/gui/gui_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/gui/gui_nix_test.go
@@ -59,7 +59,7 @@ GUI_port: %d`, authTokenFilePath, agentAPIPort, guiPort)
 	var guiClient *http.Client
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		guiClient = getGUIClient(t, v.Env().RemoteHost, authtoken)
+		guiClient = getGUIClient(t, v.Env().RemoteHost, authtoken, ipcCertPathLinux)
 	}, 30*time.Second, 5*time.Second)
 
 	v.T().Log("Testing GUI static file server")

--- a/test/new-e2e/tests/agent-configuration/gui/gui_win_test.go
+++ b/test/new-e2e/tests/agent-configuration/gui/gui_win_test.go
@@ -68,7 +68,7 @@ func (v *guiWindowsSuite) TestGUI() {
 	var guiClient *http.Client
 	// and check that the agents are using the new key
 	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		guiClient = getGUIClient(t, v.Env().RemoteHost, authtoken)
+		guiClient = getGUIClient(t, v.Env().RemoteHost, authtoken, ipcCertPathWin)
 	}, 1*time.Minute, 10*time.Second)
 
 	v.T().Log("Testing GUI static file server")

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -115,8 +115,13 @@ func (r *RemoteWindowsHostAssertions) HasARunningDatadogAgentService() *RemoteWi
 
 	r.HasAService("datadogagent").WithStatus("Running")
 
+	configRoot, err := windowsagent.GetConfigRootFromRegistry(r.remoteHost)
+	r.require.NoError(err)
+	ipcCertPath := filepath.Join(configRoot, "ipc_cert.pem")
+
 	agentClient, err := client.NewHostAgentClientWithParams(r.context, r.remoteHost.HostOutput,
 		agentclientparams.WithAgentInstallPath(installPath),
+		agentclientparams.WithIPCCertPath(ipcCertPath),
 		agentclientparams.WithSkipWaitForAgentReady(),
 	)
 	r.require.NoError(err)


### PR DESCRIPTION
### What does this PR do?
- Adds `cert.LoadIPCClientTLSConfigFromFile(path)` so callers can build a client TLS config from the agent’s IPC cert PEM.
- Updates `config-stream-client` and `remote-agent` to connect to the agent IPC with that client cert instead of `InsecureSkipVerify: true`, so they work with strict mTLS.

### Motivation
RAR and the config stream talk to the core agent over IPC. The IPC server already uses strict mTLS; these clients were not presenting a client cert and could not connect. Making them use the same IPC cert as the agent completes the mTLS story and keeps RAR/config-stream traffic to the agent mutually authenticated.

### Describe how you validated your changes
New unit tests for `LoadIPCClientTLSConfigFromFile`. Also, with the agent running: `config-stream-client` registered with RAR and received a config stream snapshot; `remote-agent` registered, refreshed, and received a telemetry request. ADP is already using configstream, and it was able to receive configuration properly with these changes included.

### Additional Notes
Clients use the same IPC cert file as the agent (e.g. `ipc_cert.pem` next to `auth_token`).
