### PR TITLE
[ACTP] Fix memory DoS via unbounded script output buffering

### DIFF
--- a/pkg/privateactionrunner/bundles/script/limited_writer.go
+++ b/pkg/privateactionrunner/bundles/script/limited_writer.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package com_datadoghq_script
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// maxOutputSize is the maximum combined stdout+stderr size allowed for script execution.
+const maxOutputSize = 10 * 1024 * 1024 // 10MB
+
+// errOutputLimitExceeded is returned when a script's output exceeds maxOutputSize.
+var errOutputLimitExceeded = fmt.Errorf("script output exceeded %dMB limit", maxOutputSize/(1024*1024))
+
+// limitedWriter wraps a bytes.Buffer and enforces a shared byte limit across
+// one or more writers. Once the combined written bytes reach the limit,
+// subsequent writes return errOutputLimitExceeded, which causes the OS to
+// deliver a broken-pipe signal to the child process.
+type limitedWriter struct {
+	buf     bytes.Buffer
+	shared  *int64 // shared counter across stdout+stderr writers
+	limit   int64
+	limited bool // sticky flag: once true, all further writes fail
+}
+
+// newLimitedWriterPair creates two limitedWriters that share the same byte
+// counter, so the combined output of stdout and stderr is bounded by limit.
+func newLimitedWriterPair(limit int64) (*limitedWriter, *limitedWriter) {
+	shared := new(int64)
+	return &limitedWriter{shared: shared, limit: limit},
+		&limitedWriter{shared: shared, limit: limit}
+}
+
+// Write implements io.Writer. It writes as many bytes as fit within the
+// remaining budget and returns an error once the limit is reached.
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if lw.limited {
+		return 0, errOutputLimitExceeded
+	}
+
+	remaining := lw.limit - *lw.shared
+	if remaining <= 0 {
+		lw.limited = true
+		return 0, errOutputLimitExceeded
+	}
+
+	toWrite := p
+	if int64(len(p)) > remaining {
+		toWrite = p[:remaining]
+		lw.limited = true
+	}
+
+	n, err := lw.buf.Write(toWrite)
+	*lw.shared += int64(n)
+	if err != nil {
+		return n, err
+	}
+
+	if lw.limited {
+		return n, errOutputLimitExceeded
+	}
+	return n, nil
+}
+
+// String returns the buffered output.
+func (lw *limitedWriter) String() string {
+	return lw.buf.String()
+}
+
+// Len returns the number of bytes in this writer's buffer.
+func (lw *limitedWriter) Len() int {
+	return lw.buf.Len()
+}
+
+// LimitReached returns true if the combined output limit was exceeded.
+func (lw *limitedWriter) LimitReached() bool {
+	return lw.limited
+}

--- a/pkg/privateactionrunner/bundles/script/limited_writer.go
+++ b/pkg/privateactionrunner/bundles/script/limited_writer.go
@@ -7,14 +7,19 @@ package com_datadoghq_script
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"sync/atomic"
 )
 
-// maxOutputSize is the maximum combined stdout+stderr size allowed for script execution.
-const maxOutputSize = 10 * 1024 * 1024 // 10MB
+const defaultMaxOutputSize = 10 * 1024 * 1024 // 10MB
 
-// errOutputLimitExceeded is returned when a script's output exceeds maxOutputSize.
-var errOutputLimitExceeded = fmt.Errorf("script output exceeded %dMB limit", maxOutputSize/(1024*1024))
+// errOutputLimitExceeded is a sentinel used for errors.Is matching.
+var errOutputLimitExceeded = errors.New("script output limit exceeded")
+
+func newOutputLimitError(limit int64) error {
+	return fmt.Errorf("script output exceeded %dMB limit: %w", limit/(1024*1024), errOutputLimitExceeded)
+}
 
 // limitedWriter wraps a bytes.Buffer and enforces a shared byte limit across
 // one or more writers. Once the combined written bytes reach the limit,
