### PR TITLE
ensure `single_machine_performance-full-amd64-a7` runs on release branches

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -186,7 +186,7 @@ single_machine_performance-full-amd64-a7:
   rules:
     - !reference [.except_mergequeue]
     # Always publish SMP images on main (needed for baseline comparisons)
-    - !reference [.on_main]
+    - !reference [.on_main_or_release_branch]
     # On dev branches, only publish when artifact-impacting files change.
     # This skips SMP for doc-only, CI-only, or e2e test-only PRs.
     - !reference [.on_dev_branches_with_artifact_changes]


### PR DESCRIPTION
### What does this PR do?

Ensures single_machine_performance-full-amd64-a7 (the jobs that makes agent images available in our ECR) runs on release branches

### Motivation

Needed for release branch work, particularly backport PRs

### Describe how you validated your changes

### Additional Notes

I believe this change is needed in order to correctly mirror images into SMP ecr on release branches.
