### PR TITLE
Test that ReadInConfig's error return is compatible

### DIFF
--- a/pkg/config/nodetreemodel/compatibility_test.go
+++ b/pkg/config/nodetreemodel/compatibility_test.go
@@ -837,6 +837,25 @@ func TestReadInConfigResetsPreviousConfig(t *testing.T) {
 	assert.Equal(t, "localhost", ntmConf.GetString("host"))
 }
 
+func TestReadInConfigExactError(t *testing.T) {
+	// Invalid YAML that will fail to parse
+	dataYaml := `site:datadoghq.eu
+`
+	viperConf, ntmConf := constructBothConfigs(dataYaml, false, func(cfg model.Setup) {
+		cfg.BindEnvAndSetDefault("site", "datadoghq.com")
+	})
+
+	// Both config implementations should return "Config File Not Found" when
+	// a parsing error is encountered
+	err := viperConf.ReadInConfig()
+	assert.ErrorIs(t, err, model.ErrConfigFileNotFound)
+	err = ntmConf.ReadInConfig()
+	assert.ErrorIs(t, err, model.ErrConfigFileNotFound)
+
+	assert.Equal(t, "datadoghq.com", viperConf.GetString("site"))
+	assert.Equal(t, "datadoghq.com", ntmConf.GetString("site"))
+}
+
 func TestCompareEnvVarsSubfields(t *testing.T) {
 	t.Run("Subsettings are merged with env vars", func(t *testing.T) {
 		data, _ := json.Marshal(map[string]string{"a": "apple"})


### PR DESCRIPTION
### What does this PR do?

This is a follow-up to https://github.com/DataDog/datadog-agent/pull/46651, adding a unit test that validates the returned error for nodetreemodel matches that of viper.

### Motivation

Viper compatibility.

### Describe how you validated your changes

Unit test.

### Additional Notes