### PR TITLE
Testbench: ignore small parquet files + add tasks to launch and build the UI

### DIFF
--- a/comp/anomalydetection/recorder/impl/parquet_reader.go
+++ b/comp/anomalydetection/recorder/impl/parquet_reader.go
@@ -134,7 +134,17 @@ func findParquetFiles(dirPath string) ([]string, error) {
 }
 
 // readParquetFile reads a single parquet file and extracts FGM metrics.
+// Will return an empty slice if the file is too small (no error).
 func readParquetFile(filePath string) ([]FGMMetric, error) {
+	// Ensure file is not too small
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("statting file: %w", err)
+	}
+	if info.Size() < minParquetFileSize {
+		return []FGMMetric{}, nil
+	}
+
 	// Open the parquet file
 	f, err := os.Open(filePath)
 	if err != nil {

--- a/comp/anomalydetection/recorder/impl/parquet_reader.go
+++ b/comp/anomalydetection/recorder/impl/parquet_reader.go
@@ -48,12 +48,13 @@ func NewParquetReader(dirPath string) (*ParquetReader, error) {
 		return nil, fmt.Errorf("no parquet files found in %s", dirPath)
 	}
 
-	// Read all metrics from all files
+	// Read all metrics from all files, skipping any that fail to parse.
 	var allMetrics []FGMMetric
 	for _, filePath := range parquetFiles {
 		metrics, err := readParquetFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("reading %s: %w", filePath, err)
+			fmt.Printf("[parquet-reader] Skipping %s: %v\n", filePath, err)
+			continue
 		}
 		allMetrics = append(allMetrics, metrics...)
 	}
@@ -105,7 +106,11 @@ func (r *ParquetReader) EndTime() int64 {
 	return r.metrics[len(r.metrics)-1].Time
 }
 
-// findParquetFiles recursively finds all .parquet files in a directory.
+// minParquetFileSize is the minimum valid size for a parquet file
+const minParquetFileSize = 20
+
+// findParquetFiles recursively finds all .parquet files in a directory,
+// skipping files that are too small to be valid parquet files.
 func findParquetFiles(dirPath string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
@@ -113,6 +118,10 @@ func findParquetFiles(dirPath string) ([]string, error) {
 			return err
 		}
 		if !info.IsDir() && strings.HasSuffix(path, ".parquet") {
+			if info.Size() < minParquetFileSize {
+				fmt.Printf("[parquet-reader] Skipping %s: file too small (%d bytes)\n", path, info.Size())
+				return nil
+			}
 			files = append(files, path)
 		}
 		return nil

--- a/comp/observer/impl/parquet_reader.go
+++ b/comp/observer/impl/parquet_reader.go
@@ -47,12 +47,13 @@ func NewParquetReader(dirPath string) (*ParquetReader, error) {
 		return nil, fmt.Errorf("no parquet files found in %s", dirPath)
 	}
 
-	// Read all metrics from all files
+	// Read all metrics from all files, skipping any that fail to parse.
 	var allMetrics []FGMMetric
 	for _, filePath := range parquetFiles {
 		metrics, err := readParquetFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("reading %s: %w", filePath, err)
+			fmt.Printf("[parquet-reader] Skipping %s: %v\n", filePath, err)
+			continue
 		}
 		allMetrics = append(allMetrics, metrics...)
 	}
@@ -104,7 +105,11 @@ func (r *ParquetReader) EndTime() int64 {
 	return r.metrics[len(r.metrics)-1].Time
 }
 
-// findParquetFiles recursively finds all .parquet files in a directory.
+// minParquetFileSize is the minimum valid size for a parquet file
+const minParquetFileSize = 20
+
+// findParquetFiles recursively finds all .parquet files in a directory,
+// skipping files that are too small to be valid parquet files.
 func findParquetFiles(dirPath string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
@@ -112,6 +117,10 @@ func findParquetFiles(dirPath string) ([]string, error) {
 			return err
 		}
 		if !info.IsDir() && strings.HasSuffix(path, ".parquet") {
+			if info.Size() < minParquetFileSize {
+				fmt.Printf("[parquet-reader] Skipping %s: file too small (%d bytes)\n", path, info.Size())
+				return nil
+			}
 			files = append(files, path)
 		}
 		return nil

--- a/comp/observer/impl/parquet_reader.go
+++ b/comp/observer/impl/parquet_reader.go
@@ -52,8 +52,7 @@ func NewParquetReader(dirPath string) (*ParquetReader, error) {
 	for _, filePath := range parquetFiles {
 		metrics, err := readParquetFile(filePath)
 		if err != nil {
-			fmt.Printf("[parquet-reader] Skipping %s: %v\n", filePath, err)
-			continue
+			return nil, fmt.Errorf("reading %s: %w", filePath, err)
 		}
 		allMetrics = append(allMetrics, metrics...)
 	}
@@ -133,7 +132,17 @@ func findParquetFiles(dirPath string) ([]string, error) {
 }
 
 // readParquetFile reads a single parquet file and extracts FGM metrics.
+// Will return an empty slice if the file is too small (no error).
 func readParquetFile(filePath string) ([]FGMMetric, error) {
+	// Ensure file is not too small
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("statting file: %w", err)
+	}
+	if info.Size() < minParquetFileSize {
+		return []FGMMetric{}, nil
+	}
+
 	// Open the parquet file
 	f, err := os.Open(filePath)
 	if err != nil {

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -64,6 +64,7 @@ from tasks import (
     process_agent,
     protobuf,
     python_version,
+    q,
     quality_gates,
     release,
     rtloader,
@@ -251,6 +252,7 @@ ns.add_collection(worktree)
 ns.add_collection(sbomgen)
 ns.add_collection(pkg_template)
 ns.add_collection(virustotal)
+ns.add_collection(q)
 ns.configure(
     {
         "run": {

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -1,0 +1,29 @@
+from invoke import task
+
+
+# --- Build ---
+@task
+def build_testbench(ctx):
+    """
+    Builds the observer-testbench binary.
+    """
+    ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench")
+
+
+@task
+def launch_testbench(ctx, scenarios_dir: str = "./comp/observer/anomaly_datasets_converted", build: bool = False):
+    """
+    Will launch both the observer-testbench backend and UI.
+
+    Args:
+        scenarios_dir: The directory containing the scenarios to load.
+        build: Whether to build the observer-testbench binary.
+    """
+    if build:
+        print("Building observer-testbench...")
+        build_testbench(ctx)
+
+    print("Launching observer-testbench backend and UI, use ^C to exit")
+    ctx.run(
+        f"bin/observer-testbench --scenarios-dir {scenarios_dir} & ( cd cmd/observer-testbench/ui && npm install && npm run dev ) &"
+    )


### PR DESCRIPTION
### What does this PR do?

This:
- Ignores parquet files that are too small such that the testbench doesn't crash (thus we can directly record in the scenarios directory)
- Adds tasks like `dda inv q.launch-testbench` to launch the testbench backend and UI in an easier way

### Motivation

### Describe how you validated your changes

### Additional Notes
