### PR TITLE
Remove 'runtime_security_config.syscall_monitor.enabled'

### DIFF
--- a/pkg/config/system-probe_template.yaml
+++ b/pkg/config/system-probe_template.yaml
@@ -142,23 +142,13 @@
 #     # Path from where the policy files are loaded
 #
 #     dir: c:\ProgramData\Datadog\runtime-security.d
-{{ else }}
+{{- else -}}
 #     # @param dir - string - default: /etc/datadog-agent/runtime-security.d
 #     # @env DD_RUNTIME_SECURITY_CONFIG_POLICIES_DIR - string - default: /etc/datadog-agent/runtime-security.d
 #     # Path from where the policy files will be loaded
 #
 #     dir: /etc/datadog-agent/runtime-security.d
-{{ end }}
-#   # @param syscall_monitor - custom object - optional
-#   # Syscall monitoring
-#
-#   syscall_monitor:
-
-#     # @param enabled - boolean - optional - default: false
-#     # @env DD_RUNTIME_SECURITY_CONFIG_SYSCALL_MONITOR_ENABLED - boolean - optional - default: false
-#     # Set to true to enable the Syscall monitoring (recommended for troubleshooting only).
-#
-#     enabled: false
+{{- end }}
 
 #   # @param custom_sensitive_words - list of strings - optional
 #   # @env DD_RUNTIME_SECURITY_CONFIG_CUSTOM_SENSITIVE_WORDS - space separated list of strings - optional


### PR DESCRIPTION
### What does this PR do?

This setting was removed from the code base by #12613 in 2022
