### PR TITLE
[ACTP] Fix PAR config url

### DIFF
--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -25,7 +25,7 @@ import (
 func FromDDConfig(config config.Component) (*Config, error) {
 	mainEndpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
 	ddHost := getDatadogHost(mainEndpoint)
-	ddSite := configutils.ExtractSiteFromURL(ddHost)
+	ddSite := configutils.ExtractSiteFromURL(mainEndpoint)
 	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
 	urn := config.GetString(setup.PARUrn)
 

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -23,7 +23,8 @@ import (
 )
 
 func FromDDConfig(config config.Component) (*Config, error) {
-	ddHost := strings.TrimSuffix(configutils.GetMainEndpoint(config, "https://api.", "dd_url"), ".")
+	mainEndpoint := configutils.GetMainEndpoint(config, "https://api.", "dd_url")
+	ddHost := getDatadogHost(mainEndpoint)
 	ddSite := configutils.ExtractSiteFromURL(ddHost)
 	encodedPrivateKey := config.GetString(setup.PARPrivateKey)
 	urn := config.GetString(setup.PARUrn)
@@ -112,6 +113,14 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 	}
 
 	return allowlist
+}
+
+// getDatadogHost extracts and normalizes the Datadog host from the main endpoint.
+// It removes the "https://" prefix and any trailing "." from the endpoint URL.
+func getDatadogHost(endpoint string) string {
+	host := strings.TrimSuffix(endpoint, ".")
+	host = strings.TrimPrefix(host, "https://")
+	return host
 }
 
 func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[string]) map[string]sets.Set[string] {

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/setup"
 )
 
 func TestGetBundleInheritedAllowedActions(t *testing.T) {
@@ -122,6 +126,81 @@ func TestGetDatadogHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := getDatadogHost(tt.endpoint)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFromDDConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		site           string
+		ddURL          string
+		expectedDDHost string
+		expectedDDSite string
+	}{
+		{
+			name:           "US site (datadoghq.com)",
+			site:           "datadoghq.com",
+			ddURL:          "",
+			expectedDDHost: "api.datadoghq.com",
+			expectedDDSite: "datadoghq.com",
+		},
+		{
+			name:           "EU site (datadoghq.eu)",
+			site:           "datadoghq.eu",
+			ddURL:          "",
+			expectedDDHost: "api.datadoghq.eu",
+			expectedDDSite: "datadoghq.eu",
+		},
+		{
+			name:           "Gov site (ddog-gov.com)",
+			site:           "ddog-gov.com",
+			ddURL:          "",
+			expectedDDHost: "api.ddog-gov.com",
+			expectedDDSite: "ddog-gov.com",
+		},
+		{
+			name:           "dd_url overrides site",
+			site:           "datadoghq.com",
+			ddURL:          "https://api.datadoghq.eu.",
+			expectedDDHost: "api.datadoghq.eu",
+			expectedDDSite: "datadoghq.eu",
+		},
+		{
+			name:           "custom domain via dd_url",
+			site:           "",
+			ddURL:          "https://custom.endpoint.example.com.",
+			expectedDDHost: "custom.endpoint.example.com",
+			expectedDDSite: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+
+			// Set required configuration values
+			if tt.site != "" {
+				mockConfig.SetWithoutSource("site", tt.site)
+			}
+			if tt.ddURL != "" {
+				mockConfig.SetWithoutSource("dd_url", tt.ddURL)
+			}
+
+			// Set minimal required PAR config to avoid errors
+			mockConfig.SetWithoutSource(setup.PARPrivateKey, "")
+			mockConfig.SetWithoutSource(setup.PARUrn, "")
+
+			// Call FromDDConfig
+			cfg, err := FromDDConfig(mockConfig)
+			require.NoError(t, err)
+
+			// Verify both DDHost and DatadogSite are set correctly
+			assert.Equal(t, tt.expectedDDHost, cfg.DDHost, "DDHost mismatch")
+			assert.Equal(t, tt.expectedDDSite, cfg.DatadogSite, "DatadogSite mismatch")
+
+			// Verify DDApiHost is also set to the same value as DDHost
+			assert.Equal(t, tt.expectedDDHost, cfg.DDApiHost, "DDApiHost should match DDHost")
 		})
 	}
 }

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -69,3 +69,59 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDatadogHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		expected string
+	}{
+		{
+			name:     "removes https prefix and trailing dot",
+			endpoint: "https://api.datadoghq.com.",
+			expected: "api.datadoghq.com",
+		},
+		{
+			name:     "removes https prefix only",
+			endpoint: "https://api.datadoghq.com",
+			expected: "api.datadoghq.com",
+		},
+		{
+			name:     "removes trailing dot only",
+			endpoint: "api.datadoghq.com.",
+			expected: "api.datadoghq.com",
+		},
+		{
+			name:     "handles clean URL without modifications",
+			endpoint: "api.datadoghq.com",
+			expected: "api.datadoghq.com",
+		},
+		{
+			name:     "handles empty string",
+			endpoint: "",
+			expected: "",
+		},
+		{
+			name:     "handles EU site with https and trailing dot",
+			endpoint: "https://api.datadoghq.eu.",
+			expected: "api.datadoghq.eu",
+		},
+		{
+			name:     "handles gov site",
+			endpoint: "https://api.ddog-gov.com.",
+			expected: "api.ddog-gov.com",
+		},
+		{
+			name:     "handles custom domain",
+			endpoint: "https://custom.endpoint.example.com.",
+			expected: "custom.endpoint.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getDatadogHost(tt.endpoint)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/datadog-agent/pull/46820 introduced a regression. We should use `api.datadoghq.*com/` instead of `https://api.datadoghq.com/*`

### Motivation

### Describe how you validated your changes
- [x] Unittests
- [x] Manually ran the PAR locally and health check + dequeue requests successfull

### Additional Notes
