### PR TITLE
Add infra_mode host tag based on infrastructure_mode config

### DIFF
--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -131,6 +131,10 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 		hostTags = appendToHostTags(hostTags, []string{"env:" + env})
 	}
 
+	if infraMode := conf.GetString("infrastructure_mode"); infraMode != "" && infraMode != "full" {
+		hostTags = appendToHostTags(hostTags, []string{"infra_mode:" + infraMode})
+	}
+
 	gpuTags := conf.GetBool("collect_gpu_tags")
 	if gpuTags {
 		hostTags = appendToHostTags(hostTags, gpu.GetTags())

--- a/comp/metadata/host/hostimpl/hosttags/tags_test.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags_test.go
@@ -92,6 +92,15 @@ func TestMarshalEmptyHostTags(t *testing.T) {
 	assert.Equal(t, string(marshaled), `{"system":[]}`)
 }
 
+func TestGetWithInfraMode(t *testing.T) {
+	mockConfig, ctx := setupTest(t)
+	mockConfig.SetWithoutSource("infrastructure_mode", "basic")
+
+	hostTags := Get(ctx, false, mockConfig)
+	assert.NotNil(t, hostTags.System)
+	assert.Contains(t, hostTags.System, "infra_mode:basic")
+}
+
 func TestCombineExtraTags(t *testing.T) {
 	mockConfig, ctx := setupTest(t)
 	mockConfig.SetWithoutSource("tags", []string{"tag1:value1", "tag2", "tag4"})


### PR DESCRIPTION
### What does this PR do?

Adds an `infra_mode:<value>` host tag when the agent is configured with a non-default `infrastructure_mode` (i.e. `basic`, `end_user_device`, or `none`). The tag is omitted when the mode is `full` (the default) to avoid adding noise for the vast majority of agents.

The tag is added in `comp/metadata/host/hostimpl/hosttags/tags.go`, following the same pattern as the existing `env:` host tag.

### Motivation

`infrastructure_mode` controls which integrations are enabled on an agent. Without a corresponding tag on metrics, it is not possible to filter or segment metrics in Datadog dashboards/monitors by the mode the reporting agent is running in.

### Describe how you validated your changes

- Added `TestGetWithInfraMode` unit test in `comp/metadata/host/hostimpl/hosttags/tags_test.go` verifying that setting `infrastructure_mode: basic` produces an `infra_mode:basic` host tag.
- Ran the full package test suite: `go test -tags test ./comp/metadata/host/hostimpl/hosttags/...` — all tests pass.
- Manual QA

### Additional Notes

- The `full` mode (default) is intentionally excluded from tagging to keep metrics clean for the common case. Only agents running in a non-default mode will carry the tag.
- Host tags are applied server-side by the Datadog backend and therefore appear on all metrics for the host. For containerized/Fargate environments without host metadata, a follow-up could add the tag to `GetStaticTagsSlice()` in `pkg/util/tags/static_tags.go` for inline attachment.