### PR TITLE
ECS Daemon Parser - Use ECS_CONTAINER_METADATA_URI_V4 as fallback

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+
+package ecs
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
+)
+
+// taskParserName returns the name of the function backing the task parser for assertion.
+func taskParserName(fn interface{}) string {
+	if fn == nil {
+		return ""
+	}
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		return ""
+	}
+	pc := v.Pointer()
+	if pc == 0 {
+		return ""
+	}
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return ""
+	}
+	return f.Name()
+}
+
+func TestSetTaskCollectionParserForDaemon(t *testing.T) {
+	v1ParserSuffix := "parseTasksFromV1Endpoint"
+	v4ParserSuffix := "parseTasksFromV4Endpoint"
+
+	tests := []struct {
+		name                  string
+		taskCollectionEnabled bool
+		version               string
+		setV4Env              bool
+		expectV4Parser        bool
+		expectParserSet       bool
+	}{
+		{
+			name:                  "task collection disabled uses V1",
+			taskCollectionEnabled: false,
+			version:               "Amazon ECS Agent - v1.39.0 (abc1234)",
+			expectV4Parser:        false,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with V4-capable version uses V4",
+			taskCollectionEnabled: true,
+			version:               "Amazon ECS Agent - v1.39.0 (abc1234)",
+			expectV4Parser:        true,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with version below V4 minimum uses V1",
+			taskCollectionEnabled: true,
+			version:               "Amazon ECS Agent - v1.30.0 (abc1234)",
+			expectV4Parser:        false,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with empty version and V4 env uses V4",
+			taskCollectionEnabled: true,
+			version:               "",
+			setV4Env:              true,
+			expectV4Parser:        true,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with empty version and no V4 env uses V1",
+			taskCollectionEnabled: true,
+			version:               "",
+			setV4Env:              false,
+			expectV4Parser:        false,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with invalid version and V4 env uses V4",
+			taskCollectionEnabled: true,
+			version:               "not-a-version",
+			setV4Env:              true,
+			expectV4Parser:        true,
+			expectParserSet:       true,
+		},
+		{
+			name:                  "task collection enabled with invalid version and no V4 env uses V1",
+			taskCollectionEnabled: true,
+			version:               "not-a-version",
+			setV4Env:              false,
+			expectV4Parser:        false,
+			expectParserSet:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v4EnvVar := v3or4.DefaultMetadataURIv4EnvVariable
+			if tt.setV4Env {
+				t.Setenv(v4EnvVar, "http://169.254.170.2/v4")
+			} else {
+				oldVal, hadKey := os.LookupEnv(v4EnvVar)
+				defer func() {
+					if hadKey {
+						os.Setenv(v4EnvVar, oldVal)
+					} else {
+						os.Unsetenv(v4EnvVar)
+					}
+				}()
+				os.Unsetenv(v4EnvVar)
+			}
+
+			c := &collector{
+				taskCollectionEnabled: tt.taskCollectionEnabled,
+			}
+
+			c.setTaskCollectionParserForDaemon(tt.version)
+
+			if !tt.expectParserSet {
+				assert.Nil(t, c.taskCollectionParser)
+				return
+			}
+			require.NotNil(t, c.taskCollectionParser, "taskCollectionParser should be set")
+
+			name := taskParserName(c.taskCollectionParser)
+			require.NotEmpty(t, name, "parser function name should be resolvable")
+
+			if tt.expectV4Parser {
+				assert.Contains(t, name, v4ParserSuffix, "expected V4 parser to be set")
+			} else {
+				assert.Contains(t, name, v1ParserSuffix, "expected V1 parser to be set")
+			}
+		})
+	}
+}

--- a/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
@@ -59,9 +59,10 @@ func TestSetTaskCollectionParserForDaemon(t *testing.T) {
 			expectParserSet:       true,
 		},
 		{
+			// Use 1.54.0+ so the test passes on both Linux (min 1.39.0) and Windows (min 1.54.0)
 			name:                  "task collection enabled with V4-capable version uses V4",
 			taskCollectionEnabled: true,
-			version:               "Amazon ECS Agent - v1.39.0 (abc1234)",
+			version:               "Amazon ECS Agent - v1.54.0 (abc1234)",
 			expectV4Parser:        true,
 			expectParserSet:       true,
 		},

