### PR TITLE
Fix DDApiHost double-scheme bug in PAR config

### DIFF
--- a/pkg/privateactionrunner/adapters/config/transform.go
+++ b/pkg/privateactionrunner/adapters/config/transform.go
@@ -85,7 +85,7 @@ func FromDDConfig(config config.Component) (*Config, error) {
 		Allowlist:                 config.GetStringSlice(setup.PARHttpAllowlist),
 		AllowIMDSEndpoint:         config.GetBool(setup.PARHttpAllowImdsEndpoint),
 		DDHost:                    ddHost,
-		DDApiHost:                 ddHost,
+		DDApiHost:                 strings.TrimPrefix(ddHost, "https://"),
 		Modes:                     []modes.Mode{modes.ModePull},
 		OrgId:                     orgID,
 		PrivateKey:                privateKey,


### PR DESCRIPTION
## Summary

- `GetMainEndpoint` returns a full URL including the `https://` scheme (e.g. `https://api.datad0g.com`)
- `DDApiHost` is used as the `Host` field in `url.URL` structs throughout `opms.go`, which expects just a hostname
- This caused all OPMS requests (dequeue, health-check, publish) to fail with a malformed URL: `https://https:%2F%2Fapi.datad0g.com/...`

Introduced in #46820, which switched `DDApiHost` from `"api." + ddSite` (hostname only) to `ddHost` (full URL).

## Fix

Strip the scheme from `ddHost` before assigning to `DDApiHost`, consistent with how dd-source sets it via `GetAPIHostFromDDHost()`.

## Test plan

- [ ] Verify PAR successfully polls OPMS after this fix
- [ ] Confirm `DDApiHost` equals `api.<site>` (no scheme) at runtime