### PR TITLE
[ACTP] [PAR] Resolve secrets from config

### DIFF
--- a/cmd/privateactionrunner/subcommands/run/command.go
+++ b/cmd/privateactionrunner/subcommands/run/command.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipcfx "github.com/DataDog/datadog-agent/comp/core/ipc/fx"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	secretsfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx"
 	"github.com/DataDog/datadog-agent/comp/core/settings"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -58,7 +58,7 @@ func runPrivateActionRunner(ctx context.Context, confPath string, extraConfFiles
 			ConfigParams: config.NewAgentParams(confPath, config.WithExtraConfFiles(extraConfFiles)),
 			LogParams:    log.ForDaemon(command.LoggerName, pkgconfigsetup.PARLogFile, pkgconfigsetup.DefaultPrivateActionRunnerLogFile)}),
 		core.Bundle(),
-		secretsnoopfx.Module(),
+		secretsfx.Module(),
 		fx.Provide(func(c config.Component) settings.Params {
 			return settings.Params{
 				Settings: map[string]settings.RuntimeSetting{

--- a/releasenotes/notes/par-secret-management-2e36ac5fdaae8e84.yaml
+++ b/releasenotes/notes/par-secret-management-2e36ac5fdaae8e84.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Private Action Runner now supports Datadog's secret management features.
+    It can now resolve secrets using the ``ENC[...]`` notation in configuration files,
+    supporting all secret backends via ``secret_backend_type`` and
+    ``secret_backend_config`` settings.


### PR DESCRIPTION
### What does this PR do?

This PR enables the Private Action Runner to resolve secrets from its configuration by switching from the no-op secret resolver to the real secret resolver implementation.

### Motivation

The Private Action Runner was using a no-op secret resolver (`secretsnoopfx.Module()`), which meant it couldn't resolve secrets in the configuration (e.g., `ENC[...]` notation for API keys). This prevented using [Datadog's secret management features](https://docs.datadoghq.com/agent/configuration/secrets-management/?tab=agentyamlfile#overview) with the Private Action Runner.

### Changes

- **cmd/privateactionrunner/subcommands/run/command.go**: Changed from `secretsnoopfx.Module()` to `secretsfx.Module()` to enable actual secret resolution

### Describe how you validated your changes

- Built and tested locally with `go run` using file.json secret backend
- Tested in Kubernetes environment with `secret_backend_type: k8s.secrets`
- Verified secrets are resolved correctly from configuration
- Confirmed Private Action Runner starts successfully with secret resolution enabled

```bash
# Build secret-generic-connector
dda inv secret-generic-connector.build

# Run the agent
cd ~/dd/datadog-agent && go run -ldflags='-X github.com/DataDog/datadog-agent/pkg/version.AgentVersion=7.68.3-devel+local' ./cmd/agent run -c dev/dist/datadog.yaml

# Run the PAR
cd ~/dd/datadog-agent && go run ./cmd/privateactionrunner run -c dev/dist/datadog.yaml
```

Using this config

```yaml
site: datadoghq.com
api_key: "ENC[api_key]"
app_key: "ENC[app_key]"

secret_backend_command: ./bin/secret-generic-connector/secret-generic-connector
secret_backend_type: file.json
secret_backend_config:
  file_path: ./dev/dist/dev.json

hostname: mmklearning

private_action_runner:
  enabled: true
  self_enroll: true
  actions_allowlist:
    - com.datadoghq.gitlab.*
    - com.datadoghq.script.*
    - com.datadoghq.kubernetes.core.*
```

### Additional Notes