### PR TITLE
Reduce excessive error logs to missing kprobe name mappings

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -451,6 +451,7 @@ retry:
 	key, stats := &cookie{}, &kprobeKernelStats{}
 
 	var toDelete []cookie
+	missingMappings := 0
 	for entries.Next(key, stats) {
 		// record this key to be deleted later on
 		toDelete = append(toDelete, *key)
@@ -464,7 +465,7 @@ retry:
 
 		name, err := ddebpf.GetProgNameFromProgID(key.Kprobe_id)
 		if err != nil {
-			log.Errorf("unable to get program name for kprobe id %d: %v", key.Kprobe_id, err)
+			missingMappings++
 			continue
 		}
 
@@ -488,6 +489,8 @@ retry:
 		})
 
 	}
+
+	log.Warnf("unable to get program name for %d kprobes due to missing mappings", missingMappings)
 
 	// we do not expect any errors including iteration aborted errors, since ebpf check
 	// does not execute concurrently. This means the map should never be modified while

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -490,9 +490,9 @@ retry:
 
 	}
 
-  if missingMappings > 0 {
-	log.Warnf("unable to get program name for %d kprobes due to missing mappings", missingMappings)
-  }
+	if missingMappings > 0 {
+		log.Warnf("unable to get program name for %d kprobes due to missing mappings", missingMappings)
+	}
 
 	// we do not expect any errors including iteration aborted errors, since ebpf check
 	// does not execute concurrently. This means the map should never be modified while

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -490,7 +490,9 @@ retry:
 
 	}
 
+  if missingMappings > 0 {
 	log.Warnf("unable to get program name for %d kprobes due to missing mappings", missingMappings)
+  }
 
 	// we do not expect any errors including iteration aborted errors, since ebpf check
 	// does not execute concurrently. This means the map should never be modified while


### PR DESCRIPTION
### What does this PR do?
This PR reduces error logs due to missing name mappings for kprobes. This is a likely condition since mappings are opt-in and a lot of kprobes running on the system may not have them.

### Motivation
Reduce excessive error logs.

### Describe how you validated your changes
Changes covered by existing tests

### Additional Notes
