### PR TITLE
Secure Fargate Sidecar Agent Communication via Envvar Public Cert

### DIFF
--- a/comp/core/ipc/impl/ipc_test.go
+++ b/comp/core/ipc/impl/ipc_test.go
@@ -267,7 +267,7 @@ func TestClusterTrustChain_NoCA_RequireVerification(t *testing.T) {
 
 	_, err := NewReadWriteComponent(reqs)
 	require.Error(t, err, "IPC component creation should fail when TLS verification is enabled without CA")
-	assert.Contains(t, err.Error(), "cluster_trust_chain.enable_tls_verification cannot be true if cluster_trust_chain.ca_cert_file_path or cluster_trust_chain.ca_key_file_path is not set")
+	assert.Contains(t, err.Error(), "cluster_trust_chain.enable_tls_verification cannot be true if cluster_trust_chain.ca_cert_file_path or cluster_trust_chain.ca_cert_pem is not set")
 }
 
 // TestClusterTrustChain_WithCA_SkipVerification_ClusterAgent tests case 3:

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -693,6 +693,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_trust_chain.ca_cert_file_path", "")
 	// Path to the cluster CA key file.
 	config.BindEnvAndSetDefault("cluster_trust_chain.ca_key_file_path", "")
+	// Base64-encoded PEM of the cluster CA certificate (used by sidecar agents).
+	config.BindEnvAndSetDefault("cluster_trust_chain.ca_cert_pem", "")
 
 	// the entity id, typically set by dca admisson controller config mutator, used for external origin detection
 	config.SetDefault("entity_id", "")

--- a/releasenotes-dca/notes/sidecar-secure-comm-9a73f14c000b5cf7.yaml
+++ b/releasenotes-dca/notes/sidecar-secure-comm-9a73f14c000b5cf7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Establish secure TLS communication between fargate sidecar agents and the
+    cluster agent by providing a cluster CA certificiate to the sidecar agent.


### PR DESCRIPTION
### What does this PR do?

Allows users to configure the Agent Sidecar webhook to use secure TLS for communication. Secure TLS is established by loading the DCA's public certificate as an environment variable in the sidecar container. Once the sidecar Agent has the trusted certificate, it can establish secure communication with the Cluster Agent.

### Motivation

Secure communication between the Sidecar Agent and the Cluster Agent with TLS.

### Describe how you validated your changes

To verify the functionality of the sidecar Agent, we can simulate a Fargate cluster locally.

First create the certificates locally:
```bash
openssl req -x509 -new -nodes -days 3650 \
  -newkey ec:<(openssl ecparam -name prime256v1) \
  -keyout tls.key \
  -out tls.crt \
  -subj "/" \
  -addext "basicConstraints=critical,CA:true,pathlen:0" \
  -addext "keyUsage=critical,keyCertSign"
```

Then create secrets for them:
```
kubectl create secret tls my-dd-tls \
  --cert=tls.crt \
  --key=tls.key \
  -n datadog-agent
```

Apply the following helm chart values to configure the Datadog Agent:
```
datadog:
  operator:
    enabled: false
  kubelet:
    tlsVerify: false
  clusterName: gabedos-dev
clusterAgent:
  token: "w6GOkzhmCZb71fy99lI6O3AsAuz3Vaqe"
  envDict:
    DD_CLUSTER_TRUST_CHAIN_ENABLE_TLS_VERIFICATION: "true"
    DD_CLUSTER_TRUST_CHAIN_CA_CERT_FILE_PATH: "/etc/datadog-agent/certificates/tls.crt"
    DD_CLUSTER_TRUST_CHAIN_CA_KEY_FILE_PATH: "/etc/datadog-agent/certificates/tls.key"
  image:
    tag: # INSERT IMAGE TAG FOR DCA
    pullPolicy: Always
  admissionController:
    agentSidecarInjection:
      enabled: true
      provider: fargate
      imageTag:# INSERT IMAGE TAG FOR SIDECAR
      imagePullPolicy: Always
  volumeMounts:
    - name: tls
      mountPath: /etc/datadog-agent/certificates
      readOnly: true
  volumes:
    - name: tls
      secret:
        secretName: my-dd-tls
```

Create the expected secret for agent sidecars in the test namespace:
(note a fixed token is being used to make it easier to re-deploy DCA w/o needing to refresh the secret)
https://docs.datadoghq.com/integrations/eks_fargate/?tab=admissioncontrollerdatadogoperator
```
kubectl create namspace test-fargate
```

```
kubectl create secret generic datadog-secret -n test-fargate \
  --from-literal=api-key="$(
    kubectl get secret datadog-agent-linux -n datadog-agent \
      -o jsonpath='{.data.api-key}' | base64 --decode
  )" \
  --from-literal=token="w6GOkzhmCZb71fy99lI6O3AsAuz3Vaqe" \
  --dry-run=client -o yaml \
| kubectl apply -f -
```

Apply the following resources onto your k8s cluster to generate the dummy workload:
```
# Workload with the admission controller sidecar injection enabled
# An tied to the service account with permissions to read the CA secret
---
apiVersion: v1
kind: Pod
metadata:
  name: dummy-app
  namespace: test-fargate
  labels:
    app: dummy-app
    admission.datadoghq.com/enabled: "true"
    agent.datadoghq.com/sidecar: fargate
spec:
  serviceAccountName: test-fargate-app
  containers:
    - name: alps
      image: docker.io/library/alpine:3.23@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62
      command: ["sleep", "600"]
```

Finally, connect to the agent sidecar and verify in the status it's able to connect to the cluster agent:
```
k exec -it dummy-pod -n test-fargate -c datadog-agent-injected -- agent status | grep Cluster
Datadog Cluster Agent
    - Datadog Cluster Agent endpoint detected: https://datadog-agent-linux-cluster-agent.datadog-agent.svc.cluster.local:5005
    Successfully connected to the Datadog Cluster Agent.
```

### Additional Notes

This approach is done by injecting the public certificate of the cluster-agent as an environment variable on the sidecar container. Environment variables should not carry sensitive information because it is not secure, however, the certificate is public so this concern does not apply here. Additionally, the certificate is expected be at most a few KB in size, whereas the max size of a pod is 1MB (as per etcd default limits)