### PR TITLE
[PROF-13652][host-profiler][standalone] Figure out log ingestion

### DIFF
--- a/comp/host-profiler/collector/impl/otel_col_factories_test.go
+++ b/comp/host-profiler/collector/impl/otel_col_factories_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,5 +28,18 @@ func TestExtraFactoriesWithoutAgentCore_GetProcessors(t *testing.T) {
 
 	_, found = processors[attributesprocessor.NewFactory().Type()]
 	require.True(t, found)
+}
 
+func TestExtraFactoriesWithoutAgentCore_GetReceivers(t *testing.T) {
+	extraFactories := NewExtraFactoriesWithoutAgentCore()
+	factories, err := createFactories(extraFactories)()
+	require.NoError(t, err)
+
+	_, found := factories.Receivers[filelogreceiver.NewFactory().Type()]
+	assert.True(t, found, "filelog receiver should be registered for standalone mode")
+}
+
+func TestExtraFactoriesWithAgentCore_GetReceivers(t *testing.T) {
+	extra := extraFactoriesWithAgentCore{}
+	assert.Nil(t, extra.GetReceivers(), "agent core mode should not add extra receivers")
 }

--- a/go.mod
+++ b/go.mod
@@ -753,7 +753,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.145.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.145.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.145.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.145.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.145.0 // indirect


### PR DESCRIPTION
### What does this PR do?

In Bundled mode, the logs are sent to the backend from the agent.
How can we send Standalone’s logs to the backend for the two standalone possible deployments:
- Full host profiler in standalone mode
- Full host profiler in standalone mode + OTel Collector

### Motivation

This PR implements the approach outlined in the decision log: https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/6267799188/Draft+Figure+out+log+ingestion+for+host-profiler+standalone+mode

It restricts the addition of the filelog receiver component to standalone mode only.

### Describe how you validated your changes

- Added two unit tests to verify that the filelog component is exclusively added in standalone mode.
- Manually validated the logging strategy.

### Additional Notes
