### PR TITLE
[ACTP] enable PAR config rendering starting from v.7.77.0

### DIFF
--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -61,8 +61,8 @@ func mkContext(buildType string, osName string) context {
 			ECS:                 true,
 			TraceAgent:          true,
 			Kubelet:             true,
-			KubeApiServer:       true,  // TODO: remove when phasing out from node-agent
-			PrivateActionRunner: false, // NOTE: hidden until v7.77.0
+			KubeApiServer:       true,                // TODO: remove when phasing out from node-agent
+			PrivateActionRunner: true,
 		}
 	case "iot-agent":
 		return context{


### PR DESCRIPTION
### What does this PR do?
Enables Private Action Runner config rendering in `datadog.yaml`.

### Motivation
We integrate Private Action Runner with Datadog Agent and starting from v7.77 we want to enable config template rendering for it to help users set up their runners.

### Describe how you validated your changes
_TODO: Installed agent on Windows from CI artefacts and checked that `datadog.yaml` contains PAR template after installation._

### Additional Notes
