### PR TITLE
[ACTP] DCA extra config

### DIFF
--- a/cmd/cluster-agent/command/command.go
+++ b/cmd/cluster-agent/command/command.go
@@ -30,6 +30,8 @@ type GlobalParams struct {
 	// ConfFilePath holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line
 	ConfFilePath string
+	// ExtraConfFilePath represents the paths to additional configuration files.
+	ExtraConfFilePath []string
 	// NoColor is a flag to disable color output
 	NoColor bool
 }
@@ -53,6 +55,7 @@ metadata for their metrics.`,
 	}
 
 	agentCmd.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "cfgpath", "c", "", "path to directory containing datadog-agent.yaml")
+	agentCmd.PersistentFlags().StringArrayVarP(&globalParams.ExtraConfFilePath, "extracfgpath", "E", []string{}, "specify additional configuration files to be loaded sequentially after the main datadog-agent.yaml")
 
 	// github.com/fatih/color sets its global color.NoColor to a default value based on
 	// whether the process is running in a tty.  So, we only want to override that when

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -158,7 +158,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			return fxutil.OneShot(start,
 				fx.Supply(globalParams),
 				fx.Supply(core.BundleParams{
-					ConfigParams: config.NewClusterAgentParams(globalParams.ConfFilePath),
+					ConfigParams: config.NewClusterAgentParams(globalParams.ConfFilePath, config.WithExtraConfFiles(globalParams.ExtraConfFilePath)),
 					LogParams:    log.ForDaemon(command.LoggerName, "log_file", defaultpaths.DCALogFile),
 				}),
 				core.Bundle(core.WithSecrets()),


### PR DESCRIPTION
### What does this PR do?
Extend the DCA `start` command to read extra config for private action runner.

### Motivation
The end goal is to create a config map and mount it in the dca pod when installing the agent via the operator. This will allow us to run
```bash
datadog-cluster-agent start -E /etc/datadog/privateactionrunner.yaml
```

### Describe how you validated your changes
I started the dca in a local k8s cluster following [these instructions](https://datadoghq.atlassian.net/wiki/spaces/ACT/pages/5394760254/PAR+in+agent+dev+setup#Private-runner-in-Datadog-Cluster-Agent-(DCA))

### Additional Notes
