### PR TITLE
[e2e-framework] Add gensim autonomous episode runner on EC2+Kind

### DIFF
--- a/tasks/e2e_framework/aws/__init__.py
+++ b/tasks/e2e_framework/aws/__init__.py
@@ -3,6 +3,7 @@ from invoke.collection import Collection
 from tasks.e2e_framework.aws.docker import create_docker, destroy_docker
 from tasks.e2e_framework.aws.ecs import create_ecs, destroy_ecs
 from tasks.e2e_framework.aws.eks import create_eks, destroy_eks
+from tasks.e2e_framework.aws.gensim import collect_parquet_files, deploy_gensim, destroy_gensim, list_gensim_episodes
 from tasks.e2e_framework.aws.installer import create_installer_lab, destroy_installer_lab
 from tasks.e2e_framework.aws.kind import create_kind, destroy_kind
 from tasks.e2e_framework.aws.vm import create_vm, destroy_vm, get_vm_password, rdp_vm, show_vm
@@ -20,6 +21,10 @@ collection.add_task(create_installer_lab)
 collection.add_task(destroy_installer_lab)
 collection.add_task(create_kind)
 collection.add_task(destroy_kind)
+collection.add_task(deploy_gensim)
+collection.add_task(destroy_gensim)
+collection.add_task(list_gensim_episodes)
+collection.add_task(collect_parquet_files)
 collection.add_task(show_vm)
 collection.add_task(get_vm_password)
 collection.add_task(rdp_vm)

--- a/tasks/e2e_framework/aws/__init__.py
+++ b/tasks/e2e_framework/aws/__init__.py
@@ -3,7 +3,7 @@ from invoke.collection import Collection
 from tasks.e2e_framework.aws.docker import create_docker, destroy_docker
 from tasks.e2e_framework.aws.ecs import create_ecs, destroy_ecs
 from tasks.e2e_framework.aws.eks import create_eks, destroy_eks
-from tasks.e2e_framework.aws.gensim import collect_parquet_files, deploy_gensim, destroy_gensim, list_gensim_episodes
+from tasks.e2e_framework.aws.gensim import deploy_gensim, destroy_gensim, list_gensim_episodes
 from tasks.e2e_framework.aws.installer import create_installer_lab, destroy_installer_lab
 from tasks.e2e_framework.aws.kind import create_kind, destroy_kind
 from tasks.e2e_framework.aws.vm import create_vm, destroy_vm, get_vm_password, rdp_vm, show_vm
@@ -24,7 +24,6 @@ collection.add_task(destroy_kind)
 collection.add_task(deploy_gensim)
 collection.add_task(destroy_gensim)
 collection.add_task(list_gensim_episodes)
-collection.add_task(collect_parquet_files)
 collection.add_task(show_vm)
 collection.add_task(get_vm_password)
 collection.add_task(rdp_vm)

