### PR TITLE
[O11YINFRA-123] Don't schedule oom_kill/tcp_queue_length checks when system-probe modules are disabled

### DIFF
--- a/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oomkill/oom_kill.go
@@ -73,6 +73,10 @@ func (c *OOMKillConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (m *OOMKillCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
+	if !pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enable_oom_kill") {
+		return fmt.Errorf("oom_kill check requires system_probe_config.enable_oom_kill to be set to true")
+	}
+
 	err := m.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err

--- a/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcpqueuelength/tcp_queue_length.go
@@ -9,6 +9,8 @@
 package tcpqueuelength
 
 import (
+	"fmt"
+
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
@@ -69,6 +71,10 @@ func (t *TCPQueueLengthConfig) Parse(data []byte) error {
 
 // Configure parses the check configuration and init the check
 func (t *TCPQueueLengthCheck) Configure(senderManager sender.SenderManager, _ uint64, config, initConfig integration.Data, source string) error {
+	if !pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enable_tcp_queue_length") {
+		return fmt.Errorf("tcp_queue_length check requires system_probe_config.enable_tcp_queue_length to be set to true")
+	}
+
 	err := t.CommonConfigure(senderManager, initConfig, config, source)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What does this change do?

The `oom_kill` and `tcp_queue_length` checks are loaded from `conf.yaml.default` and run unconditionally. However, they require their respective system-probe modules to be enabled (`system_probe_config.enable_oom_kill` and `system_probe_config.enable_tcp_queue_length`, both default to `false`).

On nodes where these modules are not enabled, the checks generate **permanent** "connection refused" errors in Fleet Automation on every check interval — because they try to connect to system-probe which either isn't running or doesn't have the module loaded.

**Fix:** Check the system-probe config in `Configure()` and return an error if the required module is not enabled. This prevents the check from being scheduled, eliminating the repeated connection errors.

## Motivation

These errors are a top contributor in Fleet Automation's integration error dashboard. The `oom_kill` and `tcp_queue_length` checks should not attempt to run on nodes where their system-probe modules are explicitly disabled.
