### PR TITLE
Fix process config missing some default

### DIFF
--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -108,7 +108,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "process_config.intervals.connections",
-			defaultValue: nil,
+			defaultValue: 30,
 		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
@@ -382,7 +382,7 @@ func TestEnvVarOverride(t *testing.T) {
 			key:      "process_config.intervals.connections",
 			env:      "DD_PROCESS_CONFIG_INTERVALS_CONNECTIONS",
 			value:    "10",
-			expected: "10",
+			expected: 10,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {
@@ -480,30 +480,6 @@ func TestProcBindEnvAndSetDefault(t *testing.T) {
 
 	// Make sure the default is set properly
 	assert.Equal(t, "asdf", cfg.GetString("process_config.foo.bar"))
-}
-
-func TestProcBindEnv(t *testing.T) {
-	cfg := newTestConf(t)
-	procBindEnv(cfg, "process_config.foo.bar")
-
-	envs := map[string]struct{}{}
-	for _, env := range cfg.GetEnvVars() {
-		envs[env] = struct{}{}
-	}
-
-	_, ok := envs["DD_PROCESS_CONFIG_FOO_BAR"]
-	assert.True(t, ok)
-
-	_, ok = envs["DD_PROCESS_AGENT_FOO_BAR"]
-	assert.True(t, ok)
-
-	// Make sure that DD_PROCESS_CONFIG_FOO_BAR shows up as unset by default
-	assert.False(t, cfg.IsSet("process_config.foo.bar"))
-
-	// Try and set DD_PROCESS_CONFIG_FOO_BAR and make sure it shows up in the config
-	t.Setenv("DD_PROCESS_CONFIG_FOO_BAR", "baz")
-	assert.True(t, cfg.IsSet("process_config.foo.bar"))
-	assert.Equal(t, "baz", cfg.GetString("process_config.foo.bar"))
 }
 
 func TestProcConfigEnabledTransform(t *testing.T) {

--- a/pkg/process/checks/host_info.go
+++ b/pkg/process/checks/host_info.go
@@ -70,10 +70,7 @@ func resolveHostName(config pkgconfigmodel.Reader, hostnameComp hostnameinterfac
 		return hostName, nil
 	}
 
-	var hostName string
-	if config.IsSet("hostname") {
-		hostName = config.GetString("hostname")
-	}
+	hostName := config.GetString("hostname")
 
 	if err := validate.ValidHostname(hostName); err != nil {
 		// lookup hostname if there is no config override or if the override is invalid

--- a/pkg/process/checks/interval.go
+++ b/pkg/process/checks/interval.go
@@ -27,17 +27,6 @@ const (
 	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
 
 	discoveryMinInterval = 10 * time.Minute
-
-	configIntervals = configPrefix + "intervals."
-
-	// The interval, in seconds, at which we will run each check. If you want consistent
-	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
-	// Defaults to 10s for normal checks and 2s for others.
-	configProcessInterval     = configIntervals + "process"
-	configRTProcessInterval   = configIntervals + "process_realtime"
-	configContainerInterval   = configIntervals + "container"
-	configRTContainerInterval = configIntervals + "container_realtime"
-	configConnectionsInterval = configIntervals + "connections"
 )
 
 var (
@@ -51,11 +40,11 @@ var (
 	}
 
 	configKeys = map[string]string{
-		ProcessCheckName:     configProcessInterval,
-		RTProcessCheckName:   configRTProcessInterval,
-		ContainerCheckName:   configContainerInterval,
-		RTContainerCheckName: configRTContainerInterval,
-		ConnectionsCheckName: configConnectionsInterval,
+		ProcessCheckName:     "process_config.intervals.process",
+		RTProcessCheckName:   "process_config.intervals.process_realtime",
+		ContainerCheckName:   "process_config.intervals.container",
+		RTContainerCheckName: "process_config.intervals.container_realtime",
+		ConnectionsCheckName: "process_config.intervals.connections",
 	}
 )
 
@@ -80,7 +69,7 @@ func GetInterval(cfg pkgconfigmodel.Reader, checkName string) time.Duration {
 	default:
 		defaultInterval := defaultIntervals[checkName]
 		configKey, ok := configKeys[checkName]
-		if !ok || !cfg.IsSet(configKey) {
+		if !ok {
 			return defaultInterval
 		}
 

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -40,12 +40,11 @@ import (
 
 const (
 	emptyCtrID                 = ""
-	configPrefix               = "process_config."
-	configCustomSensitiveWords = configPrefix + "custom_sensitive_words"
-	configScrubArgs            = configPrefix + "scrub_args"
-	configStripProcArgs        = configPrefix + "strip_proc_arguments"
-	configDisallowList         = configPrefix + "blacklist_patterns"
-	configIgnoreZombies        = configPrefix + "ignore_zombie_processes"
+	configCustomSensitiveWords = "process_config.custom_sensitive_words"
+	configScrubArgs            = "process_config.scrub_args"
+	configStripProcArgs        = "process_config.strip_proc_arguments"
+	configDisallowList         = "process_config.blacklist_patterns"
+	configIgnoreZombies        = "process_config.ignore_zombie_processes"
 )
 
 // NewProcessCheck returns an instance of the ProcessCheck.
@@ -687,17 +686,14 @@ func mergeProcWithSysprobeStats(procs map[int32]*procutil.Process, pStats *model
 
 func initScrubber(config pkgconfigmodel.Reader, scrubber *procutil.DataScrubber) {
 	// Enable/Disable the DataScrubber to obfuscate process args
-	if config.IsSet(configScrubArgs) {
-		scrubber.Enabled = config.GetBool(configScrubArgs)
-	}
+	scrubber.Enabled = config.GetBool(configScrubArgs)
 
 	if scrubber.Enabled { // Scrubber is enabled by default when it's created
 		log.Debug("Starting process collection with Scrubber enabled")
 	}
 
 	// A custom word list to enhance the default one used by the DataScrubber
-	if config.IsSet(configCustomSensitiveWords) {
-		words := config.GetStringSlice(configCustomSensitiveWords)
+	if words := config.GetStringSlice(configCustomSensitiveWords); len(words) > 0 {
 		scrubber.AddCustomSensitiveWords(words)
 		log.Debug("Adding custom sensitives words to Scrubber:", words)
 	}
@@ -712,15 +708,13 @@ func initScrubber(config pkgconfigmodel.Reader, scrubber *procutil.DataScrubber)
 func initDisallowList(config pkgconfigmodel.Reader) []*regexp.Regexp {
 	var disallowList []*regexp.Regexp
 	// A list of regex patterns that will exclude a process if matched.
-	if config.IsSet(configDisallowList) {
-		for _, b := range config.GetStringSlice(configDisallowList) {
-			r, err := regexp.Compile(b)
-			if err != nil {
-				log.Warnf("Ignoring invalid disallow list pattern: %s", b)
-				continue
-			}
-			disallowList = append(disallowList, r)
+	for _, b := range config.GetStringSlice(configDisallowList) {
+		r, err := regexp.Compile(b)
+		if err != nil {
+			log.Warnf("Ignoring invalid disallow list pattern: %s", b)
+			continue
 		}
+		disallowList = append(disallowList, r)
 	}
 	return disallowList
 }


### PR DESCRIPTION
### What does this PR do?

Now that the config has the default we no longer need custom logic to add them at runtime. Also removing string concatenation for config keys. As we found out for other module it increase binary size and make it harder for automated tool and human to track setting usage.

### Describe how you validated your changes

Running the CI,