### PR TITLE
AGTMETRICS-485 Fix logic races in the forwarder.

### DIFF
--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -288,7 +288,6 @@ type DefaultForwarder struct {
 
 	agentName                       string
 	queueDurationCapacity           *retry.QueueDurationCapacity
-	retryQueueDurationCapacityMutex sync.Mutex
 }
 
 // NewDefaultForwarder returns a new DefaultForwarder.
@@ -577,9 +576,6 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 	if f.internalState.Load() == Stopped {
 		return errors.New("the forwarder is not started")
 	}
-
-	f.retryQueueDurationCapacityMutex.Lock()
-	defer f.retryQueueDurationCapacityMutex.Unlock()
 
 	now := time.Now()
 	for _, t := range transactions {

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -571,6 +571,9 @@ func (f *DefaultForwarder) createAdvancedHTTPTransactions(endpoint transaction.E
 }
 
 func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTransaction) error {
+	f.m.Lock()
+	defer f.m.Unlock()
+
 	if f.internalState.Load() == Stopped {
 		return errors.New("the forwarder is not started")
 	}

--- a/comp/forwarder/defaultforwarder/default_forwarder.go
+++ b/comp/forwarder/defaultforwarder/default_forwarder.go
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/atomic"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	secrets "github.com/DataDog/datadog-agent/comp/core/secrets/def"
@@ -36,9 +34,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
+type forwarderState uint32
+
 const (
 	// Stopped represent the internal state of an unstarted Forwarder.
-	Stopped uint32 = iota
+	Stopped forwarderState = iota
 	// Started represent the internal state of an started Forwarder.
 	Started
 	// Disabled represent the internal state of a disabled Forwarder.
@@ -283,7 +283,7 @@ type DefaultForwarder struct {
 	domainResolvers  map[string]pkgresolver.DomainResolver
 	localForwarder   *domainForwarder // domain forward used for communication with the local cluster-agent
 	healthChecker    *forwarderHealth
-	internalState    *atomic.Uint32
+	internalState    forwarderState
 	m                sync.Mutex // To control Start/Stop races
 
 	agentName                       string
@@ -300,7 +300,7 @@ func NewDefaultForwarder(config config.Component, log log.Component, options *Op
 		NumberOfWorkers:  options.NumberOfWorkers,
 		domainForwarders: map[string]*domainForwarder{},
 		domainResolvers:  map[string]pkgresolver.DomainResolver{},
-		internalState:    atomic.NewUint32(Stopped),
+		internalState:    Stopped,
 		healthChecker: &forwarderHealth{
 			log:                   log,
 			config:                config,
@@ -437,7 +437,7 @@ func (f *DefaultForwarder) Start() error {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	if f.internalState.Load() == Started {
+	if f.internalState == Started {
 		return errors.New("the forwarder is already started")
 	}
 
@@ -455,7 +455,7 @@ func (f *DefaultForwarder) Start() error {
 		len(endpointLogs), f.NumberOfWorkers, strings.Join(endpointLogs, " ; "))
 
 	f.healthChecker.Start()
-	f.internalState.Store(Started)
+	f.internalState = Started
 	return nil
 }
 
@@ -466,12 +466,12 @@ func (f *DefaultForwarder) Stop() {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	if f.internalState.Load() == Stopped {
+	if f.internalState == Stopped {
 		f.log.Warnf("the forwarder is already stopped")
 		return
 	}
 
-	f.internalState.Store(Stopped)
+	f.internalState = Stopped
 
 	purgeTimeout := f.config.GetDuration("forwarder_stop_timeout") * time.Second
 	if purgeTimeout > 0 {
@@ -509,12 +509,13 @@ func (f *DefaultForwarder) Stop() {
 }
 
 // State returns the internal state of the forwarder (Started or Stopped)
+// Deprecated. Returned value may be stale by the time this method returns.
 func (f *DefaultForwarder) State() uint32 {
 	// Lock so we can't start/stop a Forwarder while getting its state
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	return f.internalState.Load()
+	return uint32(f.internalState)
 }
 
 func (f *DefaultForwarder) createHTTPTransactions(endpoint transaction.Endpoint, payloads transaction.BytesPayloads, kind transaction.Kind, extra http.Header) []*transaction.HTTPTransaction {
@@ -573,7 +574,7 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	if f.internalState.Load() == Stopped {
+	if f.internalState == Stopped {
 		return errors.New("the forwarder is not started")
 	}
 

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -48,7 +48,7 @@ type domainForwarder struct {
 	workers                   []*Worker
 	retryQueue                *retry.TransactionRetryQueue
 	connectionResetInterval   time.Duration
-	internalState             uint32
+	internalState             forwarderState
 	m                         sync.Mutex // To control Start/Stop races
 	transactionPrioritySorter retry.TransactionPrioritySorter
 	blockedList               *blockedEndpoints
@@ -327,7 +327,7 @@ func (f *domainForwarder) Stop(purgeHighPrio bool) {
 	f.internalState = Stopped
 }
 
-func (f *domainForwarder) State() uint32 {
+func (f *domainForwarder) State() forwarderState {
 	// Lock so we can't start/stop a Forwarder while getting its state
 	f.m.Lock()
 	defer f.m.Unlock()

--- a/comp/forwarder/defaultforwarder/forwarder_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_test.go
@@ -70,8 +70,8 @@ func TestNewDefaultForwarder(t *testing.T) {
 	assert.Equal(t, testDomain, forwarder.domainResolvers[testVersionDomain].GetConfigName())
 	assert.Equal(t, validKeys, forwarder.domainResolvers[testVersionDomain].GetAPIKeys())
 
-	assert.Equal(t, forwarder.internalState.Load(), Stopped)
-	assert.Equal(t, forwarder.State(), forwarder.internalState.Load())
+	assert.Equal(t, forwarder.internalState, Stopped)
+	assert.Equal(t, forwarder.State(), uint32(forwarder.internalState))
 }
 
 func TestNewDefaultForwarderWithAutoscaling(t *testing.T) {
@@ -101,8 +101,8 @@ func TestNewDefaultForwarderWithAutoscaling(t *testing.T) {
 	assert.Len(t, forwarder.domainResolvers[localDomain].GetAPIKeys(), 0)
 	assert.True(t, forwarder.domainResolvers[localDomain].IsLocal())
 
-	assert.Equal(t, forwarder.internalState.Load(), Stopped)
-	assert.Equal(t, forwarder.State(), forwarder.internalState.Load())
+	assert.Equal(t, forwarder.internalState, Stopped)
+	assert.Equal(t, forwarder.State(), uint32(forwarder.internalState))
 }
 
 func TestFeature(t *testing.T) {
@@ -135,7 +135,7 @@ func TestStart(t *testing.T) {
 	defer forwarder.Stop()
 
 	assert.NoError(t, err)
-	assert.Equal(t, Started, forwarder.State())
+	assert.Equal(t, Started, forwarder.internalState)
 	require.Len(t, forwarder.domainForwarders, 1)
 	require.NotNil(t, forwarder.healthChecker)
 	assert.NotNil(t, forwarder.Start())
@@ -163,12 +163,12 @@ func testStop(t *testing.T, mockConfig pkgconfigmodel.Config) {
 	options := NewOptionsWithResolvers(mockConfig, log, r)
 	options.Secrets = secrets
 	forwarder := NewDefaultForwarder(mockConfig, log, options)
-	assert.Equal(t, Stopped, forwarder.State())
+	assert.Equal(t, Stopped, forwarder.internalState)
 	forwarder.Stop() // this should be a noop
 	forwarder.Start()
 	domainForwarders := forwarder.domainForwarders
 	forwarder.Stop()
-	assert.Equal(t, Stopped, forwarder.State())
+	assert.Equal(t, Stopped, forwarder.internalState)
 	assert.Nil(t, forwarder.healthChecker)
 	assert.Len(t, forwarder.domainForwarders, 0)
 	for _, df := range domainForwarders {
@@ -187,7 +187,7 @@ func TestSubmitIfStopped(t *testing.T) {
 	forwarder := NewDefaultForwarder(mockConfig, log, options)
 
 	require.NotNil(t, forwarder)
-	require.Equal(t, Stopped, forwarder.State())
+	require.Equal(t, Stopped, forwarder.internalState)
 	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, make(http.Header)))
 	assert.NotNil(t, forwarder.SubmitHostMetadata(nil, make(http.Header)))
 	assert.NotNil(t, forwarder.SubmitMetadata(nil, make(http.Header)))

--- a/releasenotes/notes/forwarder-sync-88391371815ffc94.yaml
+++ b/releasenotes/notes/forwarder-sync-88391371815ffc94.yaml
@@ -1,0 +1,2 @@
+fixes:
+  - Fix crash when stopping otel agent.


### PR DESCRIPTION
### What does this PR do?

sendHTTPTransactions was insufficiently synchronized and could panic if transactions were submitted while the forwarder was beging stopped. It could access domainForwarders after it has been cleared, causing a nil-dereference panic, or send transaction to a domain forwarder whose channel was closed, causing a 'send on closed channel' panic.

This PR makes sendHTTPTransactions acquire the same mutex used in `Start` and `Stop`, preventing it from accessing stale data. This is not expected to increase contention, since `sendHTTPTransactions` also acquired another exclusive mutex few lines later, which is now redundant and was removed. Internal state was downgraded from atomic to a regular field, since all accesses are now synchronized.

### Motivation

Fix a rare crash on shutdown in Otel agent.

### Describe how you validated your changes

Unit and e2e tests.

### Additional Notes
