### PR TITLE
Rework portlist poller to open `/proc/net/*` fresh on each poll

### DIFF
--- a/pkg/util/port/port.go
+++ b/pkg/util/port/port.go
@@ -19,10 +19,5 @@ func GetUsedPorts() ([]Port, error) {
 		IncludeLocalhost: true,
 	}
 	ports, _, err := poller.Poll()
-	if err != nil {
-		return nil, err
-	}
-
-	err = poller.Close()
 	return ports, err
 }

--- a/pkg/util/port/portlist/poller.go
+++ b/pkg/util/port/portlist/poller.go
@@ -41,8 +41,6 @@ type Poller struct {
 
 // osImpl is the OS-specific implementation of getting the open listening ports.
 type osImpl interface {
-	Close() error
-
 	// AppendListeningPorts appends to base (which must have length 0 but
 	// optional capacity) the list of listening ports. The Port struct should be
 	// populated as completely as possible. Another pass will not add anything
@@ -57,17 +55,6 @@ func (p *Poller) setPrev(pl List) {
 	// Make a copy, as the pass in pl slice aliases pl.scratch and we don't want
 	// that to except to the caller.
 	p.prev = slices.Clone(pl)
-}
-
-// Close closes the Poller.
-func (p *Poller) Close() error {
-	if p.initErr != nil {
-		return p.initErr
-	}
-	if p.os == nil {
-		return nil
-	}
-	return p.os.Close()
 }
 
 // Poll returns the list of listening ports, if changed from

--- a/pkg/util/port/portlist/poller_darwin.go
+++ b/pkg/util/port/portlist/poller_darwin.go
@@ -50,8 +50,6 @@ func newMacOSImpl(includeLocalhost bool) osImpl {
 	}
 }
 
-func (*macOSImpl) Close() error { return nil }
-
 func (im *macOSImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 	var err error
 	im.portsBuf, err = im.appendListeningPortsNetstat(im.portsBuf[:0])

--- a/pkg/util/port/portlist/poller_darwin_test.go
+++ b/pkg/util/port/portlist/poller_darwin_test.go
@@ -24,7 +24,6 @@ func benchmarkGetList(b *testing.B, incremental bool) {
 	if p.initErr != nil {
 		b.Skip(p.initErr)
 	}
-	b.Cleanup(func() { p.Close() })
 	for i := 0; i < b.N; i++ {
 		pl, err := p.getList()
 		if err != nil {

--- a/pkg/util/port/portlist/poller_linux.go
+++ b/pkg/util/port/portlist/poller_linux.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"unsafe"
 
 	"go4.org/mem"
@@ -31,7 +30,6 @@ func (p *Poller) init() {
 }
 
 type linuxImpl struct {
-	procNetFiles    []*os.File // seeked to start & reused between calls
 	readlinkPathBuf []byte
 
 	known            map[string]*portMeta // inode string => metadata
@@ -48,41 +46,12 @@ type portMeta struct {
 
 var eofReader = bytes.NewReader(nil)
 
-func newLinuxImplBase(includeLocalhost bool) *linuxImpl {
+func newLinuxImpl(includeLocalhost bool) *linuxImpl {
 	return &linuxImpl{
 		br:               bufio.NewReader(eofReader),
 		known:            map[string]*portMeta{},
 		includeLocalhost: includeLocalhost,
 	}
-}
-
-func newLinuxImpl(includeLocalhost bool) osImpl {
-	li := newLinuxImplBase(includeLocalhost)
-	for _, name := range []string{
-		"/proc/net/tcp",
-		"/proc/net/tcp6",
-		"/proc/net/udp",
-		"/proc/net/udp6",
-	} {
-		f, err := os.Open(name)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			log.Errorf("diagnose port-conflict poller warning; ignoring: %v", err)
-			continue
-		}
-		li.procNetFiles = append(li.procNetFiles, f)
-	}
-	return li
-}
-
-func (li *linuxImpl) Close() error {
-	for _, f := range li.procNetFiles {
-		f.Close()
-	}
-	li.procNetFiles = nil
-	return nil
 }
 
 const (
@@ -103,25 +72,24 @@ func (li *linuxImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 		pm.keep = false
 	}
 
-	for i, f := range li.procNetFiles {
-		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			if !errors.Is(err, syscall.ESPIPE) {
-				return nil, err
+	for _, name := range []string{
+		"/proc/net/tcp",
+		"/proc/net/tcp6",
+		"/proc/net/udp",
+		"/proc/net/udp6",
+	} {
+		f, err := os.Open(name)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Errorf("diagnose port-conflict poller warning; ignoring: %v", err)
 			}
-			// Some kernels may return `illegal seek` on `/proc/net/*` files; re-open to
-			// read from the beginning instead of skipping the file entirely.
-			// See https://github.com/tailscale/tailscale/issues/16966
-			newF, err := os.Open(f.Name())
-			if err != nil {
-				continue
-			}
-			f.Close()
-			li.procNetFiles[i] = newF
-			f = newF
+			continue
 		}
 		br.Reset(f)
-		if err := li.parseProcNetFile(br, filepath.Base(f.Name())); err != nil {
-			return nil, fmt.Errorf("parsing %q: %w", f.Name(), err)
+		err = li.parseProcNetFile(br, filepath.Base(name))
+		f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("parsing %q: %w", name, err)
 		}
 	}
 

--- a/pkg/util/port/portlist/poller_linux_test.go
+++ b/pkg/util/port/portlist/poller_linux_test.go
@@ -97,7 +97,7 @@ func TestParsePorts(t *testing.T) {
 			if tt.file != "" {
 				file = tt.file
 			}
-			li := newLinuxImplBase(false)
+			li := newLinuxImpl(false)
 			err := li.parseProcNetFile(r, file)
 			if err != nil {
 				t.Fatal(err)
@@ -126,7 +126,7 @@ func BenchmarkParsePorts(b *testing.B) {
 		contents.WriteString("   3: 69050120005716BC64906EBE009ECD4D:D506 0047062600000000000000006E171268:01BB 01 00000000:00000000 02:0000009E 00000000  1000        0 151042856 2 0000000000000000 21 4 28 10 -1\n")
 	}
 
-	li := newLinuxImplBase(false)
+	li := newLinuxImpl(false)
 
 	r := bytes.NewReader(contents.Bytes())
 	br := bufio.NewReader(&contents)

--- a/pkg/util/port/portlist/poller_test.go
+++ b/pkg/util/port/portlist/poller_test.go
@@ -6,13 +6,9 @@
 package portlist
 
 import (
-	"errors"
-	"io"
 	"net"
-	"os"
 	"reflect"
 	"runtime"
-	"syscall"
 	"testing"
 )
 
@@ -199,20 +195,6 @@ func TestPoller(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows -- not implemented yet")
 	}
-	if runtime.GOOS == "linux" {
-		// Some kernels may return `illegal seek` on `/proc/net/tcp`s files, ignore it.
-		// See https://github.com/tailscale/tailscale/issues/16966
-		f, err := os.Open("/proc/net/tcp")
-		if err != nil {
-			t.Skipf("failed to open /proc/net/tcp: %v", err)
-		}
-		_, err = f.Seek(0, io.SeekStart)
-		_ = f.Close()
-		if errors.Is(err, syscall.ESPIPE) {
-			t.Skip("linux kernel returns illegal seek on /proc/net/tcp, skipping")
-		}
-	}
-
 	var p Poller
 	p.IncludeLocalhost = true
 	get := func(t *testing.T) []Port {

--- a/pkg/util/port/portlist/poller_test.go
+++ b/pkg/util/port/portlist/poller_test.go
@@ -252,23 +252,3 @@ func TestPoller(t *testing.T) {
 		t.Error("unexpectedly found ephemeral port in p3, after it was closed", port)
 	}
 }
-
-func TestClose(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows -- not implemented yet")
-	}
-	var p Poller
-	err := p.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-	p = Poller{}
-	_, _, err = p.Poll()
-	if err != nil {
-		t.Skipf("skipping due to poll error: %v", err)
-	}
-	err = p.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-}

--- a/pkg/util/port/portlist/poller_windows.go
+++ b/pkg/util/port/portlist/poller_windows.go
@@ -41,7 +41,6 @@ func newWindowsImpl(includeLocalhost bool) osImpl {
 		includeLocalhost: includeLocalhost,
 	}
 }
-func (*windowsImpl) Close() error { return nil }
 
 func (im *windowsImpl) AppendListeningPorts(base []Port) ([]Port, error) {
 	tab, err := GetConnTable()


### PR DESCRIPTION
### What does this PR do?
After a tentative fix, the present change implements the consensus established in a [review comment](https://github.com/DataDog/datadog-agent/pull/46927#discussion_r2854260147).

It replaces the fd-caching + seek pattern with plain open-per-poll:
- drops `procNetFiles []*os.File` from `linuxImpl`,
- opens each `/proc/net/{tcp,tcp4,udp,udp6}` anew in `AppendListeningPorts`, closed immediately after parsing,
- eliminates `lseek` on `/proc/net/*` entirely, sidestepping the `ESPIPE` [regression introduced in Linux 6.6.102/6.12.42](https://lore.kernel.org/all/20250815195616.64497967@chagall.paradoxon.rec/).
    
With no fds to release, `Close()` became a no-op on all platforms; it is therefore removed from `osImpl`, `Poller`, and all (empty) implementations, along with `TestClose` and the sole external call site in `port.go`.

This allows to always enable portlist unit test by also reverting:
- #46909.

### Motivation
Triggered by:
- #incident-50065
- #incident-50070
- #incident-50071