### PR TITLE
Check for PID reuse when enumerating Windows proceses

### DIFF
--- a/pkg/process/procutil/process_windows_toolhelp_test.go
+++ b/pkg/process/procutil/process_windows_toolhelp_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+//go:build windows
+
+package procutil
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessesByPIDReusedPID exercises the PID reuse path in ProcessesByPID by
+// pre-populating the probe's cache with a wrong createTime for a real process.
+// When ProcessesByPID runs, it sees the same PID with a different createTime and
+// replaces the cached process (reuse branch).
+func TestProcessesByPIDReusedPID(t *testing.T) {
+	now := time.Now()
+	cmd := exec.Command("powershell.exe", "-c", "sleep 60; foo bar baz")
+	err := cmd.Start()
+	require.NoError(t, err)
+	defer cmd.Process.Kill()
+
+	pid := uint32(cmd.Process.Pid)
+
+	probe := NewWindowsToolhelpProbe()
+	wp, ok := probe.(*windowsToolhelpProbe)
+	require.True(t, ok, "probe must be *windowsToolhelpProbe")
+
+	// Pre-populate cache with wrong createTime to run the reused PID logic.
+	// createTime 1 will never equal the real process's createTime.
+	const wrongCreateTime = 1
+	wp.cachedProcesses[pid] = &cachedProcess{createTime: wrongCreateTime}
+
+	procs, err := probe.ProcessesByPID(time.Now(), true)
+	require.NoError(t, err)
+
+	p, found := procs[int32(pid)]
+	require.True(t, found, "process with reused PID should be in result")
+
+	// Reuse path should have replaced the cache and filled with real createTime.
+	assert.NotEqual(t, wrongCreateTime, p.Stats.CreateTime,
+		"ProcessesByPID should have replaced cached process with real createTime (PID reuse path)")
+
+	// Sanity: process metadata should match the process we started.
+	assert.True(t, strings.HasSuffix(p.Exe, "powershell.exe"), "Exe should be powershell.exe")
+	assert.Equal(t, []string{"powershell.exe", "-c", `"sleep 60; foo bar baz"`}, p.Cmdline)
+	assert.Equal(t, int32(os.Getpid()), p.Ppid)
+	assert.Equal(t, int32(pid), p.Pid)
+	assert.Equal(t, "Windows PowerShell", p.Comm)
+
+	// Real createTime should be in a plausible range (process started around now).
+	assert.WithinRange(t, time.Unix(0, p.Stats.CreateTime*1000_000), now, now.Add(5*time.Second),
+		"CreateTime should reflect actual process start time")
+}

--- a/releasenotes/notes/windows_reused_pid_process_enum-a8ce5046a907291a.yaml
+++ b/releasenotes/notes/windows_reused_pid_process_enum-a8ce5046a907291a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed discovery of Windows processes to identify reused PIDs between process snapshots and correctly track these processes.


### PR DESCRIPTION
### What does this PR do?
This PR fixes the handling of reused PIDs when discovering Windows processes.
A customer reported that the Datadog process views incorrectly highlighted an executable suspected of using high CPU.  It turned out that it was a different executable but had the same PID.  The PID was reused for a new process between the 10s polling intervals, however the agent incorrectly assumed the PID and process remained the same.  The process create time is now used to differentiate between processes with reused PIDs.

### Motivation
https://datadoghq.atlassian.net/browse/AGENT-15614

### Describe how you validated your changes
CI/CD and E2E process windows tests.
Manually deployed agent in VM and launched multiple concurrent process creations.
agent.exe processchecks process_discovery
process-agent.exe check process_discovery