@@ -22,27 +27,25 @@ var errOutputLimitExceeded = fmt.Errorf("script output exceeded %dMB limit", max
 // deliver a broken-pipe signal to the child process.
 type limitedWriter struct {
 	buf     bytes.Buffer
-	shared  *int64 // shared counter across stdout+stderr writers
+	shared  *atomic.Int64 // shared counter across stdout+stderr writers
 	limit   int64
 	limited bool // sticky flag: once true, all further writes fail
 }
 
-// newLimitedWriterPair creates two limitedWriters that share the same byte
-// counter, so the combined output of stdout and stderr is bounded by limit.
-func newLimitedWriterPair(limit int64) (*limitedWriter, *limitedWriter) {
-	shared := new(int64)
+// newLimitedStdoutStderrWritersPair creates two limitedWriters that share the same atomic
+// byte counter, so the combined output of stdout and stderr is bounded by limit.
+func newLimitedStdoutStderrWritersPair(limit int64) (*limitedWriter, *limitedWriter) {
+	shared := &atomic.Int64{}
 	return &limitedWriter{shared: shared, limit: limit},
 		&limitedWriter{shared: shared, limit: limit}
 }
 
-// Write implements io.Writer. It writes as many bytes as fit within the
-// remaining budget and returns an error once the limit is reached.
 func (lw *limitedWriter) Write(p []byte) (int, error) {
 	if lw.limited {
 		return 0, errOutputLimitExceeded
 	}
 
-	remaining := lw.limit - *lw.shared
+	remaining := lw.limit - lw.shared.Load()
 	if remaining <= 0 {
 		lw.limited = true
 		return 0, errOutputLimitExceeded
@@ -55,7 +58,7 @@ func (lw *limitedWriter) Write(p []byte) (int, error) {
 	}
 
 	n, err := lw.buf.Write(toWrite)
-	*lw.shared += int64(n)
+	lw.shared.Add(int64(n))
 	if err != nil {
 		return n, err
 	}
@@ -66,12 +69,10 @@ func (lw *limitedWriter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// String returns the buffered output.
 func (lw *limitedWriter) String() string {
 	return lw.buf.String()
 }
 
-// Len returns the number of bytes in this writer's buffer.
 func (lw *limitedWriter) Len() int {
 	return lw.buf.Len()
 }

--- a/pkg/privateactionrunner/bundles/script/limited_writer_test.go
+++ b/pkg/privateactionrunner/bundles/script/limited_writer_test.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package com_datadoghq_script
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedWriter_UnderLimit(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(100)
+
+	n, err := stdout.Write([]byte("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	n, err = stderr.Write([]byte("world"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	assert.Equal(t, "hello", stdout.String())
+	assert.Equal(t, "world", stderr.String())
+	assert.False(t, stdout.LimitReached())
+	assert.False(t, stderr.LimitReached())
+}
+
+func TestLimitedWriter_ExactLimit(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(10)
+
+	n, err := stdout.Write([]byte("12345"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	n, err = stderr.Write([]byte("67890"))
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	assert.Equal(t, "12345", stdout.String())
+	assert.Equal(t, "67890", stderr.String())
+	assert.False(t, stdout.LimitReached())
+	assert.False(t, stderr.LimitReached())
+}
+
+func TestLimitedWriter_ExceedsLimit(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(10)
+
+	n, err := stdout.Write([]byte("12345678"))
+	require.NoError(t, err)
+	assert.Equal(t, 8, n)
+
+	// This write exceeds the combined limit of 10; only 2 bytes should be written.
+	n, err = stderr.Write([]byte("abcdef"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 2, n)
+
+	assert.Equal(t, "12345678", stdout.String())
+	assert.Equal(t, "ab", stderr.String())
+	assert.True(t, stderr.LimitReached())
+}
+
+func TestLimitedWriter_SubsequentWritesAfterLimit(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(5)
+
+	_, err := stdout.Write([]byte("12345"))
+	require.NoError(t, err)
+
+	// Limit reached on next write
+	n, err := stderr.Write([]byte("x"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 0, n)
+	assert.True(t, stderr.LimitReached())
+
+	// Further writes to stdout also fail
+	n, err = stdout.Write([]byte("y"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 0, n)
+	assert.True(t, stdout.LimitReached())
+}
+
+func TestLimitedWriter_SingleWriterExceedsLimit(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(5)
+
+	n, err := stdout.Write([]byte("0123456789"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "01234", stdout.String())
+	assert.True(t, stdout.LimitReached())
+
+	// stderr should also be blocked by the shared counter
+	n, err = stderr.Write([]byte("a"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 0, n)
+}
+
+func TestLimitedWriter_SharedCounter(t *testing.T) {
+	stdout, stderr := newLimitedWriterPair(10)
+
+	// Alternate writes between stdout and stderr
+	stdout.Write([]byte("aa"))  // shared = 2
+	stderr.Write([]byte("bbb")) // shared = 5
+	stdout.Write([]byte("cc"))  // shared = 7
+
+	// 3 bytes remaining in the shared budget
+	n, err := stderr.Write([]byte("dddd"))
+	assert.ErrorIs(t, err, errOutputLimitExceeded)
+	assert.Equal(t, 3, n)
+
+	assert.Equal(t, "aacc", stdout.String())
+	assert.Equal(t, "bbbddd", stderr.String())
+}

--- a/pkg/privateactionrunner/bundles/script/run_predefined_powershell_script.go
+++ b/pkg/privateactionrunner/bundles/script/run_predefined_powershell_script.go
@@ -96,14 +96,14 @@ func (h *RunPredefinedPowershellScriptHandler) Run(
 	}
 
 	cmd := newPowershellCommand(ctx, evaluatedScript, script.AllowedEnvVars)
-	stdoutWriter, stderrWriter := newLimitedWriterPair(maxOutputSize)
+	stdoutWriter, stderrWriter := newLimitedStdoutStderrWritersPair(defaultMaxOutputSize)
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 	start := time.Now()
 	err = cmd.Run()
 
 	if stdoutWriter.LimitReached() || stderrWriter.LimitReached() {
-		return nil, errOutputLimitExceeded
+		return nil, newOutputLimitError(defaultMaxOutputSize)
 	}
 
 	if err != nil && !inputs.NoFailOnError {

--- a/pkg/privateactionrunner/bundles/script/run_predefined_script.go
+++ b/pkg/privateactionrunner/bundles/script/run_predefined_script.go
@@ -8,7 +8,6 @@
 package com_datadoghq_script
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -79,30 +78,28 @@ func (h *RunPredefinedScriptHandler) Run(
 	if err != nil {
 		return nil, fmt.Errorf("invalid command arguments: %w", err)
 	}
-	var stdoutBuffer bytes.Buffer
-	cmd.Stdout = &stdoutBuffer
-	var stderrBuffer bytes.Buffer
-	cmd.Stderr = &stderrBuffer
+	stdoutWriter, stderrWriter := newLimitedWriterPair(maxOutputSize)
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 	start := time.Now()
 	err = cmd.Run()
 
-	const maxOutputSize = 10 * 1024 * 1024 // 10MB
-	if stdoutBuffer.Len()+stderrBuffer.Len() > maxOutputSize {
-		return nil, errors.New("script output exceeded 10MB limit")
+	if stdoutWriter.LimitReached() || stderrWriter.LimitReached() {
+		return nil, errOutputLimitExceeded
 	}
 
 	if err != nil && !inputs.NoFailOnError {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return nil, fmt.Errorf("script execution timed out after %d seconds", inputs.Timeout)
 		}
-		return nil, fmt.Errorf("failed to execute command: %w, stderr %s", err, stderrBuffer.String())
+		return nil, fmt.Errorf("failed to execute command: %w, stderr %s", err, stderrWriter.String())
 	}
 
 	return &RunPredefinedScriptOutputs{
 		ExecutedCommand: cmd.String(),
 		ExitCode:        cmd.ProcessState.ExitCode(),
-		Stdout:          formatOutput(stdoutBuffer.String(), inputs.NoStripTrailingNewline),
-		Stderr:          formatOutput(stderrBuffer.String(), inputs.NoStripTrailingNewline),
+		Stdout:          formatOutput(stdoutWriter.String(), inputs.NoStripTrailingNewline),
+		Stderr:          formatOutput(stderrWriter.String(), inputs.NoStripTrailingNewline),
 		DurationMillis:  int(time.Since(start).Milliseconds()),
 	}, nil
 }

--- a/pkg/privateactionrunner/bundles/script/run_predefined_script.go
+++ b/pkg/privateactionrunner/bundles/script/run_predefined_script.go
@@ -78,14 +78,14 @@ func (h *RunPredefinedScriptHandler) Run(
 	if err != nil {
 		return nil, fmt.Errorf("invalid command arguments: %w", err)
 	}
-	stdoutWriter, stderrWriter := newLimitedWriterPair(maxOutputSize)
+	stdoutWriter, stderrWriter := newLimitedStdoutStderrWritersPair(defaultMaxOutputSize)
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 	start := time.Now()
 	err = cmd.Run()
 
 	if stdoutWriter.LimitReached() || stderrWriter.LimitReached() {
-		return nil, errOutputLimitExceeded
+		return nil, newOutputLimitError(defaultMaxOutputSize)
 	}
 
 	if err != nil && !inputs.NoFailOnError {

--- a/pkg/privateactionrunner/bundles/script/run_shell_script_experimental.go
+++ b/pkg/privateactionrunner/bundles/script/run_shell_script_experimental.go
@@ -84,14 +84,14 @@ func (h *RunShellScriptHandler) Run(
 	if err != nil {
 		return nil, fmt.Errorf("invalid command arguments: %w", err)
 	}
-	stdoutWriter, stderrWriter := newLimitedWriterPair(maxOutputSize)
+	stdoutWriter, stderrWriter := newLimitedStdoutStderrWritersPair(maxOutputSize)
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
 	start := time.Now()
 	err = cmd.Run()
 
 	if stdoutWriter.LimitReached() || stderrWriter.LimitReached() {
-		return nil, errOutputLimitExceeded
+		return nil, newOutputLimitError(defaultMaxOutputSize)
 	}
 
 	stdErr := sanitizeErrorMessage(scriptFile.Name(), stderrWriter.String())

--- a/pkg/privateactionrunner/bundles/script/run_shell_script_experimental.go
+++ b/pkg/privateactionrunner/bundles/script/run_shell_script_experimental.go
@@ -8,7 +8,6 @@
 package com_datadoghq_script
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -85,14 +84,17 @@ func (h *RunShellScriptHandler) Run(
 	if err != nil {
 		return nil, fmt.Errorf("invalid command arguments: %w", err)
 	}
-	var stdoutBuffer bytes.Buffer
-	cmd.Stdout = &stdoutBuffer
-	var stderrBuffer bytes.Buffer
-	cmd.Stderr = &stderrBuffer
+	stdoutWriter, stderrWriter := newLimitedWriterPair(maxOutputSize)
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
 	start := time.Now()
 	err = cmd.Run()
 
-	stdErr := sanitizeErrorMessage(scriptFile.Name(), stderrBuffer.String())
+	if stdoutWriter.LimitReached() || stderrWriter.LimitReached() {
+		return nil, errOutputLimitExceeded
+	}
+
+	stdErr := sanitizeErrorMessage(scriptFile.Name(), stderrWriter.String())
 
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -106,7 +108,7 @@ func (h *RunShellScriptHandler) Run(
 	return &RunShellScriptOutputs{
 		ExecutedCommand: cmd.String(),
 		ExitCode:        cmd.ProcessState.ExitCode(),
-		Stdout:          formatOutput(stdoutBuffer.String(), inputs.NoStripTrailingNewline),
+		Stdout:          formatOutput(stdoutWriter.String(), inputs.NoStripTrailingNewline),
 		Stderr:          formatOutput(stdErr, inputs.NoStripTrailingNewline),
 		DurationMillis:  int(time.Since(start).Milliseconds()),
 	}, nil


### PR DESCRIPTION
## Summary

Enforce the 10MB script output limit during execution, not after, preventing memory DoS from unbounded buffering.

## Description

cmd.Stdout and cmd.Stderr used raw bytes.Buffer, so a script could write gigabytes into process memory before cmd.Run() returned and the size check ran. The fix introduces a limitedWriter (shared counter across stdout/stderr) that returns an error mid-write once the limit is hit, breaking the pipe to the child process. The experimental shell script runner had no size limit at all.

## Changes

- limited_writer.go — new limitedWriter type with shared byte counter and newLimitedWriterPair() constructor
- limited_writer_test.go — 6 unit tests covering under/at/over limit, sticky failure, and shared counter behavior
- run_predefined_script.go — replace bytes.Buffer with limitedWriter pair
- run_predefined_powershell_script.go — same
- run_shell_script_experimental.go — same (added limit enforcement where none existed)