### PR TITLE
[ACTP] Make script-config.yaml read only by dd-agent user

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -204,7 +204,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
   && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ /var/run/datadog/ /opt/datadog-agent/run \
   && chmod 755 /probe.sh /initlog.sh \
   && chown root:secret-manager /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
-  && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh
+  && chmod 550 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
+  && chmod u=r,g=,o= /etc/datadog-agent/private-action-runner/*
 
 # Check that the UID of dd-agent is still 100.
 #

--- a/Dockerfiles/cluster-agent/Dockerfile
+++ b/Dockerfiles/cluster-agent/Dockerfile
@@ -101,7 +101,8 @@ RUN adduser --system --no-create-home --disabled-password --ingroup root dd-agen
     && touch /tmp/.placeholder \
     && chown -R dd-agent:root /etc/datadog-agent/ /var/log/datadog/ /conf.d /tmp/ /opt/datadog-agent/run \
     && chmod g+r,g+w,g+X -R /var/log/datadog/ /conf.d /tmp/ /opt/datadog-agent/run \
-    && chmod g+r,g-w,g+X,o-w -R /etc/datadog-agent/
+    && chmod g+r,g-w,g+X,o-w -R /etc/datadog-agent/ \
+    && chmod u=r,g=,o= /etc/datadog-agent/private-action-runner/*
 
 # Ensure the glibc doesn't try to call syscalls that may not be supported
 COPY --from=nosys-seccomp /tmp/nosys.so /lib/x86_64-linux-gnu/nosys.so

--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -10,9 +10,9 @@ pkg_files(
         "//conditions:default": ["script-config.yaml"],
     }),
     attributes = pkg_attributes(
-        group = "root",
-        mode = "0644",
-        owner = "root",
+        group = "dd-agent",
+        mode = "0400",
+        owner = "dd-agent",
     ),
     prefix = select({
         "@platforms//os:windows": "ProgramData/Datadog/private-action-runner",

--- a/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
+++ b/pkg/privateactionrunner/autoconnections/conf/BUILD.bazel
@@ -10,9 +10,9 @@ pkg_files(
         "//conditions:default": ["script-config.yaml"],
     }),
     attributes = pkg_attributes(
-        group = "dd-agent",
+        group = "root",
         mode = "0400",
-        owner = "dd-agent",
+        owner = "root",
     ),
     prefix = select({
         "@platforms//os:windows": "ProgramData/Datadog/private-action-runner",


### PR DESCRIPTION
## Summary

Make files under /etc/datadog-agent/private-action-runner read-only (0400) in the core agent linux packages, core agent docker image, and cluster-agent docker image.

## Changes

- Core Agent Docker image (Dockerfiles/agent/Dockerfile): apply chmod u=r,g=,o= to files under /etc/datadog-agent/private-action-runner/*.
- Cluster Agent Docker image (Dockerfiles/cluster-agent/Dockerfile): same, after the broad /etc/datadog-agent/ permission sweep.
- Core Agent package (pkg/privateactionrunner/autoconnections/conf/BUILD.bazel): change mode from 0644 to 0400 in pkg_attributes for the Bazel/Omnibus-built .deb/.rpm packages.


**Linux deb package**
<img width="910" height="84" alt="Screenshot 2026-02-24 at 11 46 31" src="https://github.com/user-attachments/assets/90c0c50d-0596-46e6-b02e-2d4bc4d6e7f6" />

**Core Agent Docker Image**
<img width="1297" height="52" alt="Screenshot 2026-02-24 at 11 55 02" src="https://github.com/user-attachments/assets/a7d20a85-b83e-451b-9c61-b078e3856296" />


**Cluster Agent Docker Image**
<img width="1138" height="50" alt="Screenshot 2026-02-24 at 11 51 39" src="https://github.com/user-attachments/assets/f1ee91ef-0fa2-469a-a21d-a00d76e2667f" />

