### PR TITLE
[ABLD-8] Start replacing datadog-agent-integrations-py3-dependencies.rb with a BUILD file

### DIFF
--- a/packages/integrations/BUILD.bazel
+++ b/packages/integrations/BUILD.bazel
@@ -1,0 +1,116 @@
+"""Support for integrations.
+
+Replaces: datadog-agent-integrations-py3-dependencies
+"""
+
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_filegroup",
+    "pkg_mkdirs",
+)
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
+
+package(default_visibility = ["//packages:__subpackages__"])
+
+# All the parts
+pkg_filegroup(
+    name = "components",
+    srcs = [
+        "@unixodbc//:all_files",
+        "@freetds//:all_files",
+        # gstatus binary used by the glusterfs integration
+        "//deps/gstatus:all_files",
+        "//deps/nfsiostat:all_files",
+    ] + select({
+        "//packages/agent:linux_default": [
+            "//deps/msodbcsql18:all_files",
+        ],
+        "//packages/agent:linux_heroku": [],
+    }),
+    # Not clear if we want this here
+    # prefix = "/opt/datadog-agent",
+)
+
+fix_rpaths(
+    name = "components_fixed",
+    srcs = [":components"],
+)
+
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":components_fixed",
+    ],
+)
+
+# This target is only for the omnibus install
+pkg_install(
+    name = "install",
+    srcs = [":all_files"],
+)
+
+#dependency 'python3'
+#dependency 'setuptools3'
+#dependency 'openssl3'
+
+#   command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+#   " #{install_dir}/embedded/lib/libodbc.so" \
+#   " #{install_dir}/embedded/lib/libodbccr.so" \
+#   " #{install_dir}/embedded/lib/libodbcinst.so"
+
+#    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+#    " #{install_dir}/embedded/lib/libtdsodbc.so"
+
+"""
+    unless heroku_target?
+      pc_files = [
+          'gssrpc.pc',
+          'kadm-client.pc',
+          'kadm-server.pc',
+          'kdb.pc',
+          'krb5-gssapi.pc',
+          'krb5.pc',
+          'mit-krb5-gssapi.pc',
+          'mit-krb5.pc',
+        ]
+      lib_files = [
+          'krb5/plugins/tls/k5tls.so',
+          'krb5/plugins/kdb/db2.so',
+          'krb5/plugins/preauth/test.so',
+          'krb5/plugins/preauth/spake.so',
+          'krb5/plugins/preauth/pkinit.so',
+          'krb5/plugins/preauth/otp.so',
+          'libkadm5clnt_mit.so',
+          'libkrad.so',
+          'libverto.so',
+          'libk5crypto.so',
+          'libcom_err.so',
+          'libkadm5srv.so',
+          'libkrb5support.so',
+          'libgssrpc.so',
+          'libkrb5.so',
+          'libkadm5srv_mit.so',
+          'libkdb5.so',
+          'libgssapi_krb5.so',
+          'libkadm5clnt.so',
+        ]
+      bin_files = [
+          'kinit',
+        ]
+      
+      # (TODO(agent-build): Check if we still need pc files)
+      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+        + lib_files.map{ |l| "#{install_dir}/embedded/lib/#{l}" }.join(' ') \
+        + " " \
+        + pc_files.map{ |pc| "#{install_dir}/embedded/lib/pkgconfig/#{pc}" }.join(' ') \
+        + " " \
+        + bin_files.map{ |bin| "#{install_dir}/embedded/bin/#{bin}" }.join(' ') \
+        + " '#{install_dir}/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1'"
+    end
+
+  end
+end
+"""

--- a/packages/integrations/BUILD.bazel
+++ b/packages/integrations/BUILD.bazel
@@ -4,14 +4,7 @@ Replaces: datadog-agent-integrations-py3-dependencies
 """
 
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load(
-    "@rules_pkg//pkg:mappings.bzl",
-    "pkg_attributes",
-    "pkg_filegroup",
-    "pkg_mkdirs",
-)
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//bazel/rules:dd_agent_pkg_mklink.bzl", "dd_agent_pkg_mklink")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
@@ -64,6 +57,7 @@ pkg_install(
 #    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
 #    " #{install_dir}/embedded/lib/libtdsodbc.so"
 
+# buildifier: disable=no-effect
 """
     unless heroku_target?
       pc_files = [
@@ -100,7 +94,7 @@ pkg_install(
       bin_files = [
           'kinit',
         ]
-      
+
       # (TODO(agent-build): Check if we still need pc files)
       command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
         + lib_files.map{ |l| "#{install_dir}/embedded/lib/#{l}" }.join(' ') \


### PR DESCRIPTION
This may be a good place to start with rpath rewriting on a tree.
It contains a place where it would be inserted.