### PR TITLE
Read Write IPC for host profiler

### DIFF
--- a/cmd/host-profiler/subcommands/run/command.go
+++ b/cmd/host-profiler/subcommands/run/command.go
@@ -99,7 +99,7 @@ func run(collector collector.Component) error {
 
 func getRemoteTaggerOptions() []fx.Option {
 	return []fx.Option{
-		ipcfx.ModuleReadOnly(),
+		ipcfx.ModuleReadWrite(),
 		remoteTaggerFx.Module(tagger.NewRemoteParams()),
 	}
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds write permission to ipc comp, allowing it to create the token (and not crash) if the core agent hasn't done so.
### Motivation

### Describe how you validated your changes

### Additional Notes
