### PR TITLE
chore: bump internal agent template

### DIFF
--- a/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/deploy/internal_image_deploy/internal_image_deploy.yml
@@ -41,7 +41,7 @@
 
 # -- binary specific variables --
 .agent_variables: &agent_variables
-  IMAGE_VERSION: tmpl-v22
+  IMAGE_VERSION: tmpl-v23
   IMAGE_NAME: datadog-agent
   TMPL_SRC_REPO: ci/datadog-agent/agent
 


### PR DESCRIPTION
### What does this PR do?
Bumps internal agent version from tmpl-v22 to tmpl-v23

### Motivation
Updates internal integration version used

### Describe how you validated your changes
Internally deploying to staging cluster

### Additional Notes
