### PR TITLE
[CWS] Allow using 'in' and 'not in' for comparisons between string arrays

### DIFF
--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -964,13 +964,18 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					if err != nil {
 						return nil, pos, err
 					}
-					if *obj.ArrayComparison.Op == "notin" {
-						return Not(boolEvaluator, state), obj.Pos, nil
+				case *StringArrayEvaluator:
+					boolEvaluator, err = StringArrayMatchesStringArray(unary, nextStringArray, state)
+					if err != nil {
+						return nil, pos, err
 					}
-					return boolEvaluator, obj.Pos, nil
 				default:
 					return nil, pos, NewArrayTypeError(pos, reflect.Array, reflect.String)
 				}
+				if *obj.ArrayComparison.Op == "notin" {
+					return Not(boolEvaluator, state), obj.Pos, nil
+				}
+				return boolEvaluator, obj.Pos, nil
 			case *IntEvaluator:
 				switch nextInt := next.(type) {
 				case *IntArrayEvaluator:

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -943,6 +943,12 @@ func TestRegister(t *testing.T) {
 		{Expr: `process.list[A].value not in [~"ZZ*", "AAA", "nnnnn"]`, Expected: true},
 		{Expr: `process.list[A].value not in [~"ZZ*", ~"AA*", "nnnnn"]`, Expected: true},
 
+		// StringArrayEvaluator in/not in StringArrayEvaluator — previously unhandled, would fail at compile time
+		{Expr: `process.list.value in process.array.value`, Expected: false}, // ["AAA","BBB","CCC"] ∩ ["EEEE","DDDD"] = ∅
+		{Expr: `process.list.value not in process.array.value`, Expected: true},
+		{Expr: `process.array.value in process.list.value`, Expected: false},
+		{Expr: `process.array.value not in process.list.value`, Expected: true},
+
 		{Expr: `process.list[A].key == 10 && process.list[A].value == "AAA"`, Expected: true},
 		{Expr: `process.list[A].key == 9999 && process.list[A].value == "AAA"`, Expected: false},
 		{Expr: `process.list[A].key == 100 && process.list[A].value == "BBB"`, Expected: true},


### PR DESCRIPTION
### What does this PR do?

Allow using 'in' and 'not in' for comparisons between string arrays

### Motivation

Allow writing rules such as

connect.addr.hostname not in ${var_string_array}

### Describe how you validated your changes

### Additional Notes
