### PR TITLE
Run Windows fips compliance tests less often

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1109,6 +1109,16 @@ workflow:
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
+.on_windows_fips_compliance_or_e2e_changes:
+  - !reference [.on_e2e_main_release_or_rc]
+  - <<: *on_build_changes
+    when: on_success
+  - changes:
+      paths:
+        - test/new-e2e/tests/fips-compliance/**/*
+      compare_to: $COMPARE_TO_BRANCH
+    when: on_success
+
 .on_trace_agent_changes_or_manual:
   - !reference [.except_mergequeue]
   - changes:

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -487,7 +487,7 @@ new-e2e-windows-fips-compliance-test:
     - windows_msi_and_bosh_zip_x64-a7-fips
     - deploy_windows_testing-a7-fips
   rules:
-    - !reference [.on_arun_or_e2e_changes]
+    - !reference [.on_windows_fips_compliance_or_e2e_changes]
     - !reference [.manual]
   variables:
     TARGETS: ./tests/fips-compliance


### PR DESCRIPTION
### What does this PR do?

Update rule on new-e2e-windows-fips-compliance tests to run them less often as they never fail and should not be impacted by most changes to Go code

### Motivation

Faster CI

### Describe how you validated your changes

### Additional Notes
