### PR TITLE
[e2e] Speed up testHPA by accepting either scale-up or scale-down

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -1911,9 +1911,9 @@ func (suite *k8sSuite) testHPA(namespace, deployment string) {
 
 		defer func() {
 			if suite.T().Failed() {
-				sendEvent("error", "Failed to witness scale up *and* scale down events.", nil)
+				sendEvent("error", "Failed to witness a scale up *or* scale down event.", nil)
 			} else {
-				sendEvent("success", "Scale up and scale down events detected.", nil)
+				sendEvent("success", "Scale up or scale down event detected.", nil)
 			}
 		}()
 
@@ -1934,12 +1934,17 @@ func (suite *k8sSuite) testHPA(namespace, deployment string) {
 				return
 			}
 
-			// Check HPA is properly scaling up and down
+			// Check HPA is properly scaling up or down
 			// This indirectly tests the cluster-agent external metrics server
-			scaleUp := false
-			scaleDown := false
+			//
+			// The deployments that have an HPA configured (nginx and redis)
+			// exhibit a traffic pattern that follows a sine wave with a
+			// 20-minute period. This is defined in the test-infra-definitions
+			// repo. Detecting either a scale-up or a scale-down event is
+			// sufficient to validate that the external metrics pipeline works
+			// end-to-end, without having to wait for a full sine wave cycle.
+			scaled := false
 			prevValue := -1.0
-		out:
 			for _, metric := range metrics {
 				for _, point := range metric.GetPoints() {
 					if prevValue == -1.0 {
@@ -1947,30 +1952,23 @@ func (suite *k8sSuite) testHPA(namespace, deployment string) {
 						continue
 					}
 
-					if !scaleUp && point.Value > prevValue+0.5 {
-						scaleUp = true
+					if point.Value > prevValue+0.5 {
 						sendEvent("success", "Scale up detected.", pointer.Ptr(int(point.Timestamp)))
-						if scaleDown {
-							break out
-						}
-					} else if !scaleDown && point.Value < prevValue-0.5 {
-						scaleDown = true
+						scaled = true
+						break
+					} else if point.Value < prevValue-0.5 {
 						sendEvent("success", "Scale down detected.", pointer.Ptr(int(point.Timestamp)))
-						if scaleUp {
-							break out
-						}
+						scaled = true
+						break
 					}
 					prevValue = point.Value
 				}
+				if scaled {
+					break
+				}
 			}
-			assert.Truef(c, scaleUp, "No scale up detected")
-			assert.Truef(c, scaleDown, "No scale down detected")
-			// The deployments that have an HPA configured (nginx and redis)
-			// exhibit a traffic pattern that follows a sine wave with a
-			// 20-minute period. This is defined in the test-infra-definitions
-			// repo. For this reason, the timeout for this test needs to be a
-			// bit higher than 20 min to capture the scale down event.
-		}, 25*time.Minute, 10*time.Second, "Failed to witness scale up and scale down of %s.%s", namespace, deployment)
+			assert.Truef(c, scaled, "No scale up or scale down detected")
+		}, 7*time.Minute, 10*time.Second, "Failed to witness scale up or scale down of %s.%s", namespace, deployment)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Speed up `testHPA` in the containers e2e suite by accepting **either** a scale-up or a scale-down event, instead of requiring both
- A single scaling event is sufficient to validate the entire external metrics pipeline end-to-end (traffic → Datadog metric → cluster-agent external metrics API → HPA controller → replica change → KSM metric in fake intake)
- Reduces the timeout from **25 minutes to 7 minutes**
- Both `TestNginx` and `TestRedis` benefit from this change (they each call `testHPA`)

## Motivation

CI data (avg over 30 days on `main`):
- `TestNginx`: ~200s avg, **~787s (13min) at p95**
- `TestRedis`: ~158s avg, **~712s (12min) at p95**
- Most other tests in the suite: < 30s

The previous implementation waited for a full sine wave cycle (20-min period) to observe both scale-up and scale-down. Since both directions exercise the exact same code path in the cluster-agent external metrics server, observing just one is enough.
https://datadoghq.atlassian.net/browse/ACIX-1282

## Test plan

- [ ] Verify `testHPA` passes on Kind (TestKindSuite) — detects at least one scaling event
- [ ] Verify `testHPA` passes on EKS (TestEKSSuite) — same check
- [ ] Confirm CI time reduction on TestNginx and TestRedis

🤖 Generated with [Claude Code](https://claude.com/claude-code)