### PR TITLE
feat(ci): Prevent breaking gitlab by detecting skip CI tags in PRs

### DIFF
--- a/.github/workflows/check-skip.yml
+++ b/.github/workflows/check-skip.yml
@@ -1,0 +1,28 @@
+---
+name: Check PR title and description for CI skip tags
+
+on:
+  pull_request:
+    types: [opened,edited]
+
+jobs:
+  check_pr_content:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title and description for CI skip tags
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: |
+          SKIP_CI_PATTERN='\[(ci skip|skip ci|actions skip|skip actions|no ci)\]|skip-checks:\s*true'
+          if [[ "$TITLE" =~ $SKIP_CI_PATTERN ]]; then
+            echo "error: The PR title contains ci skip tags." >&2
+            exit 1
+          fi
+          if [[ "$DESCRIPTION" =~ $SKIP_CI_PATTERN ]]; then
+            echo "error: The PR description contains ci skip tags." >&2
+            exit 1
+          fi
+
+          echo "success: No ci skip tags found."
+          exit 0

--- a/.github/workflows/check-skip.yml
+++ b/.github/workflows/check-skip.yml
@@ -14,7 +14,8 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           DESCRIPTION: ${{ github.event.pull_request.body }}
         run: |
-          SKIP_CI_PATTERN='\[(ci skip|skip ci|actions skip|skip actions|no ci)\]|skip-checks:\s*true'
+          shopt -s nocasematch
+          SKIP_CI_PATTERN='\[(ci skip|skip ci|actions skip|skip actions|no ci)\]|skip-checks:[[:space:]]*true'
           if [[ "$TITLE" =~ $SKIP_CI_PATTERN ]]; then
             echo "error: The PR title contains ci skip tags." >&2
             exit 1


### PR DESCRIPTION
### What does this PR do?

Adds a new GitHub Actions workflow (`.github/workflows/check-skip.yml`) that checks PR titles and descriptions for keywords bypassing the CI.

If any of these patterns are detected, the check fails, alerting the PR author before merge.

### Motivation

CI bypass tags in PR titles or descriptions [can cause GitLab CI pipelines to be skipped entirely](https://app.datadoghq.com/incidents/48102), allowing untested code to be merged into main. This workflow acts as a guardrail to catch these tags early when a PR is opened or edited.
https://datadoghq.atlassian.net/browse/ACIX-1272

### Describe how you validated your changes

- [Error](https://github.com/DataDog/datadog-agent/actions/runs/22353542966/job/64686726730?pr=46855) with description.
- [Error](https://github.com/DataDog/datadog-agent/actions/runs/22355781754/job/64694923855?pr=46855) with title
- [Case sensitive test](https://github.com/DataDog/datadog-agent/actions/runs/22355846469/job/64695155210?pr=46855)

### Additional Notes

The workflow triggers on `pull_request` events with types `opened` and `edited`, so it re-checks whenever the PR title or description is modified.