### PR TITLE
[SDBM-2360] Add option to Oracle integration to send custom metrics with timestamp

### DIFF
--- a/pkg/collector/corechecks/oracle/config/config.go
+++ b/pkg/collector/corechecks/oracle/config/config.go
@@ -123,6 +123,9 @@ type CustomQuery struct {
 	Query        string               `yaml:"query"`
 	Columns      []CustomQueryColumns `yaml:"columns"`
 	Tags         []string             `yaml:"tags"`
+	// can be `query_start` -- BEWARE, when using this option
+	// your metric can be dropped by the intake if it's too slow to complete
+	MetricTimestamp string `yaml:"metric_timestamp"`
 }
 
 type asmConfig struct {

--- a/pkg/collector/corechecks/oracle/custom_queries.go
+++ b/pkg/collector/corechecks/oracle/custom_queries.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -99,6 +100,10 @@ func (c *Check) CustomQueries() error {
 				reconnectOnConnectionError(c, &c.dbCustomQueries, err)
 				continue
 			}
+		}
+		var queryStartTimestamp float64
+		if q.MetricTimestamp == "query_start" {
+			queryStartTimestamp = float64(time.Now().UnixNano()) / float64(time.Second)
 		}
 		rows, err := c.dbCustomQueries.Queryx(q.Query)
 		if rows != nil {
@@ -193,8 +198,13 @@ func (c *Check) CustomQueries() error {
 			continue
 		}
 		for _, m := range metricRows {
-			log.Debugf("%s send metric %+v", c.logPrompt, m)
-			sendMetric(c, m.method, m.name, m.value, m.tags)
+			if q.MetricTimestamp == "query_start" {
+				log.Debugf("%s send metric %+v with timestamp %f", c.logPrompt, m, queryStartTimestamp)
+				sendMetricWithTimestamp(c, m.method, m.name, m.value, m.tags, queryStartTimestamp)
+			} else {
+				log.Debugf("%s send metric %+v", c.logPrompt, m)
+				sendMetric(c, m.method, m.name, m.value, m.tags)
+			}
 		}
 		commit(c)
 	}

--- a/pkg/collector/corechecks/oracle/sender_util.go
+++ b/pkg/collector/corechecks/oracle/sender_util.go
@@ -85,6 +85,27 @@ func sendMetric(c *Check, method metricType, metric string, value float64, tags 
 	metricFunction(metric, value, c.dbHostname, tags)
 }
 
+func sendMetricWithTimestamp(c *Check, method metricType, metric string, value float64, tags []string, timestamp float64) {
+	sender, err := c.GetSender()
+	if err != nil {
+		log.Errorf("failed to get metric sender: %s", err)
+		return
+	}
+	switch method {
+	case gauge:
+		if err := sender.GaugeWithTimestamp(metric, value, c.dbHostname, tags, timestamp); err != nil {
+			log.Errorf("failed to send gauge with timestamp: %s", err)
+		}
+	case count:
+		if err := sender.CountWithTimestamp(metric, value, c.dbHostname, tags, timestamp); err != nil {
+			log.Errorf("failed to send count with timestamp: %s", err)
+		}
+	default:
+		log.Warnf("metric_timestamp is not supported for metric type of %s, falling back to submission without timestamp", metric)
+		sendMetric(c, method, metric, value, tags)
+	}
+}
+
 func sendMetricWithDefaultTags(c *Check, method metricType, metric string, value float64) {
 	sendMetric(c, method, metric, value, c.tags)
 }

--- a/releasenotes/notes/add-oracle-custom-queries-timestamp-config-ea8f692c0ad3aad2.yaml
+++ b/releasenotes/notes/add-oracle-custom-queries-timestamp-config-ea8f692c0ad3aad2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new hidden option `metric_timestamp` to Oracle custom queries to allow setting the metrics timestamp to the query start.


### PR DESCRIPTION
### What does this PR do?

A new hidden option to the oracle integration to send custom queries with the query start as a timestamp.
Caveat: if the query is taking too long, or the customer time is wrong, the metrics might be rejected by the intake. That's why this option is hidden and disabled by default. 

### Motivation

Some custom queries can take a long time, and querying data that is stale.  

### Describe how you validated your changes

Ran unit tests on a real DB. 

### Additional Notes
