### PR TITLE
[ACTP] fix allowlist inference for complex bundles

### DIFF
--- a/pkg/privateactionrunner/adapters/config/constants.go
+++ b/pkg/privateactionrunner/adapters/config/constants.go
@@ -27,12 +27,19 @@ const (
 	defaultHTTPClientTimeout      = 30 * time.Second
 )
 
+// BundleInheritedAllowedAction represents an action that is automatically allowed
+// if at least one other action matching the expected prefix is allowed
+type BundleInheritedAllowedAction struct {
+	ActionFQN      string
+	ExpectedPrefix string
+}
+
 // BundleInheritedAllowedActions is a list of actions that are automatically allowed
-// if at least one other action from the same bundle is allowed
-var BundleInheritedAllowedActions = []string{
-	"com.datadoghq.gitlab.users.testConnection",
-	"com.datadoghq.kubernetes.core.testConnection",
-	"com.datadoghq.script.testConnection",
-	"com.datadoghq.script.enrichScript",
-	"com.datadoghq.ddagent.testConnection",
+// if at least one other action matching their expected prefix is allowed
+var BundleInheritedAllowedActions = []BundleInheritedAllowedAction{
+	{ActionFQN: "com.datadoghq.gitlab.users.testConnection", ExpectedPrefix: "com.datadoghq.gitlab"},
+	{ActionFQN: "com.datadoghq.kubernetes.core.testConnection", ExpectedPrefix: "com.datadoghq.kubernetes"},
+	{ActionFQN: "com.datadoghq.script.testConnection", ExpectedPrefix: "com.datadoghq.script"},
+	{ActionFQN: "com.datadoghq.script.enrichScript", ExpectedPrefix: "com.datadoghq.script"},
+	{ActionFQN: "com.datadoghq.ddagent.testConnection", ExpectedPrefix: "com.datadoghq.ddagent"},
 }

--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -115,19 +115,27 @@ func makeActionsAllowlist(config config.Component) map[string]sets.Set[string] {
 func GetBundleInheritedAllowedActions(actionsAllowlist map[string]sets.Set[string]) map[string]sets.Set[string] {
 	result := make(map[string]sets.Set[string])
 
-	for _, specialAction := range BundleInheritedAllowedActions {
-		specialBundleID, specialActionName := actions.SplitFQN(specialAction)
-		specialBundleID = strings.ToLower(specialBundleID)
+	for _, inheritedAction := range BundleInheritedAllowedActions {
+		actionBundleID, actionName := actions.SplitFQN(inheritedAction.ActionFQN)
+		actionBundleID = strings.ToLower(actionBundleID)
+		prefix := strings.ToLower(inheritedAction.ExpectedPrefix)
 
-		actionsSet, ok := actionsAllowlist[specialBundleID]
-		if !ok || actionsSet.Len() == 0 {
+		matched := false
+		for bundleID, actionsSet := range actionsAllowlist {
+			if actionsSet.Len() > 0 && strings.HasPrefix(bundleID, prefix) {
+				matched = true
+				break
+			}
+		}
+
+		if !matched {
 			continue
 		}
 
-		if _, exists := result[specialBundleID]; !exists {
-			result[specialBundleID] = sets.New[string]()
+		if _, exists := result[actionBundleID]; !exists {
+			result[actionBundleID] = sets.New[string]()
 		}
-		result[specialBundleID].Insert(specialActionName)
+		result[actionBundleID].Insert(actionName)
 	}
 
 	return result

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -28,6 +28,15 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 			},
 		},
 		{
+			name: "returns special actions for sibling bundles",
+			actionsAllowlist: map[string]sets.Set[string]{
+				"com.datadoghq.kubernetes.apps": sets.New[string]("action3"),
+			},
+			expectedInheritedActions: map[string]sets.Set[string]{
+				"com.datadoghq.kubernetes.core": sets.New[string]("testConnection"),
+			},
+		},
+		{
 			name: "returns empty when bundle not in allowlist",
 			actionsAllowlist: map[string]sets.Set[string]{
 				"com.other.bundle": sets.New[string]("action1"),
@@ -53,6 +62,7 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 				"com.datadoghq.script":          sets.New[string]("action1"),
 				"com.datadoghq.gitlab.users":    sets.New[string]("action2"),
 				"com.datadoghq.kubernetes.core": sets.New[string]("action3"),
+				"com.datadoghq.kubernetes.apps": sets.New[string]("action4"),
 			},
 			expectedInheritedActions: map[string]sets.Set[string]{
 				"com.datadoghq.script":          sets.New[string]("testConnection", "enrichScript"),

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -44,6 +44,14 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 			expectedInheritedActions: map[string]sets.Set[string]{},
 		},
 		{
+			name: "returns empty when for close but wrong bundle",
+			actionsAllowlist: map[string]sets.Set[string]{
+				"com.datadoghq.dd":           sets.New[string]("action1"),
+				"com.datadoghq.dd.subbundle": sets.New[string]("action2"),
+			},
+			expectedInheritedActions: map[string]sets.Set[string]{},
+		},
+		{
 			name: "returns empty when bundle has empty set",
 			actionsAllowlist: map[string]sets.Set[string]{
 				"com.datadoghq.script": sets.New[string](),

--- a/pkg/privateactionrunner/adapters/config/transform_test.go
+++ b/pkg/privateactionrunner/adapters/config/transform_test.go
@@ -44,14 +44,6 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 			expectedInheritedActions: map[string]sets.Set[string]{},
 		},
 		{
-			name: "returns empty when for close but wrong bundle",
-			actionsAllowlist: map[string]sets.Set[string]{
-				"com.datadoghq.dd":           sets.New[string]("action1"),
-				"com.datadoghq.dd.subbundle": sets.New[string]("action2"),
-			},
-			expectedInheritedActions: map[string]sets.Set[string]{},
-		},
-		{
 			name: "returns empty when bundle has empty set",
 			actionsAllowlist: map[string]sets.Set[string]{
 				"com.datadoghq.script": sets.New[string](),
@@ -71,12 +63,22 @@ func TestGetBundleInheritedAllowedActions(t *testing.T) {
 				"com.datadoghq.gitlab.users":    sets.New[string]("action2"),
 				"com.datadoghq.kubernetes.core": sets.New[string]("action3"),
 				"com.datadoghq.kubernetes.apps": sets.New[string]("action4"),
+				"com.datadoghq.ddagent":         sets.New[string]("action5"),
 			},
 			expectedInheritedActions: map[string]sets.Set[string]{
 				"com.datadoghq.script":          sets.New[string]("testConnection", "enrichScript"),
 				"com.datadoghq.gitlab.users":    sets.New[string]("testConnection"),
 				"com.datadoghq.kubernetes.core": sets.New[string]("testConnection"),
+				"com.datadoghq.ddagent":         sets.New[string]("testConnection"),
 			},
+		},
+		{
+			name: "returns empty for similar looking bundle	",
+			actionsAllowlist: map[string]sets.Set[string]{
+				"com.datadoghq.dd":           sets.New[string]("action1"),
+				"com.datadoghq.dd.subbundle": sets.New[string]("action2"),
+			},
+			expectedInheritedActions: map[string]sets.Set[string]{},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fix BundleInheritedAllowedAction to work with "complex" bundles like kubernetes 

### Motivation

When adding a `com.datadoghq.kubernetes.apps.<action>` the kubernetes test action was not working

### Describe how you validated your changes

Unit test

### Additional Notes

Will be backported to 7.77