--- a/releasenotes/notes/ecs-metadatav4-check-b65ba27257cfd3f6.yaml
+++ b/releasenotes/notes/ecs-metadatav4-check-b65ba27257cfd3f6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On ECS Managed Instances with daemon scheduling, the agent uses ``ECS_CONTAINER_METADATA_URI_V4`` environment variable as a fallback signal for v4 availability.


### PR DESCRIPTION
### What does this PR do?
Fall back to checking for the ECS_CONTAINER_METADATA_URI_V4 env var as a signal that metadata v4 is supported

### Motivation
On ECS Managed Instances the ECS agent returns an empty version string from the v1 introspection endpoint. Since we rely on the agent version to check if metadata V4 is available, the version check fails and we lose detailed task collection.  

### Describe how you validated your changes
- Deployed the Agent on ECS Managed Instances.
- Confired detailed task collection is enabled:
<img width="1171" height="126" alt="image" src="https://github.com/user-attachments/assets/60484e35-bd6c-4550-b73f-db0debdec481" />


Task definition used:
```
{
  "family": "datadog-agent-daemon",
  "executionRoleArn": "...",
  "taskRoleArn": "...",
  "cpu": "256",
  "memory": "512",
  "containerDefinitions": [
    {
      "name": "datadog-agent",
      "image": "....dkr.ecr.af-south-1.amazonaws.com/datadog-agent-dev:stzou-EXP-280-1",
      "cpu": 100,
      "memory": 512,
      "essential": true,
      "mountPoints": [
        {
          "containerPath": "/var/run/containerd/containerd.sock",
          "sourceVolume": "containerd_sock",
          "readOnly": true
        },
        {
          "containerPath": "/host/sys/fs/cgroup",
          "sourceVolume": "cgroup",
          "readOnly": true
        },
        {
          "containerPath": "/host/proc",
          "sourceVolume": "proc",
          "readOnly": true
        },
        {
          "containerPath": "/opt/datadog-agent/run",
          "sourceVolume": "pointdir",
          "readOnly": false
        }
      ],
      "environment": [
        {
          "name": "DD_API_KEY",
          "value": "..."
        },
        {
          "name": "DD_SITE",
          "value": "datadoghq.com"
        },
        {
          "name": "DD_ECS_DEPLOYMENT_MODE",
          "value": "daemon"
        },
        {
          "name": "ECS_MANAGED_INSTANCES",
          "value": "true"
        },
        {
          "name": "DD_LOGS_ENABLED",
          "value": "true"
        },
        {
          "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
          "value": "true"
        },
        {
          "name": "DD_HOSTNAME_TRUST_UTS_NAMESPACE",
          "value": "true"
        },
        {
          "name": "DD_EC2_PRIORITIZE_INSTANCE_ID_AS_HOSTNAME",
          "value": "true"
        },
        {
          "name": "DD_CRI_SOCKET_PATH",
          "value": "/var/run/containerd/containerd.sock"
        },
        {
          "name": "DD_LOG_LEVEL",
          "value": "debug"
        }
      ],
      "logConfiguration": {
        "logDriver": "awslogs",
        "options": {
          "awslogs-group": "/aws/ecs/managed-instances-daemon/datadog-agent",
          "awslogs-region": "af-south-1",
          "awslogs-stream-prefix": "ecs"
        }
      }
    }
  ],
  "volumes": [
    {
      "name": "containerd_sock",
      "host": {
        "sourcePath": "/var/run/containerd/containerd.sock"
      }
    },
    {
      "name": "proc",
      "host": {
        "sourcePath": "/proc/"
      }
    },
    {
      "name": "cgroup",
      "host": {
        "sourcePath": "/sys/fs/cgroup/"
      }
    },
    {
      "name": "pointdir",
      "host": {
        "sourcePath": "/opt/datadog-agent/run"
      }
    }
  ]
}
```

### Additional Notes