--- a/tasks/e2e_framework/aws/gensim.py
+++ b/tasks/e2e_framework/aws/gensim.py
@@ -1,0 +1,374 @@
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from tasks.e2e_framework import doc, tool
+from tasks.e2e_framework.aws.deploy import deploy
+from tasks.e2e_framework.destroy import destroy
+
+scenario_name = "aws/gensim"
+
+
+def get_gensim_repo_path() -> Path:
+    """Get the path to the gensim-episodes repository"""
+    # Try environment variable first
+    env_path = os.getenv("GENSIM_REPO_PATH")
+    if env_path:
+        path = Path(env_path)
+        if path.exists():
+            return path
+
+    # Try to find it relative to datadog-agent repo
+    # Assume both repos are in the same parent directory
+    current_dir = Path(__file__).parent
+    repo_root = current_dir.parent.parent.parent  # Go up to datadog-agent root
+    parent_dir = repo_root.parent
+
+    possible_paths = [
+        parent_dir / "gensim-episodes" / "postmortems",
+        Path.home() / "go" / "src" / "github.com" / "DataDog" / "gensim-episodes" / "postmortems",
+    ]
+
+    for path in possible_paths:
+        if path.exists():
+            return path
+
+    raise Exit("Could not find gensim-episodes repository. Set GENSIM_REPO_PATH environment variable.")
+
+
+def list_episodes() -> list[dict]:
+    """List all available gensim episodes"""
+    gensim_path = get_gensim_repo_path()
+    episodes = []
+
+    for episode_dir in sorted(gensim_path.iterdir()):
+        if not episode_dir.is_dir():
+            continue
+
+        # Check if it's an episode directory
+        chart_dir = episode_dir / "chart"
+        play_script = episode_dir / "play-episode.sh"
+
+        if chart_dir.exists() and play_script.exists():
+            # Get scenarios for this episode
+            scenarios = []
+            episodes_subdir = episode_dir / "episodes"
+            if episodes_subdir.exists():
+                for scenario_file in episodes_subdir.glob("*.yaml"):
+                    scenarios.append(scenario_file.stem)
+
+            episodes.append(
+                {
+                    "name": episode_dir.name,
+                    "path": str(episode_dir),
+                    "chart_path": str(chart_dir),
+                    "scenarios": scenarios,
+                }
+            )
+
+    return episodes
+
+
+@task
+def list_gensim_episodes(ctx: Context):
+    """
+    List all available gensim episodes.
+    """
+    episodes = list_episodes()
+    print(json.dumps(episodes, indent=2))
+
+
+@task(
+    help={
+        "episode": "Episode directory name (e.g., 002_AWS_S3_Service_Disruption)",
+        "scenario": "Scenario name to execute (from episodes/*.yaml)",
+        "stack_name": doc.stack_name,
+        "agent_version": doc.container_agent_version,
+        "config_path": "Path to config file",
+        "interactive": "Enable interactive mode",
+        "namespace": "Kubernetes namespace for deployment (default: default)",
+    }
+)
+def deploy_gensim(
+    ctx: Context,
+    episode: str,
+    scenario: str | None = None,
+    debug: bool | None = False,
+    stack_name: str | None = None,
+    agent_version: str | None = None,
+    config_path: str | None = None,
+    interactive: bool | None = True,
+    full_image_path: str | None = None,
+    cluster_agent_full_image_path: str | None = None,
+    namespace: str | None = "default",
+    keep_after_scenario: bool | None = False,
+) -> None:
+    """
+    Deploy a gensim episode to an EC2+Kind cluster, execute scenarios, and collect results.
+
+    Example:
+        inv e2e-framework.aws.deploy-gensim --episode=002_AWS_S3_Service_Disruption --scenario=capacity-removal-outage
+    """
+
+    from pydantic_core._pydantic_core import ValidationError
+
+    from tasks.e2e_framework import config
+    from tasks.e2e_framework.config import get_full_profile_path
+
+    try:
+        cfg = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
+
+    # Find episode
+    gensim_path = get_gensim_repo_path()
+    episode_dir = gensim_path / episode
+
+    if not episode_dir.exists():
+        raise Exit(f"Episode directory not found: {episode_dir}")
+
+    chart_dir = episode_dir / "chart"
+    if not chart_dir.exists():
+        raise Exit(f"Chart directory not found: {chart_dir}")
+
+    datadog_values_path = gensim_path / "datadog-values.yaml"
+
+    # Prepare extra flags for gensim scenario
+    extra_flags = {
+        "ddinfra:osDescriptor": "amazonlinuxecs::x86_64",
+        "ddinfra:aws/defaultInstanceType": "t3.xlarge",
+        "gensim:episodeName": episode,
+        "gensim:chartPath": str(chart_dir),
+        "gensim:namespace": namespace,
+    }
+
+    if datadog_values_path.exists():
+        extra_flags["gensim:datadogValuesPath"] = str(datadog_values_path)
+
+    # Deploy the infrastructure
+    tool.notify(ctx, f"Deploying gensim episode: {episode}")
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path=config_path,
+        key_pair_required=True,
+        debug=debug,
+        app_key_required=True,
+        stack_name=stack_name,
+        install_agent=True,  # Deploy custom Datadog Agent with observer
+        install_workload=False,  # Episode chart includes workload
+        agent_version=agent_version,
+        extra_flags=extra_flags,
+        full_image_path=full_image_path,
+        cluster_agent_full_image_path=cluster_agent_full_image_path,
+    )
+
+    if interactive:
+        tool.notify(ctx, f"Kind cluster created for episode: {episode}")
+
+    # Get kubeconfig from the Kind cluster output
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    kubeconfig_output = outputs["dd-Cluster-gensim"]["kubeConfig"]
+
+    import yaml
+
+    kubeconfig_content = yaml.dump(yaml.safe_load(kubeconfig_output))
+    kubeconfig_path = Path(f"{full_stack_name}-config.yaml")
+
+    with open(kubeconfig_path, "w") as f:
+        f.write(kubeconfig_content)
+    os.chmod(kubeconfig_path, 0o600)
+
+    tool.info(f"Kubeconfig saved to: {kubeconfig_path}")
+
+    # Wait for pods to be ready
+    tool.info("Waiting for pods to be ready...")
+    time.sleep(30)
+
+    # Execute episode scenarios
+    play_script = episode_dir / "play-episode.sh"
+
+    if not play_script.exists():
+        tool.warn(f"play-episode.sh not found in {episode_dir}")
+    else:
+        tool.info("Executing episode scenario(s)...")
+
+        # Set environment variables for play-episode.sh
+        env = os.environ.copy()
+        env.update(
+            {
+                "DD_API_KEY": cfg.get_agent().apiKey or "",
+                "DD_APP_KEY": cfg.get_agent().appKey or "",
+                "DD_ENV": f"gensim-{episode}",
+                "DD_SITE": cfg.get_site() if hasattr(cfg, 'get_site') else "datadoghq.com",
+                "KUBE_NAMESPACE": namespace or "",
+                "KUBECONFIG": str(kubeconfig_path),
+            }
+        )
+
+        if scenario:
+            # Run specific scenario
+            tool.info(f"Running scenario: {scenario}")
+            cmd = [str(play_script), "run-episode", scenario]
+            subprocess.run(cmd, cwd=episode_dir, env=env, check=True)
+        else:
+            # List and prompt for scenario
+            tool.info("Listing available scenarios...")
+            result = subprocess.run(
+                [str(play_script), "list-episodes"],
+                cwd=episode_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            scenarios_json = json.loads(result.stdout)
+
+            if not scenarios_json:
+                tool.warn("No scenarios found")
+            else:
+                tool.info(f"Available scenarios: {[s['name'] for s in scenarios_json]}")
+
+                if interactive:
+                    print("\nRun scenarios manually with:")
+                    print(f"  export KUBECONFIG={kubeconfig_path}")
+                    print(f"  cd {episode_dir}")
+                    print("  ./play-episode.sh run-episode <scenario-name>")
+                else:
+                    # Run all scenarios in non-interactive mode
+                    for scenario_info in scenarios_json:
+                        scenario_name_run = scenario_info["name"]
+                        tool.info(f"Running scenario: {scenario_name_run}")
+                        cmd = [str(play_script), "run-episode", scenario_name_run]
+                        subprocess.run(cmd, cwd=episode_dir, env=env, check=True)
+
+    # Instructions for collecting parquet files
+    tool.info("\n" + "=" * 80)
+    tool.info("Episode deployment complete!")
+    tool.info("=" * 80)
+    print(f"\nKubeconfig: {kubeconfig_path}")
+    print(f"Namespace: {namespace}")
+    print("\nTo collect parquet files from Datadog Agent pods:")
+    print(f"  kubectl --kubeconfig={kubeconfig_path} -n {namespace} get pods -l app=datadog-agent")
+    print(f"  kubectl --kubeconfig={kubeconfig_path} -n {namespace} exec <pod-name> -- ls /tmp/observer-metrics/")
+    print(
+        f"  kubectl --kubeconfig={kubeconfig_path} -n {namespace} cp <pod-name>:/tmp/observer-metrics/ ./parquet_files/"
+    )
+
+    if not keep_after_scenario:
+        print("\nTo destroy the cluster:")
+        print(f"  inv e2e-framework.aws.destroy-gensim --stack-name={full_stack_name.split('/')[-1]}")
+    else:
+        tool.warn("Cluster will remain running. Remember to destroy it when done!")
+
+
+@task(help={"stack_name": doc.stack_name})
+def destroy_gensim(ctx: Context, stack_name: str | None = None, config_path: str | None = None):
+    """
+    Destroy a gensim EC2+Kind environment created with inv e2e-framework.aws.deploy-gensim.
+    """
+    destroy(ctx, scenario_name=scenario_name, stack=stack_name, config_path=config_path)
+
+
+@task(
+    help={
+        "stack_name": doc.stack_name,
+        "namespace": "Kubernetes namespace where Datadog Agent is deployed",
+        "output_dir": "Directory to save parquet files (default: ./parquet_files)",
+    }
+)
+def collect_parquet_files(
+    ctx: Context,
+    stack_name: str,
+    namespace: str | None = "default",
+    output_dir: str | None = "./parquet_files",
+):
+    """
+    Collect parquet files from Datadog Agent pods in a running gensim deployment.
+
+    Example:
+        inv e2e-framework.aws.collect-parquet-files --stack-name=gensim-002-aws-s3
+    """
+
+    # Get the full stack name
+    full_stack_name = tool.get_stack_name(stack_name, scenario_name)
+
+    # Get kubeconfig from the Kind cluster output
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    kubeconfig_output = outputs["dd-Cluster-gensim"]["kubeConfig"]
+
+    import yaml
+
+    kubeconfig_content = yaml.dump(yaml.safe_load(kubeconfig_output))
+    kubeconfig_path = Path(f"{full_stack_name}-config.yaml")
+
+    with open(kubeconfig_path, "w") as f:
+        f.write(kubeconfig_content)
+    os.chmod(kubeconfig_path, 0o600)
+
+    # Create output directory
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Get Datadog Agent pods
+    result = subprocess.run(
+        [
+            "kubectl",
+            "--kubeconfig",
+            str(kubeconfig_path),
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "-l",
+            "app=datadog-agent",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    pod_names = result.stdout.strip().split()
+
+    if not pod_names:
+        tool.warn("No Datadog Agent pods found")
+        return
+
+    tool.info(f"Found {len(pod_names)} Datadog Agent pod(s)")
+
+    # Collect parquet files from each pod
+    for pod_name in pod_names:
+        tool.info(f"Collecting from pod: {pod_name}")
+
+        pod_output_dir = output_path / pod_name
+        pod_output_dir.mkdir(exist_ok=True)
+
+        # Copy parquet files
+        subprocess.run(
+            [
+                "kubectl",
+                "--kubeconfig",
+                str(kubeconfig_path),
+                "cp",
+                f"{namespace}/{pod_name}:/tmp/observer-metrics/",
+                str(pod_output_dir),
+            ],
+            check=False,  # Don't fail if directory doesn't exist
+        )
+
+        # Count parquet files
+        parquet_files = list(pod_output_dir.rglob("*.parquet"))
+        if parquet_files:
+            tool.info(f"  Collected {len(parquet_files)} parquet file(s)")
+        else:
+            tool.warn(f"  No parquet files found in pod {pod_name}")
+
+    tool.notify(ctx, f"Parquet files collected to: {output_path}")

--- a/tasks/e2e_framework/aws/gensim.py
+++ b/tasks/e2e_framework/aws/gensim.py
@@ -151,8 +151,6 @@ def deploy_gensim(
         scenario = available[0].stem
         tool.info(f"No scenario specified, using: {scenario}")
 
-    datadog_values_path = gensim_path / "datadog-values.yaml"
-
     # Use the provided run ID to update an existing stack, or generate a fresh one.
     if run_id is None:
         run_id = secrets.token_hex(3)  # 6 hex chars, e.g. "a3f2c1"
@@ -173,9 +171,6 @@ def deploy_gensim(
         "gensim:episodePath": str(episode_dir),
         "gensim:namespace": namespace,
     }
-
-    if datadog_values_path.exists():
-        extra_flags["gensim:datadogValuesPath"] = str(datadog_values_path)
 
     extra_flags["gensim:runId"] = run_id
 
@@ -217,7 +212,8 @@ def deploy_gensim(
     ssh_key_flag = f"-i {key_path} " if key_path else ""
     print("\nTo monitor progress:")
     print(f"  ssh {ssh_key_flag}{remote_host.user}@{remote_host.address}")
-    print("  tail -f /tmp/gensim-runner.log")
+    print("  tail -f /tmp/play-episode.log   # episode execution (real-time)")
+    print("  tail -f /tmp/gensim-runner.log  # full runner log")
 
     if s3_bucket:
         print(f"\nResults will be uploaded to: s3://{s3_bucket}/gensim-results-{episode}-{run_id}.zip")

--- a/tasks/e2e_framework/aws/gensim.py
+++ b/tasks/e2e_framework/aws/gensim.py
@@ -1,5 +1,6 @@
 import json
 import os
+import secrets
 from pathlib import Path
 
 from invoke.context import Context
@@ -93,6 +94,7 @@ def list_gensim_episodes(ctx: Context):
         "config_path": "Path to config file",
         "interactive": "Enable interactive mode",
         "namespace": "Kubernetes namespace for deployment (default: default)",
+        "run_id": "Reuse the run ID of a previous deployment (e.g. 'a3f2c1') to update its stack instead of creating a new one",
     }
 )
 def deploy_gensim(
@@ -110,6 +112,7 @@ def deploy_gensim(
     cluster_agent_full_image_path: str | None = None,
     namespace: str | None = "default",
     keep_after_scenario: bool | None = False,
+    run_id: str | None = None,
 ) -> None:
     """
     Deploy a gensim episode to an EC2+Kind cluster and run it autonomously on the VM.
@@ -150,9 +153,16 @@ def deploy_gensim(
 
     datadog_values_path = gensim_path / "datadog-values.yaml"
 
-    # Default stack name to the episode name so each episode gets its own stack
+    # Use the provided run ID to update an existing stack, or generate a fresh one.
+    if run_id is None:
+        run_id = secrets.token_hex(3)  # 6 hex chars, e.g. "a3f2c1"
+        tool.info(f"Generated run ID: {run_id}")
+    else:
+        tool.info(f"Reusing run ID: {run_id}")
+
+    # Default stack name to the episode name + run ID so each invocation gets its own stack
     if stack_name is None:
-        stack_name = "gensim-" + episode.replace("_", "-").lower()
+        stack_name = "gensim-" + episode.replace("_", "-").lower() + "-" + run_id
 
     # Prepare extra flags for gensim scenario
     extra_flags = {
@@ -166,6 +176,8 @@ def deploy_gensim(
 
     if datadog_values_path.exists():
         extra_flags["gensim:datadogValuesPath"] = str(datadog_values_path)
+
+    extra_flags["gensim:runId"] = run_id
 
     if scenario:
         extra_flags["gensim:scenario"] = scenario
@@ -208,7 +220,7 @@ def deploy_gensim(
     print("  tail -f /tmp/gensim-runner.log")
 
     if s3_bucket:
-        print(f"\nResults will be uploaded to: s3://{s3_bucket}/gensim-results-{episode}-<YYYYMMDD>.zip")
+        print(f"\nResults will be uploaded to: s3://{s3_bucket}/gensim-results-{episode}-{run_id}.zip")
 
     if not keep_after_scenario:
         print("\nTo destroy the cluster:")

--- a/test/e2e-framework/registry/scenarios.go
+++ b/test/e2e-framework/registry/scenarios.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2docker"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ecs"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/eks"
+	awsgensim "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/gensim"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/installer"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/kindvm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/microVMs/microvms"
@@ -34,6 +35,7 @@ func Scenarios() ScenarioRegistry {
 		"aws/dockervm":    ec2docker.DockerRun,
 		"aws/ecs":         ecs.Run,
 		"aws/eks":         eks.Run,
+		"aws/gensim":      awsgensim.Run,
 		"aws/installer":   installer.Run,
 		"aws/microvms":    microvms.Run,
 		"aws/kind":        kindvm.Run,

--- a/test/e2e-framework/scenarios/aws/gensim/datadog-values.yaml
+++ b/test/e2e-framework/scenarios/aws/gensim/datadog-values.yaml
@@ -1,0 +1,69 @@
+datadog:
+  logLevel: "INFO"
+
+  # Enable TraceAgent
+  apm:
+    instrumentation:
+      enabled: true
+  
+    # Enable APM receiver
+    portEnabled: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+
+  # Enable process collection
+  processAgent:
+    enabled: true
+    processCollection: true
+
+  # For local kind cluster
+  kubelet:
+    tlsVerify: false
+
+  # Enable cluster checks
+  clusterChecks:
+    enabled: true
+  env:
+  # Agent capture to parquet
+  - name: DD_OBSERVER_RECORDING_ENABLED
+    value: "true"
+  - name: DD_OBSERVER_ANALYSIS_ENABLED
+    value: "false"
+  # Enable high frequency recording
+  - name: DD_OBSERVER_HIGH_FREQUENCY_INTERVAL
+    value: "1s"
+
+agents:
+  # Kind clusters bind control-plane components (etcd, kube-controller-manager,
+  # kube-scheduler) to 127.0.0.1. Without hostNetwork the agent pod sits in the
+  # pod network and cannot reach localhost of the node, causing those checks to
+  # fail at initialization. hostNetwork gives the agent the node's network
+  # namespace so it can reach those endpoints.
+  useHostNetwork: true
+  containers:
+    agent:
+      resources:
+        requests:
+          memory: 1000Mi
+        limits:
+          memory: 2000Mi
+
+clusterAgent:
+  enabled: true
+  replicas: 1
+
+  ## @param admissionController - object - required
+  ## Enable the admissionController to automatically inject APM and
+  ## DogStatsD config and standard tags (env, service, version) into
+  ## your pods
+  #
+  # This helps us to capture traces from all pods without having to label them.
+  admissionController:
+    enabled: true
+    
+    ## @param mutateUnlabelled - boolean - optional
+    ## Enable injecting config without having the pod label:
+    ## admission.datadoghq.com/enabled="true"
+    #
+    mutateUnlabelled: true

--- a/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
+++ b/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Autonomous gensim episode runner - runs on EC2 VM
+set -euo pipefail
+
+LOG_FILE="/tmp/gensim-runner.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "[$(date -u)] Starting gensim runner for episode: ${EPISODE_NAME}"
+
+# Source secrets (DD_API_KEY, DD_APP_KEY)
+# shellcheck source=/dev/null
+source /tmp/gensim-secrets.env
+
+# Build kubeconfig from local Kind cluster
+kind get kubeconfig --name "${CLUSTER_NAME}" > /tmp/kubeconfig
+export KUBECONFIG=/tmp/kubeconfig
+echo "[$(date -u)] Kubeconfig ready"
+
+# Run play-episode.sh, capturing output to a dedicated log
+# (file is root-owned after Pulumi copy, so we invoke via bash rather than relying on the execute bit)
+cd /tmp/gensim-episode
+bash ./play-episode.sh run-episode "${SCENARIO}" > /tmp/play-episode.log 2>&1
+cat /tmp/play-episode.log
+echo "[$(date -u)] Episode completed"
+
+# Collect parquet files from the Datadog Agent pod.
+# kubectl is not installed on the VM; use the Kind control-plane container which has it.
+KUBE="docker exec ${CLUSTER_NAME}-control-plane kubectl"
+POD=$(${KUBE} get pod -n "${KUBE_NAMESPACE}" -l app.kubernetes.io/component=agent \
+      -o jsonpath='{.items[0].metadata.name}')
+echo "[$(date -u)] Collecting parquet files from pod ${POD}"
+# kubectl cp fails because /tmp in the control-plane container is a tmpfs mount
+# and docker cp cannot read through tmpfs (it uses the overlay filesystem).
+# Instead: pipe tar from the pod via kubectl exec into /root of the control-plane
+# (which is on the overlay fs), then docker cp to the VM.
+${KUBE} exec -n "${KUBE_NAMESPACE}" "${POD}" -c agent -- tar cf - -C /tmp observer-metrics \
+    | docker exec -i "${CLUSTER_NAME}-control-plane" tar xf - -C /root
+mkdir -p /tmp/gensim-parquet
+docker cp "${CLUSTER_NAME}-control-plane:/root/observer-metrics" /tmp/gensim-parquet/
+echo "[$(date -u)] Parquet files collected from pod ${POD}"
+
+# Archive: parquet + play-episode log
+mkdir -p /tmp/gensim-archive
+cp -r /tmp/gensim-parquet          /tmp/gensim-archive/parquet/
+cp /tmp/play-episode.log           /tmp/gensim-archive/
+cp "$LOG_FILE"                     /tmp/gensim-archive/gensim-runner.log || true
+if [ -d /tmp/gensim-episode/results ]; then cp -r /tmp/gensim-episode/results /tmp/gensim-archive/; fi
+
+ARCHIVE="/tmp/gensim-results-${EPISODE_NAME}-$(date -u +%Y%m%d).zip"
+zip -r "${ARCHIVE}" /tmp/gensim-archive/
+echo "[$(date -u)] Archive created: ${ARCHIVE}"
+
+# Upload to S3 (only if bucket is set)
+if [ -n "${S3_BUCKET:-}" ]; then
+    S3_DEST="s3://${S3_BUCKET}/$(basename "${ARCHIVE}")"
+    aws s3 cp "${ARCHIVE}" "${S3_DEST}"
+    echo "[$(date -u)] Uploaded to ${S3_DEST}"
+fi
+
+echo "[$(date -u)] All done."

--- a/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
+++ b/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
@@ -23,24 +23,16 @@ bash ./play-episode.sh run-episode "${SCENARIO}" 2>&1 | tee /tmp/play-episode.lo
 echo "[$(date -u)] Episode completed"
 
 # Collect parquet files from the Datadog Agent pod.
-# kubectl is not installed on the VM; use the Kind control-plane container which has it.
-KUBE="docker exec ${CLUSTER_NAME}-control-plane kubectl"
-POD=$(${KUBE} get pod -n "${KUBE_NAMESPACE}" -l app.kubernetes.io/component=agent \
+POD=$(kubectl get pod -n "${KUBE_NAMESPACE}" -l app.kubernetes.io/component=agent \
       -o jsonpath='{.items[0].metadata.name}')
 echo "[$(date -u)] Collecting parquet files from pod ${POD}"
-# kubectl cp fails because /tmp in the control-plane container is a tmpfs mount
-# and docker cp cannot read through tmpfs (it uses the overlay filesystem).
-# Instead: pipe tar from the pod via kubectl exec into /root of the control-plane
-# (which is on the overlay fs), then docker cp to the VM.
-${KUBE} exec -n "${KUBE_NAMESPACE}" "${POD}" -c agent -- tar cf - -C /tmp observer-metrics \
-    | docker exec -i "${CLUSTER_NAME}-control-plane" tar xf - -C /root
 mkdir -p /tmp/gensim-parquet
-docker cp "${CLUSTER_NAME}-control-plane:/root/observer-metrics" /tmp/gensim-parquet/
+kubectl cp -n "${KUBE_NAMESPACE}" "${POD}:/var/run/datadog/observer" /tmp/gensim-parquet/observer -c agent
 echo "[$(date -u)] Parquet files collected from pod ${POD}"
 
 # Archive: parquet + play-episode log
 mkdir -p /tmp/gensim-archive
-cp -r /tmp/gensim-parquet          /tmp/gensim-archive/parquet/
+cp -r /tmp/gensim-parquet/observer /tmp/gensim-archive/parquet/
 cp /tmp/play-episode.log           /tmp/gensim-archive/
 cp "$LOG_FILE"                     /tmp/gensim-archive/gensim-runner.log || true
 if [ -d /tmp/gensim-episode/results ]; then cp -r /tmp/gensim-episode/results /tmp/gensim-archive/; fi

--- a/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
+++ b/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
@@ -46,7 +46,7 @@ cp /tmp/play-episode.log           /tmp/gensim-archive/
 cp "$LOG_FILE"                     /tmp/gensim-archive/gensim-runner.log || true
 if [ -d /tmp/gensim-episode/results ]; then cp -r /tmp/gensim-episode/results /tmp/gensim-archive/; fi
 
-ARCHIVE="/tmp/gensim-results-${EPISODE_NAME}-$(date -u +%Y%m%d).zip"
+ARCHIVE="/tmp/gensim-results-${EPISODE_NAME}-$(date -u +%Y%m%d-%H%M)-${RUN_ID}.zip"
 zip -r "${ARCHIVE}" /tmp/gensim-archive/
 echo "[$(date -u)] Archive created: ${ARCHIVE}"
 

--- a/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
+++ b/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
@@ -19,8 +19,7 @@ echo "[$(date -u)] Kubeconfig ready"
 # Run play-episode.sh, capturing output to a dedicated log
 # (file is root-owned after Pulumi copy, so we invoke via bash rather than relying on the execute bit)
 cd /tmp/gensim-episode
-bash ./play-episode.sh run-episode "${SCENARIO}" > /tmp/play-episode.log 2>&1
-cat /tmp/play-episode.log
+bash ./play-episode.sh run-episode "${SCENARIO}" 2>&1 | tee /tmp/play-episode.log
 echo "[$(date -u)] Episode completed"
 
 # Collect parquet files from the Datadog Agent pod.

--- a/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
+++ b/test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh
@@ -26,13 +26,11 @@ echo "[$(date -u)] Episode completed"
 POD=$(kubectl get pod -n "${KUBE_NAMESPACE}" -l app.kubernetes.io/component=agent \
       -o jsonpath='{.items[0].metadata.name}')
 echo "[$(date -u)] Collecting parquet files from pod ${POD}"
-mkdir -p /tmp/gensim-parquet
-kubectl cp -n "${KUBE_NAMESPACE}" "${POD}:/var/run/datadog/observer" /tmp/gensim-parquet/observer -c agent
+mkdir -p /tmp/gensim-archive/parquet
+kubectl cp -n "${KUBE_NAMESPACE}" "${POD}:/var/run/datadog/observer" /tmp/gensim-archive/parquet -c agent
 echo "[$(date -u)] Parquet files collected from pod ${POD}"
 
 # Archive: parquet + play-episode log
-mkdir -p /tmp/gensim-archive
-cp -r /tmp/gensim-parquet/observer /tmp/gensim-archive/parquet/
 cp /tmp/play-episode.log           /tmp/gensim-archive/
 cp "$LOG_FILE"                     /tmp/gensim-archive/gensim-runner.log || true
 if [ -d /tmp/gensim-episode/results ]; then cp -r /tmp/gensim-episode/results /tmp/gensim-archive/; fi

--- a/test/e2e-framework/scenarios/aws/gensim/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim/run.go
@@ -6,10 +6,13 @@
 package gensim
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	e2econfig "github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent/helm"
@@ -20,10 +23,14 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 
+	awsIam "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
 	pulumiKubernetes "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
+
+//go:embed gensim_runner.sh
+var gensimRunnerScript string
 
 // Run creates an EC2+Kind cluster and deploys a gensim episode with custom Datadog Agent
 func Run(ctx *pulumi.Context) error {
@@ -37,7 +44,10 @@ func Run(ctx *pulumi.Context) error {
 
 	episodeName := cfg.Require("episodeName")         // e.g., "002_AWS_S3_Service_Disruption"
 	episodeChartPath := cfg.Require("chartPath")      // Path to episode's Helm chart
+	episodePath := cfg.Require("episodePath")         // Full path to episode dir (contains play-episode.sh)
 	datadogValuesPath := cfg.Get("datadogValuesPath") // Path to datadog-values.yaml (optional)
+	scenario := cfg.Get("scenario")                   // Scenario to run (empty = skip run)
+	s3Bucket := cfg.Get("s3Bucket")
 	namespace := cfg.Get("namespace")
 	if namespace == "" {
 		namespace = "default"
@@ -49,8 +59,62 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
+	if err := host.Export(ctx, nil); err != nil {
+		return err
+	}
+
+	// Attach an inline S3 write policy to the instance role so the runner can upload results.
+	// Only created when s3Bucket is configured.
+	if s3Bucket != "" {
+		_, err = awsIam.NewRolePolicy(ctx, awsEnv.Namer.ResourceName("gensim-s3-upload"),
+			&awsIam.RolePolicyArgs{
+				Role: pulumi.String(awsEnv.DefaultInstanceProfileName()),
+				Policy: pulumi.Sprintf(`{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:PutObject"],
+    "Resource": "arn:aws:s3:::%s/*"
+  }]
+}`, s3Bucket),
+			},
+			awsEnv.WithProviders(e2econfig.ProviderAWS),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Install ECR credentials helper to allow pulling images from ECR
 	installEcrCredsHelperCmd, err := ec2.InstallECRCredentialsHelper(awsEnv, host)
+	if err != nil {
+		return err
+	}
+
+	// Install tools needed by the runner: aws-cli (S3 upload), zip (archiving), jq (JSON parsing).
+	// All in one command to avoid parallel apt-get lock contention.
+	// snap install is idempotent via the fallback to snap refresh.
+	installAwsCliCmd, err := host.OS.Runner().Command(
+		awsEnv.Namer.ResourceName("install-aws-cli"),
+		&command.Args{
+			Create: pulumi.String(`snap install aws-cli --classic`),
+			Sudo:   true,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Install tools needed by the runner: aws-cli (S3 upload), zip (archiving), jq (JSON parsing).
+	// All in one command to avoid parallel apt-get lock contention.
+	// snap install is idempotent via the fallback to snap refresh.
+	installToolsCmd, err := host.OS.Runner().Command(
+		awsEnv.Namer.ResourceName("install-tools"),
+		&command.Args{
+			Create: pulumi.String(`apt-get install -y zip jq`),
+			Sudo:   true,
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -72,6 +136,65 @@ func Run(ctx *pulumi.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	// If the episode has custom Docker images, build them and load into Kind before deploying the chart.
+	// Episodes with a docker-compose.yaml in their root directory define service images that must be
+	// built locally on the VM and loaded into the Kind cluster before the Helm chart can reference them.
+	var dependsOnImages pulumi.ResourceOption
+	dockerComposePath := filepath.Join(episodePath, "docker-compose.yaml")
+	if _, statErr := os.Stat(dockerComposePath); statErr == nil {
+		// Copy services/ directory to a dedicated build staging area to avoid conflicting
+		// with the /tmp/gensim-episode/ directory created later for the runner scripts.
+		servicesCopyResources, err := host.OS.FileManager().CopyAbsoluteFolder(
+			filepath.Join(episodePath, "services"), "/tmp/gensim-build/",
+		)
+		if err != nil {
+			return err
+		}
+
+		// Copy docker-compose.yaml to the same staging area
+		dockerComposeFile, err := host.OS.FileManager().CopyFile(
+			"docker-compose-yaml",
+			pulumi.String(dockerComposePath),
+			pulumi.String("/tmp/gensim-build/docker-compose.yaml"),
+			utils.PulumiDependsOn(servicesCopyResources...),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Chown so the SSH user owns the build directory for docker build output
+		fixServicesPermsCmd, err := host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("fix-services-dir-perms"),
+			&command.Args{
+				Create: pulumi.String("chown -R $(id -un):$(id -gn) /tmp/gensim-build/"),
+				Sudo:   true,
+			},
+			utils.PulumiDependsOn(append(servicesCopyResources, dockerComposeFile)...),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Build custom images and load them into Kind.
+		// Depends on kindCluster to ensure docker-compose plugin is installed and Kind is running.
+		buildLoadImagesCmd, err := host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("build-load-images"),
+			&command.Args{
+				Create: pulumi.Sprintf(
+					`cd /tmp/gensim-build && docker-compose build && `+
+						`docker-compose config --images | xargs -I{} kind load docker-image {} --name %s`,
+					kindCluster.ClusterName,
+				),
+			},
+			utils.PulumiDependsOn(fixServicesPermsCmd, kindCluster),
+		)
+		if err != nil {
+			return err
+		}
+
+		dependsOnImages = utils.PulumiDependsOn(buildLoadImagesCmd)
 	}
 
 	// Deploy custom Datadog Agent DaemonSet with observer capabilities
@@ -153,10 +276,10 @@ func Run(ctx *pulumi.Context) error {
 				"apiKey": awsEnv.AgentAPIKey(),
 				"appKey": awsEnv.AgentAPPKey(),
 				"site":   pulumi.String(awsEnv.Site()),
-				"env":    pulumi.String(fmt.Sprintf("gensim-%s", episodeName)),
+				"env":    pulumi.String(episodeReleaseName),
 			},
 		},
-	}, pulumi.Provider(kubeProvider), dependsOnDDAgent)
+	}, pulumi.Provider(kubeProvider), dependsOnDDAgent, dependsOnImages)
 
 	if err != nil {
 		return err
@@ -175,6 +298,103 @@ func Run(ctx *pulumi.Context) error {
 				),
 			},
 			utils.PulumiDependsOn(episodeChart),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Copy play-episode.sh and the episodes/ subdirectory to the VM
+	// (the chart is already deployed via Helm; results/ is generated at runtime)
+	playScript, err := host.OS.FileManager().CopyFile(
+		"play-episode-sh",
+		pulumi.String(filepath.Join(episodePath, "play-episode.sh")),
+		pulumi.String("/tmp/gensim-episode/play-episode.sh"),
+		utils.PulumiDependsOn(episodeChart),
+	)
+	if err != nil {
+		return err
+	}
+
+	// CopyAbsoluteFolder preserves the base folder name, so passing "/tmp/gensim-episode/"
+	// as remote root will produce /tmp/gensim-episode/episodes/<files>.
+	episodesCopyResources, err := host.OS.FileManager().CopyAbsoluteFolder(
+		filepath.Join(episodePath, "episodes"), "/tmp/gensim-episode/",
+		utils.PulumiDependsOn(episodeChart),
+	)
+	if err != nil {
+		return err
+	}
+
+	episodeCopyResources := append(episodesCopyResources, playScript)
+
+	// All copied files are root-owned (MoveFile always uses sudo cp).
+	// Chown the episode directory back to the SSH user so the runner can write into it
+	// (e.g. play-episode.sh creates a results/ subdirectory).
+	fixPermsCmd, err := host.OS.Runner().Command(
+		awsEnv.Namer.ResourceName("fix-episode-dir-perms"),
+		&command.Args{
+			Create: pulumi.String("chown -R $(id -un):$(id -gn) /tmp/gensim-episode/"),
+			Sudo:   true,
+		},
+		utils.PulumiDependsOn(episodeCopyResources...),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Write the embedded runner script to the VM
+	runnerFile, err := host.OS.FileManager().CopyInlineFile(
+		pulumi.String(gensimRunnerScript), "/tmp/gensim_runner.sh",
+		utils.PulumiDependsOn(fixPermsCmd),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Write secrets to a separate env file (content is a Pulumi secret, redacted in CLI output)
+	secretsContent := pulumi.Sprintf(
+		"export DD_API_KEY=%s\nexport DD_APP_KEY=%s\n",
+		awsEnv.AgentAPIKey(),
+		awsEnv.AgentAPPKey(),
+	)
+	secretsFile, err := host.OS.FileManager().CopyInlineFile(
+		secretsContent, "/tmp/gensim-secrets.env",
+		utils.PulumiDependsOn(fixPermsCmd),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Start the runner in the background if a scenario was specified
+	if scenario != "" {
+		allCopyDeps := utils.PulumiDependsOn(append(episodeCopyResources, runnerFile, secretsFile, installAwsCliCmd, installToolsCmd)...)
+		_, err = host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("gensim-run-episode"),
+			&command.Args{
+				Create: pulumi.Sprintf(
+					`nohup env `+
+						`CLUSTER_NAME=%s `+
+						`EPISODE_NAME=%s `+
+						`SCENARIO=%s `+
+						`KUBE_NAMESPACE=%s `+
+						`DD_ENV=gensim-%s `+
+						`DD_SITE=%s `+
+						`S3_BUCKET=%s `+
+						`bash /tmp/gensim_runner.sh > /tmp/gensim-runner-boot.log 2>&1 & `+
+						`PID=$! && sleep 5 && `+
+						`kill -0 $PID 2>/dev/null && echo "Runner PID: $PID" || `+
+						`(echo "Runner failed within 5s, boot log:" && tail -30 /tmp/gensim-runner-boot.log && exit 1)`,
+					kindCluster.ClusterName,
+					episodeName,
+					scenario,
+					namespace,
+					episodeName,
+					awsEnv.Site(),
+					s3Bucket,
+				),
+			},
+			allCopyDeps,
 		)
 		if err != nil {
 			return err

--- a/test/e2e-framework/scenarios/aws/gensim/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim/run.go
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package gensim
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/utils"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent/helm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
+	resAws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	helmresource "github.com/DataDog/datadog-agent/test/e2e-framework/resources/helm"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
+
+	pulumiKubernetes "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+// Run creates an EC2+Kind cluster and deploys a gensim episode with custom Datadog Agent
+func Run(ctx *pulumi.Context) error {
+	awsEnv, err := resAws.NewEnvironment(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get gensim-specific configuration
+	cfg := config.New(ctx, "gensim")
+
+	episodeName := cfg.Require("episodeName")         // e.g., "002_AWS_S3_Service_Disruption"
+	episodeChartPath := cfg.Require("chartPath")      // Path to episode's Helm chart
+	datadogValuesPath := cfg.Get("datadogValuesPath") // Path to datadog-values.yaml (optional)
+	namespace := cfg.Get("namespace")
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	// Create EC2 VM for the Kind cluster
+	host, err := ec2.NewVM(awsEnv, "gensim")
+	if err != nil {
+		return err
+	}
+
+	// Install ECR credentials helper to allow pulling images from ECR
+	installEcrCredsHelperCmd, err := ec2.InstallECRCredentialsHelper(awsEnv, host)
+	if err != nil {
+		return err
+	}
+
+	// Create Kind cluster on the EC2 VM
+	kindCluster, err := kubeComp.NewKindCluster(&awsEnv, host, "gensim", awsEnv.KubernetesVersion(), utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	if err != nil {
+		return err
+	}
+
+	if err := kindCluster.Export(ctx, nil); err != nil {
+		return err
+	}
+
+	// Create Kubernetes provider from the Kind cluster kubeconfig
+	kubeProvider, err := pulumiKubernetes.NewProvider(ctx, awsEnv.Namer.ResourceName("k8s-provider"), &pulumiKubernetes.ProviderArgs{
+		EnableServerSideApply: pulumi.Bool(true),
+		Kubeconfig:            kindCluster.KubeConfig,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Deploy custom Datadog Agent DaemonSet with observer capabilities
+	// This replaces the episode's basic agent Deployment
+	var dependsOnDDAgent pulumi.ResourceOption
+
+	if awsEnv.AgentDeploy() {
+		k8sAgentOptions := make([]kubernetesagentparams.Option, 0)
+
+		// Deploy to the same namespace as the episode so services can reach the agent
+		k8sAgentOptions = append(
+			k8sAgentOptions,
+			kubernetesagentparams.WithNamespace(namespace),
+		)
+
+		// Handle fakeintake if needed
+		if awsEnv.AgentUseFakeintake() {
+			fakeIntakeOptions := []fakeintake.Option{fakeintake.WithLoadBalancer()}
+			if awsEnv.AgentUseDualShipping() {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
+			}
+
+			fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, "gensim-fakeintake", fakeIntakeOptions...)
+			if err != nil {
+				return err
+			}
+			if err := fakeIntake.Export(ctx, nil); err != nil {
+				return err
+			}
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithFakeintake(fakeIntake))
+		}
+
+		// Load custom helm values from datadog-values.yaml if it exists
+		// This includes observer configuration (DD_OBSERVER_* env vars)
+		if datadogValuesPath != "" {
+			valuesContent, err := os.ReadFile(datadogValuesPath)
+			if err != nil {
+				return err
+			}
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithHelmValues(string(valuesContent)))
+		}
+
+		if awsEnv.AgentFullImagePath() != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithAgentFullImagePath(awsEnv.AgentFullImagePath()))
+		}
+
+		if awsEnv.ClusterAgentFullImagePath() != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithClusterAgentFullImagePath(awsEnv.ClusterAgentFullImagePath()))
+		}
+
+		k8sAgentComponent, err := helm.NewKubernetesAgent(&awsEnv, awsEnv.Namer.ResourceName("datadog-agent"), kubeProvider, k8sAgentOptions...)
+		if err != nil {
+			return err
+		}
+
+		if err := k8sAgentComponent.Export(ctx, nil); err != nil {
+			return err
+		}
+
+		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentComponent)
+	}
+
+	// Deploy the episode's Helm chart
+	// Helm release names must be lowercase alphanumeric with hyphens only, max 53 chars.
+	sanitizedEpisodeName := strings.ToLower(strings.ReplaceAll(episodeName, "_", "-"))
+	episodeReleaseName := fmt.Sprintf("gensim-%s", sanitizedEpisodeName)
+	if len(episodeReleaseName) > 53 {
+		episodeReleaseName = episodeReleaseName[:53]
+	}
+
+	episodeChart, err := helmresource.NewInstallation(&awsEnv, helmresource.InstallArgs{
+		RepoURL:     "", // Local chart, no repo
+		ChartName:   episodeChartPath,
+		InstallName: episodeReleaseName,
+		Namespace:   namespace,
+		Values: pulumi.Map{
+			"namespace": pulumi.String(namespace),
+			"datadog": pulumi.Map{
+				"apiKey": awsEnv.AgentAPIKey(),
+				"appKey": awsEnv.AgentAPPKey(),
+				"site":   pulumi.String(awsEnv.Site()),
+				"env":    pulumi.String(fmt.Sprintf("gensim-%s", episodeName)),
+			},
+		},
+	}, pulumi.Provider(kubeProvider), dependsOnDDAgent)
+
+	if err != nil {
+		return err
+	}
+
+	// The episode chart includes its own basic datadog-agent Deployment. Now that we deploy
+	// the full DaemonSet-based agent, remove the episode's duplicate agent using
+	// `docker exec` into the Kind control plane (which has kubectl pre-installed).
+	if awsEnv.AgentDeploy() {
+		_, err = host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("delete-episode-agent"),
+			&command.Args{
+				Create: pulumi.Sprintf(
+					"docker exec %s-control-plane kubectl delete deploy/datadog-agent svc/datadog-agent sa/datadog-agent --ignore-not-found=true -n %s",
+					kindCluster.ClusterName, namespace,
+				),
+			},
+			utils.PulumiDependsOn(episodeChart),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Export episode information
+	ctx.Export("episode-name", pulumi.String(episodeName))
+	ctx.Export("episode-namespace", pulumi.String(namespace))
+	ctx.Export("episode-release", episodeChart.Status.Name())
+
+	return nil
+}

--- a/test/e2e-framework/scenarios/aws/gensim/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/command"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agent/helm"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/docker"
 	kubeComp "github.com/DataDog/datadog-agent/test/e2e-framework/components/kubernetes"
 	resAws "github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
 	helmresource "github.com/DataDog/datadog-agent/test/e2e-framework/resources/helm"
@@ -31,6 +32,9 @@ import (
 
 //go:embed gensim_runner.sh
 var gensimRunnerScript string
+
+//go:embed datadog-values.yaml
+var defaultDatadogValues string
 
 // Run creates an EC2+Kind cluster and deploys a gensim episode with custom Datadog Agent
 func Run(ctx *pulumi.Context) error {
@@ -47,6 +51,7 @@ func Run(ctx *pulumi.Context) error {
 	episodePath := cfg.Require("episodePath")         // Full path to episode dir (contains play-episode.sh)
 	datadogValuesPath := cfg.Get("datadogValuesPath") // Path to datadog-values.yaml (optional)
 	scenario := cfg.Get("scenario")                   // Scenario to run (empty = skip run)
+	runID := cfg.Get("runId")                         // Short unique ID for this run (e.g. "a3f2c1")
 	s3Bucket := cfg.Get("s3Bucket")
 	namespace := cfg.Get("namespace")
 	if namespace == "" {
@@ -100,6 +105,22 @@ func Run(ctx *pulumi.Context) error {
 			Create: pulumi.String(`snap install aws-cli --classic`),
 			Sudo:   true,
 		},
+		utils.PulumiDependsOn(installEcrCredsHelperCmd),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Install tools needed by the runner: aws-cli (S3 upload), zip (archiving), jq (JSON parsing).
+	// All in one command to avoid parallel apt-get lock contention.
+	// snap install is idempotent via the fallback to snap refresh.
+	installKubectlCmd, err := host.OS.Runner().Command(
+		awsEnv.Namer.ResourceName("install-kubectl"),
+		&command.Args{
+			Create: pulumi.String(`snap install kubectl --classic`),
+			Sudo:   true,
+		},
+		utils.PulumiDependsOn(installAwsCliCmd),
 	)
 	if err != nil {
 		return err
@@ -114,13 +135,27 @@ func Run(ctx *pulumi.Context) error {
 			Create: pulumi.String(`apt-get install -y zip jq`),
 			Sudo:   true,
 		},
+		utils.PulumiDependsOn(installKubectlCmd),
 	)
 	if err != nil {
 		return err
 	}
 
+	// Install Docker and docker-compose explicitly so both the image build and the Kind
+	// cluster creation can start from a common ready state. Kind also installs Docker
+	// internally, but that becomes a fast idempotent no-op since it is already present.
+	dockerManager, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(
+		installEcrCredsHelperCmd,
+		installAwsCliCmd,
+		installKubectlCmd,
+		installToolsCmd,
+	))
+	if err != nil {
+		return err
+	}
+
 	// Create Kind cluster on the EC2 VM
-	kindCluster, err := kubeComp.NewKindCluster(&awsEnv, host, "gensim", awsEnv.KubernetesVersion(), utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	kindCluster, err := kubeComp.NewKindCluster(&awsEnv, host, "gensim", awsEnv.KubernetesVersion(), utils.PulumiDependsOn(dockerManager))
 	if err != nil {
 		return err
 	}
@@ -177,24 +212,35 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		// Build custom images and load them into Kind.
-		// Depends on kindCluster to ensure docker-compose plugin is installed and Kind is running.
-		buildLoadImagesCmd, err := host.OS.Runner().Command(
-			awsEnv.Namer.ResourceName("build-load-images"),
+		// Build custom images — runs in parallel with Kind cluster creation since
+		// Docker and docker-compose are already available via dockerManager.
+		buildImagesCmd, err := host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("build-images"),
 			&command.Args{
-				Create: pulumi.Sprintf(
-					`cd /tmp/gensim-build && docker-compose build && `+
-						`docker-compose config --images | xargs -I{} kind load docker-image {} --name %s`,
-					kindCluster.ClusterName,
-				),
+				Create: pulumi.String(`cd /tmp/gensim-build && docker-compose build`),
 			},
-			utils.PulumiDependsOn(fixServicesPermsCmd, kindCluster),
+			utils.PulumiDependsOn(fixServicesPermsCmd, dockerManager),
 		)
 		if err != nil {
 			return err
 		}
 
-		dependsOnImages = utils.PulumiDependsOn(buildLoadImagesCmd)
+		// Load images into Kind — waits for both the build and the cluster to be ready.
+		loadImagesCmd, err := host.OS.Runner().Command(
+			awsEnv.Namer.ResourceName("load-images"),
+			&command.Args{
+				Create: pulumi.Sprintf(
+					`cd /tmp/gensim-build && docker-compose config --images | xargs -I{} kind load docker-image {} --name %s`,
+					kindCluster.ClusterName,
+				),
+			},
+			utils.PulumiDependsOn(buildImagesCmd, kindCluster),
+		)
+		if err != nil {
+			return err
+		}
+
+		dependsOnImages = utils.PulumiDependsOn(loadImagesCmd)
 	}
 
 	// Deploy custom Datadog Agent DaemonSet with observer capabilities
@@ -227,8 +273,13 @@ func Run(ctx *pulumi.Context) error {
 			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithFakeintake(fakeIntake))
 		}
 
-		// Load custom helm values from datadog-values.yaml if it exists
-		// This includes observer configuration (DD_OBSERVER_* env vars)
+		// Apply embedded default Helm values (includes hostNetwork and observer config).
+		k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithHelmValues(defaultDatadogValues))
+
+		// Set the cluster name from the Kind cluster so the agent can identify it.
+		k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithClusterName(kindCluster.ClusterName))
+
+		// Optionally layer extra values on top of the defaults.
 		if datadogValuesPath != "" {
 			valuesContent, err := os.ReadFile(datadogValuesPath)
 			if err != nil {
@@ -381,6 +432,7 @@ func Run(ctx *pulumi.Context) error {
 						`DD_ENV=gensim-%s `+
 						`DD_SITE=%s `+
 						`S3_BUCKET=%s `+
+						`RUN_ID=%s `+
 						`bash /tmp/gensim_runner.sh > /tmp/gensim-runner-boot.log 2>&1 & `+
 						`PID=$! && sleep 5 && `+
 						`kill -0 $PID 2>/dev/null && echo "Runner PID: $PID" || `+
@@ -392,6 +444,7 @@ func Run(ctx *pulumi.Context) error {
 					episodeName,
 					awsEnv.Site(),
 					s3Bucket,
+					runID,
 				),
 			},
 			allCopyDeps,

--- a/test/e2e-framework/scenarios/aws/gensim/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim/run.go
@@ -46,12 +46,11 @@ func Run(ctx *pulumi.Context) error {
 	// Get gensim-specific configuration
 	cfg := config.New(ctx, "gensim")
 
-	episodeName := cfg.Require("episodeName")         // e.g., "002_AWS_S3_Service_Disruption"
-	episodeChartPath := cfg.Require("chartPath")      // Path to episode's Helm chart
-	episodePath := cfg.Require("episodePath")         // Full path to episode dir (contains play-episode.sh)
-	datadogValuesPath := cfg.Get("datadogValuesPath") // Path to datadog-values.yaml (optional)
-	scenario := cfg.Get("scenario")                   // Scenario to run (empty = skip run)
-	runID := cfg.Get("runId")                         // Short unique ID for this run (e.g. "a3f2c1")
+	episodeName := cfg.Require("episodeName")    // e.g., "002_AWS_S3_Service_Disruption"
+	episodeChartPath := cfg.Require("chartPath") // Path to episode's Helm chart
+	episodePath := cfg.Require("episodePath")    // Full path to episode dir (contains play-episode.sh)
+	scenario := cfg.Get("scenario")              // Scenario to run (empty = skip run)
+	runID := cfg.Get("runId")                    // Short unique ID for this run (e.g. "a3f2c1")
 	s3Bucket := cfg.Get("s3Bucket")
 	namespace := cfg.Get("namespace")
 	if namespace == "" {
@@ -276,17 +275,8 @@ func Run(ctx *pulumi.Context) error {
 		// Apply embedded default Helm values (includes hostNetwork and observer config).
 		k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithHelmValues(defaultDatadogValues))
 
-		// Set the cluster name from the Kind cluster so the agent can identify it.
+		// Set the cluster name last so it always wins over any hardcoded value in embedded defaults.
 		k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithClusterName(kindCluster.ClusterName))
-
-		// Optionally layer extra values on top of the defaults.
-		if datadogValuesPath != "" {
-			valuesContent, err := os.ReadFile(datadogValuesPath)
-			if err != nil {
-				return err
-			}
-			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithHelmValues(string(valuesContent)))
-		}
 
 		if awsEnv.AgentFullImagePath() != "" {
 			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithAgentFullImagePath(awsEnv.AgentFullImagePath()))
@@ -316,6 +306,10 @@ func Run(ctx *pulumi.Context) error {
 		episodeReleaseName = episodeReleaseName[:53]
 	}
 
+	// Build the env tag: "gensim-<episode>-<runID>" so each run is distinguishable in Datadog.
+	// Use a separate string from episodeReleaseName (which is truncated to 53 chars for Helm).
+	episodeEnvTag := fmt.Sprintf("gensim-%s-%s", sanitizedEpisodeName, runID)
+
 	episodeChart, err := helmresource.NewInstallation(&awsEnv, helmresource.InstallArgs{
 		RepoURL:     "", // Local chart, no repo
 		ChartName:   episodeChartPath,
@@ -327,7 +321,7 @@ func Run(ctx *pulumi.Context) error {
 				"apiKey": awsEnv.AgentAPIKey(),
 				"appKey": awsEnv.AgentAPPKey(),
 				"site":   pulumi.String(awsEnv.Site()),
-				"env":    pulumi.String(episodeReleaseName),
+				"env":    pulumi.String(episodeEnvTag),
 			},
 		},
 	}, pulumi.Provider(kubeProvider), dependsOnDDAgent, dependsOnImages)

--- a/test/e2e-framework/scenarios/aws/gensim/run.go
+++ b/test/e2e-framework/scenarios/aws/gensim/run.go
@@ -423,7 +423,7 @@ func Run(ctx *pulumi.Context) error {
 						`EPISODE_NAME=%s `+
 						`SCENARIO=%s `+
 						`KUBE_NAMESPACE=%s `+
-						`DD_ENV=gensim-%s `+
+						`DD_ENV=%s `+
 						`DD_SITE=%s `+
 						`S3_BUCKET=%s `+
 						`RUN_ID=%s `+
@@ -435,7 +435,7 @@ func Run(ctx *pulumi.Context) error {
 					episodeName,
 					scenario,
 					namespace,
-					episodeName,
+					episodeEnvTag,
 					awsEnv.Site(),
 					s3Bucket,
 					runID,


### PR DESCRIPTION
### What does this PR do?

Adds a new e2e scenario (`aws/gensim`) that provisions an EC2 VM running a Kind cluster, deploys a Datadog Agent with the observer plugin and a gensim episode Helm chart, then runs the episode **fully autonomously on the VM** so the developer's laptop does not need to stay open.

Key pieces:
- **`test/e2e-framework/scenarios/aws/gensim/run.go`** — Pulumi scenario that:
  - Creates an EC2 VM + Kind cluster
  - Installs Docker/docker-compose explicitly so image builds and Kind cluster creation can proceed in parallel
  - Optionally builds custom Docker images from a `docker-compose.yaml` in the episode directory and loads them into Kind (build runs in parallel with Kind cluster creation)
  - Deploys the Datadog Agent (with observer) using embedded `datadog-values.yaml` defaults (`agents.useHostNetwork: true` so the agent can reach Kind's control-plane components on `127.0.0.1`)
  - Sets `datadog.clusterName` from the Kind cluster name so each run is correctly identified in Datadog
  - Deploys the episode's Helm chart with an `env` tag that includes the run ID
  - Copies the episode directory (`play-episode.sh`, `episodes/*.yaml`) to the VM
  - Attaches an inline IAM policy granting S3 write access when `s3Bucket` is set
  - Installs `zip`, `jq`, `aws-cli`, and `kubectl` on the VM
  - Starts `gensim_runner.sh` in the background via `nohup`; Pulumi returns as soon as the process is confirmed alive
- **`test/e2e-framework/scenarios/aws/gensim/gensim_runner.sh`** — Self-contained bash script embedded in `run.go` via `//go:embed`. Handles:
  - Building the kubeconfig from the local Kind cluster
  - Running `play-episode.sh run-episode <scenario>` via `tee` so output is streamed in real time to both `/tmp/play-episode.log` and `/tmp/gensim-runner.log`
  - Collecting parquet files from the agent pod (using `docker exec <cluster>-control-plane kubectl` since kubectl is not installed on the VM's Kind network)
  - Archiving results (parquet + logs) into a timestamped zip (`gensim-results-<episode>-<date>-<runID>.zip`) and uploading to S3
- **`test/e2e-framework/scenarios/aws/gensim/datadog-values.yaml`** — Embedded Helm values for the Datadog Agent:
  - `agents.useHostNetwork: true` — required for Kind clusters where etcd, kube-controller-manager, and kube-scheduler bind to `127.0.0.1`
  - APM instrumentation, logs, process agent, cluster checks, and observer environment variables
- **`tasks/e2e_framework/aws/gensim.py`** — Invoke task `e2e-framework.aws.deploy-gensim` with:
  - Auto-selection of first available episode and scenario when not specified
  - A random 6-char hex run ID generated per invocation, used as suffix for the stack name, Kind cluster name, Datadog `env` tag, and S3 archive filename — ensuring parallel runs never collide
  - `--run-id` flag to reuse an existing stack instead of creating a new one
  - Default S3 bucket (`qbranch-gensim-recordings`)
  - Post-deploy SSH instructions for monitoring real-time progress

### Motivation

Gensim episodes take 30–60 minutes to run (warmup + baseline + disruption + cooldown phases). Running them locally tied up a developer's laptop for the full duration. This change moves the execution onto the ephemeral EC2 VM so the engineer can kick off the run and walk away.

### Describe how you validated your changes

- Deployed the `353_postmark_upstream_cloud_provider_outage` episode via:
  ```
  dda inv e2e-framework.aws.deploy-gensim \
    --episode=353_postmark_upstream_cloud_provider_outage \
    --scenario=dns-upstream-outage \
  ```
- Pulumi provisioned resources and returned immediately
- SSHed to the VM and confirmed `gensim-runner.sh` was running autonomously:
  ```
  tail -f /tmp/play-episode.log   # episode execution (real-time)
  tail -f /tmp/gensim-runner.log  # full runner log
  ```
- Episode progressed through warmup → baseline → disruption → cooldown phases without intervention
- Verified `cluster-name` and `env` tags correctly reflect the run ID in Datadog

### Additional Notes

- Episodes that include a `docker-compose.yaml` at their root have their service images built in parallel with the Kind cluster creation — only `kind load docker-image` waits for both to finish
- The `gensim:scenario` Pulumi config is optional; omitting it provisions the infrastructure without starting the runner (useful for interactive debugging)
- Secrets (DD_API_KEY, DD_APP_KEY) are written to `/tmp/gensim-secrets.env` via a Pulumi `CopyInlineFile` with a `pulumi.Sprintf` so they are redacted in CLI output

### Prerequisites

- The following keys must be set in `~/.test_infra_config.yaml`:
  ```yaml
  configParams:
    agent:
      apiKey: <your DD API key>
      appKey: <your DD APP key>
  ```
- The gensim episode repository must be cloned and accessible. Set `GENSIM_REPO_PATH` or place it at `~/go/src/github.com/DataDog/gensim-episodes/postmortems`. The `--episode` flag should point to the episode directory name within the `postmortems/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)