### PR TITLE
Reduce atexit_sleep_ms when using race detector

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -313,6 +313,14 @@ def test(
         with open(os.environ.get("FLAKY_PATTERNS_CONFIG"), 'w') as f:
             f.write("{}")
 
+    if race:
+        gorace = os.getenv("GORACE", "")
+        if "atexit_sleep_ms" not in gorace:
+            # https://go.dev/doc/articles/race_detector#Options
+            # The default is 1000ms, which adds minutes to the full test run
+            gorace += " atexit_sleep_ms=50"
+            env["GORACE"] = gorace.strip()
+
     if result_json and os.path.isfile(result_json):
         # Remove existing file since we append to it.
         print(f"Removing existing '{result_json}' file")


### PR DESCRIPTION
### What does this PR do?
Reduce `atexit_sleep_ms` when running tests with the race detector.

### Motivation
By default, the race detector sleeps for 1 second at the end of each package to catch races at exit, as per https://go.dev/doc/articles/race_detector#Options.
1 second is an eternity, and in particular here it's for every single package (we have around 2k), so this results in significant extra duration.
Reducing it to 50ms should still catch races but significantly reduce test duration.

### Describe how you validated your changes
CI

### Additional Notes
