### PR TITLE
[WINA-2413] enable PAR config rendering starting from v.7.77.0

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4569,7 +4569,7 @@ api_key:
 #
 #     verbosity: normal
 {{ end -}}
-{{ if .PrivateActionRunner }}
+{{ if .PrivateActionRunner -}}
 
 #########################################
 ## Private Action Runner Configuration ##

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -61,8 +61,8 @@ func mkContext(buildType string, osName string) context {
 			ECS:                 true,
 			TraceAgent:          true,
 			Kubelet:             true,
-			KubeApiServer:       true,  // TODO: remove when phasing out from node-agent
-			PrivateActionRunner: false, // NOTE: hidden until v7.77.0
+			KubeApiServer:       true, // TODO: remove when phasing out from node-agent
+			PrivateActionRunner: true,
 		}
 	case "iot-agent":
 		return context{

--- a/releasenotes/notes/par-config-template-33f0ef1dd5cc4931.yaml
+++ b/releasenotes/notes/par-config-template-33f0ef1dd5cc4931.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``datadog.yaml`` configuration file now includes a commented-out
+    ``private_action_runner`` section on all platforms.


### PR DESCRIPTION
### What does this PR do?
Enables Private Action Runner config rendering in datadog.yaml.

### Motivation
We integrate Private Action Runner with Datadog Agent and starting from v7.77 we want to enable config template rendering for it to help users set up their runners.

### Describe how you validated your changes
Installed agent on Windows from CI artefacts ([pipeline-98840805](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/98840805)) and checked that `datadog.yaml` contains PAR template after installation.

### Additional Notes
