### PR TITLE
logs: remove health platform references from Logs Agent

### DIFF
--- a/comp/logs/agent/agentimpl/agent.go
+++ b/comp/logs/agent/agentimpl/agent.go
@@ -26,7 +26,6 @@ import (
 	statusComponent "github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
@@ -86,7 +85,6 @@ type dependencies struct {
 	SchedulerProviders []schedulers.Scheduler `group:"log-agent-scheduler"`
 	Tagger             tagger.Component
 	Compression        logscompression.Component
-	HealthPlatform     option.Option[healthplatform.Component]
 }
 
 type provides struct {
@@ -124,7 +122,6 @@ type logAgent struct {
 	schedulerProviders        []schedulers.Scheduler
 	integrationsLogs          integrations.Component
 	compression               logscompression.Component
-	healthPlatform            option.Option[healthplatform.Component]
 
 	// make sure this is done only once, when we're ready
 	prepareSchedulers sync.Once
@@ -165,7 +162,6 @@ func newLogsAgent(deps dependencies) provides {
 			integrationsLogs:   integrationsLogs,
 			tagger:             deps.Tagger,
 			compression:        deps.Compression,
-			healthPlatform:     deps.HealthPlatform,
 		}
 		deps.Lc.Append(fx.Hook{
 			OnStart: logsAgent.start,

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -162,7 +162,7 @@ func (a *logAgent) addLauncherInstances(lnchrs *launchers.Launchers, wmeta optio
 	lnchrs.AddLauncher(listener.NewLauncher(a.config.GetInt("logs_config.frame_size")))
 	lnchrs.AddLauncher(journald.NewLauncher(a.flarecontroller, a.tagger))
 	lnchrs.AddLauncher(windowsevent.NewLauncher())
-	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger, a.healthPlatform))
+	lnchrs.AddLauncher(container.NewLauncher(a.sources, wmeta, a.tagger))
 	lnchrs.AddLauncher(integrationLauncher.NewLauncher(
 		afero.NewOsFs(),
 		a.sources, integrationsLogs))

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -30,8 +30,6 @@ import (
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
-	healthplatformmock "github.com/DataDog/datadog-agent/comp/healthplatform/mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	auditorfx "github.com/DataDog/datadog-agent/comp/logs/auditor/fx"
@@ -55,7 +53,6 @@ import (
 	logsStatus "github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
@@ -513,9 +510,6 @@ func (suite *AgentTestSuite) createDeps() dependencies {
 		}),
 		auditorfx.Module(),
 		fx.Provide(kubehealthmock.NewProvides),
-		fx.Provide(func() option.Option[healthplatform.Component] {
-			return option.New[healthplatform.Component](healthplatformmock.Mock(suite.T()))
-		}),
 	))
 }
 

--- a/comp/logs/agent/agentimpl/mock.go
+++ b/comp/logs/agent/agentimpl/mock.go
@@ -13,7 +13,6 @@ import (
 
 	"go.uber.org/fx"
 
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -27,8 +26,7 @@ import (
 func MockModule() fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newMock),
-		fx.Provide(func(m agent.Mock) agent.Component { return m }),
-		fx.Supply(option.None[healthplatform.Component]()))
+		fx.Provide(func(m agent.Mock) agent.Component { return m }))
 }
 
 type mockLogsAgent struct {

--- a/pkg/logs/launchers/container/launcher.go
+++ b/pkg/logs/launchers/container/launcher.go
@@ -13,7 +13,6 @@ import (
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/container/tailerfactory"
@@ -61,18 +60,15 @@ type Launcher struct {
 	wmeta option.Option[workloadmeta.Component]
 
 	tagger tagger.Component
-
-	healthPlatform option.Option[healthplatform.Component]
 }
 
 // NewLauncher returns a new launcher
-func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmeta.Component], tagger tagger.Component, healthPlatform option.Option[healthplatform.Component]) *Launcher {
+func NewLauncher(sources *sourcesPkg.LogSources, wmeta option.Option[workloadmeta.Component], tagger tagger.Component) *Launcher {
 	launcher := &Launcher{
-		sources:        sources,
-		tailers:        make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
-		wmeta:          wmeta,
-		tagger:         tagger,
-		healthPlatform: healthPlatform,
+		sources: sources,
+		tailers: make(map[*sourcesPkg.LogSource]tailerfactory.Tailer),
+		wmeta:   wmeta,
+		tagger:  tagger,
 	}
 	return launcher
 }
@@ -84,7 +80,7 @@ func (l *Launcher) Start(sourceProvider launchers.SourceProvider, pipelineProvid
 	l.cancel = cancel
 	l.stopped = make(chan struct{})
 
-	l.tailerFactory = tailerfactory.New(l.sources, pipelineProvider, registry, l.wmeta, l.tagger, l.healthPlatform)
+	l.tailerFactory = tailerfactory.New(l.sources, pipelineProvider, registry, l.wmeta, l.tagger)
 	go l.run(ctx, sourceProvider)
 }
 

--- a/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
+++ b/pkg/logs/launchers/container/launcher_no_kubelet_and_docker.go
@@ -11,7 +11,6 @@ package container
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -26,7 +25,7 @@ import (
 type Launcher struct{}
 
 // NewLauncher returns a new launcher
-func NewLauncher(_ *sourcesPkg.LogSources, _ option.Option[workloadmeta.Component], _ tagger.Component, _ option.Option[healthplatform.Component]) *Launcher {
+func NewLauncher(_ *sourcesPkg.LogSources, _ option.Option[workloadmeta.Component], _ tagger.Component) *Launcher {
 	return &Launcher{}
 }
 

--- a/pkg/logs/launchers/container/launcher_test.go
+++ b/pkg/logs/launchers/container/launcher_test.go
@@ -17,7 +17,6 @@ import (
 
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	auditorMock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -41,7 +40,7 @@ func (tf *testFactory) MakeTailer(source *sources.LogSource) (tailerfactory.Tail
 func TestStartStop(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[healthplatform.Component]())
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
 
 	sp := launchers.NewMockSourceProvider()
 	pl := pipeline.NewMockProvider()
@@ -61,7 +60,7 @@ func TestStartStop(t *testing.T) {
 func TestAddsRemovesSource(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[healthplatform.Component]())
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name}, nil
@@ -92,7 +91,7 @@ func TestAddsRemovesSource(t *testing.T) {
 func TestCannotMakeTailer(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[healthplatform.Component]())
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(_ *sources.LogSource) (tailerfactory.Tailer, error) {
 			return nil, errors.New("uhoh")
@@ -115,7 +114,7 @@ func TestCannotMakeTailer(t *testing.T) {
 func TestCannotStartTailer(t *testing.T) {
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 
-	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger, option.None[healthplatform.Component]())
+	l := NewLauncher(nil, option.None[workloadmeta.Component](), fakeTagger)
 	l.tailerFactory = &testFactory{
 		makeTailer: func(source *sources.LogSource) (tailerfactory.Tailer, error) {
 			return &tailerfactory.TestTailer{Name: source.Name, StartError: true}, nil

--- a/pkg/logs/launchers/container/tailerfactory/factory.go
+++ b/pkg/logs/launchers/container/tailerfactory/factory.go
@@ -12,7 +12,6 @@ package tailerfactory
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	healthplatform "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -63,15 +62,12 @@ type factory struct {
 	dockerUtilGetter dockerUtilGetter
 
 	tagger tagger.Component
-
-	// healthPlatform is the health platform component for reporting issues
-	healthPlatform option.Option[healthplatform.Component]
 }
 
 var _ Factory = (*factory)(nil)
 
 // New creates a new Factory.
-func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore option.Option[workloadmeta.Component], tagger tagger.Component, healthPlatform option.Option[healthplatform.Component]) Factory {
+func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, registry auditor.Registry, workloadmetaStore option.Option[workloadmeta.Component], tagger tagger.Component) Factory {
 	return &factory{
 		sources:           sources,
 		pipelineProvider:  pipelineProvider,
@@ -80,7 +76,6 @@ func New(sources *sources.LogSources, pipelineProvider pipeline.Provider, regist
 		cop:               containersorpods.NewChooser(),
 		dockerUtilGetter:  &dockerUtilGetterImpl{},
 		tagger:            tagger,
-		healthPlatform:    healthPlatform,
 	}
 }
 

--- a/pkg/logs/launchers/container/tailerfactory/file.go
+++ b/pkg/logs/launchers/container/tailerfactory/file.go
@@ -16,13 +16,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
-	"syscall"
-
-	"github.com/DataDog/agent-payload/v5/healthplatform"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
@@ -127,19 +123,6 @@ func (tf *factory) makeDockerFileSource(source *sources.LogSource) (*sources.Log
 	// try to fall back to reading from a socket.
 	f, err := opener.OpenLogFile(path)
 	if err != nil {
-		// Check if this is a permission error and report to health platform
-		if isPermissionError(err) {
-			// Extract the base docker directory from the path
-			dockerDir := dockerLogsBasePathNix
-			if overridePath := pkgconfigsetup.Datadog().GetString("logs_config.docker_path_override"); len(overridePath) > 0 {
-				dockerDir = overridePath
-			} else if runtime.GOOS == "windows" {
-				dockerDir = dockerLogsBasePathWin
-			}
-
-			// Report the issue to health platform
-			tf.reportDockerPermissionIssue(dockerDir)
-		}
 		// (this error already has the form 'open <path>: ..' so needs no further embellishment)
 		return nil, err
 	}
@@ -338,38 +321,4 @@ func findK8sLogPath(pod *workloadmeta.KubernetesPod, containerName string) strin
 
 	log.Debugf("Using the latest kubernetes logs path for container %s", containerName)
 	return filepath.Join(podLogsBasePath, getPodDirectorySince1_14(pod), containerName, anyLogFile)
-}
-
-// isPermissionError checks if an error is permission-related using proper error type checking
-func isPermissionError(err error) bool {
-	return errors.Is(err, fs.ErrPermission) ||
-		errors.Is(err, syscall.EACCES) ||
-		errors.Is(err, syscall.EPERM)
-}
-
-// reportDockerPermissionIssue reports a Docker file tailing permission issue to the health platform
-func (tf *factory) reportDockerPermissionIssue(dockerDir string) {
-	hp, exists := tf.healthPlatform.Get()
-	if !exists {
-		return
-	}
-
-	// Report the issue with minimal context - health platform registry provides all metadata and remediation
-	err := hp.ReportIssue(
-		"logs-docker-file-permissions",
-		"Docker File Tailing Permissions",
-		&healthplatform.IssueReport{
-			IssueId: "docker-file-tailing-disabled",
-			Context: map[string]string{
-				"dockerDir": dockerDir,
-				"os":        runtime.GOOS,
-			},
-		},
-	)
-
-	if err != nil {
-		log.Warnf("Failed to report Docker permission issue to health platform: %v", err)
-	} else {
-		log.Infof("Reported Docker file tailing permission issue to health platform")
-	}
 }


### PR DESCRIPTION
### What does this PR do?

Removes the Logs Agent’s integration with the Health Platform that was used to report Docker file tailing permission issues. Concretely, this PR:
- Drops the `healthplatform` dependency wiring from the logs agent component.
- Simplifies the container launcher and tailer factory constructors by removing the `healthPlatform` parameter.
- Removes the Docker file permission error detection and reporting code path (including the issue reporting helper functions).
- Updates mocks and unit tests to reflect the removal.

### Motivation

The Logs Agent should no longer mention or depend on the Health Platform for reporting issues in this flow as it is now a built-in check of the platform

### Describe how you validated your changes

- Ran unit tests for the logs agent / container launcher / tailer factory packages (including updated tests in `pkg/logs/launchers/container/...`).
- Ensured the agent compiles with the updated constructor signatures and fx wiring changes.

### Additional Notes
