### PR TITLE
installer: emit logs to stdout for non-daemon calls

### DIFF
--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -29,6 +30,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+	pkglogslog "github.com/DataDog/datadog-agent/pkg/util/log/slog"
+	slogHandlers "github.com/DataDog/datadog-agent/pkg/util/log/slog/handlers"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -48,9 +52,25 @@ type cmd struct {
 	stopSigHandler context.CancelFunc
 }
 
+func setupStdoutLogger(_ *env.Env) {
+	level := "warn"
+	if envLevel, found := os.LookupEnv("DD_LOG_LEVEL"); found && envLevel != "" {
+		level = envLevel
+	}
+	formatter := func(_ context.Context, r slog.Record) string {
+		return r.Message + "\n"
+	}
+	handler := slogHandlers.NewFormat(formatter, os.Stdout)
+	loggerInterface := pkglogslog.NewWrapper(handler)
+	pkglog.SetupLogger(loggerInterface, level)
+}
+
 // newCmd creates a new command
 func newCmd(operation string) *cmd {
 	env := env.FromEnv()
+	if !env.IsFromDaemon {
+		setupStdoutLogger(env)
+	}
 	t := newTelemetry(env)
 	span, ctx := telemetry.StartSpanFromEnv(context.Background(), operation)
 	ctx, stop := context.WithCancel(ctx)


### PR DESCRIPTION
## Summary
- Initialize the `pkg/util/log` global logger in `newCmd()` when the installer binary is called directly (i.e., not from the daemon)
- Log level defaults to `warn`, overridable via `DD_LOG_LEVEL`
- When `DD_INSTALLER_FROM_DAEMON=true`, logger is not initialized so stdout stays clean for daemon JSON parsing
- This ensures `log.Warnf` calls in `installer.go` and `packages/*.go` are flushed instead of being silently dropped

## Test plan
- [ ] Run `./bin/installer/installer install-experiment <url>` directly — warn-level logs should appear on stdout
- [ ] Set `DD_LOG_LEVEL=info` and re-run — more verbose output
- [ ] Set `DD_INSTALLER_FROM_DAEMON=true` and run — no log output on stdout
- [ ] `go test ./pkg/fleet/installer/commands/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)