### PR TITLE
Add exe-based upgrade test with custom install paths

### DIFF
--- a/.gitlab/test/e2e_install_packages/windows.yml
+++ b/.gitlab/test/e2e_install_packages/windows.yml
@@ -181,6 +181,7 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeMSI$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackage$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackageWithAltDir$"
+      - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackageFromExeWithAltDir$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeAgentPackageAfterRollback$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestDowngradeAgentPackage$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestStopExperiment$"

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -161,7 +161,7 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackageFromExeWithAltDir() {
 		installerwindows.WithExtraEnvVars(map[string]string{
 			"DD_PROJECTLOCATION":          altInstallPath,
 			"DD_APPLICATIONDATADIRECTORY": altConfigRoot,
-			// TODO: these need to be overridden here so they're not overriden by installer.InstallScriptEnv
+			// TODO: these need to be overridden here so they're not overridden by installer.InstallScriptEnv
 			"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT": "",
 			"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE":        s.StableAgentVersion().OCIPackage().Registry,
 		}),


### PR DESCRIPTION
### What does this PR do?

Adds E2E upgrade test `TestUpgradeAgentPackageFromExeWithAltDir` that installs the stable Agent via the .exe with custom paths (`DD_PROJECTLOCATION`, `DD_APPLICATIONDATADIRECTORY`), then verifies a remote update experiment preserves those paths. Mirrors the existing MSI-based `TestUpgradeAgentPackageWithAltDir`.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1429
The existing alt-dir upgrade test only covers MSI installs. This adds coverage for the .exe installer path.