### PR TITLE
[EBPF-1054] gpu: emit gr_engine_active from eBPF as a fallback

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -487,6 +487,12 @@ func TestConfiguredMetricPriority(t *testing.T) {
 				},
 			}, nvml.SUCCESS
 		}
+		device.GetSamplesFunc = func(_ nvml.SamplingType, lastTimestamp uint64) (nvml.ValueType, []nvml.Sample, nvml.Return) {
+			return nvml.VALUE_TYPE_UNSIGNED_INT, []nvml.Sample{
+				{TimeStamp: lastTimestamp + 100, SampleValue: [8]byte{0, 0, 0, 0, 0, 0, 0, 1}},
+				{TimeStamp: lastTimestamp + 200, SampleValue: [8]byte{0, 0, 0, 0, 0, 0, 0, 2}},
+			}, nvml.SUCCESS
+		}
 		return device
 	}, testutil.WithMockAllFunctions())
 	deviceUUID := device.GetDeviceInfo().UUID
@@ -531,6 +537,7 @@ func TestConfiguredMetricPriority(t *testing.T) {
 	// Set up the expected metric order. The first collector in the list should have the highest priority over the rest.
 	desiredMetricPriority := map[string][]CollectorName{
 		"sm_active":         {sampling, ebpf},
+		"gr_engine_active":  {gpm, sampling, ebpf},
 		"process.sm_active": {sampling, ebpf},
 	}
 

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf.go
@@ -237,16 +237,26 @@ func (c *ebpfCollector) Collect() ([]Metric, error) {
 		},
 	)
 
-	// Emit device-level sm_active metric
+	// Emit device-level utilization metrics as a fallback when no other
+	// sources are available (mainly Ampere MIG devices)
 	for _, deviceMetric := range stats.DeviceMetrics {
 		if deviceMetric.DeviceUUID == deviceUUID {
-			deviceMetrics = append(deviceMetrics, Metric{
-				Name:     "sm_active",
-				Value:    deviceMetric.Metrics.ActiveTimePct,
-				Type:     ddmetrics.GaugeType,
-				Priority: Low,
-				// No AssociatedWorkloads - device-wide metric
-			})
+			deviceMetrics = append(deviceMetrics,
+				Metric{
+					Name:     "sm_active",
+					Value:    deviceMetric.Metrics.ActiveTimePct,
+					Type:     ddmetrics.GaugeType,
+					Priority: Low,
+					// No AssociatedWorkloads - device-wide metric
+				},
+				Metric{
+					Name:     "gr_engine_active",
+					Value:    deviceMetric.Metrics.ActiveTimePct,
+					Type:     ddmetrics.GaugeType,
+					Priority: Low,
+					// No AssociatedWorkloads - device-wide metric
+				},
+			)
 			break
 		}
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/ebpf_test.go
@@ -105,7 +105,7 @@ func TestEbpfCollectorCollect(t *testing.T) {
 			testFunc: testCollectEmitsSmActiveMetrics,
 		},
 		{
-			name:     "collect_emits_device_sm_active_metric",
+			name:     "collect_emits_device_utilization_metrics",
 			testFunc: testCollectEmitsDeviceSmActiveMetric,
 		},
 	}
@@ -551,8 +551,8 @@ func testCollectEmitsDeviceSmActiveMetric(t *testing.T) {
 	metrics, err := collector.Collect()
 	require.NoError(t, err)
 
-	// Should have 9 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit + 1 device sm_active
-	assert.Len(t, metrics, 9)
+	// Should have 10 metrics: 6 usage (3 per process: core, memory, sm_active) + 2 limit + 2 device metrics (sm_active, gr_engine_active)
+	assert.Len(t, metrics, 10)
 
 	// Verify device-level sm_active metric
 	deviceSmActive := findMetric(metrics, "sm_active")
@@ -560,6 +560,13 @@ func testCollectEmitsDeviceSmActiveMetric(t *testing.T) {
 	assert.Equal(t, 85.0, deviceSmActive.Value)
 	assert.Equal(t, Low, deviceSmActive.Priority, "sm_active should have Low priority")
 	assert.Empty(t, deviceSmActive.AssociatedWorkloads, "device-level sm_active should not have associated workloads")
+
+	// Verify device-level gr_engine_active metric
+	deviceGrEngineActive := findMetric(metrics, "gr_engine_active")
+	require.NotNil(t, deviceGrEngineActive, "gr_engine_active metric not found")
+	assert.Equal(t, 85.0, deviceGrEngineActive.Value)
+	assert.Equal(t, Low, deviceGrEngineActive.Priority, "gr_engine_active should have Low priority")
+	assert.Empty(t, deviceGrEngineActive.AssociatedWorkloads, "device-level gr_engine_active should not have associated workloads")
 
 	// Verify per-process sm_active metrics
 	processSmActiveMetrics := findAllMetricsWithName(metrics, "process.sm_active")

--- a/pkg/collector/corechecks/gpu/nvidia/sampling.go
+++ b/pkg/collector/corechecks/gpu/nvidia/sampling.go
@@ -22,7 +22,7 @@ import (
 )
 
 // processSample handles the complex time-weighted averaging logic for NVML sample types
-func processSample(device ddnvml.Device, metricName string, samplingType nvml.SamplingType, lastTimestamp uint64) ([]Metric, uint64, error) {
+func processSample(device ddnvml.Device, metricName string, samplingType nvml.SamplingType, lastTimestamp uint64, priority MetricPriority) ([]Metric, uint64, error) {
 	// GetSamples returns a list of samples (timestamp + value) for the
 	// given counter type (GPU utilization, memory activity, etc).
 	// Note that timestamps are in microseconds always.
@@ -87,9 +87,10 @@ func processSample(device ddnvml.Device, metricName string, samplingType nvml.Sa
 	total /= float64(currentTimestamp - lastTimestamp)
 
 	metric := Metric{
-		Name:  metricName,
-		Value: total,
-		Type:  ddmetrics.GaugeType,
+		Name:     metricName,
+		Value:    total,
+		Type:     ddmetrics.GaugeType,
+		Priority: priority,
 	}
 
 	return []Metric{metric}, currentTimestamp, multiErr
@@ -160,25 +161,25 @@ func createSampleAPIs() []apiCallInfo {
 		{
 			Name: "gr_engine_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "gr_engine_active", nvml.GPU_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "gr_engine_active", nvml.GPU_UTILIZATION_SAMPLES, lastTimestamp, Medium)
 			},
 		},
 		{
 			Name: "dram_active_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "dram_active", nvml.MEMORY_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "dram_active", nvml.MEMORY_UTILIZATION_SAMPLES, lastTimestamp, Low)
 			},
 		},
 		{
 			Name: "encoder_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "encoder_active", nvml.ENC_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "encoder_active", nvml.ENC_UTILIZATION_SAMPLES, lastTimestamp, Low)
 			},
 		},
 		{
 			Name: "decoder_samples",
 			Handler: func(device ddnvml.Device, lastTimestamp uint64) ([]Metric, uint64, error) {
-				return processSample(device, "decoder_active", nvml.DEC_UTILIZATION_SAMPLES, lastTimestamp)
+				return processSample(device, "decoder_active", nvml.DEC_UTILIZATION_SAMPLES, lastTimestamp, Low)
 			},
 		}}
 }


### PR DESCRIPTION
### What does this PR do?

Adds a fallback to ensure that `gpu.gr_engine_active` is emitted for Ampere MIG devices by using eBPF metrics.

### Motivation

Metric completeness for MIG devices.

### Describe how you validated your changes

Unit tests ensure correct priority for the metric.

### Additional Notes
