### PR TITLE
Fix local package measurement by setting a default filter

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -1021,7 +1021,7 @@ def measure_package_local(
     output_path=None,
     build_job_name="local_test",
     debug=False,
-    filter: Callable[[str], bool] = None,
+    filter: Callable[[str], bool] = lambda _: True,
 ):
     """
     Run the in-place package measurer locally for testing and development.


### PR DESCRIPTION
### What does this PR do?

Fixes errors on measurements after builds by avoiding calling a possibly `None`-valued `filter` function.

### Motivation

Silent failures in measurements after builds, affecting the agent_deb-x64-a7 job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1443255420

This error seems to have been introduced in https://github.com/DataDog/datadog-agent/pull/45321 (and the error was present in the PR).

### Describe how you validated your changes

Checking that agent_deb-x64-a7 shows no errors.

### Additional Notes
