### PR TITLE
[ACTP] [PAR] Improve getDatadogSite logic

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -248,7 +248,7 @@ func (p *PrivateActionRunner) waitForStartup(ctx context.Context) error {
 
 // performSelfEnrollment handles the self-registration of a private action runner
 func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *parconfig.Config) (*parconfig.Config, error) {
-	ddSite := p.coreConfig.GetString("site")
+	ddSite := cfg.DatadogSite
 	apiKey := p.coreConfig.GetString("api_key")
 	appKey := p.coreConfig.GetString("app_key")
 

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
+	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/actions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/modes"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
@@ -22,7 +23,7 @@ import (
 )
 
 func FromDDConfig(config config.Component) (*Config, error) {
-	ddSite := config.GetString("site")
+	ddSite := getDatadogSite(config)
 	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
 	urn := config.GetString(setup.PARUrn)
 
@@ -110,6 +111,24 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 	}
 
 	return allowlist
+}
+
+func getDatadogSite(config config.Component) string {
+	ddSite := ""
+	ddURL := config.GetString("dd_url")
+	if ddURL != "" {
+		extractedSite := configutils.ExtractSiteFromURL(ddURL)
+		if extractedSite != "" {
+			ddSite = extractedSite
+		}
+	}
+	if ddSite == "" {
+		ddSite = config.GetString("site")
+	}
+	if ddSite == "" {
+		ddSite = setup.DefaultSite
+	}
+	return ddSite
 }
 
 func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[string]) map[string]sets.Set[string] {

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -23,7 +23,8 @@ import (
 )
 
 func FromDDConfig(config config.Component) (*Config, error) {
-	ddSite := getDatadogSite(config)
+	ddHost := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
+	ddSite := configutils.ExtractSiteFromURL(ddHost)
 	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
 	urn := config.GetString(setup.PARUrn)
 
@@ -82,8 +83,8 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		ActionsAllowlist:          makeActionsAllowlist(config),
 		Allowlist:                 config.GetStringSlice(setup.PARHttpAllowlist),
 		AllowIMDSEndpoint:         config.GetBool(setup.PARHttpAllowImdsEndpoint),
-		DDHost:                    strings.Join([]string{"api", ddSite}, "."),
-		DDApiHost:                 strings.Join([]string{"api", ddSite}, "."),
+		DDHost:                    ddHost,
+		DDApiHost:                 ddHost,
 		Modes:                     []modes.Mode{modes.ModePull},
 		OrgId:                     orgID,
 		PrivateKey:                privateKey,
@@ -111,12 +112,6 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 	}
 
 	return allowlist
-}
-
-func getDatadogSite(config config.Component) string {
-	// This handles dd_url, site, and default site in the correct precedence
-	endpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
-	return configutils.ExtractSiteFromURL(endpoint)
 }
 
 func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[string]) map[string]sets.Set[string] {

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -23,7 +23,7 @@ import (
 )
 
 func FromDDConfig(config config.Component) (*Config, error) {
-	ddHost := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
+	ddHost := strings.TrimSuffix(configutils.GetMainEndpoint(config, "https://api.", "dd_url"), ".")
 	ddSite := configutils.ExtractSiteFromURL(ddHost)
 	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
 	urn := config.GetString(setup.PARUrn)

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -114,21 +114,9 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 }
 
 func getDatadogSite(config config.Component) string {
-	ddSite := ""
-	ddURL := config.GetString("dd_url")
-	if ddURL != "" {
-		extractedSite := configutils.ExtractSiteFromURL(ddURL)
-		if extractedSite != "" {
-			ddSite = extractedSite
-		}
-	}
-	if ddSite == "" {
-		ddSite = config.GetString("site")
-	}
-	if ddSite == "" {
-		ddSite = setup.DefaultSite
-	}
-	return ddSite
+	// This handles dd_url, site, and default site in the correct precedence
+	endpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
+	return configutils.ExtractSiteFromURL(endpoint)
 }
 
 func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[string]) map[string]sets.Set[string] {

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -10,9 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestGetBundleInheritedAllowedActions(t *testing.T) {
@@ -69,61 +66,6 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetBundleInheritedAllowedActions(tt.actionsAllowlist)
 			assert.Equal(t, tt.expectedInheritedActions, result)
-		})
-	}
-}
-
-func TestGetDatadogSite(t *testing.T) {
-	tests := []struct {
-		name         string
-		ddURL        string
-		site         string
-		expectedSite string
-	}{
-		{
-			name:         "dd_url takes precedence and site is extracted",
-			ddURL:        "https://app.datadoghq.eu",
-			site:         "datadoghq.com",
-			expectedSite: "datadoghq.eu",
-		},
-		{
-			name:         "dd_url with US3 site",
-			ddURL:        "https://app.us3.datadoghq.com",
-			site:         "",
-			expectedSite: "us3.datadoghq.com",
-		},
-		{
-			name:         "site config used when dd_url not set",
-			ddURL:        "",
-			site:         "datadoghq.eu",
-			expectedSite: "datadoghq.eu",
-		},
-		{
-			name:         "default site used when neither dd_url nor site is set",
-			ddURL:        "",
-			site:         "",
-			expectedSite: setup.DefaultSite,
-		},
-		{
-			name:         "site config used when dd_url is empty string",
-			ddURL:        "",
-			site:         "us5.datadoghq.com",
-			expectedSite: "us5.datadoghq.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := configmock.New(t)
-			if tt.ddURL != "" {
-				cfg.SetWithoutSource("dd_url", tt.ddURL)
-			}
-			if tt.site != "" {
-				cfg.SetWithoutSource("site", tt.site)
-			}
-
-			result := getDatadogSite(cfg)
-			assert.Equal(t, tt.expectedSite, result)
 		})
 	}
 }

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestGetBundleInheritedAllowedActions(t *testing.T) {
@@ -66,6 +69,61 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetBundleInheritedAllowedActions(tt.actionsAllowlist)
 			assert.Equal(t, tt.expectedInheritedActions, result)
+		})
+	}
+}
+
+func TestGetDatadogSite(t *testing.T) {
+	tests := []struct {
+		name         string
+		ddURL        string
+		site         string
+		expectedSite string
+	}{
+		{
+			name:         "dd_url takes precedence and site is extracted",
+			ddURL:        "https://app.datadoghq.eu",
+			site:         "datadoghq.com",
+			expectedSite: "datadoghq.eu",
+		},
+		{
+			name:         "dd_url with US3 site",
+			ddURL:        "https://app.us3.datadoghq.com",
+			site:         "",
+			expectedSite: "us3.datadoghq.com",
+		},
+		{
+			name:         "site config used when dd_url not set",
+			ddURL:        "",
+			site:         "datadoghq.eu",
+			expectedSite: "datadoghq.eu",
+		},
+		{
+			name:         "default site used when neither dd_url nor site is set",
+			ddURL:        "",
+			site:         "",
+			expectedSite: setup.DefaultSite,
+		},
+		{
+			name:         "site config used when dd_url is empty string",
+			ddURL:        "",
+			site:         "us5.datadoghq.com",
+			expectedSite: "us5.datadoghq.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := configmock.New(t)
+			if tt.ddURL != "" {
+				cfg.SetWithoutSource("dd_url", tt.ddURL)
+			}
+			if tt.site != "" {
+				cfg.SetWithoutSource("site", tt.site)
+			}
+
+			result := getDatadogSite(cfg)
+			assert.Equal(t, tt.expectedSite, result)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Fixes Private Action Runner to use proper site configuration fallback logic, preventing malformed API URLs when site is not explicitly configured.

### Motivation
When `site` config is not set, PAR fails with:
```
Error: self-enrollment failed: enrollment API call failed: failed to send runner creation request:
Post "https://api./api/unstable/on_prem_runners": dial tcp: lookup api.: no such host
```

The issue is caused by directly using `config.GetString("site")` without fallback to the default site, resulting in malformed URLs like `"https://api."`.

### Describe how you validated your changes
Ran the par locally with various config (with site, with dd_url, without any of these, etc...)
```bash
# Run the agent
cd ~/dd/datadog-agent && go run -ldflags='-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=7.68.3-devel+local' ./cmd/agent run -c dev/dist/datadog.yaml

# Run the PAR
cd ~/dd/datadog-agent && go run ./cmd/privateactionrunner run -c dev/dist/datadog.yaml
```

### Additional Notes