### PR TITLE
Detect hostname on ECS managed instances with daemon mode

### DIFF
--- a/pkg/config/env/environment.go
+++ b/pkg/config/env/environment.go
@@ -93,6 +93,13 @@ func IsECSSidecarMode(cfg model.Reader) bool {
 	return false
 }
 
+// IsECSManagedInstancesDaemonMode returns true when the agent is running on ECS Managed Instances
+// in daemon mode (i.e. not sidecar). Callers should use this when behavior differs between
+// daemon and sidecar on Managed Instances (e.g. hostname resolution via EC2 IMDS).
+func IsECSManagedInstancesDaemonMode(cfg model.Reader) bool {
+	return IsFeaturePresent(ECSManagedInstances) && !IsECSSidecarMode(cfg)
+}
+
 // IsHostProcAvailable returns whether host proc is available or not
 func IsHostProcAvailable() bool {
 	if IsContainerized() {

--- a/pkg/util/hostname/common.go
+++ b/pkg/util/hostname/common.go
@@ -142,8 +142,10 @@ func resolveEC2Hostname(ctx context.Context, currentHostname string, legacyHostn
 	log.Debugf("ec2_prioritize_instance_id_as_hostname is set to %v", prioritizeEC2Hostname)
 
 	// We use the instance id if we're on an ECS cluster or we're on EC2 and the hostname is one of the default ones
-	// or ec2_prioritize_instance_id_as_hostname is set to true
-	if env.IsFeaturePresent(env.ECSEC2) || ec2.IsDefaultHostname(currentHostname) || prioritizeEC2Hostname {
+	// or ec2_prioritize_instance_id_as_hostname is set to true. For ECS Managed Instances, we only want to use
+	// the instance ID if we're in daemon mode.
+	ecsManaged := env.IsECSManagedInstancesDaemonMode(pkgconfigsetup.Datadog())
+	if env.IsFeaturePresent(env.ECSEC2) || ecsManaged || ec2.IsDefaultHostname(currentHostname) || prioritizeEC2Hostname {
 		log.Debugf("Trying to fetch hostname from EC2 metadata")
 		return getValidEC2Hostname(ctx, legacyHostnameResolution)
 	} else if ec2.IsWindowsDefaultHostname(currentHostname) {

--- a/releasenotes/notes/ecs-managed-instance-hostname-43c10ce113501620.yaml
+++ b/releasenotes/notes/ecs-managed-instance-hostname-43c10ce113501620.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On ECS Managed Instances, detect hostname from IMDS when the agent runs in daemon mode.


### PR DESCRIPTION
### What does this PR do?
On ECS Managed Instances in daemon mode, the agent is unable to detect a hostname from IMDS. Since IsDefaultHostname("") is false and `AWS_ECS_EC2` is not set (managed instances use `AWS_ECS_MANAGED_INSTANCES`), `resolveEC2Hostname` never consults IMDS and hostname resolution fails.

This PR adds an explicit ECSManagedInstances (daemon-only) check to `resolveEC2Hostname`, mirroring the existing `ECSEC2` check. Sidecar mode is excluded since fromFargate already handles that case earlier.

This eliminates the need for the `DD_HOSTNAME_TRUST_UTS_NAMESPACE` and `DD_EC2_PRIORITIZE_INSTANCE_ID_AS_HOSTNAME` workarounds.

### Describe how you validated your changes
- Deployed the Agent on ECS Managed Instances.
- Confirmed the agent is able to detect a hostname from IMDS
```
2026-02-25 16:10:29 UTC | CORE | DEBUG | (pkg/util/hostname/providers.go:222 in getHostname) | hostname provider 'aws' successfully found hostname 'i-...'
```

